### PR TITLE
Replace radial menu with boxy edit menu

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,8 +96,8 @@ Use `make` to build the translations with the local changes.
 ## Contributing Documentation
 
 Documentation is maintained as a series of [Markdown](http://daringfireball.net/projects/markdown/)
-documents in [core.yaml](/data/core.yaml). The documentation 
-is in the `help` section (currently starting at line 258). The first line 
+documents in [core.yaml](/data/core.yaml). The documentation
+is in the `help` section (currently starting at line 258). The first line
 of each new section of documentation should be of the form
 
     # GPS
@@ -110,8 +110,8 @@ To add a new piece of documentation, simply add to [core.yaml](/data/core.yaml) 
 
 ## Adding or Refining Presets
 
-Presets save time for iD users by automatically showing them the tags they are 
-likely to add for a given feature. They are stored in `data/presets/presets`. If 
+Presets save time for iD users by automatically showing them the tags they are
+likely to add for a given feature. They are stored in `data/presets/presets`. If
 you're going to update the presets, [review the Presets README](/data/presets/README.md).
 
 ## Javascript
@@ -143,7 +143,7 @@ always, indented by the level of the tree:
 Just like HTML and Javascript, 4 space soft tabs always.
 
 ```css
-.radial-menu-tooltip {
+.edit-menu-tooltip {
     background: rgba(255, 255, 255, 0.8);
 }
 ```

--- a/css/app.css
+++ b/css/app.css
@@ -86,7 +86,7 @@ a,
 button,
 .checkselect label:hover,
 .opacity-options li,
-.radial-menu-item {
+.edit-menu-item {
     cursor: pointer; /* Opera */
     cursor: url(img/cursor-pointer.png) 6 1, pointer; /* FF */
 }
@@ -2763,35 +2763,39 @@ img.wiki-image {
     left: 60px;
 }
 
-.radial-menu-tooltip {
+.edit-menu-tooltip {
     opacity: 0.8;
     display: none;
     position: absolute;
     width: 200px;
 }
 
-.radial-menu-background {
+.edit-menu-background {
     stroke: black;
     stroke-opacity: 0.5;
     fill: black;
     fill-opacity: 0.5;
 }
 
-.radial-menu-item {
+.edit-menu-item {
     fill: white;
 }
 
-.radial-menu-item:hover {
+.edit-menu-item:hover {
     fill: #ececec;
 }
 
-.radial-menu-item:active {
+.edit-menu-item:active {
     fill: #ececec;
 }
 
-.radial-menu-item.disabled {
+.edit-menu-item.disabled {
     cursor: auto;
     fill: rgba(255,255,255,.5);
+}
+
+.edit-menu .icon {
+    pointer-events: none;
 }
 
 .lasso-box {

--- a/css/app.css
+++ b/css/app.css
@@ -2773,6 +2773,8 @@ img.wiki-image {
 .radial-menu-background {
     stroke: black;
     stroke-opacity: 0.5;
+    fill: black;
+    fill-opacity: 0.5;
 }
 
 .radial-menu-item {

--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
         <script src="js/id/ui.js"></script>
         <script src='js/id/ui/intro.js'></script>
         <script src='js/id/ui/attribution.js'></script>
-        <script src='js/id/ui/radial_menu.js'></script>
+        <script src='js/id/ui/edit_menu.js'></script>
         <script src='js/id/ui/inspector.js'></script>
         <script src='js/id/ui/modal.js'></script>
         <script src='js/id/ui/cmd.js'></script>

--- a/js/id/modes/select.js
+++ b/js/id/modes/select.js
@@ -28,12 +28,25 @@ iD.modes.Select = function(context, selectedIDs) {
     }
 
     function positionMenu() {
-        var entity = singular();
+        var entity = singular(),
+            direction = [1, 1];   // TODO: can be used to avoid nearbyPoints..
+
+        nearbyPoints = selectedIDs.map(function(ent) {
+            return context.projection(context.entity(ent).loc);
+        });
+
+console.info('selectedIDs=[' + selectedIDs + ']');
+console.info('entity=' + entity);
+console.info('nearbyPoints=[' + nearbyPoints + ']');
 
         if (entity && entity.type === 'node') {
-            editMenu.center(context.projection(entity.loc));
+            editMenu
+                .position(context.projection(entity.loc))
+                .direction(direction);
         } else {
-            editMenu.center(context.mouse());
+            editMenu
+                .position(context.mouse())
+                .direction(direction);
         }
     }
 
@@ -78,6 +91,15 @@ iD.modes.Select = function(context, selectedIDs) {
             .map(function(o) { return o(selectedIDs, context); })
             .filter(function(o) { return o.available(); });
         operations.unshift(iD.operations.Delete(selectedIDs, context));
+
+// bhousel testing big menu..
+operations.push(iD.operations.Delete(selectedIDs, context));
+operations.push(iD.operations.Delete(selectedIDs, context));
+operations.push(iD.operations.Delete(selectedIDs, context));
+operations.push(iD.operations.Delete(selectedIDs, context));
+operations.push(iD.operations.Delete(selectedIDs, context));
+operations.push(iD.operations.Delete(selectedIDs, context));
+// end testing
 
         keybinding.on('⎋', function() {
             context.enter(iD.modes.Browse(context));

--- a/js/id/modes/select.js
+++ b/js/id/modes/select.js
@@ -30,21 +30,10 @@ iD.modes.Select = function(context, selectedIDs) {
     function positionMenu() {
         var entity = singular();
 
-// for testing .. send editmenu in random direction -1, 0, 1
-// var direction = [
-//     Math.floor(Math.random()*3) - 1,
-//     Math.floor(Math.random()*3) - 1
-//   ]
-// editMenu
-//     .position(context.mouse())
-//     .direction(direction);
-
         if (entity && entity.type === 'node') {
-            editMenu
-                .position(context.projection(entity.loc));
+            editMenu.position(iD.geo.roundCoords(context.projection(entity.loc)));
         } else {
-            editMenu
-                .position(context.mouse());
+            editMenu.position(context.mouse());
         }
     }
 
@@ -94,9 +83,6 @@ iD.modes.Select = function(context, selectedIDs) {
 //operations.push(iD.operations.Delete(selectedIDs, context));
 //operations.push(iD.operations.Delete(selectedIDs, context));
 //operations.push(iD.operations.Delete(selectedIDs, context));
-operations.push(iD.operations.Delete(selectedIDs, context));
-operations.push(iD.operations.Delete(selectedIDs, context));
-operations.push(iD.operations.Delete(selectedIDs, context));
 // end testing
 
         keybinding.on('⎋', function() {

--- a/js/id/modes/select.js
+++ b/js/id/modes/select.js
@@ -14,7 +14,7 @@ iD.modes.Select = function(context, selectedIDs) {
                 .selectedIDs(selectedIDs)
                 .behavior],
         inspector,
-        radialMenu,
+        editMenu,
         newFeature = false,
         suppressMenu = false;
 
@@ -31,16 +31,16 @@ iD.modes.Select = function(context, selectedIDs) {
         var entity = singular();
 
         if (entity && entity.type === 'node') {
-            radialMenu.center(context.projection(entity.loc));
+            editMenu.center(context.projection(entity.loc));
         } else {
-            radialMenu.center(context.mouse());
+            editMenu.center(context.mouse());
         }
     }
 
     function showMenu() {
         context.surface()
-            .call(radialMenu.close)
-            .call(radialMenu);
+            .call(editMenu.close)
+            .call(editMenu);
     }
 
     mode.selectedIDs = function() {
@@ -101,7 +101,7 @@ iD.modes.Select = function(context, selectedIDs) {
             .on('redone.select', update);
 
         function update() {
-            context.surface().call(radialMenu.close);
+            context.surface().call(editMenu.close);
 
             if (_.any(selectedIDs, function(id) { return !context.hasEntity(id); })) {
                 // Exit mode if selected entity gets undone
@@ -110,7 +110,7 @@ iD.modes.Select = function(context, selectedIDs) {
         }
 
         context.map().on('move.select', function() {
-            context.surface().call(radialMenu.close);
+            context.surface().call(editMenu.close);
         });
 
         function dblclick() {
@@ -145,7 +145,7 @@ iD.modes.Select = function(context, selectedIDs) {
         context.map().on('drawn.select', selectElements);
         selectElements();
 
-        radialMenu = iD.ui.RadialMenu(context, operations);
+        editMenu = iD.ui.EditMenu(context, operations);
         var show = d3.event && !suppressMenu;
 
         if (show) {
@@ -183,7 +183,7 @@ iD.modes.Select = function(context, selectedIDs) {
             .on('redone.select', null);
 
         context.surface()
-            .call(radialMenu.close)
+            .call(editMenu.close)
             .on('dblclick.select', null)
             .selectAll('.selected')
             .classed('selected', false);

--- a/js/id/modes/select.js
+++ b/js/id/modes/select.js
@@ -28,25 +28,23 @@ iD.modes.Select = function(context, selectedIDs) {
     }
 
     function positionMenu() {
-        var entity = singular(),
-            direction = [1, 1];   // TODO: can be used to avoid nearbyPoints..
+        var entity = singular();
 
-        nearbyPoints = selectedIDs.map(function(ent) {
-            return context.projection(context.entity(ent).loc);
-        });
-
-console.info('selectedIDs=[' + selectedIDs + ']');
-console.info('entity=' + entity);
-console.info('nearbyPoints=[' + nearbyPoints + ']');
+// for testing .. send editmenu in random direction -1, 0, 1
+// var direction = [
+//     Math.floor(Math.random()*3) - 1,
+//     Math.floor(Math.random()*3) - 1
+//   ]
+// editMenu
+//     .position(context.mouse())
+//     .direction(direction);
 
         if (entity && entity.type === 'node') {
             editMenu
-                .position(context.projection(entity.loc))
-                .direction(direction);
+                .position(context.projection(entity.loc));
         } else {
             editMenu
-                .position(context.mouse())
-                .direction(direction);
+                .position(context.mouse());
         }
     }
 
@@ -93,9 +91,9 @@ console.info('nearbyPoints=[' + nearbyPoints + ']');
         operations.unshift(iD.operations.Delete(selectedIDs, context));
 
 // bhousel testing big menu..
-operations.push(iD.operations.Delete(selectedIDs, context));
-operations.push(iD.operations.Delete(selectedIDs, context));
-operations.push(iD.operations.Delete(selectedIDs, context));
+//operations.push(iD.operations.Delete(selectedIDs, context));
+//operations.push(iD.operations.Delete(selectedIDs, context));
+//operations.push(iD.operations.Delete(selectedIDs, context));
 operations.push(iD.operations.Delete(selectedIDs, context));
 operations.push(iD.operations.Delete(selectedIDs, context));
 operations.push(iD.operations.Delete(selectedIDs, context));

--- a/js/id/ui/edit_menu.js
+++ b/js/id/ui/edit_menu.js
@@ -37,9 +37,9 @@ iD.ui.EditMenu = function(context, operations) {
         // pack menu items into columns and rows..
         if (items <= 5) {
             cols = items;
-        } else if ([7, 8, 11, 12].indexOf(items) != -1) {
+        } else if ([7, 8, 11, 12].indexOf(items) !== -1) {
             cols = 4;
-        } else if ([6, 9].indexOf(items) != -1) {
+        } else if ([6, 9].indexOf(items) !== -1) {
             cols = 3;
         } else {
             cols = 5;
@@ -58,7 +58,7 @@ iD.ui.EditMenu = function(context, operations) {
 
         // pick the menu direction that obscures the fewest points..
         var best = Infinity,
-            dim = id.map().dimensions();
+            dim = context.map().dimensions();
 
         _.each(_.values(directions), function(dir) {
             var min = [0,0],
@@ -113,7 +113,7 @@ iD.ui.EditMenu = function(context, operations) {
             .attr('width', width)
             .attr('height', height)
             .attr('rx', spacing / 2)
-            .attr('ry', spacing / 2)
+            .attr('ry', spacing / 2);
 
         var button = menu.selectAll()
             .data(operations)
@@ -148,7 +148,7 @@ iD.ui.EditMenu = function(context, operations) {
             d3.event.stopPropagation(); // https://github.com/openstreetmap/iD/issues/1869
         }
 
-        function mouseover(d, i) {
+        function mouseover(d) {
             // pin tooltip to bottom of editmenu..
             var rect = context.surfaceRect(),
                 top = rect.top + start[1] + height + 'px',

--- a/js/id/ui/edit_menu.js
+++ b/js/id/ui/edit_menu.js
@@ -1,6 +1,7 @@
 iD.ui.EditMenu = function(context, operations) {
     var menu,
-        center = [0, 0],
+        position = [0, 0],
+        direction = [1, 1],
         tooltip;
 
     var editMenu = function(selection) {
@@ -17,19 +18,12 @@ iD.ui.EditMenu = function(context, operations) {
             editMenu.close();
         }
 
-        menu = selection.append('g')
-            .attr('class', 'edit-menu')
-            .attr('transform', 'translate(' + center + ')')
-            .attr('opacity', 0);
-
-        menu.transition()
-            .attr('opacity', 1);
-
         var spacing = 40,
             xoffset = 10,
             yoffset = 10,
             items = operations.length,
-            cols, rows;
+            cols,
+            rows;
 
         if (items <= 5) {
             cols = items;
@@ -40,9 +34,17 @@ iD.ui.EditMenu = function(context, operations) {
         } else {
             cols = 5;
         }
-// to test column packing
-// cols = Math.min(items, 3);
         rows = Math.ceil(items / cols);
+
+console.info('position=[' + position + '] direction=[' + direction + ']');
+
+        menu = selection.append('g')
+            .attr('class', 'edit-menu')
+            .attr('transform', 'translate(' + position + ')')
+            .attr('opacity', 0);
+
+        menu.transition()
+            .attr('opacity', 1);
 
         menu.append('rect')
             .attr('class', 'edit-menu-background')
@@ -59,8 +61,8 @@ iD.ui.EditMenu = function(context, operations) {
             .attr('transform', function(d, i) {
                 var col = (i % cols) + 1,
                     row = Math.trunc(i / cols) + 1,
-                    x = (spacing * col) - (spacing / 2) + xoffset,
-                    y = (spacing * row) - (spacing / 2) + yoffset;
+                    x = ((spacing * col) - (spacing / 2) + xoffset),
+                    y = ((spacing * row) - (spacing / 2) + yoffset);
                 return 'translate(' + x + ',' + y + ')';
             });
 
@@ -88,8 +90,8 @@ iD.ui.EditMenu = function(context, operations) {
 
         function mouseover(d, i) {
             var rect = context.surfaceRect(),
-                top = rect.top + center[1] + (rows * spacing) + yoffset + 'px',
-                left = rect.left + center[0] + xoffset + 'px';
+                top = rect.top + position[1] + (rows * spacing) + yoffset + 'px',
+                left = rect.left + position[0] + xoffset + 'px';
 
             tooltip
                 .style('top', null)
@@ -133,9 +135,15 @@ iD.ui.EditMenu = function(context, operations) {
         }
     };
 
-    editMenu.center = function(_) {
-        if (!arguments.length) return center;
-        center = _;
+    editMenu.position = function(_) {
+        if (!arguments.length) return position;
+        position = _;
+        return editMenu;
+    };
+
+    editMenu.direction = function(_) {
+        if (!arguments.length) return direction;
+        direction = _;
         return editMenu;
     };
 

--- a/js/id/ui/edit_menu.js
+++ b/js/id/ui/edit_menu.js
@@ -87,7 +87,7 @@ console.info('position=[' + position + '] direction=[' + direction + '] xwidth='
             .enter().append('g')
             .attr('transform', function(d, i) {
                 var col = (i % cols) + 1,
-                    row = Math.trunc(i / cols) + 1,
+                    row = Math.floor(i / cols) + 1,
                     x = (xstart + (spacing * col) - (spacing / 2)),
                     y = (ystart + (spacing * row) - (spacing / 2));
                 return 'translate(' + x + ',' + y + ')';

--- a/js/id/ui/edit_menu.js
+++ b/js/id/ui/edit_menu.js
@@ -19,12 +19,16 @@ iD.ui.EditMenu = function(context, operations) {
         }
 
         var spacing = 40,
-            xoffset = 10,
-            yoffset = 10,
+            offset  = 10,
             items = operations.length,
             cols,
-            rows;
+            rows,
+            xstart,
+            ystart,
+            xwidth,
+            yheight;
 
+        // pack menu items into columns..
         if (items <= 5) {
             cols = items;
         } else if ([7, 8, 11, 12].indexOf(items) != -1) {
@@ -36,7 +40,30 @@ iD.ui.EditMenu = function(context, operations) {
         }
         rows = Math.ceil(items / cols);
 
-console.info('position=[' + position + '] direction=[' + direction + ']');
+        xwidth = cols * spacing;
+        yheight = rows * spacing;
+
+        if(direction[0] < 0) {
+            xstart = (-1 * (xwidth + offset));
+        }
+        else if (direction[0] === 0) {
+            xstart = (-1 * (xwidth + offset)) / 2;
+        }
+        else {
+            xstart = offset;
+        }
+
+        if(direction[1] < 0) {
+            ystart = (-1 * (yheight + offset));
+        }
+        else if (direction[0] === 0) {
+            ystart = (-1 * (yheight + offset)) / 2;
+        }
+        else {
+            ystart = offset;
+        }
+
+console.info('position=[' + position + '] direction=[' + direction + '] xwidth=' + xwidth + ' yheight=' + yheight + ' xstart=' + xstart + ' ystart=' + ystart );
 
         menu = selection.append('g')
             .attr('class', 'edit-menu')
@@ -48,10 +75,10 @@ console.info('position=[' + position + '] direction=[' + direction + ']');
 
         menu.append('rect')
             .attr('class', 'edit-menu-background')
-            .attr('x', xoffset)
-            .attr('y', yoffset)
-            .attr('width', cols * spacing)
-            .attr('height', rows * spacing)
+            .attr('x', xstart)
+            .attr('y', ystart)
+            .attr('width', xwidth)
+            .attr('height', yheight)
             .attr('rx', spacing / 2)
             .attr('ry', spacing / 2)
 
@@ -61,8 +88,8 @@ console.info('position=[' + position + '] direction=[' + direction + ']');
             .attr('transform', function(d, i) {
                 var col = (i % cols) + 1,
                     row = Math.trunc(i / cols) + 1,
-                    x = ((spacing * col) - (spacing / 2) + xoffset),
-                    y = ((spacing * row) - (spacing / 2) + yoffset);
+                    x = (xstart + (spacing * col) - (spacing / 2)),
+                    y = (ystart + (spacing * row) - (spacing / 2));
                 return 'translate(' + x + ',' + y + ')';
             });
 
@@ -89,31 +116,16 @@ console.info('position=[' + position + '] direction=[' + direction + ']');
         }
 
         function mouseover(d, i) {
+            // pin tooltip to bottom of editmenu..
             var rect = context.surfaceRect(),
-                top = rect.top + position[1] + (rows * spacing) + yoffset + 'px',
-                left = rect.left + position[0] + xoffset + 'px';
+                top = rect.top + position[1] + ystart + yheight + 'px',
+                left = rect.left + position[0] + xstart + 'px';
 
             tooltip
-                .style('top', null)
-                .style('left', null)
-                .style('bottom', null)
-                .style('right', null)
+                .style('left', left)
+                .style('top', top)
                 .style('display', 'block')
                 .html(iD.ui.tooltipHtml(d.tooltip(), d.keys[0]));
-
-            // if (i === 0) {
-            //     tooltip
-            //         .style('right', right)
-            //         .style('top', top);
-            // } else if (i >= 4) {
-            //     tooltip
-            //         .style('left', left)
-            //         .style('bottom', bottom);
-            // } else {
-                tooltip
-                    .style('left', left)
-                    .style('top', top);
-            // }
         }
 
         function mouseout() {
@@ -135,12 +147,17 @@ console.info('position=[' + position + '] direction=[' + direction + ']');
         }
     };
 
+    // position where the menu should start, specified like [x,y]
     editMenu.position = function(_) {
         if (!arguments.length) return position;
         position = _;
         return editMenu;
     };
 
+    // direction to grow the menu, specified like [x,y]
+    //      -1
+    //   -1  0  1
+    //       1
     editMenu.direction = function(_) {
         if (!arguments.length) return direction;
         direction = _;

--- a/js/id/ui/edit_menu.js
+++ b/js/id/ui/edit_menu.js
@@ -1,9 +1,9 @@
-iD.ui.RadialMenu = function(context, operations) {
+iD.ui.EditMenu = function(context, operations) {
     var menu,
         center = [0, 0],
         tooltip;
 
-    var radialMenu = function(selection) {
+    var editMenu = function(selection) {
         if (!operations.length)
             return;
 
@@ -14,31 +14,17 @@ iD.ui.RadialMenu = function(context, operations) {
             if (operation.disabled())
                 return;
             operation();
-            radialMenu.close();
+            editMenu.close();
         }
 
         menu = selection.append('g')
-            .attr('class', 'radial-menu')
+            .attr('class', 'edit-menu')
             .attr('transform', 'translate(' + center + ')')
             .attr('opacity', 0);
 
         menu.transition()
             .attr('opacity', 1);
 
-//radial
-        // var r = 50,
-        //     a = Math.PI / 4,
-        //     a0 = -Math.PI / 4,
-        //     a1 = a0 + (operations.length - 1) * a;
-
-//linear
-        // var spacing = 40,
-        //     offset = 40,
-        //     items = operations.length,
-        //     x0 = 0,
-        //     x1 = x0 + (items - 1) * spacing;
-
-//boxy
         var spacing = 40,
             xoffset = 10,
             yoffset = 10,
@@ -58,25 +44,8 @@ iD.ui.RadialMenu = function(context, operations) {
 // cols = Math.min(items, 3);
         rows = Math.ceil(items / cols);
 
-//radial
-        // menu.append('path')
-        //     .attr('class', 'radial-menu-background')
-        //     .attr('d', 'M' + r * Math.sin(a0) + ',' +
-        //                      r * Math.cos(a0) +
-        //               ' A' + r + ',' + r + ' 0 ' + (operations.length > 5 ? '1' : '0') + ',0 ' +
-        //                      (r * Math.sin(a1) + 1e-3) + ',' +
-        //                      (r * Math.cos(a1) + 1e-3)) // Force positive-length path (#1305)
-        //     .attr('stroke-width', 50)
-        //     .attr('stroke-linecap', 'round');
-//linear
-        // menu.append('path')
-        //     .attr('class', 'radial-menu-background')
-        //     .attr('d', 'M' + x0 + ',' + offset + ' L' + x1 + ',' + offset)
-        //     .attr('stroke-width', 50)
-        //     .attr('stroke-linecap', 'round');
-//boxy
         menu.append('rect')
-            .attr('class', 'radial-menu-background')
+            .attr('class', 'edit-menu-background')
             .attr('x', xoffset)
             .attr('y', yoffset)
             .attr('width', cols * spacing)
@@ -87,27 +56,16 @@ iD.ui.RadialMenu = function(context, operations) {
         var button = menu.selectAll()
             .data(operations)
             .enter().append('g')
-//radial
-            // .attr('transform', function(d, i) {
-            //     return 'translate(' + r * Math.sin(a0 + i * a) + ',' +
-            //                           r * Math.cos(a0 + i * a) + ')';
-            // });
-//linear
-            // .attr('transform', function(d, i) {
-            //     return 'translate(' + (x0+(spacing * i)) + ',' + offset + ')';
-            // });
-//boxy
             .attr('transform', function(d, i) {
                 var col = (i % cols) + 1,
                     row = Math.trunc(i / cols) + 1,
                     x = (spacing * col) - (spacing / 2) + xoffset,
                     y = (spacing * row) - (spacing / 2) + yoffset;
-                // console.info('i=' + i + ', row=' + row + ', col=' + col + ', x=' + x + ', y=' + y);
                 return 'translate(' + x + ',' + y + ')';
             });
 
         button.append('circle')
-            .attr('class', function(d) { return 'radial-menu-item radial-menu-item-' + d.id; })
+            .attr('class', function(d) { return 'edit-menu-item edit-menu-item-' + d.id; })
             .attr('r', 15)
             .classed('disabled', function(d) { return d.disabled(); })
             .on('click', click)
@@ -122,7 +80,7 @@ iD.ui.RadialMenu = function(context, operations) {
 
         tooltip = d3.select(document.body)
             .append('div')
-            .attr('class', 'tooltip-inner radial-menu-tooltip');
+            .attr('class', 'tooltip-inner edit-menu-tooltip');
 
         function mousedown() {
             d3.event.stopPropagation(); // https://github.com/openstreetmap/iD/issues/1869
@@ -130,16 +88,6 @@ iD.ui.RadialMenu = function(context, operations) {
 
         function mouseover(d, i) {
             var rect = context.surfaceRect(),
-//radial
-                // angle = a0 + i * a,
-                // top = rect.top + (r + 25) * Math.cos(angle) + center[1] + 'px',
-                // left = rect.left + (r + 25) * Math.sin(angle) + center[0] + 'px',
-                // bottom = rect.height - (r + 25) * Math.cos(angle) - center[1] + 'px',
-                // right = rect.width - (r + 25) * Math.sin(angle) - center[0] + 'px';
-//linear
-                // top = rect.top + center[1] + (offset + 25) + 'px',
-                // left = rect.left + center[0] + (i*spacing) - ((x1-x0)/2) + 'px'
-//boxy
                 top = rect.top + center[1] + (rows * spacing) + yoffset + 'px',
                 left = rect.left + center[0] + xoffset + 'px';
 
@@ -151,7 +99,6 @@ iD.ui.RadialMenu = function(context, operations) {
                 .style('display', 'block')
                 .html(iD.ui.tooltipHtml(d.tooltip(), d.keys[0]));
 
-//radial tooltip positioning
             // if (i === 0) {
             //     tooltip
             //         .style('right', right)
@@ -172,7 +119,7 @@ iD.ui.RadialMenu = function(context, operations) {
         }
     };
 
-    radialMenu.close = function() {
+    editMenu.close = function() {
         if (menu) {
             menu
                 .style('pointer-events', 'none')
@@ -186,11 +133,11 @@ iD.ui.RadialMenu = function(context, operations) {
         }
     };
 
-    radialMenu.center = function(_) {
+    editMenu.center = function(_) {
         if (!arguments.length) return center;
         center = _;
-        return radialMenu;
+        return editMenu;
     };
 
-    return radialMenu;
+    return editMenu;
 };

--- a/js/id/ui/intro/point.js
+++ b/js/id/ui/intro/point.js
@@ -120,7 +120,7 @@ iD.ui.intro.point = function(context, reveal) {
             context.history().on('change.intro', deleted);
 
             setTimeout(function() {
-                var node = d3.select('.radial-menu-item-delete').node();
+                var node = d3.select('.edit-menu-item-delete').node();
                 var pointBox = iD.ui.intro.pad(node.getBoundingClientRect(), 50, context);
                 reveal(pointBox, t('intro.points.delete'));
             }, 300);

--- a/js/id/ui/radial_menu.js
+++ b/js/id/ui/radial_menu.js
@@ -25,27 +25,34 @@ iD.ui.RadialMenu = function(context, operations) {
         menu.transition()
             .attr('opacity', 1);
 
-        var r = 50,
-            a = Math.PI / 4,
-            a0 = -Math.PI / 4,
-            a1 = a0 + (operations.length - 1) * a;
+        // var r = 50,
+        //     a = Math.PI / 4,
+        //     a0 = -Math.PI / 4,
+        //     a1 = a0 + (operations.length - 1) * a;
+        var step = 40,
+            offset = 40,
+            x0 = 0,
+            x1 = x0 + (operations.length - 1) * step;
 
         menu.append('path')
             .attr('class', 'radial-menu-background')
-            .attr('d', 'M' + r * Math.sin(a0) + ',' +
-                             r * Math.cos(a0) +
-                      ' A' + r + ',' + r + ' 0 ' + (operations.length > 5 ? '1' : '0') + ',0 ' +
-                             (r * Math.sin(a1) + 1e-3) + ',' +
-                             (r * Math.cos(a1) + 1e-3)) // Force positive-length path (#1305)
+            // .attr('d', 'M' + r * Math.sin(a0) + ',' +
+            //                  r * Math.cos(a0) +
+            //           ' A' + r + ',' + r + ' 0 ' + (operations.length > 5 ? '1' : '0') + ',0 ' +
+            //                  (r * Math.sin(a1) + 1e-3) + ',' +
+            //                  (r * Math.cos(a1) + 1e-3)) // Force positive-length path (#1305)
+            .attr('d', 'M' + x0 + ',' + offset + ' L' + x1 + ',' + offset)
             .attr('stroke-width', 50)
             .attr('stroke-linecap', 'round');
 
         var button = menu.selectAll()
             .data(operations)
             .enter().append('g')
+            // .attr('transform', function(d, i) {
+            //     return 'translate(' + r * Math.sin(a0 + i * a) + ',' +
+            //                           r * Math.cos(a0 + i * a) + ')';
             .attr('transform', function(d, i) {
-                return 'translate(' + r * Math.sin(a0 + i * a) + ',' +
-                                      r * Math.cos(a0 + i * a) + ')';
+                return 'translate(' + (x0+(step * i)) + ',' + offset + ')';
             });
 
         button.append('circle')
@@ -72,11 +79,15 @@ iD.ui.RadialMenu = function(context, operations) {
 
         function mouseover(d, i) {
             var rect = context.surfaceRect(),
-                angle = a0 + i * a,
-                top = rect.top + (r + 25) * Math.cos(angle) + center[1] + 'px',
-                left = rect.left + (r + 25) * Math.sin(angle) + center[0] + 'px',
-                bottom = rect.height - (r + 25) * Math.cos(angle) - center[1] + 'px',
-                right = rect.width - (r + 25) * Math.sin(angle) - center[0] + 'px';
+                // angle = a0 + i * a,
+                // top = rect.top + (r + 25) * Math.cos(angle) + center[1] + 'px',
+                // left = rect.left + (r + 25) * Math.sin(angle) + center[0] + 'px',
+                // bottom = rect.height - (r + 25) * Math.cos(angle) - center[1] + 'px',
+                // right = rect.width - (r + 25) * Math.sin(angle) - center[0] + 'px';
+                top = rect.top + center[1] + (offset + 25) + 'px',
+                left = rect.left + center[0] + (i*step) - ((x1-x0)/2) + 'px',
+                bottom = rect.height - center[1] + 'px',
+                right = rect.width - center[0] + 'px';
 
             tooltip
                 .style('top', null)
@@ -86,19 +97,19 @@ iD.ui.RadialMenu = function(context, operations) {
                 .style('display', 'block')
                 .html(iD.ui.tooltipHtml(d.tooltip(), d.keys[0]));
 
-            if (i === 0) {
-                tooltip
-                    .style('right', right)
-                    .style('top', top);
-            } else if (i >= 4) {
+            // if (i === 0) {
+            //     tooltip
+            //         .style('right', right)
+            //         .style('top', top);
+            // } else if (i >= 4) {
+            //     tooltip
+            //         .style('left', left)
+            //         .style('bottom', bottom);
+            // } else {
                 tooltip
                     .style('left', left)
-                    .style('bottom', bottom);
-            } else {
-                tooltip
-                    .style('left', left)
                     .style('top', top);
-            }
+            // }
         }
 
         function mouseout() {

--- a/js/id/ui/radial_menu.js
+++ b/js/id/ui/radial_menu.js
@@ -25,34 +25,85 @@ iD.ui.RadialMenu = function(context, operations) {
         menu.transition()
             .attr('opacity', 1);
 
+//radial
         // var r = 50,
         //     a = Math.PI / 4,
         //     a0 = -Math.PI / 4,
         //     a1 = a0 + (operations.length - 1) * a;
-        var step = 40,
-            offset = 40,
-            x0 = 0,
-            x1 = x0 + (operations.length - 1) * step;
 
-        menu.append('path')
+//linear
+        // var spacing = 40,
+        //     offset = 40,
+        //     items = operations.length,
+        //     x0 = 0,
+        //     x1 = x0 + (items - 1) * spacing;
+
+//boxy
+        var spacing = 40,
+            xoffset = 10,
+            yoffset = 10,
+            items = operations.length,
+            cols, rows;
+
+        if (items <= 5) {
+            cols = items;
+        } else if ([7, 8, 11, 12].indexOf(items) != -1) {
+            cols = 4;
+        } else if ([6, 9].indexOf(items) != -1) {
+            cols = 3;
+        } else {
+            cols = 5;
+        }
+// to test column packing
+// cols = Math.min(items, 3);
+        rows = Math.ceil(items / cols);
+
+//radial
+        // menu.append('path')
+        //     .attr('class', 'radial-menu-background')
+        //     .attr('d', 'M' + r * Math.sin(a0) + ',' +
+        //                      r * Math.cos(a0) +
+        //               ' A' + r + ',' + r + ' 0 ' + (operations.length > 5 ? '1' : '0') + ',0 ' +
+        //                      (r * Math.sin(a1) + 1e-3) + ',' +
+        //                      (r * Math.cos(a1) + 1e-3)) // Force positive-length path (#1305)
+        //     .attr('stroke-width', 50)
+        //     .attr('stroke-linecap', 'round');
+//linear
+        // menu.append('path')
+        //     .attr('class', 'radial-menu-background')
+        //     .attr('d', 'M' + x0 + ',' + offset + ' L' + x1 + ',' + offset)
+        //     .attr('stroke-width', 50)
+        //     .attr('stroke-linecap', 'round');
+//boxy
+        menu.append('rect')
             .attr('class', 'radial-menu-background')
-            // .attr('d', 'M' + r * Math.sin(a0) + ',' +
-            //                  r * Math.cos(a0) +
-            //           ' A' + r + ',' + r + ' 0 ' + (operations.length > 5 ? '1' : '0') + ',0 ' +
-            //                  (r * Math.sin(a1) + 1e-3) + ',' +
-            //                  (r * Math.cos(a1) + 1e-3)) // Force positive-length path (#1305)
-            .attr('d', 'M' + x0 + ',' + offset + ' L' + x1 + ',' + offset)
-            .attr('stroke-width', 50)
-            .attr('stroke-linecap', 'round');
+            .attr('x', xoffset)
+            .attr('y', yoffset)
+            .attr('width', cols * spacing)
+            .attr('height', rows * spacing)
+            .attr('rx', spacing / 2)
+            .attr('ry', spacing / 2)
 
         var button = menu.selectAll()
             .data(operations)
             .enter().append('g')
+//radial
             // .attr('transform', function(d, i) {
             //     return 'translate(' + r * Math.sin(a0 + i * a) + ',' +
             //                           r * Math.cos(a0 + i * a) + ')';
+            // });
+//linear
+            // .attr('transform', function(d, i) {
+            //     return 'translate(' + (x0+(spacing * i)) + ',' + offset + ')';
+            // });
+//boxy
             .attr('transform', function(d, i) {
-                return 'translate(' + (x0+(step * i)) + ',' + offset + ')';
+                var col = (i % cols) + 1,
+                    row = Math.trunc(i / cols) + 1,
+                    x = (spacing * col) - (spacing / 2) + xoffset,
+                    y = (spacing * row) - (spacing / 2) + yoffset;
+                // console.info('i=' + i + ', row=' + row + ', col=' + col + ', x=' + x + ', y=' + y);
+                return 'translate(' + x + ',' + y + ')';
             });
 
         button.append('circle')
@@ -79,15 +130,18 @@ iD.ui.RadialMenu = function(context, operations) {
 
         function mouseover(d, i) {
             var rect = context.surfaceRect(),
+//radial
                 // angle = a0 + i * a,
                 // top = rect.top + (r + 25) * Math.cos(angle) + center[1] + 'px',
                 // left = rect.left + (r + 25) * Math.sin(angle) + center[0] + 'px',
                 // bottom = rect.height - (r + 25) * Math.cos(angle) - center[1] + 'px',
                 // right = rect.width - (r + 25) * Math.sin(angle) - center[0] + 'px';
-                top = rect.top + center[1] + (offset + 25) + 'px',
-                left = rect.left + center[0] + (i*step) - ((x1-x0)/2) + 'px',
-                bottom = rect.height - center[1] + 'px',
-                right = rect.width - center[0] + 'px';
+//linear
+                // top = rect.top + center[1] + (offset + 25) + 'px',
+                // left = rect.left + center[0] + (i*spacing) - ((x1-x0)/2) + 'px'
+//boxy
+                top = rect.top + center[1] + (rows * spacing) + yoffset + 'px',
+                left = rect.left + center[0] + xoffset + 'px';
 
             tooltip
                 .style('top', null)
@@ -97,6 +151,7 @@ iD.ui.RadialMenu = function(context, operations) {
                 .style('display', 'block')
                 .html(iD.ui.tooltipHtml(d.tooltip(), d.keys[0]));
 
+//radial tooltip positioning
             // if (i === 0) {
             //     tooltip
             //         .style('right', right)

--- a/test/index.html
+++ b/test/index.html
@@ -69,7 +69,7 @@
 
     <script src="../js/id/ui.js"></script>
     <script src='../js/id/ui/attribution.js'></script>
-    <script src='../js/id/ui/radial_menu.js'></script>
+    <script src='../js/id/ui/edit_menu.js'></script>
     <script src='../js/id/ui/inspector.js'></script>
     <script src='../js/id/ui/modal.js'></script>
     <script src='../js/id/ui/cmd.js'></script>


### PR DESCRIPTION
After much frustration with the radial menu, I decided to take a shot at #1994 - Radial Menu gets in the way.

I changed the menu to be a more tightly packed box.  This is nice because it tends to avoid nearby points, and we can add many more operations to the menu without it becoming too unwieldy.

I also added the ability to control which direction the menu pops up.  The calling code in select.js could check for nearby points on the selected entity, and tell the edit menu to avoid them, although I haven't implemented this yet.

![editmenu](https://f.cloud.github.com/assets/38784/2306713/34f3b026-a292-11e3-89db-7913ba4fe7f0.png)
(In this screenshot I added extra dummy "delete" operations to test column packing code and show what a larger menu would look like).