### PR TITLE
inline "taginfo" help broken on "additional tags"

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -1496,7 +1496,7 @@ div.combobox {
 
 .additional-tags div.tag-help {
     float: left;
-    width: 33.3333%;
+    width: 100%;
     width: -webkit-calc(100% + 40px);
     width: calc(100% + 40px);
 }


### PR DESCRIPTION
"taginfo" inline help in the "additional tags" section is somewhat broken because of wrong styling in the css. The help text of the last item in the list is moved below the "+" button, and the borders of the item right below the help text gets truncated (see images below).

Its still not perfect in browsers that don't support the [calc()](http://caniuse.com/#feat=calc) css-method, though. But I think that's acceptable, isn't it?

![ID editor - bugs - additional tags taginfo](https://f.cloud.github.com/assets/1927298/406144/7cd88c78-aa62-11e2-813f-8003a437cedd.png)

![ID editor - bugs - weitere merkmale - taginfo](https://f.cloud.github.com/assets/1927298/406145/8a0c4a74-aa62-11e2-926b-ecd729a86ef5.png)
