### PR TITLE
Add amenity=public_bookcase preset

### DIFF
--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -777,6 +777,9 @@ en:
       amenity/pub:
         name: Pub
         terms: "<translate with synonyms or related terms for 'Pub', separated by commas>"
+      amenity/public_bookcase:
+        name: Public Bookcase
+        terms: "<translate with synonyms or related terms for 'Public Bookcase', separated by commas>"
       amenity/ranger_station:
         name: Ranger Station
         terms: "<translate with synonyms or related terms for 'Ranger Station', separated by commas>"

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -1364,6 +1364,27 @@
         ],
         "name": "Pub"
     },
+    "amenity/public_bookcase": {
+        "icon": "library",
+        "fields": [
+            "name",
+            "operator",
+            "capacity",
+            "website"
+        ],
+        "geometry": [
+            "point",
+            "area"
+        ],
+        "terms": [
+            "library",
+            "bookcrossing"
+        ],
+        "tags": {
+            "amenity": "public_bookcase"
+        },
+        "name": "Public Bookcase"
+    },
     "amenity/ranger_station": {
         "fields": [
             "operator",

--- a/data/presets/presets/amenity/public_bookcase.json
+++ b/data/presets/presets/amenity/public_bookcase.json
@@ -1,0 +1,21 @@
+{
+    "icon": "library",
+    "fields": [
+        "name",
+        "operator",
+        "capacity",
+        "website"
+    ],
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "terms": [
+        "library",
+        "bookcrossing"
+    ],
+    "tags": {
+        "amenity": "public_bookcase"
+    },
+    "name": "Public Bookcase"
+}

--- a/data/taginfo.json
+++ b/data/taginfo.json
@@ -298,6 +298,10 @@
         },
         {
             "key": "amenity",
+            "value": "public_bookcase"
+        },
+        {
+            "key": "amenity",
             "value": "ranger_station"
         },
         {

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -1558,6 +1558,10 @@
                 "name": "Pub",
                 "terms": "dive,beer,bier,booze"
             },
+            "amenity/public_bookcase": {
+                "name": "Public Bookcase",
+                "terms": "library,bookcrossing"
+            },
             "amenity/ranger_station": {
                 "name": "Ranger Station",
                 "terms": "visitor center,visitor centre,permit center,permit centre,backcountry office,warden office,warden center"


### PR DESCRIPTION
This commit adds support to amenity=public_bookcase, a recently approved tag:

http://wiki.openstreetmap.org/wiki/Tag:amenity%3Dpublic_bookcase

Contributing to iD is actually easy. Thanks for it!