### PR TITLE
don't load parent into tree repeatedly when multiple childs are changed

### DIFF
--- a/js/id/core/tree.js
+++ b/js/id/core/tree.js
@@ -22,14 +22,14 @@ iD.Tree = function(head) {
         head.parentWays(entity).forEach(function(parent) {
             if (rectangles[parent.id]) {
                 rtree.remove(rectangles[parent.id]);
-                insertions.push(entityRectangle(parent));
+                insertions.push(parent);
             }
         });
 
         head.parentRelations(entity).forEach(function(parent) {
             if (rectangles[parent.id]) {
                 rtree.remove(rectangles[parent.id]);
-                insertions.push(entityRectangle(parent));
+                insertions.push(parent);
             }
             updateParents(parent, insertions);
         });
@@ -44,10 +44,11 @@ iD.Tree = function(head) {
             if (head.entities.hasOwnProperty(entity.id) || rectangles[entity.id])
                 return;
 
-            insertions.push(entityRectangle(entity));
+            insertions.push(entity);
             updateParents(entity, insertions);
         });
 
+        insertions = _.unique(insertions).map(entityRectangle);
         rtree.load(insertions);
 
         return tree;
@@ -67,14 +68,15 @@ iD.Tree = function(head) {
 
             diff.modified().forEach(function(entity) {
                 rtree.remove(rectangles[entity.id]);
-                insertions.push(entityRectangle(entity));
+                insertions.push(entity);
                 updateParents(entity, insertions);
             });
 
             diff.created().forEach(function(entity) {
-                insertions.push(entityRectangle(entity));
+                insertions.push(entity);
             });
 
+            insertions = _.unique(insertions).map(entityRectangle);
             rtree.load(insertions);
         }
 

--- a/test/spec/core/tree.js
+++ b/test/spec/core/tree.js
@@ -118,6 +118,26 @@ describe("iD.Tree", function() {
             expect(tree.intersects(extent, graph)).to.eql([n1]);
         });
 
+        it("don't include parent way multiple times when multiple child nodes are moved", function() {
+            // checks against the following regression: https://github.com/systemed/iD/issues/1978
+            var graph = iD.Graph(),
+                tree = iD.Tree(graph),
+                n1 = iD.Node({id: 'n1', loc: [1, 1]}),
+                n2 = iD.Node({id: 'n2', loc: [3, 3]}),
+                way = iD.Way({nodes: ['n1', 'n2']}),
+                extent = iD.geo.Extent([0, 0], [4, 4]);
+
+            graph = graph.replace(n1).replace(n2).replace(way);
+            expect(tree.intersects(extent, graph)).to.eql([n1, n2, way]);
+
+            graph = graph.replace(n1.move([1.1,1.1])).replace(n2.move([2.1,2.1]));
+            expect(
+                _.pluck(tree.intersects(extent, graph),'id').sort()
+            ).to.eql(
+                _.pluck([n1, n2, way],'id').sort()
+            );
+        });
+
         it("doesn't include removed entities", function() {
             var graph = iD.Graph(),
                 tree = iD.Tree(graph),


### PR DESCRIPTION
When an action (e.g. moving a way) caused multiple child elements of the same parent to be changed, their parent was also loaded into the tree multiple times during `tree.intersects()`.

This fixes #1978
