### PR TITLE
[WIP] Tiled OSM data

### DIFF
--- a/js/id/core/connection.js
+++ b/js/id/core/connection.js
@@ -305,6 +305,9 @@ iD.Connection = function() {
 
                 return {
                     id: tile.toString(),
+                    z: tile[2],
+                    x: tile[0],
+                    y: tile[1],
                     extent: iD.geo.Extent(
                         projection.invert([x, y + ts]),
                         projection.invert([x + ts, y]))
@@ -312,7 +315,7 @@ iD.Connection = function() {
             });
 
         function bboxUrl(tile) {
-            return 'http://tile.osm.osuosl.org/tiles/tiled_osm/' + z + "/" + tile[0] + "/" + tile[1] + ".osm";
+            return 'http://tile.osm.osuosl.org/tiles/tiled_osm/' + tile.z + "/" + tile.x + "/" + tile.y + ".osm";
         }
 
         _.filter(inflight, function(v, i) {


### PR DESCRIPTION
Makes requests for OSM data to a highly-cacheable resource instead of the API map call.

A couple sticking points;
- When a change is saved, iD clears and re-requests all existing data. Chances are the tiles will not have expired by the time iD requests the tiles again (because the minutely diff hasn't been processed yet -- most systems using the minutely diffs are ~1.2 minutes behind at best).
- The goal is to have the cache be served entirely from a static store (like S3), making it extremely fault tolerant, but there's an awful lot of tiles that would need to be pre-generated for that to make sense, so right now the endpoint uses TileStache to cache requests as they come in.
