### PR TITLE
Reversing for cardinal directions in relation member roles

### DIFF
--- a/js/id/actions/reverse.js
+++ b/js/id/actions/reverse.js
@@ -14,6 +14,8 @@
 
     Relation members:
        role=forward ⟺ role=backward
+         role=north ⟺ role=south
+          role=east ⟺ role=west
 
    In addition, numeric-valued `incline` tags are negated.
 
@@ -64,7 +66,14 @@ iD.actions.Reverse = function(wayId) {
 
         graph.parentRelations(way).forEach(function(relation) {
             relation.members.forEach(function(member, index) {
-                if (member.id === way.id && (role = {forward: 'backward', backward: 'forward'}[member.role])) {
+                if (member.id === way.id && (role = {
+						forward: 'backward',
+						backward: 'forward',
+						north: 'south',
+						south: 'north',
+						east: 'west',
+						west: 'east'
+					}[member.role])) {
                     relation = relation.updateMember({role: role}, index);
                     graph = graph.replace(relation);
                 }

--- a/test/spec/actions/reverse.js
+++ b/test/spec/actions/reverse.js
@@ -114,4 +114,29 @@ describe("iD.actions.Reverse", function () {
         graph = iD.actions.Reverse(way.id)(graph);
         expect(graph.entity(relation.id).members[0].role).to.eql('forward');
     });
+	
+    it("transforms role=north ⟺ role=south in member relations", function () {
+        var way = iD.Way({tags: {highway: 'residential'}}),
+            relation = iD.Relation({members: [{type: 'way', id: way.id, role: 'north'}]}),
+            graph = iD.Graph([way, relation]);
+
+        graph = iD.actions.Reverse(way.id)(graph);
+        expect(graph.entity(relation.id).members[0].role).to.eql('south');
+
+        graph = iD.actions.Reverse(way.id)(graph);
+        expect(graph.entity(relation.id).members[0].role).to.eql('north');
+    });
+
+    it("transforms role=east ⟺ role=west in member relations", function () {
+        var way = iD.Way({tags: {highway: 'residential'}}),
+            relation = iD.Relation({members: [{type: 'way', id: way.id, role: 'east'}]}),
+            graph = iD.Graph([way, relation]);
+
+        graph = iD.actions.Reverse(way.id)(graph);
+        expect(graph.entity(relation.id).members[0].role).to.eql('west');
+
+        graph = iD.actions.Reverse(way.id)(graph);
+        expect(graph.entity(relation.id).members[0].role).to.eql('east');
+    });
+	
 });


### PR DESCRIPTION
This adds smart reversing for north<->south and east<->west in relation member roles when reversing a way.
