### PR TITLE
Fast zooming based on transforms.

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -783,9 +783,14 @@ img.tile {
     -o-transform-origin:0 0;
 }
 
-#tile-g {
+#surface, #tile-g {
     position:absolute;
     top:0;
+    transform-origin:0 0;
+    -ms-transform-origin:0 0;
+    -webkit-transform-origin:0 0;
+    -moz-transform-origin:0 0;
+    -o-transform-origin:0 0;
 }
 
 /* About Section
@@ -993,6 +998,7 @@ div.typeahead a:first-child {
     height:38px;
     padding:10px 20px;
     background:#fff;
+    color:#000;
     font-weight: normal;
     line-height: 21px;
     border-radius:5px;


### PR DESCRIPTION
- Replaces the mouseup-tranformStart method with a redraw debouced by 1/5s

This makes zooming of large datasets much faster in Chrome & Safari and a bit faster in Firefox, though FF is more or less a lost cause.
