### PR TITLE
Presets : access=yes instead of access=public for toilets

### DIFF
--- a/data/presets/fields.json
+++ b/data/presets/fields.json
@@ -66,7 +66,7 @@
         "type": "combo",
         "label": "Access",
         "options": [
-            "public",
+            "yes",
             "permissive",
             "private",
             "customers"


### PR DESCRIPTION
Hello,

In general on OSM access=yes is used to mean that an amenity/feature is accessible by everyone.

Toilets seems to be the only exception where access=public is used with no apparent reason. This PR replace access=public by access=yes for toilets.