### PR TITLE
Vietnamese address preset

### DIFF
--- a/data/address-formats.json
+++ b/data/address-formats.json
@@ -16,6 +16,6 @@
     },
     {
         "countryCodes": ["vn"],
-        "format": [["housenumber", "street"], ["subdistrict", "district"], ["suburb", "city"], ["province", "postcode"]]
+        "format": [["housenumber", "street"], ["subdistrict"], ["district"], ["city"], ["province", "postcode"]]
     }
 ]


### PR DESCRIPTION
Much of the addresses in Vietnam in OSM are either incomplete or malformed. From a glance at overpass turbo, virtually all them were entered using iD and JOSM, which both present the same address fields. For example:
- [This way](http://www.openstreetmap.org/way/242188595) includes the provincial route number, ward, arrondissement, city, and country in `addr:city`.
- [This POI](http://www.openstreetmap.org/way/248188830) includes the street, ward, and arrondissement in `addr:street`.
- [This POI](http://www.openstreetmap.org/node/2278045527) places the city in `addr:city` but the ward and arrondissement in `addr:postcode`.
- [This way](http://www.openstreetmap.org/way/282224277) makes use of the `name` and `addr:postcode` fields to encode the full housenumber (see the discussion on alleys below).

Most of the remaining addresses simply don’t bother with anything beyond the street, which makes it hard for Nominatim to give decent results in large cities where the third-level administrative boundaries haven’t been mapped and the wards aren’t perfect circles.

The problem stems from the limited number of fields available in iD’s and JOSM’s address presets. Vietnamese addresses in urban areas typically have more components than you’d find in a North American address, for example. So mappers tend to stuff the full address into one of the fields they see. iD can help stem this problem by providing better presets.

Vietnamese address formats are based on the administrative hierarchy, which varies between rural and urban areas. [This org chart](https://vi.wikipedia.org/wiki/T%E1%BA%ADp_tin:PhancaphanhchinhVN.png) shows the relationships between all the officially recognized administrative units in Vietnam. Not all levels need to be included in every given street address, but the order will always go from smallest to largest in the org chart. Based on the existing (well-formed) addresses and [wiki documentation](http://wiki.openstreetmap.org/wiki/Vi:Key:addr), the full tagging scheme for each possible Vietnamese address format would be:
- 123 `housenumber` Street `street`, Ward `subdistrict`, Arrondissement `district`, Municipality `city` 123456 `postcode`
- 123 `housenumber` Street `street`, Ward `subdistrict`, Town `district`, Municipality `city` 123456 `postcode`
- 123 `housenumber` Street `street`, Commune `subdistrict`, Town `district`, Municipality `city` 123456 `postcode`
- 123 `housenumber` Street `street`, Commune `subdistrict`, District `district`, Municipality `city` 123456 `postcode`
- 123 `housenumber` Street `street`, Townlet `subdistrict`, District `district`, Municipality `city` 123456 `postcode`
- 123 `housenumber` Street `street`, Ward `subdistrict`, Town `city`, Province `province` 123456 `postcode`
- 123 `housenumber` Street `street`, Commune `subdistrict`, Town `city`, Province `province` 123456 `postcode`
- 123 `housenumber` Street `street`, Commune `subdistrict`, District `district`, Province `province` 123456 `postcode`
- 123 `housenumber` Street `street`, Townlet `subdistrict`, District `district`, Province `province` 123456 `postcode`
- 123 `housenumber` Street `street`, Ward `subdistrict`, Provincial City `city`, Province `province` 123456 `postcode`
- 123 `housenumber` Street `street`, Commune `subdistrict`, Provincial City `city`, Province `province` 123456 `postcode`

Therefore, I think it makes sense to lay out iD’s address preset like this (with English translations of the Vietnamese translations already in Transifex):

```
housenumber street   # 123 Street
subdistrict          # Ward/Commune/Townlet
district             # Arrondissement/Town/District
city                 # City/Town
province    postcode # Province Postcode
```

Everything is on its own line to ensure that the placeholder text fits at all window sizes. This is also how addresses are written on post in Vietnam.

One caveat is that street addresses on alleys in urban areas include the name of the collector street and any alleys needed to reach the address. For example:
- “[64B Ngõ 51](http://www.openstreetmap.org/way/249675380) Lương Khánh Thiện” lies on Alley 51, Luong Khanh Thien Street.
- The house number sign “[205/39/66](http://www.openstreetmap.org/way/282224277)” is for Number 66 on Alley 39 off Alley 205 off Tran Van Dang Street.

There seems to be no consensus on whether to include the extra alley numbers in `addr:housenumber` or `addr:street`, so I wouldn’t worry about accommodating them for the time being.
