### PR TITLE
updated path preset:

### DIFF
--- a/data/presets/fields/incline.json
+++ b/data/presets/fields/incline.json
@@ -1,0 +1,5 @@
+{
+    "key": "incline",
+    "type": "combo",
+    "label": "Incline"
+}

--- a/data/presets/fields/sac_scale.json
+++ b/data/presets/fields/sac_scale.json
@@ -1,0 +1,5 @@
+{
+    "key": "sac_scale",
+    "type": "combo",
+    "label": "Path Difficulty"
+}

--- a/data/presets/fields/trail_visibility.json
+++ b/data/presets/fields/trail_visibility.json
@@ -1,0 +1,5 @@
+{
+    "key": "trail_visibility",
+    "type": "combo",
+    "label": "Trail Visibility"
+}

--- a/data/presets/presets/highway/path.json
+++ b/data/presets/presets/highway/path.json
@@ -1,11 +1,13 @@
 {
     "icon": "highway-path",
     "fields": [
-        "oneway",
         "structure",
         "access",
-        "maxspeed",
-        "surface"
+        "sac_scale",
+        "surface",
+        "incline",
+        "trail_visibility",
+        "ref"
     ],
     "geometry": [
         "line"


### PR DESCRIPTION
- added new sac_scale, incline and trail_visibility fields
- added ref field
- removed oneway and maxspeed field

this should better reflect how highway=path is used.
See: http://taginfo.openstreetmap.org/tags/highway=path#combinations
