### PR TITLE
Error handling is added to the GPX loading callback.

### DIFF
--- a/js/id/renderer/background.js
+++ b/js/id/renderer/background.js
@@ -262,8 +262,10 @@ iD.Background = function(context) {
         var gpx = q.gpx;
         if (gpx) {
             d3.text(gpx, function(err, gpxTxt) {
-                gpxLayer.geojson(toGeoJSON.gpx(toDom(gpxTxt)));
-                dispatch.change();
+                if (!err) {
+                    gpxLayer.geojson(toGeoJSON.gpx(toDom(gpxTxt)));
+                    dispatch.change();
+                }
             });
         }
     };


### PR DESCRIPTION
Previously erroneous response was corrupting the GpxLayer, which could
potential corrupt the whole Map, if user were to use 'Zoom to GPX'
feature. Callback logic is wrapped in the error guard to fix this.