### PR TITLE
fix: build.js tests wrong fields in validatePresetFields()

### DIFF
--- a/build.js
+++ b/build.js
@@ -177,8 +177,6 @@ function validateCategoryPresets(categories, presets) {
 }
 
 function validatePresetFields(presets, fields) {
-    var presets = rp('presets.json'),
-        fields = rp('fields.json');
     _.forEach(presets, function(preset) {
         if (preset.fields) {
             preset.fields.forEach(function(field) {


### PR DESCRIPTION
validatePresetFields() tested old fields from file, not newly aggregated ones.