### PR TITLE
Fixed save button change count display in Firefox.

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -200,7 +200,6 @@ button {
     color:#222;
     background: white;
     font-weight:bold;
-    white-space:nowrap;
     font-size:14px;
     display: inline-block;
     height:40px;


### PR DESCRIPTION
This fixes the improperly displayed change count on the save button in Firefox.

Before:
![save-button](https://f.cloud.github.com/assets/1450212/59178/4e264d62-5ba6-11e2-9fe2-24d984e7973b.png)
