### PR TITLE
Fix line labels for wide characters

### DIFF
--- a/js/id/svg/labels.js
+++ b/js/id/svg/labels.js
@@ -70,7 +70,6 @@ iD.svg.Labels = function(projection, context) {
 
     function textWidth(text, size, elem) {
         var c = textWidthCache[size];
-	var str;
         if (!c) c = textWidthCache[size] = {};
 
         if (c[text]) {
@@ -81,7 +80,7 @@ iD.svg.Labels = function(projection, context) {
             return c[text];
 
         } else {
-            str = encodeURIComponent(text).match(/%[CDEFcdef]/g);
+            var str = encodeURIComponent(text).match(/%[CDEFcdef]/g);
             if (str == null) {
                 return size / 3 * 2 * text.length;
             } else {


### PR DESCRIPTION
Ref: issue #1453

This is a patch on `js/id/svg/labels.js` to solve the issue of Chinese labels, modifying the calculation of `textWidth()` taking into account wide characters.  Tested locally and the labels displayed correctly.  
