### PR TITLE
Bump threshold for Orthogonalize to 12 degrees

### DIFF
--- a/js/id/actions/orthogonalize.js
+++ b/js/id/actions/orthogonalize.js
@@ -3,7 +3,7 @@
  */
 
 iD.actions.Orthogonalize = function(wayId, projection) {
-    var threshold = 7, // degrees within right or straight to alter
+    var threshold = 12, // degrees within right or straight to alter
         lowerThreshold = Math.cos((90 - threshold) * Math.PI / 180),
         upperThreshold = Math.cos(threshold * Math.PI / 180);
 


### PR DESCRIPTION
To finally address https://github.com/openstreetmap/iD/issues/1902  I talked to @jfirebaugh about this a while ago, so finally pushing through the change.

Basically the "square" action only tries to square or straighten nodes that are within a certain threshold. It leaves the others untouched. This PR changes the threshold from 7 -> 12 degrees.
