### PR TITLE
use 'node' in a more uniform way

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -17,9 +17,9 @@ en:
       title: Browse
       description: Pan and zoom the map.
     draw_area:
-      tail: Click to add points to your area. Click the first point to finish the area.
+      tail: Click to add nodes to your area. Click the first node to finish the area.
     draw_line:
-      tail: "Click to add more points to the line. Click on other lines to connect to them, and double-click to end the line."
+      tail: "Click to add more nodes to the line. Click on other lines to connect to them, and double-click to end the line."
   operations:
     add:
       annotation:
@@ -110,9 +110,9 @@ en:
     split:
       title: Split
       description:
-        line: Split this line into two at this point.
+        line: Split this line into two at this node.
         area: Split the boundary of this area into two.
-        multiple: Split the lines/area boundaries at this point into two.
+        multiple: Split the lines/area boundaries at this node into two.
       key: X
       annotation:
         line: Split a line.
@@ -193,7 +193,7 @@ en:
     on_wiki: "{tag} on wiki.osm.org"
     used_with: "used with {type}"
   validations:
-    untagged_point: Untagged point which is not part of a line or area
+    untagged_point: Untagged point
     untagged_line: Untagged line
     untagged_area: Untagged area
     many_deletions: "You're deleting {n} objects. Are you sure you want to do this? This will delete them from the map that everyone else sees on openstreetmap.org."
@@ -280,7 +280,7 @@ en:
       First click on the road you want to change. This will highlight it and show
       control points along it that you can drag to better locations. If
       you want to add new control points for more detail, double-click a part
-      of the road without a point, and one will be added.
+      of the road without a node, and one will be added.
 
       If the road connects to another road, but doesn't properly connect on
       the map, you can drag one of its control points onto the other road in
@@ -419,7 +419,7 @@ en:
       To move an entire building, select it, then click the 'Move' tool. Move your
       mouse to shift the building, and click when it's correctly placed.
 
-      To fix the specific shape of a building, click and drag the points that form
+      To fix the specific shape of a building, click and drag the nodes that form
       its border into better places.
 
       ### Creating
@@ -432,7 +432,7 @@ en:
 
       Start drawing a building as a shape by clicking the 'Area' button in the top
       left of the interface, and end it either by pressing 'Return' on your keyboard
-      or clicking on the first point drawn to close the shape.
+      or clicking on the first node drawn to close the shape.
 
       ### Deleting
 
@@ -465,15 +465,15 @@ en:
     areas:
       add: "Areas are a more detailed way to represent features. They provide information on the boundaries of the feature. Areas can be used for most features types points can be used for, and are often preferred. **Click the Area button to add a new area.**"
       corner: "Areas are drawn by placing nodes that mark the boundary of the area. **Place the starting node on one of the corners of the playground.**"
-      place: "Draw the area by placing more nodes. Finish the area by clicking on the starting point. **Draw an area for the playground.**"
+      place: "Draw the area by placing more nodes. Finish the area by clicking on the starting node. **Draw an area for the playground.**"
       search: "**Search for Playground.**"
       choose: "**Choose Playground from the grid.**"
       describe: "**Add a name, and close the feature editor**"
     lines:
       add: "Lines are used to represent features such as roads, railways and rivers. **Click the Line button to add a new line.**"
       start: "**Start the line by clicking on the end of the road.**"
-      intersect: "Click to add more points to the line. You can drag the map while drawing if necessary. Roads, and many other types of lines, are part of a larger network. It is important for these lines to be connected properly in order for routing applications to work. **Click on Flower Street, to create an intersection connecting the two lines.**"
-      finish: "Lines can be finished by clicking on the last point again. **Finish drawing the road.**"
+      intersect: "Click to add more nodes to the line. You can drag the map while drawing if necessary. Roads, and many other types of lines, are part of a larger network. It is important for these lines to be connected properly in order for routing applications to work. **Click on Flower Street, to create an intersection connecting the two lines.**"
+      finish: "Lines can be finished by clicking on the last node again. **Finish drawing the road.**"
       road: "**Select Road from the grid**"
       residential: "There are different types of roads, the most common of which is Residential. **Choose the Residential road type**"
       describe: "**Name the road and close the feature editor.**"


### PR DESCRIPTION
this changes 'point' to 'node' whenever we refer to an entity inside a line or area.
sorry about the previous pull request, i apparently failed at using the in-browser editor at github :)
