### PR TITLE
Update photographic_labratory.json

### DIFF
--- a/data/presets/presets/craft/photographic_labratory.json
+++ b/data/presets/presets/craft/photographic_labratory.json
@@ -1,15 +1,15 @@
 {
-    "name": "Photographic Labratory",
+    "name": "Photographic Laboratory",
     "geometry": [
         "point",
         "area"
     ],
     "terms": [
-        "photographic labratory",
+        "photographic laboratory",
         "film developer"
     ],
     "tags": {
-        "craft": "photographic_labratory"
+        "craft": "photographic_laboratory"
     },
     "icon": "camera",
     "fields": [


### PR DESCRIPTION
spelling correction to match tag from OSM wiki. https://wiki.openstreetmap.org/wiki/Tag:craft%3Dphotographic_laboratory
