### PR TITLE
Fix a typo: Confectionary → Confectionery

### DIFF
--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -1019,9 +1019,9 @@ en:
       craft/clockmaker:
         name: Clockmaker
         terms: "<translate with synonyms or related terms for 'Clockmaker', separated by commas>"
-      craft/confectionary:
-        name: Confectionary
-        terms: "<translate with synonyms or related terms for 'Confectionary', separated by commas>"
+      craft/confectionery:
+        name: Confectionery
+        terms: "<translate with synonyms or related terms for 'Confectionery', separated by commas>"
       craft/dressmaker:
         name: Dressmaker
         terms: "<translate with synonyms or related terms for 'Dressmaker', separated by commas>"

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -2749,7 +2749,7 @@
         },
         "name": "Clockmaker"
     },
-    "craft/confectionary": {
+    "craft/confectionery": {
         "icon": "bakery",
         "fields": [
             "operator",
@@ -2766,9 +2766,9 @@
             "candy"
         ],
         "tags": {
-            "craft": "confectionary"
+            "craft": "confectionery"
         },
-        "name": "Confectionary"
+        "name": "Confectionery"
     },
     "craft/dressmaker": {
         "icon": "clothing-store",

--- a/data/presets/presets/craft/confectionery.json
+++ b/data/presets/presets/craft/confectionery.json
@@ -15,7 +15,7 @@
         "candy"
     ],
     "tags": {
-        "craft": "confectionary"
+        "craft": "confectionery"
     },
-    "name": "Confectionary"
+    "name": "Confectionery"
 }

--- a/data/taginfo.json
+++ b/data/taginfo.json
@@ -635,7 +635,7 @@
         },
         {
             "key": "craft",
-            "value": "confectionary"
+            "value": "confectionery"
         },
         {
             "key": "craft",

--- a/dist/locales/ast.json
+++ b/dist/locales/ast.json
@@ -1257,7 +1257,7 @@
                 "name": "Reloxería",
                 "terms": "Reloxeru"
             },
-            "craft/confectionary": {
+            "craft/confectionery": {
                 "name": "Confitería",
                 "terms": "Pastelería, Bollería"
             },

--- a/dist/locales/ca.json
+++ b/dist/locales/ca.json
@@ -1717,7 +1717,7 @@
             "craft/clockmaker": {
                 "name": "Rellotger"
             },
-            "craft/confectionary": {
+            "craft/confectionery": {
                 "name": "Confiteria"
             },
             "craft/dressmaker": {

--- a/dist/locales/cs.json
+++ b/dist/locales/cs.json
@@ -1380,7 +1380,7 @@
                 "name": "Hodinář (ne hodinky)",
                 "terms": "hodinářství,hodinář,hodiny"
             },
-            "craft/confectionary": {
+            "craft/confectionery": {
                 "name": "Cukrář",
                 "terms": "cukrářství,cukrář,cukrovinky,sladkost"
             },

--- a/dist/locales/da.json
+++ b/dist/locales/da.json
@@ -1785,7 +1785,7 @@
                 "name": "Urmager",
                 "terms": "Urmager"
             },
-            "craft/confectionary": {
+            "craft/confectionery": {
                 "name": "Slikbutik",
                 "terms": "Slikbutik, Konfekturebutik"
             },

--- a/dist/locales/de.json
+++ b/dist/locales/de.json
@@ -1790,7 +1790,7 @@
                 "name": "Uhrmacher",
                 "terms": "Uhrmacher"
             },
-            "craft/confectionary": {
+            "craft/confectionery": {
                 "name": "Süßwarengeschäft",
                 "terms": "Süßwarengeschäfts, Konditorei, Konfektladen"
             },

--- a/dist/locales/el.json
+++ b/dist/locales/el.json
@@ -1251,7 +1251,7 @@
                 "name": "Ωρολογοποιός",
                 "terms": "ρολογάς"
             },
-            "craft/confectionary": {
+            "craft/confectionery": {
                 "name": "Ζαχαροπλαστείο",
                 "terms": "ζαχαροπλάστης, ζαχαροπλαστική"
             },

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -1796,8 +1796,8 @@
                 "name": "Clockmaker",
                 "terms": ""
             },
-            "craft/confectionary": {
-                "name": "Confectionary",
+            "craft/confectionery": {
+                "name": "Confectionery",
                 "terms": "sweets,candy"
             },
             "craft/dressmaker": {

--- a/dist/locales/es.json
+++ b/dist/locales/es.json
@@ -1785,7 +1785,7 @@
                 "name": "Relojero",
                 "terms": "relojero, joyero, reloj"
             },
-            "craft/confectionary": {
+            "craft/confectionery": {
                 "name": "Golosinas",
                 "terms": "golosinas, chucherías, caramelos"
             },

--- a/dist/locales/fa.json
+++ b/dist/locales/fa.json
@@ -1333,7 +1333,7 @@
             "craft/clockmaker": {
                 "name": "ساعت سازی"
             },
-            "craft/confectionary": {
+            "craft/confectionery": {
                 "name": "قنادی"
             },
             "craft/dressmaker": {

--- a/dist/locales/fi.json
+++ b/dist/locales/fi.json
@@ -1428,7 +1428,7 @@
             "craft/clockmaker": {
                 "name": "Kelloseppä"
             },
-            "craft/confectionary": {
+            "craft/confectionery": {
                 "name": "Konditoria"
             },
             "craft/dressmaker": {

--- a/dist/locales/fr.json
+++ b/dist/locales/fr.json
@@ -1785,7 +1785,7 @@
                 "name": "Horloger",
                 "terms": "Horloger, Horlogerie"
             },
-            "craft/confectionary": {
+            "craft/confectionery": {
                 "name": "Confiserie",
                 "terms": "Confiserie"
             },

--- a/dist/locales/hr.json
+++ b/dist/locales/hr.json
@@ -1491,7 +1491,7 @@
             "craft/clockmaker": {
                 "name": "Urar (ručni satovi)"
             },
-            "craft/confectionary": {
+            "craft/confectionery": {
                 "name": "Trgovina slatkišima"
             },
             "craft/dressmaker": {

--- a/dist/locales/it.json
+++ b/dist/locales/it.json
@@ -1713,7 +1713,7 @@
                 "name": "Costruttore di orologi",
                 "terms": "orologi"
             },
-            "craft/confectionary": {
+            "craft/confectionery": {
                 "name": "Pasticceria"
             },
             "craft/dressmaker": {

--- a/dist/locales/ja.json
+++ b/dist/locales/ja.json
@@ -1774,7 +1774,7 @@
                 "name": "時計製造所",
                 "terms": "時計製造所"
             },
-            "craft/confectionary": {
+            "craft/confectionery": {
                 "name": "製菓店",
                 "terms": "製菓店"
             },

--- a/dist/locales/lt.json
+++ b/dist/locales/lt.json
@@ -1400,7 +1400,7 @@
             "craft/clockmaker": {
                 "name": "Laikrodininkas"
             },
-            "craft/confectionary": {
+            "craft/confectionery": {
                 "name": "Konditerija"
             },
             "craft/dressmaker": {

--- a/dist/locales/nl.json
+++ b/dist/locales/nl.json
@@ -1503,7 +1503,7 @@
                 "name": "Klokmaker",
                 "terms": "klok, uurwerk"
             },
-            "craft/confectionary": {
+            "craft/confectionery": {
                 "name": "Snoep",
                 "terms": "snoep, zoetwaar, zoetigheid, zoet"
             },

--- a/dist/locales/pl.json
+++ b/dist/locales/pl.json
@@ -1582,7 +1582,7 @@
                 "name": "Zegarmistrz",
                 "terms": "zegarmistrz"
             },
-            "craft/confectionary": {
+            "craft/confectionery": {
                 "name": "Cukiernik"
             },
             "craft/dressmaker": {

--- a/dist/locales/pt-BR.json
+++ b/dist/locales/pt-BR.json
@@ -1789,7 +1789,7 @@
                 "name": "Relojoeiro",
                 "terms": "Relojoeiro"
             },
-            "craft/confectionary": {
+            "craft/confectionery": {
                 "name": "Confeitaria",
                 "terms": "Confeitaria, Doceria, Doçaria"
             },

--- a/dist/locales/pt.json
+++ b/dist/locales/pt.json
@@ -1785,7 +1785,7 @@
                 "name": "Relojoeiro",
                 "terms": "Clockmaker, Relógios"
             },
-            "craft/confectionary": {
+            "craft/confectionery": {
                 "name": "Confeitaria",
                 "terms": "Confectionary, Bolos, Sobremesas"
             },

--- a/dist/locales/ru.json
+++ b/dist/locales/ru.json
@@ -1697,7 +1697,7 @@
                 "name": "Мастерская часовщика",
                 "terms": "часовщик"
             },
-            "craft/confectionary": {
+            "craft/confectionery": {
                 "name": "Мастерская кондитера"
             },
             "craft/dressmaker": {

--- a/dist/locales/sk.json
+++ b/dist/locales/sk.json
@@ -1757,7 +1757,7 @@
                 "name": "Výroba hodín",
                 "terms": "vyroba hodin"
             },
-            "craft/confectionary": {
+            "craft/confectionery": {
                 "name": "Cukrárstvo",
                 "terms": "cukrarstvo,cukrovinky"
             },

--- a/dist/locales/sl.json
+++ b/dist/locales/sl.json
@@ -1750,7 +1750,7 @@
                 "name": "Urar",
                 "terms": "urar,urarstvo,popravljanje ur"
             },
-            "craft/confectionary": {
+            "craft/confectionery": {
                 "name": "Slaščičarstvo",
                 "terms": "slaščice,bonboni,slaščičarna"
             },

--- a/dist/locales/sv.json
+++ b/dist/locales/sv.json
@@ -1785,7 +1785,7 @@
                 "name": "Urmakare (väggur)",
                 "terms": "Urmakare, klockmakare"
             },
-            "craft/confectionary": {
+            "craft/confectionery": {
                 "name": "Konditori",
                 "terms": "konfektyr, godis, godsaker, choklad, Konditori, kondis, sockerbageri, finbageri"
             },

--- a/dist/locales/vi.json
+++ b/dist/locales/vi.json
@@ -1790,7 +1790,7 @@
                 "name": "Xây Đồng hồ",
                 "terms": "thợ đồng hồ, người làm đồng hồ, người xây đồng hồ, tho dong ho, nguoi lam dong ho, nguoi xay dong ho"
             },
-            "craft/confectionary": {
+            "craft/confectionery": {
                 "name": "Mứt kẹo",
                 "terms": "tiệm mứt kẹo, cửa hàng mứt kẹo, tiem mut keo, cua hang mut keo"
             },

--- a/dist/locales/zh-CN.json
+++ b/dist/locales/zh-CN.json
@@ -1552,7 +1552,7 @@
             "craft/clockmaker": {
                 "name": "钟表匠"
             },
-            "craft/confectionary": {
+            "craft/confectionery": {
                 "name": "糖果店"
             },
             "craft/dressmaker": {

--- a/dist/locales/zh-TW.json
+++ b/dist/locales/zh-TW.json
@@ -1791,7 +1791,7 @@
                 "name": "製鐘廠",
                 "terms": "製鐘店"
             },
-            "craft/confectionary": {
+            "craft/confectionery": {
                 "name": "甜品店",
                 "terms": "甜品店"
             },


### PR DESCRIPTION
See [Tag:craft=confectionery](http://wiki.openstreetmap.org/wiki/Tag:craft%3Dconfectionery)
