### PR TITLE
Change default max zoom to 20

### DIFF
--- a/js/id/renderer/background.js
+++ b/js/id/renderer/background.js
@@ -172,7 +172,7 @@ iD.Background = function() {
         if (!arguments.length) return source;
         source = _;
         cache = {};
-        tile.scaleExtent((source.data && source.data.scaleExtent) || [1, 17]);
+        tile.scaleExtent((source.data && source.data.scaleExtent) || [1, 20]);
         setPermalink(source);
         return background;
     };


### PR DESCRIPTION
A lot of imagery goes to z20 now. Where the max zoom is not known it should be set high to allow the imagery to be used at its maximum resolution

Where the source imagery does not support up to z20 it will fall back to higher zoom levels. It is unlikely that editors will be zoomed in far past the max zoom of the imagery.

This does not replace the lack of max zoom support for preset imagery layers (issue #784)
