### PR TITLE
Radio mast preset

### DIFF
--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -1564,6 +1564,9 @@ en:
       man_made/lighthouse:
         name: Lighthouse
         terms: "<translate with synonyms or related terms for 'Lighthouse', separated by commas>"
+      man_made/mast:
+        name: Radio Mast
+        terms: "<translate with synonyms or related terms for 'Radio Mast', separated by commas>"
       man_made/observation:
         name: Observation Tower
         terms: "<translate with synonyms or related terms for 'Observation Tower', separated by commas>"

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -5398,6 +5398,27 @@
         },
         "name": "Lighthouse"
     },
+    "man_made/mast": {
+        "geometry": [
+            "point"
+        ],
+        "terms": [
+            "broadcast tower",
+            "cell phone tower",
+            "cell tower",
+            "guyed tower",
+            "mobile phone tower",
+            "radio tower",
+            "television tower",
+            "transmission mast",
+            "transmission tower",
+            "tv tower"
+        ],
+        "tags": {
+            "man_made": "mast"
+        },
+        "name": "Radio Mast"
+    },
     "man_made/observation": {
         "geometry": [
             "point",

--- a/data/presets/presets/man_made/mast.json
+++ b/data/presets/presets/man_made/mast.json
@@ -1,0 +1,21 @@
+{
+    "geometry": [
+        "point"
+    ],
+    "terms": [
+        "broadcast tower",
+        "cell phone tower",
+        "cell tower",
+        "guyed tower",
+        "mobile phone tower",
+        "radio tower",
+        "television tower",
+        "transmission mast",
+        "transmission tower",
+        "tv tower"
+    ],
+    "tags": {
+        "man_made": "mast"
+    },
+    "name": "Radio Mast"
+}

--- a/data/taginfo.json
+++ b/data/taginfo.json
@@ -1272,6 +1272,10 @@
             "value": "lighthouse"
         },
         {
+            "key": "man_made",
+            "value": "mast"
+        },
+        {
             "key": "tower:type",
             "value": "observation"
         },

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -2631,6 +2631,10 @@
                 "name": "Lighthouse",
                 "terms": ""
             },
+            "man_made/mast": {
+                "name": "Radio Mast",
+                "terms": "broadcast tower,cell phone tower,cell tower,guyed tower,mobile phone tower,radio tower,television tower,transmission mast,transmission tower,tv tower"
+            },
             "man_made/observation": {
                 "name": "Observation Tower",
                 "terms": "lookout tower,fire tower"


### PR DESCRIPTION
This PR adds a preset for `man_made=mast` called “radio mast”, along with various synonyms. OSM’s distinction between masts, towers, and communication towers is a bit idiosyncratic, but `man_made=mast` is [appropriate for most communications towers and guyed broadcast towers](http://wiki.openstreetmap.org/wiki/Tag:man_made%3Dmast#First_question:_Is_it_a_mast_or_a_tower.3F).

/cc @gregcrago