### PR TITLE
support for overlay layers

### DIFF
--- a/data/imagery.json
+++ b/data/imagery.json
@@ -51,6 +51,7 @@
     {
         "name": " TIGER 2012 Roads Overlay",
         "template": "http://{t}.tile.openstreetmap.us/tiger2012_roads_expanded/{z}/{x}/{y}.png",
+        "overlay": true,
         "subdomains": [
             "a",
             "b",

--- a/js/id/renderer/background.js
+++ b/js/id/renderer/background.js
@@ -1,4 +1,7 @@
-iD.Background = function() {
+iD.Background = function(backgroundType) {
+
+    backgroundType = backgroundType || 'layer';
+
     var tileSize = 256,
         tile = d3.geo.tile(),
         projection,
@@ -157,14 +160,13 @@ iD.Background = function() {
     };
 
     function setHash(source) {
-        var tag = source.data.sourcetag;
+        var tag = source.data && source.data.sourcetag;
         var q = iD.util.stringQs(location.hash.substring(1));
         if (tag) {
-            location.replace('#' + iD.util.qsString(_.assign(q, {
-                layer: tag
-            }), true));
+            q[backgroundType] = tag;
+            location.replace('#' + iD.util.qsString(q, true));
         } else {
-            location.replace('#' + iD.util.qsString(_.omit(q, 'layer'), true));
+            location.replace('#' + iD.util.qsString(_.omit(q, backgroundType), true));
         }
     }
 

--- a/js/id/renderer/map.js
+++ b/js/id/renderer/map.js
@@ -13,7 +13,9 @@ iD.Map = function(context) {
         minzoom = 0,
         layers = [
             iD.Background().projection(projection),
-            iD.LocalGpx(context).projection(projection)],
+            iD.LocalGpx(context).projection(projection),
+            iD.Background('overlay').projection(projection)
+            ],
         transformProp = iD.util.prefixCSSProperty('Transform'),
         points = iD.svg.Points(roundedProjection, context),
         vertices = iD.svg.Vertices(roundedProjection, context),


### PR DESCRIPTION
This is mostly added for the Tiger2012 road overlay, #535

Overlay is just on/off. No adjustments and opacity changes.

Right now it the only overlay layer is Tiger2012. I just added an overlay=true in imagery.json. Does this need to be set somewhere upstream? Are we waiting on editor-imagery-index for that?
