### PR TITLE
Corrected oil well preset tag

### DIFF
--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -5449,7 +5449,7 @@
             "pumpjack"
         ],
         "tags": {
-            "man_made": "mast"
+            "man_made": "petroleum_well"
         },
         "name": "Oil Well"
     },

--- a/data/presets/presets/man_made/petroleum_well.json
+++ b/data/presets/presets/man_made/petroleum_well.json
@@ -13,7 +13,7 @@
         "pumpjack"
     ],
     "tags": {
-        "man_made": "mast"
+        "man_made": "petroleum_well"
     },
     "name": "Oil Well"
 }

--- a/data/taginfo.json
+++ b/data/taginfo.json
@@ -1281,7 +1281,7 @@
         },
         {
             "key": "man_made",
-            "value": "mast"
+            "value": "petroleum_well"
         },
         {
             "key": "man_made",


### PR DESCRIPTION
@gregcrago pointed out that the oil well preset added for #2618 actually adds `man_made=mast` instead of `man_made=petroleum_well`, due to my copy-pasta. :disappointed: