### PR TITLE
add unique style for landuse military

### DIFF
--- a/css/map.css
+++ b/css/map.css
@@ -245,6 +245,10 @@ path.stroke.tag-landuse-landfill {
     stroke: #ff9933;
 }
 
+path.stroke.tag-landuse-military {
+    stroke: #e06e5f;
+}
+
 path.stroke.tag-landuse-residential,
 path.stroke.tag-landuse-construction {
     stroke: #e06e5f;
@@ -393,9 +397,15 @@ path.fill.tag-landuse-industrial {
     fill: #e4a4f5;
 }
 
+path.fill.tag-landuse-military {
+    fill: url(#pattern-construction);
+    opacity: 1;
+}
+
 path.stroke.tag-amenity-parking {
     stroke: #aaa;
 }
+
 path.fill.tag-amenity-parking {
     fill: #aaa;
 }


### PR DESCRIPTION
Replaces default green with red stroke with diagonal line pattern fill for 'landuse-military' polygons:
![screen shot 2014-04-14 at 3 49 57 pm](https://cloud.githubusercontent.com/assets/108094/2700002/0f2205a8-c40e-11e3-9458-fb7897e88d17.png)

References https://github.com/openstreetmap/iD/issues/2177
