### PR TITLE
Add basic browser and platform into to changeset tags

### DIFF
--- a/js/id/core/connection.js
+++ b/js/id/core/connection.js
@@ -241,11 +241,14 @@ iD.Connection = function() {
     };
 
     connection.changesetTags = function(comment, imageryUsed) {
-        var tags = {
+        var detected = iD.detect(),
+            tags = {
             created_by: 'iD ' + iD.version,
-            host: (window.location.origin + window.location.pathname).substr(0, 255),
-            locale: iD.detect().locale,
             imagery_used: imageryUsed.join(';').substr(0, 255),
+            'iD:host': (window.location.origin + window.location.pathname).substr(0, 255),
+            'iD:locale': detected.locale,
+            'iD:browser': detected.browser + ' ' + detected.version,
+            'iD:platform': detected.platform
         };
 
         if (comment) {

--- a/js/id/core/connection.js
+++ b/js/id/core/connection.js
@@ -243,13 +243,13 @@ iD.Connection = function() {
     connection.changesetTags = function(comment, imageryUsed) {
         var detected = iD.detect(),
             tags = {
-            created_by: 'iD ' + iD.version,
-            imagery_used: imageryUsed.join(';').substr(0, 255),
-            'iD:host': (window.location.origin + window.location.pathname).substr(0, 255),
-            'iD:locale': detected.locale,
-            'iD:browser': detected.browser + ' ' + detected.version,
-            'iD:platform': detected.platform
-        };
+                created_by: 'iD ' + iD.version,
+                imagery_used: imageryUsed.join(';').substr(0, 255),
+                host: (window.location.origin + window.location.pathname).substr(0, 255),
+                locale: detected.locale,
+                browser: detected.browser + ' ' + detected.version,
+                platform: detected.platform
+            };
 
         if (comment) {
             tags.comment = comment.substr(0, 255);

--- a/js/id/id.js
+++ b/js/id/id.js
@@ -330,17 +330,39 @@ iD.version = '1.7.0';
     var detected = {};
 
     var ua = navigator.userAgent,
-        msie = new RegExp('MSIE ([0-9]{1,}[\\.0-9]{0,})');
+        m = null;
 
-    if (msie.exec(ua) !== null) {
-        var rv = parseFloat(RegExp.$1);
-        detected.support = !(rv && rv < 9);
+    m = ua.match(/Trident\/.*rv:([0-9]{1,}[\.0-9]{0,})/i);   // IE11
+    if (m !== null) {
+        detected.browser = 'msie';
+        detected.version = m[1];
+    } else {
+        m = ua.match(/(opera|chrome|safari|firefox|msie)\/?\s*(\.?\d+(\.\d+)*)/i);
+        if (m !== null) {
+            detected.browser = m[1];
+            detected.version = m[2];
+            m = ua.match(/version\/([\.\d]+)/i);
+            if (m !== null) {
+                detected.version = m[1];
+            }
+        } else {
+            detected.browser = navigator.appName;
+            detected.version = navigator.appVersion;
+        }
+    }
+
+    // keep major.minor version only..
+    detected.version = detected.version.split(/\W/).slice(0,2).join('.');
+
+    if (detected.browser.toLowerCase() === 'msie') {
+        detected.browser = 'Internet Explorer';
+        detected.support = parseFloat(detected.version) > 9;
     } else {
         detected.support = true;
     }
 
     // Added due to incomplete svg style support. See #715
-    detected.opera = ua.indexOf('Opera') >= 0;
+    detected.opera = (detected.browser.toLowerCase() === 'opera');
 
     detected.locale = navigator.language || navigator.userLanguage;
 
@@ -350,11 +372,22 @@ iD.version = '1.7.0';
         return navigator.userAgent.indexOf(x) !== -1;
     }
 
-    if (nav('Win')) detected.os = 'win';
-    else if (nav('Mac')) detected.os = 'mac';
-    else if (nav('X11')) detected.os = 'linux';
-    else if (nav('Linux')) detected.os = 'linux';
-    else detected.os = 'win';
+    if (nav('Win')) {
+        detected.os = 'win';
+        detected.platform = 'Windows';
+    }
+    else if (nav('Mac')) {
+        detected.os = 'mac';
+        detected.platform = 'Macintosh';
+    }
+    else if (nav('X11') || nav('Linux')) {
+        detected.os = 'linux';
+        detected.platform = 'Linux';
+    }
+    else {
+        detected.os = 'win';
+        detected.platform = 'Unknown';
+    }
 
     iD.detect = function() { return detected; };
 })();


### PR DESCRIPTION
This adds some simple info to the changeset tags about browser and platform used.
Reporting this info is useful for some things (see #2449).

* Browser version is detected as major.minor only (no patch included).
* Platform is very simple (Windows/Macintosh/Linux) with no version.
* These fields are namespaced with 'iD:' to not conflict anything

Looks like this in practice:

![screenshot 2015-03-20 14 27 37](https://cloud.githubusercontent.com/assets/38784/6758289/6ef1b22a-cf0d-11e4-96d3-142d1362c016.png)

cc @pnorman 