### PR TITLE
maxlength="255" on commit comment textarea

### DIFF
--- a/js/id/ui/commit.js
+++ b/js/id/ui/commit.js
@@ -41,6 +41,7 @@ iD.ui.Commit = function(context) {
 
         var commentField = commentSection.append('textarea')
             .attr('placeholder', t('commit.description_placeholder'))
+            .attr('maxlength', 255)
             .property('value', context.storage('comment') || '')
             .on('blur.save', function () {
                 context.storage('comment', this.value);


### PR DESCRIPTION
Per API 0.6 limit. Fixes #2410. This attribute is already present in the other place textareas are created, in js/id/ui/preset/textarea.js.
