### PR TITLE
Fix pan/zoom lags in Chrome before/after move

### DIFF
--- a/js/id/renderer/map.js
+++ b/js/id/renderer/map.js
@@ -194,7 +194,7 @@ iD.Map = function(context) {
 
     function resetTransform() {
         if (!transformed) return false;
-        supersurface.style(transformProp, '');
+        supersurface.style(transformProp, iD.detect().opera ? '' : 'translate3d(0,0,0)');
         transformed = false;
         return true;
     }


### PR DESCRIPTION
Previously, the surface switched between HW-accelerated and non-accelerated state all the time due to resetting transform property to `'translate3d'` (triggering HW) and back to `''`, which caused lags in Chrome.

I'm sure it's a pretty noticeable improvement now. Check it out.
