### PR TITLE
Added oil well preset

### DIFF
--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -1570,6 +1570,9 @@ en:
       man_made/observation:
         name: Observation Tower
         terms: "<translate with synonyms or related terms for 'Observation Tower', separated by commas>"
+      man_made/petroleum_well:
+        name: Oil Well
+        terms: "<translate with synonyms or related terms for 'Oil Well', separated by commas>"
       man_made/pier:
         name: Pier
         terms: "<translate with synonyms or related terms for 'Pier', separated by commas>"

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -5434,6 +5434,25 @@
         },
         "name": "Observation Tower"
     },
+    "man_made/petroleum_well": {
+        "icon": "oil-well",
+        "geometry": [
+            "point"
+        ],
+        "terms": [
+            "drilling rig",
+            "oil derrick",
+            "oil drill",
+            "oil horse",
+            "oil rig",
+            "oil pump",
+            "pumpjack"
+        ],
+        "tags": {
+            "man_made": "petroleum_well"
+        },
+        "name": "Oil Well"
+    },
     "man_made/pier": {
         "geometry": [
             "line",

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -5446,6 +5446,7 @@
             "oil horse",
             "oil rig",
             "oil pump",
+            "petroleum well",
             "pumpjack"
         ],
         "tags": {

--- a/data/presets/presets/man_made/petroleum_well.json
+++ b/data/presets/presets/man_made/petroleum_well.json
@@ -9,6 +9,7 @@
         "oil horse",
         "oil rig",
         "oil pump",
+        "petroleum well",
         "pumpjack"
     ],
     "tags": {

--- a/data/presets/presets/man_made/petroleum_well.json
+++ b/data/presets/presets/man_made/petroleum_well.json
@@ -1,0 +1,18 @@
+{
+    "geometry": [
+        "point"
+    ],
+    "terms": [
+        "drilling rig",
+        "oil derrick",
+        "oil drill",
+        "oil horse",
+        "oil rig",
+        "oil pump",
+        "pumpjack"
+    ],
+    "tags": {
+        "man_made": "mast"
+    },
+    "name": "Oil Well"
+}

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -2641,7 +2641,7 @@
             },
             "man_made/petroleum_well": {
                 "name": "Oil Well",
-                "terms": "drilling rig,oil derrick,oil drill,oil horse,oil rig,oil pump,pumpjack"
+                "terms": "drilling rig,oil derrick,oil drill,oil horse,oil rig,oil pump,petroleum well,pumpjack"
             },
             "man_made/pier": {
                 "name": "Pier",

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -2639,6 +2639,10 @@
                 "name": "Observation Tower",
                 "terms": "lookout tower,fire tower"
             },
+            "man_made/petroleum_well": {
+                "name": "Oil Well",
+                "terms": "drilling rig,oil derrick,oil drill,oil horse,oil rig,oil pump,pumpjack"
+            },
             "man_made/pier": {
                 "name": "Pier",
                 "terms": ""


### PR DESCRIPTION
This PR adds a preset for [`man_made=petroleum_well`](http://taginfo.openstreetmap.org/tags/man_made=petroleum_well) called “oil well”, along with various synonyms. It uses the existing oil well icon.

@gregcrago also asked for a way to tag oil fields – areas where one can find many of derricks or pumpjacks. Unfortunately, there [doesn’t appear to be consensus](http://wiki.openstreetmap.org/wiki/WikiProject_Oil_and_Gas_Infrastructure#Tags_currently_in_use_for_Oil_and_Gas_Infrastructure) around a particular tagging scheme for oil fields yet. The only common tag is specifically for [offshore fields](http://wiki.openstreetmap.org/wiki/Tag:waterway%3Doffshore_field). So I only added a preset for individual wells, to be applied to points.