### PR TITLE
use fill:none instead of fill:transparent

### DIFF
--- a/css/map.css
+++ b/css/map.css
@@ -1051,9 +1051,9 @@ text.point {
 
 /* GPX Paths */
 path.gpx {
-    stroke:#6AFF25;
-    stroke-width:2;
-    fill:transparent;
+    stroke: #6AFF25;
+    stroke-width: 2;
+    fill: none;
     pointer-events: none;
 }
 


### PR DESCRIPTION
`transparent` is not a valid [svg](http://www.w3.org/TR/SVG/painting.html#SpecifyingPaint) [color](http://www.w3.org/TR/SVG/types.html#DataTypeColor). Use `none` instead.
