### PR TITLE
Fixes some walkthrough glitches

### DIFF
--- a/js/id/ui/intro/line.js
+++ b/js/id/ui/intro/line.js
@@ -61,7 +61,7 @@ iD.ui.intro.line = function(context, reveal) {
         // ended line before creating intersection
         function retry(mode) {
             if (mode.id !== 'select') return;
-            var pointBox = iD.ui.intro.pad(intersection, 30);
+            var pointBox = iD.ui.intro.pad(intersection, 30, context);
             reveal(pointBox, t('intro.lines.restart'));
             timeout(function() {
                 context.replace(iD.actions.DeleteMultiple(mode.selectedIDs()));


### PR DESCRIPTION
1. the lines chapter intro message has the wrong icon (same as area)
2. #1742
3. the walkthrough crashes in line mode when one doesn't connect the new road to the existing one
