### PR TITLE
add preset for amenity=vending_machine

### DIFF
--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -248,6 +248,8 @@ en:
         label: Type
       trail_visibility: 
         label: Trail Visibility
+      vending: 
+        label: Type of Goods
       water: 
         label: Type
       waterway: 
@@ -438,6 +440,9 @@ en:
       amenity/university: 
         name: University
         terms: "<translate with synonyms or related terms for 'University', separated by commas>"
+      amenity/vending_machine: 
+        name: Vending Machine
+        terms: "<translate with synonyms or related terms for 'Vending Machine', separated by commas>"
       amenity/waste_basket: 
         name: Waste Basket
         terms: "<translate with synonyms or related terms for 'Waste Basket', separated by commas>"

--- a/data/presets/fields.json
+++ b/data/presets/fields.json
@@ -613,6 +613,11 @@
         "type": "combo",
         "label": "Trail Visibility"
     },
+    "vending": {
+        "key": "vending",
+        "type": "combo",
+        "label": "Type of Goods"
+    },
     "water": {
         "key": "water",
         "type": "combo",

--- a/data/presets/fields/vending.json
+++ b/data/presets/fields/vending.json
@@ -1,0 +1,5 @@
+{
+    "key": "vending",
+    "type": "combo",
+    "label": "Type of Goods"
+}

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -1188,6 +1188,19 @@
         ],
         "name": "University"
     },
+    "amenity/vending_machine": {
+        "fields": [
+            "vending",
+            "operator"
+        ],
+        "geometry": [
+            "point"
+        ],
+        "tags": {
+            "amenity": "vending_machine"
+        },
+        "name": "Vending Machine"
+    },
     "amenity/waste_basket": {
         "icon": "waste-basket",
         "geometry": [

--- a/data/presets/presets/amenity/vending_machine.json
+++ b/data/presets/presets/amenity/vending_machine.json
@@ -1,0 +1,13 @@
+{
+    "fields": [
+        "vending",
+        "operator"
+    ],
+    "geometry": [
+        "point"
+    ],
+    "tags": {
+        "amenity": "vending_machine"
+    },
+    "name": "Vending Machine"
+}

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -726,6 +726,9 @@
             "trail_visibility": {
                 "label": "Trail Visibility"
             },
+            "vending": {
+                "label": "Type of Goods"
+            },
             "water": {
                 "label": "Type"
             },
@@ -981,6 +984,10 @@
             "amenity/university": {
                 "name": "University",
                 "terms": "college"
+            },
+            "amenity/vending_machine": {
+                "name": "Vending Machine",
+                "terms": ""
             },
             "amenity/waste_basket": {
                 "name": "Waste Basket",


### PR DESCRIPTION
[`amenity=vending_machine`](http://taginfo.openstreetmap.org/tags/amenity=vending_machine#overview) is used quite frequently. I'd say it deserves its own preset.
