### PR TITLE
protect against relation loops, part 2.

### DIFF
--- a/js/id/core/tree.js
+++ b/js/id/core/tree.js
@@ -18,7 +18,11 @@ iD.Tree = function(head) {
         return rect;
     }
 
-    function updateParents(entity, insertions) {
+    function updateParents(entity, insertions, memo) {
+        if (memo && memo[entity.id]) return;
+        memo = memo || {};
+        memo[entity.id] = true;
+
         head.parentWays(entity).forEach(function(parent) {
             if (rectangles[parent.id]) {
                 rtree.remove(rectangles[parent.id]);
@@ -31,7 +35,7 @@ iD.Tree = function(head) {
                 rtree.remove(rectangles[parent.id]);
                 insertions.push(parent);
             }
-            updateParents(parent, insertions);
+            updateParents(parent, insertions, memo);
         });
     }
 

--- a/test/spec/core/tree.js
+++ b/test/spec/core/tree.js
@@ -41,6 +41,21 @@ describe("iD.Tree", function() {
             expect(tree.intersects(iD.geo.Extent([0, 0], [2, 2]), g)).to.eql([]);
             expect(tree.intersects(iD.geo.Extent([0, 0], [11, 11]), g)).to.eql([node_]);
         });
+
+        it("does not error on self-referencing relations", function() {
+            var graph = iD.Graph(),
+                tree = iD.Tree(graph),
+                node = iD.Node({id: 'n', loc: [1, 1]}),
+                relation = iD.Relation();
+
+            relation = relation.addMember({id: node.id});
+            relation = relation.addMember({id: relation.id});
+
+            graph.rebase([node, relation], [graph]);
+            tree.rebase([relation]);
+
+            expect(tree.intersects(iD.geo.Extent([0, 0], [2, 2]), graph)).to.eql([relation]);
+        });
     });
 
     describe("#intersects", function() {


### PR DESCRIPTION
Like https://github.com/openstreetmap/iD/commit/7bbca76a2012a4337d54efdb3c9ba2dec5192bdf. Fixes #2096.
