### PR TITLE
Do not show combobox if input has lost focus

### DIFF
--- a/js/lib/d3.combobox.js
+++ b/js/lib/d3.combobox.js
@@ -187,7 +187,8 @@ d3.combobox = function() {
 
             function render(data) {
 
-                if (data.length) show();
+                if (data.length &&
+                    document.activeElement === input.node()) show();
                 else hide();
 
                 autocomplete(e, data);


### PR DESCRIPTION
@ansis this fix the discussed issue where combobox where never hidden when one hit tab key before the combobox where shown.

Honestly, I don't see a way to do a proper unittest for this, but if you have some hints, I'll do with pleasure! :)

Yohan
