### PR TITLE
Fix missing midpoint after undo (#2040)

### DIFF
--- a/js/id/renderer/map.js
+++ b/js/id/renderer/map.js
@@ -119,6 +119,13 @@ iD.Map = function(context) {
                     }
                     return true;
 
+                } else if (d.type === 'node') {
+                    // if a node was deleted, only the way will be in the diff
+                    // so we should redraw midpoints for all nodes in that way
+                    var parentWays = graph.parentWays({ id: d.id });
+                    if (parentWays.length > 0 && parentWays[0].id in complete) return true;
+
+                    return d.id in complete;
                 } else {
                     return d.id in complete;
                 }


### PR DESCRIPTION
See issue in #2040: when a segment is split by moving a midpoint, then the move is undone, the segment is left selected but no midpoint is visible.

The previous filter for determining which midpoints to redraw did not handle the case where a node was removed and the rejoined segment needed its midpoint drawn. I have added an extra condition to draw midpoints related to any nodes if its parent way that has changed.

I would love help writing a test for this but had quite a hard time since the code to test is several layers removed from its effect. I couldn't even figure out how to thread a spy in to it.
