### PR TITLE
experiment with eliminating global footer

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -775,6 +775,10 @@ a:hover .icon.out-link   { background-position: -500px -14px;}
     padding-left: 10px;
 }
 
+.bug-report {
+    float: right;
+}
+
 /* Presets
 ------------------------------------------------------- */
 
@@ -2130,6 +2134,12 @@ img.wiki-image {
     margin-right: 10px;
 }
 
+.source-switch {
+    position: absolute;
+    bottom: 40px;
+    left: 10px;
+}
+
 .source-switch a {
     padding: 2px 4px 4px 4px;
     border-radius: 2px;
@@ -2142,7 +2152,7 @@ img.wiki-image {
 /* Attribution overlay */
 .attribution {
     position: absolute;
-    bottom: 35px;
+    bottom: 10px;
     left:10px;
     color:#888;
     font-size:10px;
@@ -2153,6 +2163,10 @@ img.wiki-image {
     vertical-align:top;
 }
 
+.user-list {
+    width: 90%;
+    display: inline-block;
+}
 .user-list a:not(:last-child):after {
     content: ', ';
 }

--- a/index.html
+++ b/index.html
@@ -212,7 +212,7 @@
                 d3.select('#id-container')
                     .call(id.ui());
 
-                d3.select('#about').insert('li', '.user-list')
+                d3.select('#content').insert('span')
                     .attr('class', 'source-switch')
                     .call(iD.ui.SourceSwitch(id)
                         .keys([

--- a/js/id/ui.js
+++ b/js/id/ui.js
@@ -82,49 +82,6 @@ iD.ui = function(context) {
             .attr('class', 'map-control geolocate-control')
             .call(iD.ui.Geolocate(map));
 
-        var about = content.append('div')
-            .attr('class','col12 about-block fillD');
-
-        about.append('div')
-            .attr('class', 'api-status')
-            .call(iD.ui.Status(context));
-
-        if (!context.embed()) {
-            about.append('div')
-                .attr('class', 'account')
-                .call(iD.ui.Account(context));
-        }
-
-        var linkList = about.append('ul')
-            .attr('id', 'about')
-            .attr('class', 'link-list');
-
-        linkList.append('li')
-            .append('a')
-            .attr('target', '_blank')
-            .attr('tabindex', -1)
-            .attr('href', 'http://github.com/systemed/iD')
-            .text(iD.version);
-
-        var bugReport = linkList.append('li')
-            .append('a')
-            .attr('target', '_blank')
-            .attr('tabindex', -1)
-            .attr('href', 'https://github.com/systemed/iD/issues');
-
-        bugReport.append('span')
-            .attr('class','icon bug light');
-
-        bugReport.call(bootstrap.tooltip()
-                .title(t('report_a_bug'))
-                .placement('top')
-            );
-
-        linkList.append('li')
-            .attr('class', 'user-list')
-            .attr('tabindex', -1)
-            .call(iD.ui.Contributors(context));
-
         window.onbeforeunload = function() {
             history.save();
             if (history.hasChanges()) return t('save.unsaved_changes');

--- a/js/id/ui/commit.js
+++ b/js/id/ui/commit.js
@@ -76,9 +76,21 @@ iD.ui.Commit = function(context) {
             .attr('tabindex', -1)
             .attr('target', '_blank');
 
+        if (!context.embed() && user.display_name) {
+            userLink.append('a')
+                .attr('class', 'logout')
+                .attr('href', '#')
+                .text(' (' + t('logout') + ')');
+        }
+
         saveSection.append('p')
             .attr('class', 'commit-info')
             .html(t('commit.upload_explanation', {user: userLink.html()}));
+
+        saveSection.selectAll('.logout').on('click.logout', function() {
+            d3.event.preventDefault();
+            connection.logout();
+        });
 
         // Confirm Button
         var saveButton = saveSection.append('button')

--- a/js/id/ui/contributors.js
+++ b/js/id/ui/contributors.js
@@ -1,19 +1,24 @@
 iD.ui.Contributors = function(context) {
-    function update(selection) {
-        var users = {},
-            limit = 4,
-            entities = context.intersects(context.map().extent());
 
-        entities.forEach(function(entity) {
-            if (entity && entity.user) users[entity.user] = true;
-        });
+    var lineheight;
 
-        var u = Object.keys(users),
-            subset = u.slice(0, u.length > limit ? limit - 1 : limit);
+    function update(selection, u, limit) {
 
-        selection.html('')
-            .append('span')
-            .attr('class', 'icon nearby light icon-pre-text');
+        if (!u) {
+            var users = {},
+                entities = context.intersects(context.map().extent());
+
+            entities.forEach(function(entity) {
+                if (entity && entity.user) users[entity.user] = true;
+            });
+
+            limit = 4;
+            u = Object.keys(users);
+        }
+
+        var subset = u.slice(0, u.length > limit ? limit - 1 : limit);
+
+        selection.html('');
 
         var userList = d3.select(document.createElement('span'));
 
@@ -45,11 +50,16 @@ iD.ui.Contributors = function(context) {
                 .html(t('contributors.list', {users: userList.html()}));
         }
 
-        if (!u.length) {
+        lineheight = lineheight || parseInt(selection.style('line-height'), 10);
+
+        if (selection.size()[1] > lineheight && limit > 1) {
+            return update(selection, u, limit - 1);
+        } else if (!u.length) {
             selection.transition().style('opacity', 0);
         } else if (selection.style('opacity') === '0') {
             selection.transition().style('opacity', 1);
         }
+
     }
 
     return function(selection) {

--- a/js/id/ui/feature_list.js
+++ b/js/id/ui/feature_list.js
@@ -32,6 +32,26 @@ iD.ui.FeatureList = function(context) {
         var list = listWrap.append('div')
             .attr('class', 'feature-list fillL cf');
 
+        var footer = selection.append('div')
+            .attr('class', 'footer');
+
+        var bugReport = footer.append('a')
+            .attr('target', '_blank')
+            .attr('tabindex', -1)
+            .attr('class', 'bug-report')
+            .attr('href', 'https://github.com/systemed/iD/issues')
+            .call(bootstrap.tooltip()
+                .title(t('report_a_bug'))
+                .placement('top'))
+            .append('span')
+            .attr('class','icon bug');
+
+
+        footer.append('span')
+            .attr('class', 'user-list')
+            .attr('tabindex', -1)
+            .call(iD.ui.Contributors(context));
+
         drawList();
 
         context.history()

--- a/js/id/ui/inspector.js
+++ b/js/id/ui/inspector.js
@@ -44,7 +44,17 @@ iD.ui.Inspector = function(context) {
             .data([0]);
 
         $footer.enter().append('div')
-            .attr('class', 'footer');
+            .attr('class', 'footer')
+            .append('a')
+              .attr('target', '_blank')
+              .attr('tabindex', -1)
+              .attr('class', 'bug-report')
+              .attr('href', 'https://github.com/systemed/iD/issues')
+              .call(bootstrap.tooltip()
+                  .title(t('report_a_bug'))
+                  .placement('top'))
+              .append('span')
+              .attr('class','icon bug');
 
         selection.select('.footer')
             .call(iD.ui.ViewOnOSM(context)


### PR DESCRIPTION
An experiment with eliminating the global footer. Improvement?
- bug report link moved to footer in feature list and inspector
- local user list moved to feature list footer
- logout button moved to save page (shown only when not embedded)
- source switch moved to above the attribution (only shown when not embedded)

@samanpwbb 
