### PR TITLE
Fix trembling on zoom in

### DIFF
--- a/js/id/renderer/map.js
+++ b/js/id/renderer/map.js
@@ -176,14 +176,13 @@ iD.Map = function(context) {
             .scale(d3.event.scale / (2 * Math.PI));
 
         var scale = d3.event.scale / transformStart[0],
-            tX = Math.round(d3.event.translate[0] / scale - transformStart[1][0]),
-            tY = Math.round(d3.event.translate[1] / scale - transformStart[1][1]);
+            tX = Math.round((d3.event.translate[0] / scale - transformStart[1][0]) * scale),
+            tY = Math.round((d3.event.translate[1] / scale - transformStart[1][1]) * scale);
 
         var transform =
-            'scale(' + scale + ')' +
             (iD.detect().opera ?
                 'translate(' + tX + 'px,' + tY + 'px)' :
-                'translate3d(' + tX + 'px,' + tY + 'px, 0)');
+                'translate3d(' + tX + 'px,' + tY + 'px, 0)') + ' scale(' + scale + ')';
 
         transformed = true;
         supersurface.style(transformProp, transform);


### PR DESCRIPTION
As you zoomed in, the rounding error in translate was multiplied by scale because it was applied post-translate (which was rounded). This seems to fix the issue.
