### PR TITLE
fix test case "does not delete tagged nodes" of iD.actions.Straighten

### DIFF
--- a/test/spec/actions/straighten.js
+++ b/test/spec/actions/straighten.js
@@ -24,7 +24,7 @@ describe("iD.actions.Straighten", function () {
 
         graph = iD.actions.Straighten('-', projection)(graph);
         
-        expect(graph.entity('-').nodes.sort()).to.eql(['a', 'b', 'c']); 
+        expect(graph.entity('-').nodes).to.eql(['a', 'b', 'c']);
     });
     
     it("does not delete nodes connected to other ways", function() {


### PR DESCRIPTION
The nodes.sort() statement caused some trouble in older browsers such as (FF 20, Chromium 25). Also, the straighten action should conserve node order. Thus, the sorting made the test weaker than it had to be.

This just removes the unnecessary sorting.
