### PR TITLE
fix geocode result classifications

### DIFF
--- a/js/id/ui/feature_list.js
+++ b/js/id/ui/feature_list.js
@@ -112,7 +112,8 @@ iD.ui.FeatureList = function(context) {
                     result.push({
                         id: iD.Entity.id.fromOSM(d.osm_type, d.osm_id),
                         geometry: d.osm_type === 'relation' ? 'relation' : d.osm_type === 'way' ? 'line' : 'point',
-                        type: (d.type.charAt(0).toUpperCase() + d.type.slice(1)).replace('_', ' '),
+                        type: d.type !== 'yes' ? (d.type.charAt(0).toUpperCase() + d.type.slice(1)).replace('_', ' ')
+                                               : (d.class.charAt(0).toUpperCase() + d.class.slice(1)).replace('_', ' '),
                         name: d.display_name,
                         extent: new iD.geo.Extent(
                             [parseFloat(d.boundingbox[3]), parseFloat(d.boundingbox[0])],


### PR DESCRIPTION
Some geocoded results are listed with the classification "Yes" (instead of something meaningful like "Highway", "Bridge", etc.). For example: try to search for `Mendelbahn`.

This is fixed by using nominatim's "class" property instead of "type" for result classifications when "type" is "yes". Happens for "bridge"s, "tunnel"s, etc.
