### PR TITLE
Fix loading graph of unserialized objects. Fixes walkthrough

### DIFF
--- a/js/id/ui/intro.js
+++ b/js/id/ui/intro.js
@@ -12,12 +12,18 @@ iD.ui.intro = function(context) {
             background = context.background().baseLayerSource(),
             opacity = d3.select('.background-layer').style('opacity'),
             loadedTiles = context.connection().loadedTiles(),
-            baseEntities = context.history().graph().base().entities;
+            baseEntities = context.history().graph().base().entities,
+            introGraph;
 
         // Load semi-real data used in intro
         context.connection().toggle(false).flush();
         context.history().save().reset();
-        context.history().merge(iD.Graph().load(JSON.parse(iD.introGraph)).entities);
+        
+        introGraph = JSON.parse(iD.introGraph);
+        for (var key in introGraph) {
+            introGraph[key] = iD.Entity(introGraph[key]);
+        }
+        context.history().merge(iD.Graph().load(introGraph).entities);
         context.background().bing();
 
         // Block saving


### PR DESCRIPTION
After commit 2efafa087b25373ab65b600c12c9f36e2af79f1b, the walkthrough was broken (#1737). The problem is that the walkthrough entities were loaded into the graph without beeing proper `iD.Entity` objects. This adds the same entity casting to the intro loader as it is implemented in [`history.fromJSON`](https://github.com/systemed/iD/commit/2efafa087b25373ab65b600c12c9f36e2af79f1b#L2R233).
