### PR TITLE
Enhancement: Allow user to load incomplete relation members

### DIFF
--- a/js/id/ui/raw_member_editor.js
+++ b/js/id/ui/raw_member_editor.js
@@ -1,7 +1,7 @@
 iD.ui.RawMemberEditor = function(context) {
     var id;
 
-    function downloadMember(d) {
+    function downloadMember() {
         // using interim class to indicate progress
         // need advice on the appropriate class to use
         d3.select(this.parentNode).classed('tag-reference-loading', true);
@@ -75,9 +75,10 @@ iD.ui.RawMemberEditor = function(context) {
                 .classed('member-incomplete', function(d) { return !d.member; });
 
             $enter.each(function(d) {
+                var $label = d3.select(this).append('label');
+
                 if (d.member) {
-                    var $label = d3.select(this).append('label')
-                        .attr('class', 'form-label')
+                    $label.attr('class', 'form-label')
                         .append('a')
                         .attr('href', '#')
                         .on('click', selectMember);
@@ -91,8 +92,7 @@ iD.ui.RawMemberEditor = function(context) {
                         .text(function(d) { return iD.util.displayName(d.member); });
 
                 } else {
-                    var $label = d3.select(this).append('label')
-                        .attr('class', 'form-label')
+                    $label.attr('class', 'form-label')
                         .text(t('inspector.incomplete'));
 
                     var wrap = $label.append('div')

--- a/js/id/ui/raw_member_editor.js
+++ b/js/id/ui/raw_member_editor.js
@@ -1,6 +1,14 @@
 iD.ui.RawMemberEditor = function(context) {
     var id;
 
+    function downloadMember(d) {
+        // using interim class to indicate progress
+        // need advice on the appropriate class to use
+        d3.select(this.parentNode).classed('tag-reference-loading', true);
+        context.connection().loadEntity(id); // discussion: a possible alternative would be to loadEntity(d.id) one at a time.
+        d3.event.preventDefault();
+    }
+
     function selectMember(d) {
         d3.event.preventDefault();
         context.enter(iD.modes.Select(context, [d.id]));
@@ -83,9 +91,19 @@ iD.ui.RawMemberEditor = function(context) {
                         .text(function(d) { return iD.util.displayName(d.member); });
 
                 } else {
-                    d3.select(this).append('label')
+                    var $label = d3.select(this).append('label')
                         .attr('class', 'form-label')
                         .text(t('inspector.incomplete'));
+
+                    var wrap = $label.append('div')
+                        .attr('class', 'form-label-button-wrap');
+
+                    // need advise on the appropriate icon
+                    wrap.append('button')
+                        .attr('tabindex', -1)
+                        .append('div')
+                        .attr('class', 'icon geolocate')
+                        .on('click', downloadMember);
                 }
             });
 

--- a/js/id/ui/raw_member_editor.js
+++ b/js/id/ui/raw_member_editor.js
@@ -75,10 +75,9 @@ iD.ui.RawMemberEditor = function(context) {
                 .classed('member-incomplete', function(d) { return !d.member; });
 
             $enter.each(function(d) {
-                var $label = d3.select(this).append('label');
-
                 if (d.member) {
-                    $label.attr('class', 'form-label')
+                    var $label = d3.select(this).append('label')
+                        .attr('class', 'form-label')
                         .append('a')
                         .attr('href', '#')
                         .on('click', selectMember);
@@ -92,10 +91,11 @@ iD.ui.RawMemberEditor = function(context) {
                         .text(function(d) { return iD.util.displayName(d.member); });
 
                 } else {
-                    $label.attr('class', 'form-label')
+                    var $incomplete_label = d3.select(this).append('label')
+                        .attr('class', 'form-label')
                         .text(t('inspector.incomplete'));
 
-                    var wrap = $label.append('div')
+                    var wrap = $incomplete_label.append('div')
                         .attr('class', 'form-label-button-wrap');
 
                     // need advise on the appropriate icon


### PR DESCRIPTION
**Description**
This enhancement is to enable user to load incomplete relation members, shown as `<not downloaded>` in `iD.ui.RawMemberEditor`.
This is a simple change but enhances the user experience greatly, especially in managing relation entities.

By simply calling `connection.loadEntity(relationId)`, we can fill in the missing related entities (ways / nodes).

![screenshot-01](https://cloud.githubusercontent.com/assets/78585/3547215/a48c8ac8-0892-11e4-90cd-112a38fc45bc.png)

**Demo**
Checkout feature branch [feature:load-incomplete-members](https://github.com/sogko/iD/tree/feature/load-incomplete-members) and edit the following relations to demonstrate typical relation member sizes:
- Singapore's East-West Line (49 relation members)
  [http://localhost:8000/#background=Bing&id=r445764&map=20.00/103.90306/1.31981](http://localhost:8000/#background=Bing&id=r445764&map=20.00/103.90306/1.31981)
- Paris' RER B Train Route (352 relation members)
  [http://localhost:8000/#background=Bing&id=r65074&map=19.00/2.56124/49.00988](http://localhost:8000/#background=Bing&id=r65074&map=19.00/2.56124/49.00988)

**Discussion**
- Impact on performance
  - According to [OSM Wiki](http://wiki.openstreetmap.org/wiki/Relations), relations are not recommended to have more than 300 members. But of course, contributors may choose to ignore this guideline
- Letting user complete one relation member at a time
  - Instead of loading all of the relation members at one time, another possibility would be to load one at a time
  - But currently, there is no hint as to the full content of the incomplete member. In other words, user would only be shown `<not downloaded>` at first and possibly the `role`. The user would have to load each one of them until he/she finds the member that he/she is looking for.
- Placement of button
  - Currently, the enhancement has the button next to the form-label of a member, which might suggest that the action to be taken would only affect one member.
  - A better placement would be somewhere else where it suggests that the action will affect all members. (Like 'Complete All Members' or something to that affect)

**Notes**
- The buttons are currently styled with an interim icon ('geocode'). 
- jshint OK `jshint js/id/ui/raw_member_editor.js`
