### PR TITLE
Sort relation suggestions most recent first

### DIFF
--- a/js/id/core/relation.js
+++ b/js/id/core/relation.js
@@ -8,6 +8,14 @@ iD.Relation = iD.Entity.relation = function iD_Relation() {
 
 iD.Relation.prototype = Object.create(iD.Entity.prototype);
 
+iD.Relation.creationOrder = function(a, b) {
+    var aId = parseInt(iD.Entity.id.toOSM(a.id), 10);
+    var bId = parseInt(iD.Entity.id.toOSM(b.id), 10);
+
+    if (aId < 0 || bId < 0) return aId - bId;
+    return bId - aId;
+};
+
 _.extend(iD.Relation.prototype, {
     type: 'relation',
     members: [],

--- a/js/id/ui/raw_membership_editor.js
+++ b/js/id/ui/raw_membership_editor.js
@@ -65,14 +65,9 @@ iD.ui.RawMembershipEditor = function(context) {
         });
 
         result.sort(function(a, b) {
-            var aId = parseInt(iD.Entity.id.toOSM(a.relation.id), 10);
-            var bId = parseInt(iD.Entity.id.toOSM(b.relation.id), 10);
-            if (aId < 0) aId = Number.MAX_VALUE / 2 - aId;
-            if (bId < 0) bId = Number.MAX_VALUE / 2 - bId;
-
-            return d3.descending(aId, bId);
+            return iD.Relation.creationOrder(a.relation, b.relation);
         });
-        result.unshift(newRelation)
+        result.unshift(newRelation);
 
         return result;
     }

--- a/test/spec/core/relation.js
+++ b/test/spec/core/relation.js
@@ -470,4 +470,20 @@ describe('iD.Relation', function () {
             expect(r.multipolygon(g)).to.eql([[[a.loc, b.loc, c.loc]]]);
         });
     });
+
+    describe(".creationOrder comparator", function () {
+        specify("orders existing relations newest-first", function () {
+            var a = iD.Relation({ id: 'r1' }),
+                b = iD.Relation({ id: 'r2' });
+            expect(iD.Relation.creationOrder(a, b)).to.be.above(0);
+            expect(iD.Relation.creationOrder(b, a)).to.be.below(0);
+        });
+
+        specify("orders new relations newest-first", function () {
+            var a = iD.Relation({ id: 'r-1' }),
+                b = iD.Relation({ id: 'r-2' });
+            expect(iD.Relation.creationOrder(a, b)).to.be.above(0);
+            expect(iD.Relation.creationOrder(b, a)).to.be.below(0);
+        });
+    });
 });


### PR DESCRIPTION
Solves #1918. Sort the relations by id. Also some extra code to handle unsaved relations so that they appear before all others, and again with newer-created ones first. Once again, not a very testable bit of the codebase but I'm happy to add one if you suggest an approach.
