### PR TITLE
Preserve Graph immutability

### DIFF
--- a/js/iD/Connection.js
+++ b/js/iD/Connection.js
@@ -1,4 +1,4 @@
-iD.Connection = function(graph) {
+iD.Connection = function() {
     var apiURL = 'http://www.openstreetmap.org/api/0.6/';
 
     var connection = {};
@@ -85,14 +85,19 @@ iD.Connection = function(graph) {
         return function(dom) {
             if (!dom.childNodes) return callback(new Error('Bad request'));
             var root = dom.childNodes[0];
-            connection.graph.insert(_.map(root.getElementsByTagName('way'), objectData));
-            connection.graph.insert(_.map(root.getElementsByTagName('node'), objectData));
-            connection.graph.insert(_.map(root.getElementsByTagName('relation'), objectData));
-            callback(null);
+            var entities = {};
+            var addEntity = function (obj) {
+                var o = objectData(obj);
+                entities[o.id] = o;
+            };
+
+            _.forEach(root.getElementsByTagName('way'), addEntity);
+            _.forEach(root.getElementsByTagName('node'), addEntity);
+            _.forEach(root.getElementsByTagName('relation'), addEntity);
+
+            callback(iD.Graph(entities));
         };
     }
-
-    connection.graph = graph;
 
     connection.bboxFromAPI = bboxFromAPI;
     connection.wayFromAPI = wayFromAPI;

--- a/js/iD/graph/Graph.js
+++ b/js/iD/graph/Graph.js
@@ -27,11 +27,10 @@ iD.Graph.prototype = {
         return pois;
     },
 
-    insert: function(a) {
-        for (var i = 0; i < a.length; i++) {
-            if (this.entities[a[i].id]) return;
-            this.entities[a[i].id] = a[i];
-        }
+    merge: function(graph) {
+        var entities = _.clone(this.entities);
+        _.defaults(entities, graph.entities);
+        return iD.Graph(entities, this.annotation);
     },
 
     replace: function(entity, annotation) {

--- a/js/iD/graph/History.js
+++ b/js/iD/graph/History.js
@@ -9,6 +9,12 @@ iD.History.prototype = {
         return this.stack[this.index];
     },
 
+    merge: function(graph) {
+        for (var i = 0; i < this.stack.length; i++) {
+            this.stack[i] = this.stack[i].merge(graph);
+        }
+    },
+
     do: function(operation) {
         this.stack = this.stack.slice(0, this.index + 1);
         this.stack.push(operation(this.graph()));

--- a/js/iD/renderer/Map.js
+++ b/js/iD/renderer/Map.js
@@ -201,7 +201,14 @@ iD.Map = function(elem) {
     }
 
     var download = _.debounce(function() {
-        connection.bboxFromAPI(getExtent(), drawVector);
+        connection.bboxFromAPI(getExtent(), function (result) {
+            if (result instanceof Error) {
+                // TODO: handle
+            } else {
+                history.merge(result);
+                drawVector();
+            }
+        });
     }, 1000);
 
     function deselectClick() {


### PR DESCRIPTION
The connection calls back with a Graph, rather than updating the one
passed in the constructor in-place.

History takes care of merging the new Graph into each version. (If we used
prototype-based sharing, we could instead update a single special-case
mutable root entity map.)
