### PR TITLE
rudimental support for providing gpx-files via urls

### DIFF
--- a/js/id/renderer/background.js
+++ b/js/id/renderer/background.js
@@ -228,5 +228,14 @@ iD.Background = function(context) {
         if (overlay) background.toggleOverlayLayer(overlay);
     });
 
+    var gpx = q.gpx;
+    if (gpx) {
+        d3.text(gpx, function(err, gpxTxt) {
+            gpxLayer.geojson(toGeoJSON.gpx(toDom(gpxTxt)));
+            dispatch.change();
+            context.map().pan([0, 0]);
+        });
+    }
+
     return d3.rebind(background, dispatch, 'on');
 };


### PR DESCRIPTION
Loads and shows gpx file from an URL provided via the hash-parameter `gpx`.

see #1965 (esp: https://github.com/systemed/iD/issues/1965#issuecomment-29045054)
