### PR TITLE
Adding "what" word facilitating understanding

### DIFF
--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -389,7 +389,7 @@
         },
         "areas": {
             "title": "Areas",
-            "add": "Areas are a more detailed way to represent features. They provide information on the boundaries of the feature. Areas can be used for most feature types points can be used for, and are often preferred. **Click the Area button to add a new area.**",
+            "add": "Areas are a more detailed way to represent features. They provide information on the boundaries of the feature. Areas can be used for what most feature types points can be used for, and are often preferred. **Click the Area button to add a new area.**",
             "corner": "Areas are drawn by placing nodes that mark the boundary of the area. **Place the starting node on one of the corners of the playground.**",
             "place": "Draw the area by placing more nodes. Finish the area by clicking on the starting node. **Draw an area for the playground.**",
             "search": "**Search for '{name}'.**",


### PR DESCRIPTION
Added word "what" to this sentence: 
"Areas can be used for most feature types points can be used for, and are often preferred."

Now:
"Areas can be used for what most feature types points can be used for, and are often preferred."

It's lot easier to understand. (and probably more correct)
