### PR TITLE
Show relation type descriptions when choosing a relation type

### DIFF
--- a/js/id/presets/preset.js
+++ b/js/id/presets/preset.js
@@ -46,8 +46,14 @@ iD.presets.Preset = function(id, preset, fields) {
         return Object.keys(preset.tags).length === 0;
     };
 
-    preset.reference = function() {
-        var reference = {key: Object.keys(preset.tags)[0]};
+    preset.reference = function(geometry) {
+        var key = Object.keys(preset.tags)[0];
+
+        if (geometry === 'relation' && key === 'type') {
+            return {rtype: preset.tags[key]};
+        }
+        
+        var reference = {key: key};
 
         if (preset.tags[reference.key] !== '*') {
             reference.value = preset.tags[reference.key];

--- a/js/id/services/taginfo.js
+++ b/js/id/services/taginfo.js
@@ -117,7 +117,12 @@ iD.taginfo = function() {
     taginfo.docs = function(parameters, callback) {
         var debounce = parameters.debounce;
         parameters = clean(setSort(parameters));
-        request(endpoint + (parameters.value ? 'tag/wiki_pages?' : 'key/wiki_pages?') +
+
+        var path = 'key/wiki_pages?';
+        if (parameters.value) path = 'tag/wiki_pages?';
+        else if (parameters.rtype) path = 'relation/wiki_pages?';
+
+        request(endpoint + path +
             iD.util.qsString(parameters), debounce, callback);
     };
 

--- a/js/id/ui/entity_editor.js
+++ b/js/id/ui/entity_editor.js
@@ -169,7 +169,7 @@ iD.ui.EntityEditor = function(context) {
         if (!arguments.length) return preset;
         if (_ !== preset) {
             preset = _;
-            reference = iD.ui.TagReference(preset.reference())
+            reference = iD.ui.TagReference(preset.reference(context.geometry(id)))
                 .showing(false);
         }
         return entityEditor;

--- a/js/id/ui/preset_list.js
+++ b/js/id/ui/preset_list.js
@@ -213,7 +213,7 @@ iD.ui.PresetList = function(context) {
         };
 
         item.preset = preset;
-        item.reference = iD.ui.TagReference(preset.reference());
+        item.reference = iD.ui.TagReference(preset.reference(context.geometry(id)));
 
         return item;
     }


### PR DESCRIPTION
Fixes issue #1862.

Taginfo has a [separate API](http://taginfo.openstreetmap.org/taginfo/apidoc#api_4_relation_wiki_pages) for getting information about a relation type.
![relationinfo](https://f.cloud.github.com/assets/1231218/1234749/3483a312-2989-11e3-9401-c765cb9df62d.png)
