### PR TITLE
Fix for Safari selection bug in combo box

### DIFF
--- a/js/lib/d3.combobox.js
+++ b/js/lib/d3.combobox.js
@@ -99,6 +99,8 @@ d3.combobox = function() {
                    input.on('input.typeahead', function() {
                        idx = -1;
                        render();
+                       var start = input.property('selectionStart');
+                       input.node().setSelectionRange(start, start);
                        input.on('input.typeahead', change);
                    });
                    break;


### PR DESCRIPTION
Problem reported in #1934.

After the delete key sequence in the iD combobox, Safari is getting confused about the current state of the selection. By manually setting the selection to what it should be after the delete key, things are shiny.

What is happening? I'll show the state of the field with the selection in parentheses:
- Type in "bu" and the combobox autocompletes to "bu(ilding)"
- Type backspace to kill the autocomplete and get to "bu()"
- Type a letter without an autocomplete and you expect to get "bua()" but Safari gives "bu(ilding)"

After the second step, Safari gets a bit confused, so that after the next letter is typed, it thinks the state is "bu()a", which means combobox things the user has typed "bu" and wants an autocomplete. I don't know why Safari loses the cursor position. But setting the position to where we expect it to be solves the problem.
