### PR TITLE
Allow overzoom to be set on overlays. Fix #2558

### DIFF
--- a/data/imagery.json
+++ b/data/imagery.json
@@ -10515,6 +10515,7 @@
             0,
             16
         ],
+        "overzoom": false,
         "terms_url": "http://www.mapbox.com/about/maps/",
         "terms_text": "Terms & Feedback",
         "default": true,

--- a/data/update_imagery.js
+++ b/data/update_imagery.js
@@ -83,6 +83,10 @@ sources.forEach(function(source) {
         ]];
     }
 
+    if (source.name == 'Locator Overlay') {
+        im.overzoom = false;
+    }
+
     var attribution = source.attribution || {};
     if (attribution.url) {
         im.terms_url = attribution.url;

--- a/js/id/renderer/background_source.js
+++ b/js/id/renderer/background_source.js
@@ -4,6 +4,7 @@ iD.BackgroundSource = function(data) {
         name = source.name;
 
     source.scaleExtent = data.scaleExtent || [0, 20];
+    source.overzoom = data.overzoom !== false ? true : false;
 
     source.offset = function(_) {
         if (!arguments.length) return offset;
@@ -58,7 +59,7 @@ iD.BackgroundSource = function(data) {
 
     source.validZoom = function(z) {
         return source.scaleExtent[0] <= z &&
-            (!source.isLocatorOverlay() || source.scaleExtent[1] > z);
+            (source.overzoom || source.scaleExtent[1] > z);
     };
 
     source.isLocatorOverlay = function() {

--- a/js/id/renderer/background_source.js
+++ b/js/id/renderer/background_source.js
@@ -4,7 +4,7 @@ iD.BackgroundSource = function(data) {
         name = source.name;
 
     source.scaleExtent = data.scaleExtent || [0, 20];
-    source.overzoom = data.overzoom !== false ? true : false;
+    source.overzoom = data.overzoom !== false;
 
     source.offset = function(_) {
         if (!arguments.length) return offset;

--- a/test/spec/renderer/background_source.js
+++ b/test/spec/renderer/background_source.js
@@ -19,4 +19,32 @@ describe('iD.BackgroundSource', function() {
         expect(source.url([0,1,1])).to.equal('b/1/0/1');
         expect(source.url([0,2,1])).to.equal('a/1/0/2');
     });
+
+    it('correctly displays an overlay with no overzoom specified', function() {
+        var source = iD.BackgroundSource({ scaleExtent: [6,16] });
+        expect(source.validZoom(10)).to.be.true;
+        expect(source.validZoom(3)).to.be.false;
+        expect(source.validZoom(17)).to.be.true;
+    });
+
+    it('correctly displays an overlay with an invalid overzoom', function() {
+        var source = iD.BackgroundSource({ scaleExtent: [6,16], overzoom: 'gibberish'});
+        expect(source.validZoom(10)).to.be.true;
+        expect(source.validZoom(3)).to.be.false;
+        expect(source.validZoom(17)).to.be.true;
+    });
+
+    it('correctly displays an overlay with overzoom:true', function() {
+        var source = iD.BackgroundSource({ scaleExtent: [6,16], overzoom: true});
+        expect(source.validZoom(10)).to.be.true;
+        expect(source.validZoom(3)).to.be.false;
+        expect(source.validZoom(17)).to.be.true;
+    });
+
+    it('correctly displays an overlay with overzoom:false', function() {
+        var source = iD.BackgroundSource({ scaleExtent: [6,16], overzoom: false});
+        expect(source.validZoom(10)).to.be.true;
+        expect(source.validZoom(3)).to.be.false;
+        expect(source.validZoom(17)).to.be.false;
+    });
 });


### PR DESCRIPTION
The default behaviour is to overzoom overlays past their max scaleExtent.
When 'overzoom':false is defined in imagery.json, the layer will disappear on the max scaleExtent.