### PR TITLE
fix typo in tourism/information preset

### DIFF
--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -5591,7 +5591,7 @@
     },
     "tourism/information": {
         "fields": [
-            "infomation",
+            "information",
             "building_area",
             "address",
             "operator"

--- a/data/presets/presets/tourism/information.json
+++ b/data/presets/presets/tourism/information.json
@@ -1,6 +1,6 @@
 {
     "fields": [
-        "infomation",
+        "information",
         "building_area",
         "address",
         "operator"


### PR DESCRIPTION
was referencing the field "infomation" instead of "info<b>r</b>mation"

fixes #2044
fixes #2034
