### PR TITLE
Add/Prioritize network=* tag in public transport presets

### DIFF
--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -3781,6 +3781,7 @@
     "highway/bus_stop": {
         "icon": "bus",
         "fields": [
+            "network",
             "operator",
             "bench",
             "shelter",
@@ -6536,8 +6537,8 @@
     "public_transport/platform": {
         "fields": [
             "ref",
-            "operator",
             "network",
+            "operator",
             "shelter"
         ],
         "geometry": [
@@ -6555,8 +6556,8 @@
         "icon": "bus",
         "fields": [
             "ref",
-            "operator",
-            "network"
+            "network",
+            "operator"
         ],
         "geometry": [
             "vertex"

--- a/data/presets/presets/highway/bus_stop.json
+++ b/data/presets/presets/highway/bus_stop.json
@@ -1,6 +1,7 @@
 {
     "icon": "bus",
     "fields": [
+        "network",
         "operator",
         "bench",
         "shelter",

--- a/data/presets/presets/public_transport/platform.json
+++ b/data/presets/presets/public_transport/platform.json
@@ -1,8 +1,8 @@
 {
     "fields": [
         "ref",
-        "operator",
         "network",
+        "operator",
         "shelter"
     ],
     "geometry": [

--- a/data/presets/presets/public_transport/stop_position.json
+++ b/data/presets/presets/public_transport/stop_position.json
@@ -2,8 +2,8 @@
     "icon": "bus",
     "fields": [
         "ref",
-        "operator",
-        "network"
+        "network",
+        "operator"
     ],
     "geometry": [
         "vertex"

--- a/data/presets/presets/railway/station.json
+++ b/data/presets/presets/railway/station.json
@@ -1,6 +1,7 @@
 {
     "icon": "rail",
     "fields": [
+        "network",
         "operator",
         "address",
         "building_area"


### PR DESCRIPTION
There are multiple companies involved in public transport (PT), but the one which the user faces (and mostly cares about) is the *network*, and the operator is at best not clearly visible to users.

However, operator=* is often used to store the PT network name instead of network=*.
I suspect it might be caused by the ordering (and sometimes lack) of the network=* tag in presets, which this PR tries to fix.