### PR TITLE
fix dragging nodes by touch

### DIFF
--- a/js/id/behavior/drag.js
+++ b/js/id/behavior/drag.js
@@ -66,7 +66,7 @@ iD.behavior.drag = function() {
             started = false,
             selectEnable = d3_event_userSelectSuppress(touchId !== null ? 'drag-' + touchId : 'drag');
 
-        var w = d3.select(window)
+        var w = d3.select(touchId !== null ? target : window)
             .on(touchId !== null ? 'touchmove.drag-' + touchId : 'mousemove.drag', dragmove)
             .on(touchId !== null ? 'touchend.drag-' + touchId : 'mouseup.drag', dragend, true);
 
@@ -77,7 +77,7 @@ iD.behavior.drag = function() {
             offset = [0, 0];
         }
 
-        if (touchId === null) d3.event.stopPropagation();
+        d3.event.stopPropagation();
 
         function point() {
             var p = target.parentNode || surface;

--- a/js/id/modes/drag_node.js
+++ b/js/id/modes/drag_node.js
@@ -98,13 +98,13 @@ iD.modes.DragNode = function(context) {
         if (nudge) startNudge(nudge);
         else stopNudge();
 
-        var loc = context.map().mouseCoordinates();
+        var loc = context.projection.invert(d3.event.point);
 
         var d = datum();
         if (d.type === 'node' && d.id !== entity.id) {
             loc = d.loc;
         } else if (d.type === 'way' && !d3.select(d3.event.sourceEvent.target).classed('fill')) {
-            loc = iD.geo.chooseEdge(context.childNodes(d), context.mouse(), context.projection).loc;
+            loc = iD.geo.chooseEdge(context.childNodes(d), d3.event.point, context.projection).loc;
         }
 
         context.replace(
@@ -118,7 +118,7 @@ iD.modes.DragNode = function(context) {
         var d = datum();
 
         if (d.type === 'way') {
-            var choice = iD.geo.chooseEdge(context.childNodes(d), context.mouse(), context.projection);
+            var choice = iD.geo.chooseEdge(context.childNodes(d), d3.event.point, context.projection);
             context.replace(
                 iD.actions.AddMidpoint({ loc: choice.loc, edge: [d.nodes[choice.index - 1], d.nodes[choice.index]] }, entity),
                 connectAnnotation(d));


### PR DESCRIPTION
Works in Firefox on Windows Vista and Android 4.4.4. I don't know why, but it doesn't in Chrome on the same OSes. I haven't tested it in other browsers.

There is no multitouch support.
