### PR TITLE
Trim tag keys, and prevent duplicate tag keys (#2043)

### DIFF
--- a/js/id/ui/raw_tag_editor.js
+++ b/js/id/ui/raw_tag_editor.js
@@ -162,12 +162,12 @@ iD.ui.RawTagEditor = function(context) {
         }
 
         function keyChange(d) {
-            var kOld = d.key.trim(),
+            var kOld = d.key,
                 kNew = this.value.trim(),
                 tag = {};
 
             if (kNew && kNew !== kOld) {
-                var a = kNew.split(/_(\d+)$/),
+                var a = _.compact(kNew.split(/^(.*)_(\d+)$/)),
                     base = a[0],
                     suffix = (a.length > 1) ? parseInt(a[1]): 1;
                 while (tags[kNew]) {  // rename key if already in use


### PR DESCRIPTION
This pull request addresses issue #2043.
- trims extra whitespace from tag keys
- prevents duplicate tag keys

The duplicate check will add a numeric suffix to the tag key (e.g. 'name_1') if a conflict is detected. This is a little friendlier than the old code which just wipes out the existing key-value if the user accidentally tries to enter a tag key that is already used.
