### PR TITLE
typo

### DIFF
--- a/js/iD/renderer/Map.js
+++ b/js/iD/renderer/Map.js
@@ -15,7 +15,7 @@ iD.Map = function(elem) {
         dispatch = d3.dispatch('move'),
         // data
         graph = new iD.Graph(),
-        connection = new iD.Connection(graph);
+        connection = new iD.Connection(graph),
         inspector = iD.Inspector(graph),
         parent = d3.select(elem),
         selection = [],


### PR DESCRIPTION
This typo broke the app in Opera, because Opera doesn't allow the global parent object to be overwritten (but thats not what was intended anyhow...).
