### PR TITLE
add preset for route=hiking relations

### DIFF
--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -1194,6 +1194,9 @@ en:
       type/route/foot: 
         name: Foot Route
         terms: "<translate with synonyms or related terms for 'Foot Route', separated by commas>"
+      type/route/hiking: 
+        name: Hiking Route
+        terms: "<translate with synonyms or related terms for 'Hiking Route', separated by commas>"
       type/route/pipeline: 
         name: Pipeline Route
         terms: "<translate with synonyms or related terms for 'Pipeline Route', separated by commas>"

--- a/data/presets/categories.json
+++ b/data/presets/categories.json
@@ -68,8 +68,9 @@
         "icon": "route",
         "members": [
             "type/route/road",
-            "type/route/foot",
             "type/route/bicycle",
+            "type/route/foot",
+            "type/route/hiking",
             "type/route/bus",
             "type/route/train",
             "type/route/tram",

--- a/data/presets/categories/route.json
+++ b/data/presets/categories/route.json
@@ -4,8 +4,9 @@
     "icon": "route",
     "members": [
         "type/route/road",
-        "type/route/foot",
         "type/route/bicycle",
+        "type/route/foot",
+        "type/route/hiking",
         "type/route/bus",
         "type/route/train",
         "type/route/tram",

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -4966,6 +4966,22 @@
             "network"
         ]
     },
+    "type/route/hiking": {
+        "geometry": [
+            "relation"
+        ],
+        "tags": {
+            "type": "route",
+            "route": "hiking"
+        },
+        "name": "Hiking Route",
+        "icon": "route-foot",
+        "fields": [
+            "ref",
+            "operator",
+            "network"
+        ]
+    },
     "type/route/pipeline": {
         "geometry": [
             "relation"

--- a/data/presets/presets/type/route/hiking.json
+++ b/data/presets/presets/type/route/hiking.json
@@ -1,0 +1,16 @@
+{
+    "geometry": [
+        "relation"
+    ],
+    "tags": {
+        "type": "route",
+        "route": "hiking"
+    },
+    "name": "Hiking Route",
+    "icon": "route-foot",
+    "fields": [
+        "ref",
+        "operator",
+        "network"
+    ]
+}

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -1990,6 +1990,10 @@
                 "name": "Foot Route",
                 "terms": ""
             },
+            "type/route/hiking": {
+                "name": "Hiking Route",
+                "terms": ""
+            },
             "type/route/pipeline": {
                 "name": "Pipeline Route",
                 "terms": ""


### PR DESCRIPTION
This adds a preset for `route=hiking` relations.

An issue could be that we would have two very similar route presets: `route=foot` and `route=hiking`. According to the [wiki](http://wiki.openstreetmap.org/wiki/Hiking#Tags_of_the_relation), those two are equivalent, but route=hiking is used [more frequently](http://taginfo.openstreetmap.org/keys/route#values).
