### PR TITLE
evenly spaced oneway markers

### DIFF
--- a/css/map.css
+++ b/css/map.css
@@ -823,11 +823,8 @@ marker#oneway-marker path {
     opacity: .5;
 }
 
-text.tag-oneway {
-    fill:#91CFFF;
-    stroke:#2C6B9B;
-    stroke-width:1;
-    pointer-events:none;
+path.oneway {
+    stroke-width: 6px;
 }
 
 /*

--- a/js/id/svg/lines.js
+++ b/js/id/svg/lines.js
@@ -112,14 +112,16 @@ iD.svg.Lines = function(projection) {
             casing = surface.select('.layer-casing'),
             stroke = surface.select('.layer-stroke'),
             defs   = surface.select('defs'),
-            text   = surface.select('.layer-text'),
+            oneway = surface.select('.layer-oneway'),
             shadows = drawPaths(shadow, lines, filter, 'shadow', lineString),
             casings = drawPaths(casing, lines, filter, 'casing', lineString),
-            strokes = drawPaths(stroke, lines, filter, 'stroke', lineString);
+            strokes = drawPaths(stroke, lines, filter, 'stroke', lineString),
+            oneways = drawPaths(oneway, lines, filter, 'oneway', lineStringOneway);
 
-            strokes
-                .filter(function(d) { return d.isOneWay(); })
-                .attr('marker-mid', 'url(#oneway-marker)')
-                .attr('d', lineStringResampled);
+        oneways.attr('marker-mid', 'url(#oneway-marker)');
+
+        function lineStringOneway(d) {
+            return d.isOneWay() && lineStringResampled(d);
+        }
     };
 };

--- a/js/id/svg/surface.js
+++ b/js/id/svg/surface.js
@@ -34,12 +34,13 @@ iD.svg.Surface = function(context) {
                 id: 'oneway-marker',
                 viewBox: '0 0 10 10',
                 refY: 2.5,
+                refX: 5,
                 markerWidth: 2,
                 markerHeight: 2,
                 orient: 'auto'
             })
             .append('path')
-            .attr('d', 'M 0 0 L 5 2.5 L 0 5 z');
+            .attr('d', 'M 5 3 L 0 3 L 0 2 L 5 2 L 5 0 L 10 2.5 L 5 5 z');
 
         var patterns = defs.selectAll('pattern')
             .data([
@@ -109,7 +110,7 @@ iD.svg.Surface = function(context) {
             maki));
 
         var layers = selection.selectAll('.layer')
-            .data(['fill', 'shadow', 'casing', 'stroke', 'text', 'hit', 'halo', 'label']);
+            .data(['fill', 'shadow', 'casing', 'stroke', 'oneway', 'hit', 'halo', 'label']);
 
         layers.enter().append('g')
             .attr('class', function(d) { return 'layer layer-' + d; });


### PR DESCRIPTION
For #1366 

Markers now have their own path, which is resampled without preserving corners. This means markers near sharp turns are rotated towards that turn. Tails are added to the arrows to make them clear even when rotated. Overall, I think its good enough, and that drawing markers individually will have other problems. See:

![2013-04-26-180944_1222x510_scrot](https://f.cloud.github.com/assets/1421652/433151/2c4bbedc-aebe-11e2-97dd-a3a2ad3a7cdb.png)
