### PR TITLE
walkthrough: handle wrongly selected road type

### DIFF
--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -356,7 +356,8 @@
             "road": "**Select Road from the list**",
             "residential": "There are different types of roads, the most common of which is Residential. **Choose the Residential road type**",
             "describe": "**Name the road and close the feature editor.**",
-            "restart": "The road needs to intersect Flower Street."
+            "restart": "The road needs to intersect Flower Street.",
+            "wrong_preset": "You didn't select the Residential road type. **Click here to choose again**"
         },
         "startediting": {
             "title": "Start Editing",

--- a/js/id/ui/intro/line.js
+++ b/js/id/ui/intro/line.js
@@ -95,6 +95,10 @@ iD.ui.intro.line = function(context, reveal) {
             context.on('enter.intro', null);
             d3.select('#curtain').style('pointer-events', 'all');
 
+            presetCategory();
+        }
+
+        function presetCategory() {
             timeout(function() {
                 d3.select('#curtain').style('pointer-events', 'none');
                 var road = d3.select('.preset-category-road .preset-list-button');
@@ -107,8 +111,19 @@ iD.ui.intro.line = function(context, reveal) {
             timeout(function() {
                 var grid = d3.select('.subgrid');
                 reveal(grid.node(), t('intro.lines.residential'));
+                grid.selectAll(':not(.preset-highway-residential) .preset-list-button')
+                    .one('click.intro', retryPreset);
                 grid.selectAll('.preset-highway-residential .preset-list-button')
                     .one('click.intro', roadDetails);
+            }, 500);
+        }
+
+        // selected wrong road type
+        function retryPreset(mode) {
+            timeout(function() {
+                var preset = d3.select('.entity-editor-pane .preset-list-button');
+                reveal(preset.node(), t('intro.lines.wrong_preset'));
+                preset.one('click.intro', presetCategory);
             }, 500);
         }
 


### PR DESCRIPTION
Currently, when one selects a road type other than residential, the walkthrough gets stuck. This adds an additional step for this case and tells the user to redo the preset selection.
