### PR TITLE
Tankstelle is not a name

### DIFF
--- a/data/name-suggestions.json
+++ b/data/name-suggestions.json
@@ -216,9 +216,6 @@
             "ABC": {
                 "count": 80
             },
-            "Tankstelle": {
-                "count": 115
-            },
             "ARAL": {
                 "count": 366
             },


### PR DESCRIPTION
Tankstelle is German for petrol station and not a name. There are a couple of other questionable entries like "Freie Tankstelle" (which is a petrol station not associated with a chain) and "Raiffeisenbank" which is a chain of banks, defintely not known for operating petrol stations. I've left those in, but  IMHO the list should support correct tagging and naming not the opposite.
