### PR TITLE
Fixes the icon on the final "begin mapping" dialog of the walkthough

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -2793,6 +2793,6 @@ img.wiki-image {
 .huge-modal-button .illustration {
     height: 100px;
     width: 100px;
-    background: rgba(0, 0, 0, 0) url(img/sprite.svg) no-repeat -301px -220px;
+    background: rgba(0, 0, 0, 0) url(img/sprite.svg) no-repeat -400px -220px;
     margin: auto;
 }


### PR DESCRIPTION
Because of recent changes of the sprite.svg image, the dialog did accidentaly show the google plus logo.
