### PR TITLE
Handle https wikipedia URLs

### DIFF
--- a/js/id/ui/preset/wikipedia.js
+++ b/js/id/ui/preset/wikipedia.js
@@ -84,7 +84,7 @@ iD.ui.preset.wikipedia = function(field, context) {
 
     function change() {
         var value = title.value(),
-            m = value.match(/http:\/\/([a-z]+)\.wikipedia\.org\/wiki\/(.+)/),
+            m = value.match(/https?:\/\/([a-z]+)\.wikipedia\.org\/wiki\/(.+)/),
             l = m && _.find(iD.data.wikipedia, function(d) { return m[1] === d[2]; });
 
         if (l) {


### PR DESCRIPTION
Currently iD fails to parse Wikipedia URLs if the scheme is https.  This seems to help.
