### PR TITLE
Use dictionary instead of array to prevent split changes.

### DIFF
--- a/js/id/ui/commit.js
+++ b/js/id/ui/commit.js
@@ -12,12 +12,12 @@ iD.ui.Commit = function(context) {
                 tagText: iD.util.tagText(d[i])
             };
 
-			var fingerprint = desc.name + desc.tagText;
-			if (c[fingerprint]) {
-				c[fingerprint].count++;
-			} else {
-				c[fingerprint] = desc;
-			}
+            var fingerprint = desc.name + desc.tagText;
+            if (c[fingerprint]) {
+                c[fingerprint].count++;
+            } else {
+                c[fingerprint] = desc;
+            }
         }
         return _.values(c);
     }


### PR DESCRIPTION
Changeset components for a new area can be in an unexpected order, this patch fixes an issue (#1722) where they could show up in the commit confirm as 'point, area, point(s)' instead of 'points, area'.

The trigger for the issue appears to be that the changes for a newly created area consist of the first point, the way and then the rest of the points. Changing zipSame seemed less invasive than altering the way changesets are created.

There is still room for more clever bundling and representing the changes for the commit review but that is probably best left to another issue.
