### PR TITLE
Fixed: Widget Expanding on Repeated Clicking

### DIFF
--- a/js/iD/ui/StepPane.js
+++ b/js/iD/ui/StepPane.js
@@ -89,8 +89,6 @@ declare("iD.ui.StepPane", null, {
 		// summary:		Show the window.
                 if(dijit.byId(this.divname).domNode.style.visibility == 'hidden')
                     dijit.byId(this.divname).show();
-                
-                console.log(dijit.byId(this.divname));
 	},
 	hide:function() {
 		// summary:		Hide the window.


### PR DESCRIPTION
When clicking one of the action buttons with a StepPane widget, it gradually expanded on every subsequent click. This was due to the show() method being executed when the widget was already showing. Therefore, I have just simply added a check to see if the widget is visible or not before executing the show method.
