### PR TITLE
dead code cleanup

### DIFF
--- a/js/id/ui/inspector.js
+++ b/js/id/ui/inspector.js
@@ -187,10 +187,6 @@ iD.ui.inspector = function() {
                             }
                         });
                     }
-                    d3.event.preventDefault();
-                })
-                .attr('href', function(d) {
-                    return 'http://taginfo.openstreetmap.org/keys/' + d.key;
                 });
 
         helpBtn.append('span')


### PR DESCRIPTION
it looks like the link to the taginfo help page has been superseded by the popup + api call.
