### PR TITLE
Fixed chrome selection bug (fixes #2151)

### DIFF
--- a/js/id/behavior/drag.js
+++ b/js/id/behavior/drag.js
@@ -91,6 +91,9 @@ iD.behavior.drag = function() {
             var p = point(),
                 dx = p[0] - origin_[0],
                 dy = p[1] - origin_[1];
+            
+            if (dx === 0 && dy === 0)
+                return;
 
             if (!started) {
                 started = true;


### PR DESCRIPTION
It seems that sometimes Chrome triggers a mousemove event before a click event with webkitMovementX == 0 and webkitMovementY == 0, which causes the behavior described in #2151.

Couldn't find a way to reproduce it on demand, but ignoring these events fixed it.

I've also found a few open bug entries regarding these phantom events in Chromium bug tracker.
