### PR TITLE
Fix German and French translation of 'flush toilet'

### DIFF
--- a/dist/locales/de.json
+++ b/dist/locales/de.json
@@ -1088,7 +1088,7 @@
             "toilets/disposal": {
                 "label": "Toiletten-Bauart",
                 "options": {
-                    "flush": "flach",
+                    "flush": "Spülung",
                     "pitlatrine": "Grube/Latrine",
                     "chemical": "Chemisch",
                     "bucket": "Eimer"

--- a/dist/locales/fr.json
+++ b/dist/locales/fr.json
@@ -1087,7 +1087,7 @@
             "toilets/disposal": {
                 "label": "Élimination",
                 "options": {
-                    "flush": "Toilettes publiques",
+                    "flush": "Chasse d'eau / liquide",
                     "pitlatrine": "Latrines",
                     "chemical": "Chimique",
                     "bucket": "Seau"


### PR DESCRIPTION
The original translation for flush were flach (flat) and toilettes publiques (public toilettes).