### PR TITLE
Typo in Save button tooltip

### DIFF
--- a/locale/da.js
+++ b/locale/da.js
@@ -190,7 +190,7 @@ locale.da = {
 
     save: {
         title: "Gem",
-        help: "Gem ændringer til OpenStreetMap vil gøre dem synlige for andre brugere",
+        help: "Gem ændringer til OpenStreetMap vil gøre dem synlige for andre brugere.",
         error: "Der skete en fejl da du prøvede at gemme",
         uploading: "Gemmer nu ændringer til OpenStreetMap.",
         unsaved_changes: "Du har ændringer der ikke er gemt endnu",

--- a/locale/de.js
+++ b/locale/de.js
@@ -190,7 +190,7 @@ locale.de = {
 
     save: {
         title: "Speichern",
-        help: "Speichere Änderungen auf OpenStreetMap, um diese für andere Nutzer sichtbar zu machen",
+        help: "Speichere Änderungen auf OpenStreetMap, um diese für andere Nutzer sichtbar zu machen.",
         error: "Beim Speichern ist ein Fehler aufgetreten",
         uploading: "Änderungen werden zu OpenStreetMap hochgeladen.",
         unsaved_changes: "Ungespeicherte Änderugen vorhanden",

--- a/locale/en.js
+++ b/locale/en.js
@@ -190,7 +190,7 @@ locale.en = {
 
     save: {
         title: "Save",
-        help: "Save changes to OpenStreetMap, making them visible to other users",
+        help: "Save changes to OpenStreetMap, making them visible to other users.",
         error: "An error occurred while trying to save",
         uploading: "Uploading changes to OpenStreetMap.",
         unsaved_changes: "You have unsaved changes"

--- a/locale/es.js
+++ b/locale/es.js
@@ -190,7 +190,7 @@ locale.es = {
 
     save: {
         title: "Guardar", //"Save",
-        help: "Guardar los cambios en OpenStreetMap haciéndolos visibles a otros usuarios", //"Save changes to OpenStreetMap, making them visible to other users",
+        help: "Guardar los cambios en OpenStreetMap haciéndolos visibles a otros usuarios.", //"Save changes to OpenStreetMap, making them visible to other users.",
         error: "Ha ocurrido un error tratando de guardar", //"An error occurred while trying to save",
         uploading: "Subiendo cambios a OpenStreetMap", //"Uploading changes to OpenStreetMap.",
         unsaved_changes: "Tienes cambios sin guardar" //"You have unsaved changes",

--- a/locale/it.js
+++ b/locale/it.js
@@ -190,7 +190,7 @@ locale.it = {
 
     save: {
         title: "Salva",
-        help: "Salva i cambiamenti su OpenStreetMap, rendendoli visibili ad altri utenti",
+        help: "Salva i cambiamenti su OpenStreetMap, rendendoli visibili ad altri utenti.",
         error: "E' accaduto un errore mentre veniva tentato il salvataggio",
         uploading: "Caricando le modifiche su OpenStreetMap.",
         unsaved_changes: "Hai modifiche non salvate"

--- a/locale/ja.js
+++ b/locale/ja.js
@@ -190,7 +190,7 @@ locale.ja = {
 
     save: {
         title: "Save",
-        help: "変更点をOpenStreetMapに保存し、他ユーザが確認できるようにします",
+        help: "変更点をOpenStreetMapに保存し、他ユーザが確認できるようにします。",
         error: "データ保存中にエラーが発生しました",
         uploading: "変更点をOpenStreetMapへアップロードしています",
         unsaved_changes: "変更が保存されていません"

--- a/locale/lv.js
+++ b/locale/lv.js
@@ -190,7 +190,7 @@ locale.lv = {
 
     save: {
         title: "Saglabāt",
-        help: "Saglabā izmaiņas, padarot tās redzamas citiem",
+        help: "Saglabā izmaiņas, padarot tās redzamas citiem.",
         error: "Kļūda. Nevarēja saglabāt izmaiņas",
         uploading: "Augšupielādē",
         unsaved_changes: "Jums ir nesaglabātas izmaiņas"

--- a/locale/tr.js
+++ b/locale/tr.js
@@ -190,7 +190,7 @@ locale.tr = {
 
     save: {
         title: "Kaydet",
-        help: "Diğer kullanıcıların yaptığınız değişiklikleri görmesi için OpenStreetMap'e kaydediniz",
+        help: "Diğer kullanıcıların yaptığınız değişiklikleri görmesi için OpenStreetMap'e kaydediniz.",
         error: "Kaydederken bir hata oluştu",
         uploading: "Değişiklikleriniz OpenStreetMap'e gönderiliyor.",
         unsaved_changes: "Kaydedilmemiş değişiklikleriniz var"

--- a/locale/vi.js
+++ b/locale/vi.js
@@ -190,7 +190,7 @@ locale.vi = {
 
     save: {
         title: "Lưu",
-        help: "Lưu các thay đổi vào OpenStreetMap để cho mọi người xem",
+        help: "Lưu các thay đổi vào OpenStreetMap để cho mọi người xem.",
         error: "Đã xuất hiện lỗi khi lưu",
         uploading: "Đang tải các thay đổi lên OpenStreetMap.",
         unsaved_changes: "Bạn có Thay đổi Chưa lưu"


### PR DESCRIPTION
Appended a period to the Save button’s tooltip, for consistency with the other toolbar buttons’ tooltips, in each of the languages that lack it. (French already had a period.)
