### PR TITLE
Changed order of check preferenence

### DIFF
--- a/js/id/ui/preset/check.js
+++ b/js/id/ui/preset/check.js
@@ -1,6 +1,6 @@
 iD.ui.preset.check = function(field) {
     var event = d3.dispatch('change'),
-        values = [undefined, 'yes', 'no'],
+        values = ['yes', undefined, 'no'],
         value,
         box,
         text,


### PR DESCRIPTION
The current order add the `*:no` tag if `*:yes` is unchecked. This behavior can be slightly confusing to the user as if a new user simply unchecks the box, they would expect nothing to be added as they are unfamiliar with the `unknown` option. The change slightly changes the order, instead adding no tags if `yes` is unchecked.
