### PR TITLE
Use simple inheritance for entities, use less dynamic new

### DIFF
--- a/js/id/connection.js
+++ b/js/id/connection.js
@@ -77,15 +77,8 @@ iD.Connection = function() {
             delete o.lat;
         }
         o.id = iD.Entity.id.fromOSM(o.type, o.id);
-        switch (o.type) {
-            case 'node':
-                o._poi = !refNodes[o.id];
-                return iD.Node(o);
-            case 'way':
-                return iD.Way(o);
-            case 'relation':
-                return iD.Relation(o);
-        }
+        if (o.type === 'node')  o._poi = !refNodes[o.id];
+        return new iD.Entity[o.type](o);
     }
 
     function parse(dom) {

--- a/js/id/graph/entity.js
+++ b/js/id/graph/entity.js
@@ -3,7 +3,9 @@ iD.Entity = function(attrs) {
     if (this instanceof iD.Entity) return;
 
     // Create the appropriate subtype.
-    if (attrs && attrs.type) return iD.Entity[attrs.type].apply(this, arguments);
+    if (attrs && attrs.type) {
+        return new iD.Entity[attrs.type](arguments);
+    }
 
     // Initialize a generic Entity (used only in tests).
     return (new iD.Entity()).initialize(arguments);
@@ -114,15 +116,11 @@ iD.Entity.prototype = {
     }
 };
 
-iD.Entity.extend = function(properties) {
-    var Subclass = function() {
-        if (this instanceof Subclass) return;
-        return (new Subclass()).initialize(arguments);
-    };
-
-    Subclass.prototype = new iD.Entity();
-    _.extend(Subclass.prototype, properties);
-    iD.Entity[properties.type] = Subclass;
-
-    return Subclass;
+iD.Entity.simpleExtend = function(child, parent) {
+    for (var property in parent.prototype) {
+        if (typeof child.prototype[property] == "undefined") {
+            child.prototype[property] = parent.prototype[property];
+        }
+    }
+    return child;
 };

--- a/js/id/graph/node.js
+++ b/js/id/graph/node.js
@@ -1,4 +1,29 @@
-iD.Node = iD.Entity.extend({
+iD.Node = function(sources) {
+    if (!sources.length || sources.length === 0) sources = [sources];
+    for (var i = 0; i < sources.length; ++i) {
+        var source = sources[i];
+        for (var prop in source) {
+            if (Object.prototype.hasOwnProperty.call(source, prop)) {
+                this[prop] = source[prop];
+            }
+        }
+    }
+
+    if (!this.id && this.type) {
+        this.id = iD.Entity.id(this.type);
+        this._updated = true;
+    }
+
+    if (iD.debug) {
+        Object.freeze(this);
+        Object.freeze(this.tags);
+
+        if (this.nodes) Object.freeze(this.nodes);
+        if (this.members) Object.freeze(this.members);
+    }
+};
+
+iD.Node.prototype = {
     type: "node",
 
     extent: function() {
@@ -8,4 +33,7 @@ iD.Node = iD.Entity.extend({
     geometry: function() {
         return this._poi ? 'point' : 'vertex';
     }
-});
+};
+
+iD.Entity.simpleExtend(iD.Node, iD.Entity);
+iD.Entity.node = iD.Node;

--- a/js/id/graph/relation.js
+++ b/js/id/graph/relation.js
@@ -1,4 +1,29 @@
-iD.Relation = iD.Entity.extend({
+iD.Relation = function(sources) {
+    if (!sources.length || sources.length === 0) sources = [sources];
+    for (var i = 0; i < sources.length; ++i) {
+        var source = sources[i];
+        for (var prop in source) {
+            if (Object.prototype.hasOwnProperty.call(source, prop)) {
+                this[prop] = source[prop];
+            }
+        }
+    }
+
+    if (!this.id && this.type) {
+        this.id = iD.Entity.id(this.type);
+        this._updated = true;
+    }
+
+    if (iD.debug) {
+        Object.freeze(this);
+        Object.freeze(this.tags);
+
+        if (this.nodes) Object.freeze(this.nodes);
+        if (this.members) Object.freeze(this.members);
+    }
+};
+
+iD.Relation.prototype = {
     type: "relation",
     members: [],
 
@@ -9,4 +34,7 @@ iD.Relation = iD.Entity.extend({
     geometry: function() {
         return 'relation';
     }
-});
+};
+
+iD.Entity.simpleExtend(iD.Relation, iD.Entity);
+iD.Entity.relation = iD.Relation;

--- a/js/id/graph/way.js
+++ b/js/id/graph/way.js
@@ -1,4 +1,29 @@
-iD.Way = iD.Entity.extend({
+iD.Way = function(sources) {
+    if (!sources.length || sources.length === 0) sources = [sources];
+    for (var i = 0; i < sources.length; ++i) {
+        var source = sources[i];
+        for (var prop in source) {
+            if (Object.prototype.hasOwnProperty.call(source, prop)) {
+                this[prop] = source[prop];
+            }
+        }
+    }
+
+    if (!this.id && this.type) {
+        this.id = iD.Entity.id(this.type);
+        this._updated = true;
+    }
+
+    if (iD.debug) {
+        Object.freeze(this);
+        Object.freeze(this.tags);
+
+        if (this.nodes) Object.freeze(this.nodes);
+        if (this.members) Object.freeze(this.members);
+    }
+};
+
+iD.Way.prototype = {
     type: "way",
     nodes: [],
 
@@ -41,4 +66,7 @@ iD.Way = iD.Entity.extend({
     geometry: function() {
         return this.isArea() ? 'area' : 'line';
     }
-});
+};
+
+iD.Entity.simpleExtend(iD.Way, iD.Entity);
+iD.Entity.way = iD.Way;


### PR DESCRIPTION
Simpler inheritance - this makes it easier to track memory taken up by objects (otherwise called just Subclass in the heap) and appears to give a decent perf boost for creating objects.
