### PR TITLE
allow 'footway', 'highway', 'railway' when generating areaKeys

### DIFF
--- a/build.js
+++ b/build.js
@@ -158,7 +158,7 @@ function generatePresets() {
         for (var key in preset.tags) break;
         var value = preset.tags[key];
 
-        if (['highway', 'footway', 'railway', 'type'].indexOf(key) === -1) {
+        if (['type'].indexOf(key) === -1) {
             if (preset.geometry.indexOf('area') >= 0) {
                 areaKeys[key] = areaKeys[key] || {};
             } else if (key in areaKeys && value !== '*') {

--- a/js/id/core/area_keys.js
+++ b/js/id/core/area_keys.js
@@ -37,6 +37,35 @@ iD.areaKeys = {
     "golf": {
         "hole": true
     },
+    "highway": {
+        "bridleway": true,
+        "bus_stop": true,
+        "crossing": true,
+        "cycleway": true,
+        "living_street": true,
+        "mini_roundabout": true,
+        "motorway": true,
+        "motorway_junction": true,
+        "motorway_link": true,
+        "path": true,
+        "primary": true,
+        "primary_link": true,
+        "residential": true,
+        "road": true,
+        "secondary": true,
+        "secondary_link": true,
+        "service": true,
+        "steps": true,
+        "stop": true,
+        "tertiary": true,
+        "tertiary_link": true,
+        "track": true,
+        "traffic_signals": true,
+        "trunk": true,
+        "trunk_link": true,
+        "turning_circle": true,
+        "unclassified": true
+    },
     "historic": {
         "boundary_stone": true
     },
@@ -69,6 +98,17 @@ iD.areaKeys = {
     },
     "public_transport": {
         "stop_position": true
+    },
+    "railway": {
+        "abandoned": true,
+        "disused": true,
+        "halt": true,
+        "level_crossing": true,
+        "monorail": true,
+        "rail": true,
+        "subway": true,
+        "subway_entrance": true,
+        "tram": true
     },
     "shop": {},
     "tourism": {


### PR DESCRIPTION
fixes #2069
