### PR TITLE
updated Haitian imagery sources

### DIFF
--- a/data/imagery.json
+++ b/data/imagery.json
@@ -348,23 +348,23 @@
         "sourcetag": "Surrey aerial"
     },
     {
-        "name": "Haiti - GeoEye Jan 13",
-        "template": "http://gravitystorm.dev.openstreetmap.org/imagery/haiti/{z}/{x}/{y}.jpg",
+        "name": "Port au Prince - GeoEye Jan 2010",
+        "template": "http://gravitystorm.dev.openstreetmap.org/imagery/haiti/{z}/{x}/{y}.png",
         "extent": [
             [
-                -74.5,
-                17.95
+                -72.43,
+                18.50
             ],
             [
-                -71.58,
-                20.12
+                -72.31,
+                18.58
             ]
         ],
-        "sourcetag": "Haiti GeoEye"
+        "sourcetag": "GeoEye, 2010-01"
     },
     {
-        "name": "Haiti - GeoEye Jan 13+",
-        "template": "http://maps.nypl.org/tilecache/1/geoeye/{z}/{x}/{y}.jpg",
+        "name": "Haiti - IOM Drone Imagery, 2012-13",
+        "template": "http://wms.openstreetmap.fr/tms/1.0.0/iomhaiti/{zoom}/{x}/{y}",
         "extent": [
             [
                 -74.5,
@@ -375,37 +375,7 @@
                 20.12
             ]
         ],
-        "sourcetag": "Haiti GeoEye"
-    },
-    {
-        "name": "Haiti - DigitalGlobe",
-        "template": "http://maps.nypl.org/tilecache/1/dg_crisis/{z}/{x}/{y}.jpg",
-        "extent": [
-            [
-                -74.5,
-                17.95
-            ],
-            [
-                -71.58,
-                20.12
-            ]
-        ],
-        "sourcetag": "Haiti DigitalGlobe"
-    },
-    {
-        "name": "Haiti - Street names",
-        "template": "http://hypercube.telascience.org/tiles/1.0.0/haiti-city/{z}/{x}/{y}.jpg",
-        "extent": [
-            [
-                -74.5,
-                17.95
-            ],
-            [
-                -71.58,
-                20.12
-            ]
-        ],
-        "sourcetag": "Haiti streetnames"
+        "sourcetag": "iom_image2013"
     },
     {
         "name": "NAIP",

--- a/data/imagery.xml
+++ b/data/imagery.xml
@@ -142,25 +142,15 @@
     <url>http://gravitystorm.dev.openstreetmap.org/surrey/$z/$x/$y.png</url>
     <sourcetag>Surrey aerial</sourcetag>
   </set>
-  <set minlat="17.95" minlon="-74.5" maxlat="20.12" maxlon="-71.58">
-    <name>Haiti - GeoEye Jan 13</name>
-    <url>http://gravitystorm.dev.openstreetmap.org/imagery/haiti/$z/$x/$y.jpg</url>
-    <sourcetag>Haiti GeoEye</sourcetag>
+  <set minlat="18.50" minlon="-72.43" maxlat="18.58" maxlon="-72.31">
+    <name>Port au Prince - GeoEye Jan 2010</name>
+    <url>http://gravitystorm.dev.openstreetmap.org/imagery/haiti/$z/$x/$y.png</url>
+    <sourcetag>Port au Prince GeoEye, 2010-01</sourcetag>
   </set>
   <set minlat="17.95" minlon="-74.5" maxlat="20.12" maxlon="-71.58">
-    <name>Haiti - GeoEye Jan 13+</name>
-    <url>http://maps.nypl.org/tilecache/1/geoeye/$z/$x/$y.jpg</url>
-    <sourcetag>Haiti GeoEye</sourcetag>
-  </set>
-  <set minlat="17.95" minlon="-74.5" maxlat="20.12" maxlon="-71.58">
-    <name>Haiti - DigitalGlobe</name>
-    <url>http://maps.nypl.org/tilecache/1/dg_crisis/$z/$x/$y.jpg</url>
-    <sourcetag>Haiti DigitalGlobe</sourcetag>
-  </set>
-  <set minlat="17.95" minlon="-74.5" maxlat="20.12" maxlon="-71.58">
-    <name>Haiti - Street names</name>
-    <url>http://hypercube.telascience.org/tiles/1.0.0/haiti-city/$z/$x/$y.jpg</url>
-    <sourcetag>Haiti streetnames</sourcetag>
+    <name>Haiti - IOM Drone Imagery, 2012-13</name>
+    <url>http://wms.openstreetmap.fr/tms/1.0.0/iomhaiti/{zoom}/{x}/{y}</url>
+    <sourcetag>iom_image2013</sourcetag>
   </set>
   <set minlat="24.2" minlon="-125.8" maxlat="49.5" maxlon="-62.3">
     <name>National Agriculture Imagery Program</name>


### PR DESCRIPTION
The Haiti imagery sources in iD were outdated. (perhaps they were taken from the wiki -which was outdated until last month, or potlatch ?)

While in Haiti in May/June w/ HOT, I reviewed the imagery sources and have updated this (And the wiki) to reflect the current imagery available for Haiti. 
- added iom_image2013 which is from IOM - http://www.droneadventures.org/2013/05/29/haiti/ 
  The imagery is compatible with the odbl license, and HOT has used this imagery with mappers in Haiti. 
- geoeye imagery that andy allen has mirrored. We've determined this imagery is from 2010-01, changed the sourcetag from 2013 to 2010. 
- bing imagery, which is still available, remains listed.
- Removed old ones that are no longer available and/or had dead links. 
