### PR TITLE
Don't pass extra arguments from map to Entity initializer

### DIFF
--- a/js/id/core/history.js
+++ b/js/id/core/history.js
@@ -234,7 +234,9 @@ iD.History = function(context) {
                     // this merges originals for changed entities into the base of
                     // the stack even if the current stack doesn't have them (for
                     // example when iD has been restarted in a different region)
-                    var baseEntities = h.baseEntities.map(iD.Entity);
+                    var baseEntities = h.baseEntities.map(function(entity) {
+                        return iD.Entity(entity);
+                    });
                     stack[0].graph.rebase(baseEntities, _.pluck(stack, 'graph'));
                     tree.rebase(baseEntities);
                 }


### PR DESCRIPTION
fixes #2465 

Map passes extra arguments to the callback, including the contents of the original array. The array was getting passed down to the initializer function and imported as properties into each Entity.

I still think there is a potential issue with the history restoring code... on line 240 where it rebases these originals back into the base graph -- isn't it possible that newer versioned entities are already loaded and this rebase call will do nothing (say if the user was is looking at that tile and the API fetched them before the user chose to restore their history)?

I think rebase needs something like a `--force` option for when restoring from localstorage.

Thoughts, @jfirebaugh?
