### PR TITLE
Add support for an externally provided asset map

### DIFF
--- a/js/id/id.js
+++ b/js/id/id.js
@@ -212,8 +212,16 @@ window.iD = function () {
         return context;
     };
 
+    var assetMap = {};
+    context.assetMap = function(_) {
+        if (!arguments.length) return assetMap;
+        assetMap = _;
+        return context;
+    };
+
     context.imagePath = function(_) {
-        return assetPath + 'img/' + _;
+        var asset = 'img/' + _;
+        return assetMap[asset] || assetPath + asset;
     };
 
     context.toggleFullscreen = function() {


### PR DESCRIPTION
This allows an embedding site to provide a map from individual
asset names to the URLs to use, thus allowing them to be served
through (for example) the rails asset pipeline.
