### PR TITLE
Better orthogonalization of skinny quads. Fixes #1812

### DIFF
--- a/js/id/actions/orthogonalize.js
+++ b/js/id/actions/orthogonalize.js
@@ -25,7 +25,7 @@ iD.actions.Orthogonalize = function(wayId, projection) {
                 .move(projection.invert(points[corner.i])));
         } else {
             var best;
-            points = nodes.map(function(n) { return projection(n.loc); });
+            points = _.uniq(nodes).map(function(n) { return projection(n.loc); });
             score = squareness();
 
             for (i = 0; i < 1000; i++) {
@@ -45,7 +45,7 @@ iD.actions.Orthogonalize = function(wayId, projection) {
 
             points = best;
 
-            for (i = 0; i < points.length - 1; i++) {
+            for (i = 0; i < points.length; i++) {
                 graph = graph.replace(graph.entity(nodes[i].id)
                     .move(projection.invert(points[i])));
             }
@@ -59,7 +59,7 @@ iD.actions.Orthogonalize = function(wayId, projection) {
                 p = subtractPoints(a, b),
                 q = subtractPoints(c, b);
 
-            var scale = iD.geo.dist(p, [0, 0]) + iD.geo.dist(q, [0, 0]);
+            var scale = 2*Math.min(iD.geo.dist(p, [0, 0]), iD.geo.dist(q, [0, 0]));
             p = normalizePoint(p, 1.0);
             q = normalizePoint(q, 1.0);
 

--- a/test/spec/actions/orthogonalize.js
+++ b/test/spec/actions/orthogonalize.js
@@ -27,4 +27,35 @@ describe("iD.actions.Orthogonalize", function () {
 
         expect(graph.entity('-').nodes).to.have.length(4);
     });
+
+    it("should not shrink skinny quads", function () {
+        var tests = [[[-77.0339864831478, 38.8616391227204],
+                      [-77.0209775298677, 38.8613609264884],
+                      [-77.0210405781065, 38.8607390721519],
+                      [-77.0339024188294, 38.8610663645859]
+                     ],
+                     [[-89.4706683, 40.6261177],
+                      [-89.4706664, 40.6260574],
+                      [-89.4693973, 40.6260830],
+                      [-89.4694012, 40.6261355]
+                     ]
+                    ];
+
+        for (var i = 0; i < tests.length; i++) {
+            var graph = iD.Graph({
+                    'a': iD.Node({id: 'a', loc: tests[i][0]}),
+                    'b': iD.Node({id: 'b', loc: tests[i][1]}),
+                    'c': iD.Node({id: 'c', loc: tests[i][2]}),
+                    'd': iD.Node({id: 'd', loc: tests[i][3]}),
+                    '-': iD.Way({id: '-', nodes: ['a', 'b', 'c', 'd', 'a']})
+                }),
+                initialWidth = iD.geo.dist(graph.entity('a').loc, graph.entity('b').loc),
+                finalWidth;
+
+            graph = iD.actions.Orthogonalize('-', projection)(graph);
+
+            finalWidth = iD.geo.dist(graph.entity('a').loc, graph.entity('b').loc);
+            expect(finalWidth/initialWidth).within(0.90, 1.10);
+        }
+    });
 });


### PR DESCRIPTION
This pull request is meant to fix https://github.com/systemed/iD/issues/1812

The orthogonalizer works by refining the polygon, at each step making the corners more right or straight. The bug was caused by a big step size overshooting the first/best local minimum. I made two changes to address this:
1. Removed the last duplicate node in the way. This actually messed up the algorithm, for the origin node it was computing angles between node ids 0,0,1  This change fixes the first testcase.
2. The other change is to reduce the step size. I wanted to reduce it but still keep some information about the local geometry so we don't over work. I made the 'scale' 2x the minimum length of the 2 side incident the point vs. the sum of the two sides. This lowers it for all cases, some more than others, but gives it a reasonable bound. 

Impact? Lowering the step size will cause the code to run ever so slightly slower, but the result will not change. 

Since this code is based off of P2, what did P2 do in this case? Nothing, with the bad step size, the refinement initially gets worse before it gets better, so it just quit. P2 will quit if the refinement didn't improve things. In iD the code continues for 1000 iterations or until the error is < 1e-8

For testing, see the ways in the issue:
- http://www.openstreetmap.org/browse/way/236759157
- http://www.openstreetmap.org/browse/way/237927962
