### PR TITLE
remove 'move' button from toolbar

### DIFF
--- a/js/id/ui.js
+++ b/js/id/ui.js
@@ -37,7 +37,7 @@ iD.ui = function(context) {
             .attr('class', 'limiter');
 
         limiter.append('div')
-            .attr('class', 'button-wrap joined col4')
+            .attr('class', 'button-wrap joined col3')
             .call(iD.ui.Modes(context), limiter);
 
         limiter.append('div')

--- a/js/id/ui/modes.js
+++ b/js/id/ui/modes.js
@@ -1,6 +1,5 @@
 iD.ui.Modes = function(context) {
     var modes = [
-        iD.modes.Browse(context),
         iD.modes.AddPoint(context),
         iD.modes.AddLine(context),
         iD.modes.AddArea(context)];
@@ -11,7 +10,7 @@ iD.ui.Modes = function(context) {
 
        buttons.enter().append('button')
            .attr('tabindex', -1)
-           .attr('class', function(mode) { return mode.id + ' add-button col3'; })
+           .attr('class', function(mode) { return mode.id + ' add-button col4'; })
            .on('click.mode-buttons', function(mode) { context.enter(mode); })
            .call(bootstrap.tooltip()
                .placement('bottom')


### PR DESCRIPTION
We should remove the 'move' button from the top bar:

![Screen Shot 2013-03-17 at 11 54 24 PM](https://f.cloud.github.com/assets/108094/269153/938a4e5a-8f7f-11e2-9a49-d2fcbfbd1798.png)

I like this, it feels more intuitive to me. I recommend you try it out first if you're skeptical.

I am not concerned about the user not having an obvious way to escape a draw mode after it's been selected. The 'ESC' key is intuitive. We can make this clear in another way if we need to.
