### PR TITLE
Taglist: do not addTag when presssing TAB in shiftKey mode

### DIFF
--- a/js/id/ui/taglist.js
+++ b/js/id/ui/taglist.js
@@ -182,7 +182,8 @@ iD.ui.Taglist = function() {
 
     function pushMore() {
         if (d3.event.keyCode === 9 &&
-            list.selectAll('li:last-child input.value').node() === this) {
+            list.selectAll('li:last-child input.value').node() === this &&
+            !d3.event.shiftKey) {
             addTag();
             focusNewKey();
             d3.event.preventDefault();

--- a/test/spec/ui/inspector.js
+++ b/test/spec/ui/inspector.js
@@ -75,4 +75,21 @@ describe("iD.ui.Inspector", function () {
 
         expect(spy).to.have.been.calledWith(entity, tags);
     });
+
+    it("adds tags when pressing the TAB key on last input.value", function () {
+        expect(element.selectAll('.tag-list li')[0].length).to.eql(1);
+        var input = d3.select('.tag-list li:last-child input.value')[0][0];
+        happen.keydown(d3.select(input).node(), {keyCode: 9});
+        expect(element.selectAll('.tag-list li')[0].length).to.eql(2);
+        expect(element.select('.tag-list').selectAll("input")[0][2].value).to.be.empty;
+        expect(element.select('.tag-list').selectAll("input")[0][3].value).to.be.empty;
+    });
+
+    it("does not add a tag when pressing TAB while shift is pressed", function () {
+        expect(element.selectAll('.tag-list li')[0].length).to.eql(1);
+        var input = d3.select('.tag-list li:last-child input.value')[0][0];
+        happen.keydown(d3.select(input).node(), {keyCode: 9, shiftKey: true});
+        expect(element.selectAll('.tag-list li')[0].length).to.eql(1);
+    });
+
 });


### PR DESCRIPTION
Just hit myself this behaviour: when having the cursor in last tag value in taglist, I use shift+tab to go up in the tags list, but it first creates a new tag entry.
This commit fixes it.
And it's unittested.

Thanks :)

Yohan
