### PR TITLE
Adding some traffic_calming=* presets

### DIFF
--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -2135,6 +2135,18 @@ en:
       tourism/zoo:
         name: Zoo
         terms: "<translate with synonyms or related terms for 'Zoo', separated by commas>"
+      traffic_calming/bump:
+        name: Speed Bump
+        terms: "<translate with synonyms or related terms for 'Speed Bump', separated by commas>"
+      traffic_calming/hump:
+        name: Speed Hump
+        terms: "<translate with synonyms or related terms for 'Speed Hump', separated by commas>"
+      traffic_calming/rumble_strip:
+        name: Rumble Strip
+        terms: "<translate with synonyms or related terms for 'Rumble Strip', separated by commas>"
+      traffic_calming/table:
+        name: Raised Pedestrian Crossing
+        terms: "<translate with synonyms or related terms for 'Raised Pedestrian Crossing', separated by commas>"
       type/boundary:
         name: Boundary
         terms: "<translate with synonyms or related terms for 'Boundary', separated by commas>"

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -8959,6 +8959,67 @@
         },
         "name": "Zoo"
     },
+    "traffic_calming/bump": {
+        "fields": [
+            "surface"
+        ],
+        "geometry": [
+            "vertex"
+        ],
+        "tags": {
+            "traffic_calming": "bump"
+        },
+        "terms": [
+            "speed hump"
+        ],
+        "name": "Speed Bump"
+    },
+    "traffic_calming/hump": {
+        "fields": [
+            "surface"
+        ],
+        "geometry": [
+            "vertex"
+        ],
+        "tags": {
+            "traffic_calming": "hump"
+        },
+        "terms": [
+            "speed bump"
+        ],
+        "name": "Speed Hump"
+    },
+    "traffic_calming/rumble_strip": {
+        "geometry": [
+            "vertex"
+        ],
+        "tags": {
+            "traffic_calming": "rumble_strip"
+        },
+        "terms": [
+            "sleeper lines",
+            "audible lines",
+            "growlers"
+        ],
+        "name": "Rumble Strip"
+    },
+    "traffic_calming/table": {
+        "fields": [
+            "surface"
+        ],
+        "geometry": [
+            "vertex"
+        ],
+        "tags": {
+            "highway": "crossing",
+            "traffic_calming": "table"
+        },
+        "terms": [
+            "speed table",
+            "flat top hump"
+        ],
+        "name": "Raised Pedestrian Crossing"
+    },
     "type/boundary": {
         "geometry": [
             "relation"

--- a/data/presets/presets/traffic_calming/bump.json
+++ b/data/presets/presets/traffic_calming/bump.json
@@ -1,0 +1,15 @@
+{
+    "fields": [
+        "surface"
+    ],
+    "geometry": [
+        "vertex"
+    ],
+    "tags": {
+        "traffic_calming": "bump"
+    },
+    "terms": [
+        "speed hump"
+    ],
+    "name": "Speed Bump"
+}

--- a/data/presets/presets/traffic_calming/hump.json
+++ b/data/presets/presets/traffic_calming/hump.json
@@ -1,0 +1,15 @@
+{
+    "fields": [
+        "surface"
+    ],
+    "geometry": [
+        "vertex"
+    ],
+    "tags": {
+        "traffic_calming": "hump"
+    },
+    "terms": [
+        "speed bump"
+    ],
+    "name": "Speed Hump"
+}

--- a/data/presets/presets/traffic_calming/rumble_strip.json
+++ b/data/presets/presets/traffic_calming/rumble_strip.json
@@ -1,0 +1,14 @@
+{
+    "geometry": [
+        "vertex"
+    ],
+    "tags": {
+        "traffic_calming": "rumble_strip"
+    },
+    "terms": [
+        "sleeper lines",
+        "audible lines",
+        "growlers"
+    ],
+    "name": "Rumble Strip"
+}

--- a/data/presets/presets/traffic_calming/table.json
+++ b/data/presets/presets/traffic_calming/table.json
@@ -1,0 +1,17 @@
+{
+    "fields": [
+        "surface"
+    ],
+    "geometry": [
+        "vertex"
+    ],
+    "tags": {
+        "highway":"crossing",
+        "traffic_calming": "table"
+    },
+    "terms": [
+        "speed table",
+        "flat top hump"
+    ],
+    "name": "Raised Pedestrian Crossing"
+}

--- a/data/taginfo.json
+++ b/data/taginfo.json
@@ -2096,6 +2096,22 @@
             "value": "zoo"
         },
         {
+            "key": "traffic_calming",
+            "value": "bump"
+        },
+        {
+            "key": "traffic_calming",
+            "value": "hump"
+        },
+        {
+            "key": "traffic_calming",
+            "value": "rumble_strip"
+        },
+        {
+            "key": "traffic_calming",
+            "value": "table"
+        },
+        {
             "key": "type",
             "value": "boundary"
         },

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -3281,6 +3281,22 @@
                 "name": "Zoo",
                 "terms": ""
             },
+            "traffic_calming/bump": {
+                "name": "Speed Bump",
+                "terms": "speed hump"
+            },
+            "traffic_calming/hump": {
+                "name": "Speed Hump",
+                "terms": "speed bump"
+            },
+            "traffic_calming/rumble_strip": {
+                "name": "Rumble Strip",
+                "terms": "sleeper lines,audible lines,growlers"
+            },
+            "traffic_calming/table": {
+                "name": "Raised Pedestrian Crossing",
+                "terms": "speed table,flat top hump"
+            },
             "type/boundary": {
                 "name": "Boundary",
                 "terms": ""


### PR DESCRIPTION
fixes #2400 

Presets being added:
- `traffic_calming=bump`
- `traffic_calming=hump`
- `traffic_calming=table`
- `traffic_calming=rumble_strip`

Quick comments:
- I'm assuming a `traffic_calming=table` always has a pedestrian crossing on it (it is commonly called a "raised pedestrian crossing" after all);
- It would be good to have a icon "bump" in the future.
- When I added `"highway":"crossing"` as the second item in the `"tags":{}` section of the file `data/presets/presets/traffic_calming/table`, the pair `"traffic_calming":"table"` didn't appear in the file `data/taginfo.json`. Is this a bug?
