### PR TITLE
Simple Network field in Road Route relation preset

### DIFF
--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -8360,7 +8360,8 @@
         "name": "Road Route",
         "icon": "route-road",
         "fields": [
-            "ref"
+            "ref",
+            "network"
         ]
     },
     "type/route/train": {

--- a/data/presets/presets/type/route/road.json
+++ b/data/presets/presets/type/route/road.json
@@ -9,6 +9,7 @@
     "name": "Road Route",
     "icon": "route-road",
     "fields": [
-        "ref"
+        "ref",
+        "network"
     ]
 }


### PR DESCRIPTION
This PR just adds a simple Network field to the Road Route relation preset, just like the one in the Bicycle Route and Walking Route relation presets. As explained in #2369, `route=road` is expected to come with a `network` value to disambiguate the `ref` value.
