### PR TITLE
U.S. and Canadian address formats

### DIFF
--- a/data/address-formats.json
+++ b/data/address-formats.json
@@ -25,5 +25,13 @@
     {
         "countryCodes": ["vn"],
         "format": [["housenumber", "street"], ["subdistrict"], ["district"], ["city"], ["province", "postcode"]]
+    },
+    {
+        "countryCodes": ["us"],
+        "format": [["housenumber", "street"], ["city", "state", "postcode"]]
+    },
+    {
+        "countryCodes": ["ca"],
+        "format": [["housenumber", "street"], ["city", "province", "postcode"]]
     }
 ]


### PR DESCRIPTION
In the U.S., iD users keep setting `addr:city` to things like “[Youngstown, Ohio](http://www.openstreetmap.org/node/2647332019/history)” or “[Dublin, OH](http://www.openstreetmap.org/node/2152729301/history)”, or setting `addr:postcode` to things like “[OH 45202](http://www.openstreetmap.org/node/2573293336/history)”, “[OH](http://www.openstreetmap.org/node/392309592/history)”, or “[Ohio](http://www.openstreetmap.org/node/357466455/history)” because Postcode is the only field to the right of City. (It probably doesn’t help that people may be unfamiliar with the Britishism “postcode”, which would be addressed by #2254.)

With this change, U.S. addresses now have a State field corresponding to [`addr:state`](http://wiki.openstreetmap.org/wiki/Key:addr:state#For_countries_using_hamlet.2C_subdistrict.2C_district.2C_province.2C_state) between City and Postcode. I also added Province between City and Postcode for Canadian addresses, since they’re formatted similarly in both English and French.

![U.S. address](https://cloud.githubusercontent.com/assets/1231218/4660919/60ee6534-551d-11e4-88f2-b87d1f0d4fe2.png)
