### PR TITLE
Support for editing a single focused feature at any zoom level

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -63,7 +63,8 @@
         "osmAuth": false,
         "sexagesimal": false,
         "toGeoJSON": false,
-        "marked": false
+        "marked": false,
+        "simplify": false
     },
 
     "env": {

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ dist/iD.js: \
 	js/lib/sexagesimal.js \
 	js/lib/togeojson.js \
 	js/lib/marked.js \
+	js/lib/simplify.js \
 	js/id/start.js \
 	js/id/id.js \
 	js/id/services/*.js \

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -317,6 +317,9 @@ en:
     others:
       description: Others
       tooltip: "Everything Else"
+    focused:
+      description: Focused Feature
+      tooltip: "Feature that is focused via the URL"
   area_fill:
     wireframe:
       description: No Fill (Wireframe)

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -387,6 +387,10 @@
         "others": {
             "description": "Others",
             "tooltip": "Everything Else"
+        },
+        "focused": {
+            "description": "Focused Feature",
+            "tooltip": "Feature that is focused via the URL"
         }
     },
     "area_fill": {

--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
         <script src='js/lib/sexagesimal.js'></script>
         <script src='js/lib/togeojson.js'></script>
         <script src='js/lib/marked.js'></script>
+        <script src='js/lib/simplify.js'></script>
 
         <script src='js/id/id.js'></script>
 

--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@
         <script src='js/id/ui/contributors.js'></script>
         <script src='js/id/ui/help.js'></script>
         <script src='js/id/ui/geolocate.js'></script>
-        <script src='js/id/ui/notice.js'></script>
+        <script src='js/id/ui/zoom_in_to_edit.js'></script>
         <script src='js/id/ui/flash.js'></script>
         <script src='js/id/ui/feature_info.js'></script>
         <script src='js/id/ui/save.js'></script>

--- a/js/id/behavior/hash.js
+++ b/js/id/behavior/hash.js
@@ -66,7 +66,13 @@ iD.behavior.Hash = function(context) {
 
         if (location.hash) {
             var q = iD.util.stringQs(location.hash.substring(1));
-            if (q.id) context.zoomToEntity(q.id.split(',')[0], !q.map);
+            if (q.id) {
+                var entityIDs = q.id.split(',');
+                if (entityIDs.length === 1) {
+                    context.zoomToEntity(entityIDs[0], !q.map);
+                    context.focusedID(entityIDs[0]);
+                }
+            }
             if (q.comment) context.storage('comment', q.comment);
             hashchange();
             if (q.map) hash.hadHash = true;

--- a/js/id/id.js
+++ b/js/id/id.js
@@ -219,6 +219,13 @@ window.iD = function () {
         }
     };
 
+    var focusedID;
+    context.focusedID = function(_) {
+        if (!arguments.length) return focusedID;
+        focusedID = _;
+        return context;
+    };
+
     /* Behaviors */
     context.install = function(behavior) {
         context.surface().call(behavior);

--- a/js/id/renderer/features.js
+++ b/js/id/renderer/features.js
@@ -66,7 +66,7 @@ iD.Features = function(context) {
             defaultMax: (max || Infinity),
             enable: function() { this.enabled = true; this.currentMax = this.defaultMax; },
             disable: function() { this.enabled = false; this.currentMax = 0; },
-            hidden: function() { return !context.editable() || this.count > this.currentMax * _cullFactor; },
+            hidden: function() { return (k !== 'focused' && !context.editable()) || this.count > this.currentMax * _cullFactor; },
             autoHidden: function() { return this.hidden() && this.currentMax > 0; }
         };
     }
@@ -162,6 +162,10 @@ iD.Features = function(context) {
         return (geometry === 'line' || geometry === 'area');
     });
 
+    // Features selected via the URL hash.
+    defineFeature('focused', function(entity) {
+        return entity.id === context.focusedID();
+    });
 
     function features() {}
 
@@ -170,7 +174,7 @@ iD.Features = function(context) {
     };
 
     features.keys = function() {
-        return _keys;
+        return context.focusedID() ? _keys : _.without(_keys, 'focused');
     };
 
     features.enabled = function(k) {
@@ -398,6 +402,7 @@ iD.Features = function(context) {
     features.isHidden = function(entity, resolver, geometry) {
         if (!_hidden.length) return false;
         if (!entity.version) return false;
+        if (features.isFocusedFeature(entity)) return false;
 
         var fn = (geometry === 'vertex' ? features.isHiddenChild : features.isHiddenFeature);
         return fn(entity, resolver, geometry);
@@ -414,6 +419,10 @@ iD.Features = function(context) {
             }
         }
         return result;
+    };
+
+    features.isFocusedFeature = function(entity) {
+        return entity.id === context.focusedID() && _features.focused && _features.focused.enabled;
     };
 
     return d3.rebind(features, dispatch, 'on');

--- a/js/id/renderer/features.js
+++ b/js/id/renderer/features.js
@@ -402,7 +402,7 @@ iD.Features = function(context) {
     features.isHidden = function(entity, resolver, geometry) {
         if (!_hidden.length) return false;
         if (!entity.version) return false;
-        if (features.isFocusedFeature(entity)) return false;
+        if (features.isFocusedFeature(entity, resolver, geometry)) return false;
 
         var fn = (geometry === 'vertex' ? features.isHiddenChild : features.isHiddenFeature);
         return fn(entity, resolver, geometry);
@@ -421,8 +421,20 @@ iD.Features = function(context) {
         return result;
     };
 
-    features.isFocusedFeature = function(entity) {
-        return entity.id === context.focusedID() && _features.focused && _features.focused.enabled;
+    features.isFocusedFeature = function(entity, resolver, geometry) {
+        var focusedID = context.focusedID();
+
+        if (!_features.focused || !_features.focused.enabled) return false;
+        if (entity.id === focusedID) return true;
+
+        var parents = features.getParents(entity, resolver, geometry);
+        for (var i = 0; i < parents.length; i++) {
+            if (parents[i].id === focusedID) {
+                return true;
+            }
+        }
+
+        return false;
     };
 
     return d3.rebind(features, dispatch, 'on');

--- a/js/id/renderer/map.js
+++ b/js/id/renderer/map.js
@@ -14,8 +14,8 @@ iD.Map = function(context) {
         minzoom = 0,
         points = iD.svg.Points(projection, context),
         vertices = iD.svg.Vertices(projection, context),
-        lines = iD.svg.Lines(projection),
-        areas = iD.svg.Areas(projection),
+        lines = iD.svg.Lines(projection, context),
+        areas = iD.svg.Areas(projection, context),
         midpoints = iD.svg.Midpoints(projection, context),
         labels = iD.svg.Labels(projection, context),
         supersurface, surface,
@@ -139,12 +139,6 @@ iD.Map = function(context) {
         dispatch.drawn({full: true});
     }
 
-    function editOff() {
-        context.features().resetStats();
-        surface.selectAll('.layer *').remove();
-        dispatch.drawn({full: true});
-    }
-
     function dblClick() {
         if (!dblclickEnabled) {
             d3.event.preventDefault();
@@ -208,12 +202,11 @@ iD.Map = function(context) {
             supersurface.call(context.background());
         }
 
-        if (map.editable()) {
+        if (map.zoom() >= context.minEditableZoom()) {
             context.loadTiles(projection, dimensions);
-            drawVector(difference, extent);
-        } else {
-            editOff();
         }
+
+        drawVector(difference, extent);
 
         transformStart = [
             projection.scale() * 2 * Math.PI,
@@ -383,7 +376,7 @@ iD.Map = function(context) {
         if (!isFinite(extent.area())) return;
 
         var zoom = map.trimmedExtentZoom(extent);
-        zoomLimits = zoomLimits || [context.minEditableZoom(), 20];
+        zoomLimits = zoomLimits || [0, 20];
         map.centerZoom(extent.center(), Math.min(Math.max(zoom, zoomLimits[0]), zoomLimits[1]));
     };
 

--- a/js/id/svg/areas.js
+++ b/js/id/svg/areas.js
@@ -1,4 +1,4 @@
-iD.svg.Areas = function(projection) {
+iD.svg.Areas = function(projection, context) {
     // Patterns only work in Firefox when set directly on element.
     // (This is not a bug: https://bugzilla.mozilla.org/show_bug.cgi?id=750632)
     var patterns = {
@@ -28,7 +28,8 @@ iD.svg.Areas = function(projection) {
     }
 
     return function drawAreas(surface, graph, entities, filter) {
-        var path = iD.svg.Path(projection, graph, true),
+        var simplify = !context.map().editable(),
+            path = iD.svg.Path(projection, graph, true, simplify),
             areas = {},
             multipolygon;
 

--- a/js/id/svg/lines.js
+++ b/js/id/svg/lines.js
@@ -1,4 +1,4 @@
-iD.svg.Lines = function(projection) {
+iD.svg.Lines = function(projection, context) {
 
     var highway_stack = {
         motorway: 0,
@@ -25,7 +25,8 @@ iD.svg.Lines = function(projection) {
 
     return function drawLines(surface, graph, entities, filter) {
         var ways = [], pathdata = {}, onewaydata = {},
-            getPath = iD.svg.Path(projection, graph);
+            simplify = !context.map().editable(),
+            getPath = iD.svg.Path(projection, graph, false, simplify);
 
         for (var i = 0; i < entities.length; i++) {
             var entity = entities[i],

--- a/js/id/svg/vertices.js
+++ b/js/id/svg/vertices.js
@@ -12,7 +12,7 @@ iD.svg.Vertices = function(projection, context) {
         var vertices = {};
 
         function addChildVertices(entity) {
-            if (!context.features().isHiddenFeature(entity, graph, entity.geometry(graph))) {
+            if (!context.features().isHiddenFeature(entity, graph, entity.geometry(graph)) && context.map().editable()) {
                 var i;
                 if (entity.type === 'way') {
                     for (i = 0; i < entity.nodes.length; i++) {
@@ -156,8 +156,9 @@ iD.svg.Vertices = function(projection, context) {
                 continue;
 
             if (entity.id in selected ||
-                entity.hasInterestingTags() ||
-                entity.isIntersection(graph)) {
+                (context.map().editable() &&
+                (entity.hasInterestingTags() ||
+                 entity.isIntersection(graph)))) {
                 vertices.push(entity);
             }
         }

--- a/js/id/ui.js
+++ b/js/id/ui.js
@@ -49,8 +49,12 @@ iD.ui = function(context) {
             .attr('class', 'limiter');
 
         limiter.append('div')
+            .attr('class', 'button-wrap col3')
+            .call(iD.ui.ZoomInToEdit(context));
+
+        limiter.append('div')
             .attr('class', 'button-wrap joined col3')
-            .call(iD.ui.Modes(context), limiter);
+            .call(iD.ui.Modes(context));
 
         limiter.append('div')
             .attr('class', 'button-wrap joined col1')

--- a/js/id/ui/feature_list.js
+++ b/js/id/ui/feature_list.js
@@ -228,8 +228,7 @@ iD.ui.FeatureList = function(context) {
             d3.event.preventDefault();
             if (d.location) {
                 context.map().centerZoom([d.location[1], d.location[0]], 20);
-            }
-            else if (d.entity) {
+            } else if (d.entity) {
                 if (d.entity.type === 'node') {
                     context.map().center(d.entity.loc);
                 } else if (d.entity.type === 'way') {
@@ -240,6 +239,7 @@ iD.ui.FeatureList = function(context) {
                 context.enter(iD.modes.Select(context, [d.entity.id]).suppressMenu(true));
             } else {
                 context.zoomToEntity(d.id);
+                context.focusedID(d.id);
             }
         }
 

--- a/js/id/ui/map_data.js
+++ b/js/id/ui/map_data.js
@@ -1,6 +1,5 @@
 iD.ui.MapData = function(context) {
     var key = 'F',
-        features = context.features().keys(),
         fills = ['wireframe', 'partial', 'full'],
         fillDefault = context.storage('area-fill') || 'partial',
         fillSelected = fillDefault;
@@ -58,8 +57,16 @@ iD.ui.MapData = function(context) {
                 .call(bootstrap.tooltip()
                     .html(true)
                     .title(function(d) {
-                        var tip = t(name + '.' + d + '.tooltip'),
-                            key = (d === 'wireframe' ? 'W' : null);
+                        var key,
+                            tip = t(name + '.' + d + '.tooltip');
+                        if (d === 'focused') {
+                            var focusedEntity = context.entity(context.focusedID());
+                            var displayName = iD.util.displayName(focusedEntity);
+                            if (displayName) {
+                                tip = displayName;
+                            }
+                        }
+                        key = (d === 'wireframe' ? 'W' : null);
 
                         if (name === 'feature' && autoHiddenFeature(d)) {
                             tip += '<div>' + t('map_data.autohidden') + '</div>';
@@ -94,7 +101,7 @@ iD.ui.MapData = function(context) {
         }
 
         function update() {
-            featureList.call(drawList, features, 'checkbox', 'feature', clickFeature, showsFeature);
+            featureList.call(drawList, context.features().keys(), 'checkbox', 'feature', clickFeature, showsFeature);
             fillList.call(drawList, fills, 'radio', 'area_fill', setFill, showsFill);
 
             var hasGpx = context.background().hasGpxLayer(),

--- a/js/id/ui/modes.js
+++ b/js/id/ui/modes.js
@@ -4,10 +4,6 @@ iD.ui.Modes = function(context) {
         iD.modes.AddLine(context),
         iD.modes.AddArea(context)];
 
-    function editable() {
-        return context.editable() && context.mode().id !== 'save';
-    }
-
     return function(selection) {
         var buttons = selection.selectAll('button.add-button')
             .data(modes);
@@ -58,14 +54,19 @@ iD.ui.Modes = function(context) {
         var keybinding = d3.keybinding('mode-buttons');
 
         modes.forEach(function(m) {
-            keybinding.on(m.key, function() { if (editable()) context.enter(m); });
+            keybinding.on(m.key, function() {
+                if (context.editable() && context.mode().id !== 'save') {
+                    context.enter(m);
+                }
+            });
         });
 
         d3.select(document)
             .call(keybinding);
 
         function update() {
-            buttons.property('disabled', !editable());
+            selection.style('display', context.editable() ? '' : 'none');
+            buttons.property('disabled', context.mode().id === 'save');
         }
     };
 };

--- a/js/id/ui/sidebar.js
+++ b/js/id/ui/sidebar.js
@@ -7,8 +7,6 @@ iD.ui.Sidebar = function(context) {
             .attr('class', 'feature-list-pane')
             .call(iD.ui.FeatureList(context));
 
-        selection.call(iD.ui.Notice(context));
-
         var inspectorWrap = selection.append('div')
             .attr('class', 'inspector-hidden inspector-wrap fr');
 

--- a/js/id/ui/zoom_in_to_edit.js
+++ b/js/id/ui/zoom_in_to_edit.js
@@ -1,10 +1,7 @@
-iD.ui.Notice = function(context) {
+iD.ui.ZoomInToEdit = function(context) {
     return function(selection) {
-        var div = selection.append('div')
-            .attr('class', 'notice');
-
-        var button = div.append('button')
-            .attr('class', 'zoom-to notice')
+        var button = selection.append('button')
+            .attr('class', 'zoom-to')
             .on('click', function() { context.map().zoom(context.minEditableZoom()); });
 
         button
@@ -14,7 +11,7 @@ iD.ui.Notice = function(context) {
             .text(t('zoom_in_edit'));
 
         function disableTooHigh() {
-            div.style('display', context.editable() ? 'none' : 'block');
+            selection.style('display', context.editable() ? 'none' : '');
         }
 
         context.map()

--- a/js/lib/simplify.js
+++ b/js/lib/simplify.js
@@ -1,0 +1,132 @@
+/*
+ (c) 2013, Vladimir Agafonkin
+ Simplify.js, a high-performance JS polyline simplification library
+ mourner.github.io/simplify-js
+*/
+
+(function () { 'use strict';
+
+// to suit your point format, run search/replace for '.x' and '.y';
+// for 3D version, see 3d branch (configurability would draw significant performance overhead)
+
+// square distance between 2 points
+function getSqDist(p1, p2) {
+
+    var dx = p1[0] - p2[0],
+        dy = p1[1] - p2[1];
+
+    return dx * dx + dy * dy;
+}
+
+// square distance from a point to a segment
+function getSqSegDist(p, p1, p2) {
+
+    var x = p1[0],
+        y = p1[1],
+        dx = p2[0] - x,
+        dy = p2[1] - y;
+
+    if (dx !== 0 || dy !== 0) {
+
+        var t = ((p[0] - x) * dx + (p[1] - y) * dy) / (dx * dx + dy * dy);
+
+        if (t > 1) {
+            x = p2[0];
+            y = p2[1];
+
+        } else if (t > 0) {
+            x += dx * t;
+            y += dy * t;
+        }
+    }
+
+    dx = p[0] - x;
+    dy = p[1] - y;
+
+    return dx * dx + dy * dy;
+}
+// rest of the code doesn't care about point format
+
+// basic distance-based simplification
+function simplifyRadialDist(points, sqTolerance) {
+
+    var prevPoint = points[0],
+        newPoints = [prevPoint],
+        point;
+
+    for (var i = 1, len = points.length; i < len; i++) {
+        point = points[i];
+
+        if (getSqDist(point, prevPoint) > sqTolerance) {
+            newPoints.push(point);
+            prevPoint = point;
+        }
+    }
+
+    if (prevPoint !== point) newPoints.push(point);
+
+    return newPoints;
+}
+
+// simplification using optimized Douglas-Peucker algorithm with recursion elimination
+function simplifyDouglasPeucker(points, sqTolerance) {
+
+    var len = points.length,
+        MarkerArray = typeof Uint8Array !== 'undefined' ? Uint8Array : Array,
+        markers = new MarkerArray(len),
+        first = 0,
+        last = len - 1,
+        stack = [],
+        newPoints = [],
+        i, maxSqDist, sqDist, index;
+
+    markers[first] = markers[last] = 1;
+
+    while (last) {
+
+        maxSqDist = 0;
+
+        for (i = first + 1; i < last; i++) {
+            sqDist = getSqSegDist(points[i], points[first], points[last]);
+
+            if (sqDist > maxSqDist) {
+                index = i;
+                maxSqDist = sqDist;
+            }
+        }
+
+        if (maxSqDist > sqTolerance) {
+            markers[index] = 1;
+            stack.push(first, index, index, last);
+        }
+
+        last = stack.pop();
+        first = stack.pop();
+    }
+
+    for (i = 0; i < len; i++) {
+        if (markers[i]) newPoints.push(points[i]);
+    }
+
+    return newPoints;
+}
+
+// both algorithms combined for awesome performance
+function simplify(points, tolerance, highestQuality) {
+    if (points.length <= 1) return points;
+
+    var sqTolerance = tolerance !== undefined ? tolerance * tolerance : 1;
+
+    points = highestQuality ? points : simplifyRadialDist(points, sqTolerance);
+    points = simplifyDouglasPeucker(points, sqTolerance);
+
+    return points;
+}
+
+// export as AMD module / Node module / browser or worker variable
+if (typeof define === 'function' && define.amd) define(function() { return simplify; });
+else if (typeof module !== 'undefined') module.exports = simplify;
+else if (typeof self !== 'undefined') self.simplify = simplify;
+else window.simplify = simplify;
+
+})();

--- a/test/index.html
+++ b/test/index.html
@@ -91,7 +91,7 @@
     <script src='../js/id/ui/modes.js'></script>
     <script src='../js/id/ui/contributors.js'></script>
     <script src='../js/id/ui/geolocate.js'></script>
-    <script src='../js/id/ui/notice.js'></script>
+    <script src='../js/id/ui/zoom_in_to_edit.js'></script>
     <script src='../js/id/ui/flash.js'></script>
     <script src='../js/id/ui/feature_info.js'></script>
     <script src='../js/id/ui/save.js'></script>

--- a/test/index.html
+++ b/test/index.html
@@ -35,6 +35,7 @@
     <script src='../js/lib/rbush.js'></script>
     <script src='../js/lib/togeojson.js'></script>
     <script src='../js/lib/osmauth.js'></script>
+    <script src='../js/lib/simplify.js'></script>
 
     <script src='../js/id/id.js'></script>
     <script src='../js/id/util.js'></script>

--- a/test/spec/behavior/select.js
+++ b/test/spec/behavior/select.js
@@ -4,7 +4,7 @@ describe("iD.behavior.Select", function() {
     beforeEach(function() {
         container = d3.select('body').append('div');
 
-        context = iD().imagery(iD.data.imagery).container(container);
+        context = iD().presets(iD.data.presets).imagery(iD.data.imagery).container(container);
 
         a = iD.Node({loc: [0, 0]});
         b = iD.Node({loc: [0, 0]});

--- a/test/spec/renderer/features.js
+++ b/test/spec/renderer/features.js
@@ -542,4 +542,13 @@ describe('iD.Features', function() {
         });
     });
 
+    it('focused feature filter if a focused ID', function() {
+        context.focusedID('w16');
+
+        var keys = features.keys(),
+            hidden = features.hidden();
+
+        expect(keys).to.include('focused');
+        expect(hidden).not.to.include('focused');
+    });
 });

--- a/test/spec/svg/areas.js
+++ b/test/spec/svg/areas.js
@@ -1,11 +1,13 @@
 describe("iD.svg.Areas", function () {
     var surface,
+        context,
         projection = d3.geo.projection(function(x, y) { return [x, y]; })
             .clipExtent([[0, 0], [Infinity, Infinity]]),
         all = d3.functor(true),
         none = d3.functor(false);
 
     beforeEach(function () {
+        context = iD().presets(iD.data.presets);
         surface = d3.select(document.createElementNS('http://www.w3.org/2000/svg', 'svg'))
             .call(iD.svg.Surface(iD()));
     });
@@ -19,7 +21,7 @@ describe("iD.svg.Areas", function () {
                 iD.Way({id: 'w', tags: {building: 'yes'}, nodes: ['a', 'b', 'c', 'a']})
             ]);
 
-        surface.call(iD.svg.Areas(projection), graph, [graph.entity('w')], none);
+        surface.call(iD.svg.Areas(projection, context), graph, [graph.entity('w')], none);
 
         expect(surface.select('path.way')).to.be.classed('way');
         expect(surface.select('path.area')).to.be.classed('area');
@@ -34,7 +36,7 @@ describe("iD.svg.Areas", function () {
                 iD.Way({id: 'w', tags: {building: 'yes'}, nodes: ['a', 'b', 'c', 'a']})
             ]);
 
-        surface.call(iD.svg.Areas(projection), graph, [graph.entity('w')], none);
+        surface.call(iD.svg.Areas(projection, context), graph, [graph.entity('w')], none);
 
         expect(surface.select('.area')).to.be.classed('tag-building');
         expect(surface.select('.area')).to.be.classed('tag-building-yes');
@@ -50,10 +52,10 @@ describe("iD.svg.Areas", function () {
                 iD.Way({id: 'x', tags: {area: 'yes'}, nodes: ['a', 'b', 'd', 'a']})
             ]);
 
-        surface.call(iD.svg.Areas(projection), graph, [graph.entity('x')], all);
+        surface.call(iD.svg.Areas(projection, context), graph, [graph.entity('x')], all);
         graph = graph.remove(graph.entity('x')).remove(graph.entity('d'));
 
-        surface.call(iD.svg.Areas(projection), graph, [graph.entity('w')], all);
+        surface.call(iD.svg.Areas(projection, context), graph, [graph.entity('w')], all);
         expect(surface.select('.area').size()).to.equal(1);
     });
 
@@ -72,30 +74,30 @@ describe("iD.svg.Areas", function () {
             ]);
 
         it("stacks smaller areas above larger ones in a single render", function () {
-            surface.call(iD.svg.Areas(projection), graph, [graph.entity('s'), graph.entity('l')], none);
+            surface.call(iD.svg.Areas(projection, context), graph, [graph.entity('s'), graph.entity('l')], none);
 
             expect(surface.select('.area:nth-child(1)')).to.be.classed('tag-landuse-park');
             expect(surface.select('.area:nth-child(2)')).to.be.classed('tag-building-yes');
         });
 
         it("stacks smaller areas above larger ones in a single render (reverse)", function () {
-            surface.call(iD.svg.Areas(projection), graph, [graph.entity('l'), graph.entity('s')], none);
+            surface.call(iD.svg.Areas(projection, context), graph, [graph.entity('l'), graph.entity('s')], none);
 
             expect(surface.select('.area:nth-child(1)')).to.be.classed('tag-landuse-park');
             expect(surface.select('.area:nth-child(2)')).to.be.classed('tag-building-yes');
         });
 
         it("stacks smaller areas above larger ones in separate renders", function () {
-            surface.call(iD.svg.Areas(projection), graph, [graph.entity('s')], none);
-            surface.call(iD.svg.Areas(projection), graph, [graph.entity('l')], none);
+            surface.call(iD.svg.Areas(projection, context), graph, [graph.entity('s')], none);
+            surface.call(iD.svg.Areas(projection, context), graph, [graph.entity('l')], none);
 
             expect(surface.select('.area:nth-child(1)')).to.be.classed('tag-landuse-park');
             expect(surface.select('.area:nth-child(2)')).to.be.classed('tag-building-yes');
         });
 
         it("stacks smaller areas above larger ones in separate renders (reverse)", function () {
-            surface.call(iD.svg.Areas(projection), graph, [graph.entity('l')], none);
-            surface.call(iD.svg.Areas(projection), graph, [graph.entity('s')], none);
+            surface.call(iD.svg.Areas(projection, context), graph, [graph.entity('l')], none);
+            surface.call(iD.svg.Areas(projection, context), graph, [graph.entity('s')], none);
 
             expect(surface.select('.area:nth-child(1)')).to.be.classed('tag-landuse-park');
             expect(surface.select('.area:nth-child(2)')).to.be.classed('tag-building-yes');
@@ -111,7 +113,7 @@ describe("iD.svg.Areas", function () {
             graph = iD.Graph([a, b, c, w, r]),
             areas = [w, r];
 
-        surface.call(iD.svg.Areas(projection), graph, areas, none);
+        surface.call(iD.svg.Areas(projection, context), graph, areas, none);
 
         expect(surface.select('.fill')).to.be.classed('relation');
     });
@@ -125,7 +127,7 @@ describe("iD.svg.Areas", function () {
             graph = iD.Graph([a, b, c, w, r]),
             areas = [w, r];
 
-        surface.call(iD.svg.Areas(projection), graph, areas, none);
+        surface.call(iD.svg.Areas(projection, context), graph, areas, none);
 
         expect(surface.selectAll('.stroke')[0].length).to.equal(0);
     });
@@ -138,7 +140,7 @@ describe("iD.svg.Areas", function () {
             r = iD.Relation({members: [{id: w.id, type: 'way'}], tags: {type: 'multipolygon'}}),
             graph = iD.Graph([a, b, c, w, r]);
 
-        surface.call(iD.svg.Areas(projection), graph, [w, r], none);
+        surface.call(iD.svg.Areas(projection, context), graph, [w, r], none);
 
         expect(surface.selectAll('.way.fill')[0].length).to.equal(0);
         expect(surface.selectAll('.relation.fill')[0].length).to.equal(1);
@@ -153,8 +155,46 @@ describe("iD.svg.Areas", function () {
             r = iD.Relation({members: [{id: w.id, type: 'way'}], tags: {type: 'multipolygon'}}),
             graph = iD.Graph([a, b, c, w, r]);
 
-        surface.call(iD.svg.Areas(projection), graph, [w, r], none);
+        surface.call(iD.svg.Areas(projection, context), graph, [w, r], none);
 
         expect(surface.selectAll('.stroke')[0].length).to.equal(0);
+    });
+
+    it("simplifies the polygon if the map is not editable", function() {
+        var graph = iD.Graph([
+                iD.Node({id: '1', loc: [0, 0]}),
+                iD.Node({id: '2', loc: [0, 0]}),
+                iD.Node({id: '3', loc: [0, 0]}),
+                iD.Node({id: '4', loc: [0, 0]}),
+                iD.Node({id: '5', loc: [1, 1]}),
+                iD.Node({id: '6', loc: [1, 1]}),
+                iD.Node({id: '7', loc: [1, 1]}),
+                iD.Node({id: '8', loc: [1, 1]}),
+                iD.Node({id: '9', loc: [0, 1]}),
+                iD.Node({id: '10', loc: [0, 1]}),
+                iD.Node({id: '11', loc: [0, 1]}),
+                iD.Node({id: '12', loc: [0, 1]}),
+                iD.Way({id: 'w', tags: {building: 'yes'}, nodes: ['1', '2', '3', '4', '5', '6', '7',
+                    '8', '9', '10', '11', '12', '1']})
+            ]);
+
+        context.map().zoom(context.minEditableZoom() - 1);
+        surface.call(iD.svg.Areas(projection, context), graph, [graph.entity('w')], none);
+
+        expect(surface.select('path.way.stroke').attr('d').split(',').length).to.equal(9);
+    });
+
+    it("no simplification if the map is editable", function() {
+        var graph = iD.Graph([
+                iD.Node({id: '1', loc: [0, 0]}),
+                iD.Node({id: '2', loc: [1, 1]}),
+                iD.Node({id: '3', loc: [0, 1]}),
+                iD.Way({id: 'w', tags: {building: 'yes'}, nodes: ['1', '2', '3', '1']})
+            ]);
+
+            context.map().zoom(context.minEditableZoom());
+            surface.call(iD.svg.Areas(projection, context), graph, [graph.entity('w')], none);
+
+            expect(surface.select('path.way.stroke').attr('d').split(',').length).to.equal(25);
     });
 });

--- a/test/spec/svg/lines.js
+++ b/test/spec/svg/lines.js
@@ -1,11 +1,13 @@
 describe("iD.svg.Lines", function () {
     var surface,
+        context,
         projection = d3.geo.projection(function(x, y) { return [x, y]; })
             .clipExtent([[0, 0], [Infinity, Infinity]]),
         all = d3.functor(true),
         none = d3.functor(false);
 
     beforeEach(function () {
+        context = iD().presets(iD.data.presets);
         surface = d3.select(document.createElementNS('http://www.w3.org/2000/svg', 'svg'))
             .call(iD.svg.Surface(iD()));
     });
@@ -16,7 +18,7 @@ describe("iD.svg.Lines", function () {
             line = iD.Way({nodes: [a.id, b.id]}),
             graph = iD.Graph([a, b, line]);
 
-        surface.call(iD.svg.Lines(projection), graph, [line], all);
+        surface.call(iD.svg.Lines(projection, context), graph, [line], all);
 
         expect(surface.select('path.way')).to.be.classed('way');
         expect(surface.select('path.line')).to.be.classed('line');
@@ -28,7 +30,7 @@ describe("iD.svg.Lines", function () {
             line = iD.Way({nodes: [a.id, b.id], tags: {highway: 'residential'}}),
             graph = iD.Graph([a, b, line]);
 
-        surface.call(iD.svg.Lines(projection), graph, [line], all);
+        surface.call(iD.svg.Lines(projection, context), graph, [line], all);
 
         expect(surface.select('.line')).to.be.classed('tag-highway');
         expect(surface.select('.line')).to.be.classed('tag-highway-residential');
@@ -41,7 +43,7 @@ describe("iD.svg.Lines", function () {
             relation = iD.Relation({members: [{id: line.id}], tags: {type: 'multipolygon', natural: 'wood'}}),
             graph = iD.Graph([a, b, line, relation]);
 
-        surface.call(iD.svg.Lines(projection), graph, [line], all);
+        surface.call(iD.svg.Lines(projection, context), graph, [line], all);
 
         expect(surface.select('.stroke')).to.be.classed('tag-natural-wood');
     });
@@ -54,7 +56,7 @@ describe("iD.svg.Lines", function () {
             r = iD.Relation({members: [{id: w.id}], tags: {type: 'multipolygon'}}),
             graph = iD.Graph([a, b, c, w, r]);
 
-        surface.call(iD.svg.Lines(projection), graph, [w], all);
+        surface.call(iD.svg.Lines(projection, context), graph, [w], all);
 
         expect(surface.select('.stroke')).to.be.classed('tag-natural-wood');
     });
@@ -68,9 +70,59 @@ describe("iD.svg.Lines", function () {
             r = iD.Relation({members: [{id: o.id, role: 'outer'}, {id: i.id, role: 'inner'}], tags: {type: 'multipolygon'}}),
             graph = iD.Graph([a, b, c, o, i, r]);
 
-        surface.call(iD.svg.Lines(projection), graph, [i], all);
+        surface.call(iD.svg.Lines(projection, context), graph, [i], all);
 
         expect(surface.select('.stroke')).to.be.classed('tag-natural-wood');
+    });
+
+    it("simplify line if map is not editable", function() {
+        var graph = iD.Graph([
+                iD.Node({id: 'a', loc: [0, 0]}),
+                iD.Node({id: 'b', loc: [0, 0]}),
+                iD.Node({id: 'c', loc: [0, 0]}),
+                iD.Node({id: 'd', loc: [0, 0]}),
+                iD.Node({id: 'e', loc: [1, 1]}),
+                iD.Node({id: 'f', loc: [1, 1]}),
+                iD.Node({id: 'g', loc: [1, 1]}),
+                iD.Node({id: 'h', loc: [1, 1]}),
+                iD.Node({id: 'i', loc: [0, 0]}),
+                iD.Node({id: 'j', loc: [1, 1]}),
+                iD.Node({id: 'k', loc: [1, 1]}),
+                iD.Node({id: 'l', loc: [1, 1]}),
+                iD.Node({id: 'm', loc: [1, 1]}),
+                iD.Way({id: 'w', tags: {highway: 'residential'}, nodes: ['a', 'b', 'c',
+                    'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm']})
+            ]);
+
+        context.map().zoom(context.minEditableZoom() - 1);
+        surface.call(iD.svg.Lines(projection, context), graph, [graph.entity('w')], all);
+
+        expect(surface.select('path.line.stroke').attr('d').split(',').length).to.equal(3);
+    });
+
+    it("no simplification if map is editable", function() {
+        var graph = iD.Graph([
+                iD.Node({id: 'a', loc: [0, 0]}),
+                iD.Node({id: 'b', loc: [0, 0]}),
+                iD.Node({id: 'c', loc: [0, 0]}),
+                iD.Node({id: 'd', loc: [0, 0]}),
+                iD.Node({id: 'e', loc: [1, 1]}),
+                iD.Node({id: 'f', loc: [1, 1]}),
+                iD.Node({id: 'g', loc: [1, 1]}),
+                iD.Node({id: 'h', loc: [1, 1]}),
+                iD.Node({id: 'i', loc: [0, 0]}),
+                iD.Node({id: 'j', loc: [1, 1]}),
+                iD.Node({id: 'k', loc: [1, 1]}),
+                iD.Node({id: 'l', loc: [1, 1]}),
+                iD.Node({id: 'm', loc: [1, 1]}),
+                iD.Way({id: 'w', tags: {highway: 'residential'}, nodes: ['a', 'b', 'c',
+                    'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm']})
+            ]);
+
+        context.map().zoom(context.minEditableZoom());
+        surface.call(iD.svg.Lines(projection, context), graph, [graph.entity('w')], all);
+
+        expect(surface.select('path.line.stroke').attr('d').split(',').length).to.equal(14);
     });
 
     describe("z-indexing", function() {
@@ -84,7 +136,7 @@ describe("iD.svg.Lines", function () {
             ]);
 
         it("stacks higher lines above lower ones in a single render", function () {
-            surface.call(iD.svg.Lines(projection), graph, [graph.entity('lo'), graph.entity('hi')], none);
+            surface.call(iD.svg.Lines(projection, context), graph, [graph.entity('lo'), graph.entity('hi')], none);
 
             var selection = surface.selectAll('g.line-stroke > path.line');
             expect(selection[0][0].__data__.id).to.eql('lo');
@@ -92,7 +144,7 @@ describe("iD.svg.Lines", function () {
         });
 
         it("stacks higher lines above lower ones in a single render (reverse)", function () {
-            surface.call(iD.svg.Lines(projection), graph, [graph.entity('hi'), graph.entity('lo')], none);
+            surface.call(iD.svg.Lines(projection, context), graph, [graph.entity('hi'), graph.entity('lo')], none);
 
             var selection = surface.selectAll('g.line-stroke > path.line');
             expect(selection[0][0].__data__.id).to.eql('lo');
@@ -100,8 +152,8 @@ describe("iD.svg.Lines", function () {
         });
 
         it("stacks higher lines above lower ones in separate renders", function () {
-            surface.call(iD.svg.Lines(projection), graph, [graph.entity('lo')], none);
-            surface.call(iD.svg.Lines(projection), graph, [graph.entity('hi')], none);
+            surface.call(iD.svg.Lines(projection, context), graph, [graph.entity('lo')], none);
+            surface.call(iD.svg.Lines(projection, context), graph, [graph.entity('hi')], none);
 
             var selection = surface.selectAll('g.line-stroke > path.line');
             expect(selection[0][0].__data__.id).to.eql('lo');
@@ -109,8 +161,8 @@ describe("iD.svg.Lines", function () {
         });
 
         it("stacks higher lines above lower in separate renders (reverse)", function () {
-            surface.call(iD.svg.Lines(projection), graph, [graph.entity('hi')], none);
-            surface.call(iD.svg.Lines(projection), graph, [graph.entity('lo')], none);
+            surface.call(iD.svg.Lines(projection, context), graph, [graph.entity('hi')], none);
+            surface.call(iD.svg.Lines(projection, context), graph, [graph.entity('lo')], none);
 
             var selection = surface.selectAll('g.line-stroke > path.line');
             expect(selection[0][0].__data__.id).to.eql('lo');

--- a/test/spec/svg/vertices.js
+++ b/test/spec/svg/vertices.js
@@ -5,6 +5,7 @@ describe("iD.svg.Vertices", function () {
 
     beforeEach(function () {
         context = iD();
+        context.map().zoom(context.minEditableZoom());
         surface = d3.select(document.createElementNS('http://www.w3.org/2000/svg', 'svg'))
             .call(iD.svg.Surface(context));
     });
@@ -16,7 +17,18 @@ describe("iD.svg.Vertices", function () {
             graph = iD.Graph([node, way1, way2]);
 
         surface.call(iD.svg.Vertices(projection, context), graph, [node], 17);
-
         expect(surface.select('.vertex')).to.be.classed('shared');
+    });
+
+    it("no vertices are drawn if map is not editable", function () {
+        var node = iD.Node({loc: [0, 0], tags: {amenity: 'atm'}}),
+            way = iD.Way({nodes: [node.id], tags: {highway: 'residential'}}),
+            graph = iD.Graph([node, way]);
+
+        context.map().zoom(context.minEditableZoom() - 1);
+        surface.call(iD.svg.Vertices(projection, context), graph, [node], 17);
+
+        expect(surface.select('.vertex').empty()).to.be.true;
+
     });
 });


### PR DESCRIPTION
Continuing from https://github.com/openstreetmap/iD/issues/2427.

Remaining tasks:
- [x] Title/tooltip for focused feature checkbox should be the name of the feature itself (`iD.util.displayName`)
- [x] "Zoom in to edit" button and feature editor should not both appear in the sidebar when zoomed out
- [ ] Shouldn't do expensive intersect/filter of features when < minimum editable zoom
- [x] Should work with relations
