### PR TITLE
Avoid zorroing connected ways when moving a way

### DIFF
--- a/js/id/actions/move.js
+++ b/js/id/actions/move.js
@@ -51,6 +51,8 @@ iD.actions.Move = function(moveIds, tryDelta, projection, cache) {
                         unmoved = _.find(parents, function(way) { return !cache.moving[way.id]; });
                     if (!unmoved) return;
 
+                    if (moved.isArea() || unmoved.isArea()) return;
+
                     cache.intersection[node.id] = {
                         nodeId: node.id,
                         movedId: moved.id,

--- a/js/id/actions/move.js
+++ b/js/id/actions/move.js
@@ -1,30 +1,144 @@
 // https://github.com/openstreetmap/josm/blob/mirror/src/org/openstreetmap/josm/command/MoveCommand.java
 // https://github.com/openstreetmap/potlatch2/blob/master/net/systemeD/halcyon/connection/actions/MoveNodeAction.as
-iD.actions.Move = function(ids, delta, projection) {
-    function addNodes(ids, nodes, graph) {
-        ids.forEach(function(id) {
+iD.actions.Move = function(moveIds, delta, projection, cache) {
+
+    function addIds(ids, nodes, ways, graph) {
+        _.each(ids, function(id) {
             var entity = graph.entity(id);
+
             if (entity.type === 'node') {
-                nodes.push(id);
+                nodes.push(entity);
             } else if (entity.type === 'way') {
-                nodes.push.apply(nodes, entity.nodes);
+                ways.push(entity);
+                addIds(entity.nodes, nodes, ways, graph);
             } else {
-                addNodes(_.pluck(entity.members, 'id'), nodes, graph);
+                addIds(_.pluck(entity.members, 'id'), nodes, ways, graph);
             }
         });
     }
 
+    // Place a vertex where the moved vertex used to be, to preserve way shape..
+    function replaceMovedVertex(nodeId, wayId, graph) {
+        var way = graph.entity(wayId),
+            moved = graph.entity(nodeId),
+            movedIndex = way.nodes.indexOf(nodeId),
+            len, prevIndex, nextIndex;
+
+        if (way.isClosed()) {
+            len = way.nodes.length - 1;
+            prevIndex = (movedIndex + len - 1) % len;
+            nextIndex = (movedIndex + len + 1) % len;
+        } else {
+            len = way.nodes.length;
+            prevIndex = movedIndex - 1;
+            nextIndex = movedIndex + 1;
+        }
+
+        var prev = graph.hasEntity(way.nodes[prevIndex]),
+            next = graph.hasEntity(way.nodes[nextIndex]);
+
+        // Don't add orig vertex at endpoint..
+        if (!prev || !next) return graph;
+
+        var orig = iD.Node({loc: cache.startLoc[nodeId]}),
+            angle = Math.abs(iD.geo.angle(orig, prev, projection) -
+                iD.geo.angle(orig, next, projection)) * 180 / Math.PI;
+
+        // Don't add orig vertex if it would just make a straight line..
+        if (angle > 175 && angle < 185) return graph;
+
+        // moving forward or backward along way?
+        var p1 = [prev.loc, orig.loc, moved.loc, next.loc].map(projection),
+            p2 = [prev.loc, moved.loc, orig.loc, next.loc].map(projection),
+            d1 = iD.geo.pathLength(p1),
+            d2 = iD.geo.pathLength(p2),
+            insertAt = (d1 < d2) ? movedIndex : nextIndex;
+
+        // moving around closed loop?
+        if (way.isClosed() && insertAt === 0) insertAt = len;
+
+        way = way.addNode(orig.id, insertAt);
+        return graph.replace(orig).replace(way);
+    }
+
+    function isEndpoint(id, way) {
+        return !way.isClosed() && way.affix(id);
+    }
+
+    function cleanupWays(movedWays, graph) {
+        _.each(movedWays, function(movedWay) {
+            var movedVertices = _.filter(graph.childNodes(movedWay),
+                function(vertex) { return (graph.parentWays(vertex).length === 2); });
+
+            _.each(movedVertices, function(movedVertex) {
+                var id = movedVertex.id,
+                    loc = movedVertex.loc,
+                    firstTime = !cache.lastEdge[id],
+                    way = _.find(graph.parentWays(movedVertex),
+                        function(way) { return way.id !== movedWay.id; });
+
+                if (firstTime) {
+                    graph = replaceMovedVertex(id, way.id, graph);
+                    way = graph.entity(way.id);
+                }
+
+                // get closest edge on connected way..
+                var nodes = _.without(graph.childNodes(way), movedVertex);
+                if (way.isClosed() && way.first() === id) nodes.push(nodes[0]);
+
+                var lastEdge = cache.lastEdge[id],
+                    currEdge = iD.geo.chooseEdge(nodes, projection(loc), projection);
+
+                // zorro happened, reorder nodes..
+                if (lastEdge && lastEdge.index !== currEdge.index) {
+                    way = way.removeNode(id).addNode(id, currEdge.index);
+                    graph = graph.replace(way);
+                }
+
+                // snap movedVertex to edge of connected way..
+                if (!isEndpoint(id, way)) {
+                    graph = graph.replace(movedVertex.move(currEdge.loc));
+                }
+
+                // TODO:
+                //  extend search to a connected way beyond end of way?
+                //  don't mess up points between two intersections
+
+                cache.lastEdge[id] = currEdge;
+
+            });
+        });
+        return graph;
+    }
+
+    // Don't move a vertex where >2 ways meet, unless all parentWays are moving too..
+    function canMove(entity, graph) {
+        var parents = graph.parentWays(entity);
+        if (parents.length < 3) return true;
+
+        return _.all(_.pluck(parents, 'id'), function(id) {
+            return _.contains(moveIds, id);
+        });
+    }
+
     var action = function(graph) {
-        var nodes = [];
+        if (_.isEqual(delta, [0,0])) return graph;
 
-        addNodes(ids, nodes, graph);
+        var nodes = [],
+            ways = [];
 
-        _.uniq(nodes).forEach(function(id) {
-            var node = graph.entity(id),
-                start = projection(node.loc),
+        addIds(moveIds, nodes, ways, graph);
+        nodes = _.filter(nodes, function(node) { return canMove(node, graph); });
+
+        _.uniq(nodes).forEach(function(node) {
+            var start = projection(node.loc),
                 end = projection.invert([start[0] + delta[0], start[1] + delta[1]]);
             graph = graph.replace(node.move(end));
         });
+
+        if (cache) {
+            graph = cleanupWays(_.uniq(ways), graph);
+        }
 
         return graph;
     };
@@ -35,7 +149,7 @@ iD.actions.Move = function(ids, delta, projection) {
             return entity.type === 'relation' && !entity.isComplete(graph);
         }
 
-        if (_.any(ids, incompleteRelation))
+        if (_.any(moveIds, incompleteRelation))
             return 'incomplete_relation';
     };
 

--- a/js/id/core/history.js
+++ b/js/id/core/history.js
@@ -77,6 +77,21 @@ iD.History = function(context) {
             }
         },
 
+        // Same as calling pop and then perform
+        overwrite: function() {
+            var previous = stack[index].graph;
+
+            if (index > 0) {
+                index--;
+                stack.pop();
+            }
+            stack = stack.slice(0, index + 1);
+            stack.push(perform(arguments));
+            index++;
+
+            return change(previous);
+        },
+
         undo: function() {
             var previous = stack[index].graph;
 

--- a/js/id/geo.js
+++ b/js/id/geo.js
@@ -147,6 +147,19 @@ iD.geo.lineIntersection = function(a, b) {
     return null;
 };
 
+iD.geo.pathIntersections = function(path1, path2) {
+    var intersections = [];
+    for (var i = 0; i < path1.length - 1; i++) {
+        for (var j = 0; j < path2.length - 1; j++) {
+            var a = [ path1[i], path1[i+1] ],
+                b = [ path2[j], path2[j+1] ],
+                hit = iD.geo.lineIntersection(a, b);
+            if (hit) intersections.push(hit);
+        }
+    }
+    return intersections;
+};
+
 // Return whether point is contained in polygon.
 //
 // `point` should be a 2-item array of coordinates.

--- a/js/id/geo/extent.js
+++ b/js/id/geo/extent.js
@@ -55,6 +55,14 @@ _.extend(iD.geo.Extent.prototype, {
         ];
     },
 
+    contains: function(obj) {
+        if (!(obj instanceof iD.geo.Extent)) obj = new iD.geo.Extent(obj);
+        return obj[0][0] >= this[0][0] &&
+               obj[0][1] >= this[0][1] &&
+               obj[1][0] <= this[1][0] &&
+               obj[1][1] <= this[1][1];
+    },
+
     intersects: function(obj) {
         if (!(obj instanceof iD.geo.Extent)) obj = new iD.geo.Extent(obj);
         return obj[0][0] <= this[1][0] &&

--- a/js/id/id.js
+++ b/js/id/id.js
@@ -126,6 +126,7 @@ window.iD = function () {
     context.perform = withDebouncedSave(history.perform);
     context.replace = withDebouncedSave(history.replace);
     context.pop = withDebouncedSave(history.pop);
+    context.overwrite = withDebouncedSave(history.overwrite);
     context.undo = withDebouncedSave(history.undo);
     context.redo = withDebouncedSave(history.redo);
 

--- a/js/id/modes/move.js
+++ b/js/id/modes/move.js
@@ -16,7 +16,6 @@ iD.modes.Move = function(context, entityIDs) {
     function clearCache() {
         cache = {
             startLoc: {},
-            lastEdge: {}
         };
     }
 

--- a/js/id/modes/move.js
+++ b/js/id/modes/move.js
@@ -14,6 +14,8 @@ iD.modes.Move = function(context, entityIDs) {
         delta,
         nudgeInterval;
 
+    function vecSub(a, b) { return [a[0] - b[0], a[1] - b[1]]; }
+
     function edge(point, size) {
         var pad = [30, 100, 30, 100];
         if (point[0] > size[0] - pad[0]) return [-10, 0];
@@ -30,13 +32,13 @@ iD.modes.Move = function(context, entityIDs) {
 
             var orig = context.projection(origin);
 
-            orig = [orig[0] - nudge[1], orig[1] - nudge[1]];
-            delta = [delta[0] - nudge[0], delta[1] - nudge[1]];
+            orig = vecSub(orig, nudge);
             origin = context.projection.invert(orig);
 
-            context.overwrite(
-                iD.actions.Move(entityIDs, delta, context.projection, cache),
-                annotation);
+            // delta = vecSub(delta, nudge);
+            // context.overwrite(
+            //     iD.actions.Move(entityIDs, delta, context.projection, cache),
+            //     annotation);
         }, 50);
     }
 
@@ -49,15 +51,15 @@ iD.modes.Move = function(context, entityIDs) {
         var mouse = context.mouse(),
             orig = context.projection(origin);
 
-        delta = [mouse[0] - orig[0], mouse[1] - orig[1]];
+        var action = iD.actions.Move(entityIDs, vecSub(mouse, orig), context.projection, cache);
+        context.overwrite(action, annotation);
+        delta = action.delta();
 
+        // TODO restrict nudging if move was restricted..
+        // (because geometry may not be under the mouse pointer)
         var nudge = edge(mouse, context.map().dimensions());
         if (nudge) startNudge(nudge);
         else stopNudge();
-
-        context.overwrite(
-            iD.actions.Move(entityIDs, delta, context.projection, cache),
-            annotation);
     }
 
     function finish() {

--- a/test/spec/geo/extent.js
+++ b/test/spec/geo/extent.js
@@ -109,6 +109,35 @@ describe("iD.geo.Extent", function () {
         });
     });
 
+    describe('#contains', function () {
+        it("returns true for a point inside self", function () {
+            expect(iD.geo.Extent([0, 0], [5, 5]).contains([2, 2])).to.be.true;
+        });
+
+        it("returns true for a point on the boundary of self", function () {
+            expect(iD.geo.Extent([0, 0], [5, 5]).contains([0, 0])).to.be.true;
+        });
+
+        it("returns false for a point outside self", function () {
+            expect(iD.geo.Extent([0, 0], [5, 5]).contains([6, 6])).to.be.false;
+        });
+
+        it("returns true for an extent contained by self", function () {
+            expect(iD.geo.Extent([0, 0], [5, 5]).contains([[1, 1], [2, 2]])).to.be.true;
+            expect(iD.geo.Extent([1, 1], [2, 2]).contains([[0, 0], [5, 5]])).to.be.false;
+        });
+
+        it("returns false for an extent partially contained by self", function () {
+            expect(iD.geo.Extent([0, 0], [5, 5]).contains([[1, 1], [6, 6]])).to.be.false;
+            expect(iD.geo.Extent([1, 1], [6, 6]).contains([[0, 0], [5, 5]])).to.be.false;
+        });
+
+        it("returns false for an extent not intersected by self", function () {
+            expect(iD.geo.Extent([0, 0], [5, 5]).contains([[6, 6], [7, 7]])).to.be.false;
+            expect(iD.geo.Extent([[6, 6], [7, 7]]).contains([[0, 0], [5, 5]])).to.be.false;
+        });
+    });
+
     describe('#intersects', function () {
         it("returns true for a point inside self", function () {
             expect(iD.geo.Extent([0, 0], [5, 5]).intersects([2, 2])).to.be.true;
@@ -127,7 +156,7 @@ describe("iD.geo.Extent", function () {
             expect(iD.geo.Extent([1, 1], [2, 2]).intersects([[0, 0], [5, 5]])).to.be.true;
         });
 
-        it("returns true for an extent intersected by self", function () {
+        it("returns true for an extent partially contained by self", function () {
             expect(iD.geo.Extent([0, 0], [5, 5]).intersects([[1, 1], [6, 6]])).to.be.true;
             expect(iD.geo.Extent([1, 1], [6, 6]).intersects([[0, 0], [5, 5]])).to.be.true;
         });


### PR DESCRIPTION
The simple case wasn't too bad:
![zorro1](https://cloud.githubusercontent.com/assets/38784/5888535/8c6be0ea-a3d0-11e4-8ac6-9d25ea62dd44.gif)

These get tricker, handling endpoints, closed ways, etc
![zorro2](https://cloud.githubusercontent.com/assets/38784/5886396/8772ebf8-a36a-11e4-8ae6-4671480ffc6e.gif)

![zorro3](https://cloud.githubusercontent.com/assets/38784/5886394/87722b3c-a36a-11e4-93ec-21beddd922c3.gif)

I'm mostly happy with how it works, may make a few improvements before merging.