### PR TITLE
Tighten up Wikipedia URL handling

### DIFF
--- a/js/id/ui/preset/wikipedia.js
+++ b/js/id/ui/preset/wikipedia.js
@@ -84,12 +84,22 @@ iD.ui.preset.wikipedia = function(field, context) {
 
     function change() {
         var value = title.value(),
-            m = value.match(/https?:\/\/([-a-z]+)\.wikipedia\.org\/wiki\/(.+)/),
-            l = m && _.find(iD.data.wikipedia, function(d) { return m[1] === d[2]; });
+            m = value.match(/https?:\/\/([-a-z]+)\.wikipedia\.org\/(?:wiki|\1-[-a-z]+)\/([^#]+)(?:#(.+))?/),
+            l = m && _.find(iD.data.wikipedia, function(d) { return m[1] === d[2]; }),
+            anchor;
 
         if (l) {
             // Normalize title http://www.mediawiki.org/wiki/API:Query#Title_normalization
-            value = m[2].replace(/_/g, ' ');
+            value = decodeURIComponent(m[2]).replace(/_/g, ' ');
+            if (m[3]) {
+                try {
+                    // Best-effort `anchordecode:` implementation
+                    anchor = decodeURIComponent(m[3].replace(/\.([0-9A-F]{2})/g, '%$1'));
+                } catch (e) {
+                    anchor = decodeURIComponent(m[3]);
+                }
+                value += "#" + anchor.replace(/_/g, ' ');
+            }
             value = value.slice(0, 1).toUpperCase() + value.slice(1);
             lang.value(l[1]);
             title.value(value);
@@ -102,14 +112,22 @@ iD.ui.preset.wikipedia = function(field, context) {
 
     i.tags = function(tags) {
         var value = tags[field.key] || '',
-            m = value.match(/([^:]+):(.+)/),
-            l = m && _.find(iD.data.wikipedia, function(d) { return m[1] === d[2]; });
+            m = value.match(/([^:]+):([^#]+)(?:#(.+))?/),
+            l = m && _.find(iD.data.wikipedia, function(d) { return m[1] === d[2]; }),
+            anchor = m && m[3];
 
         // value in correct format
         if (l) {
             lang.value(l[1]);
-            title.value(m[2]);
-            link.attr('href', 'http://' + m[1] + '.wikipedia.org/wiki/' + m[2]);
+            title.value(m[2] + (anchor ? ('#' + anchor) : ''));
+            try {
+                // Best-effort `anchorencode:` implementation
+                anchor = encodeURIComponent(anchor.replace(/ /g, '_')).replace(/%/g, '.');
+            } catch (e) {
+                anchor = anchor.replace(/ /g, '_');
+            }
+            link.attr('href', 'http://' + m[1] + '.wikipedia.org/wiki/' +
+                      m[2].replace(/ /g, '_') + (anchor ? ('#' + anchor) : ''));
 
         // unrecognized value format
         } else {

--- a/js/id/ui/preset/wikipedia.js
+++ b/js/id/ui/preset/wikipedia.js
@@ -84,7 +84,7 @@ iD.ui.preset.wikipedia = function(field, context) {
 
     function change() {
         var value = title.value(),
-            m = value.match(/https?:\/\/([a-z]+)\.wikipedia\.org\/wiki\/(.+)/),
+            m = value.match(/https?:\/\/([-a-z]+)\.wikipedia\.org\/wiki\/(.+)/),
             l = m && _.find(iD.data.wikipedia, function(d) { return m[1] === d[2]; });
 
         if (l) {

--- a/js/id/ui/preset/wikipedia.js
+++ b/js/id/ui/preset/wikipedia.js
@@ -98,7 +98,7 @@ iD.ui.preset.wikipedia = function(field, context) {
                 } catch (e) {
                     anchor = decodeURIComponent(m[3]);
                 }
-                value += "#" + anchor.replace(/_/g, ' ');
+                value += '#' + anchor.replace(/_/g, ' ');
             }
             value = value.slice(0, 1).toUpperCase() + value.slice(1);
             lang.value(l[1]);
@@ -120,11 +120,13 @@ iD.ui.preset.wikipedia = function(field, context) {
         if (l) {
             lang.value(l[1]);
             title.value(m[2] + (anchor ? ('#' + anchor) : ''));
-            try {
-                // Best-effort `anchorencode:` implementation
-                anchor = encodeURIComponent(anchor.replace(/ /g, '_')).replace(/%/g, '.');
-            } catch (e) {
-                anchor = anchor.replace(/ /g, '_');
+            if (anchor) {
+                try {
+                    // Best-effort `anchorencode:` implementation
+                    anchor = encodeURIComponent(anchor.replace(/ /g, '_')).replace(/%/g, '.');
+                } catch (e) {
+                    anchor = anchor.replace(/ /g, '_');
+                }
             }
             link.attr('href', 'http://' + m[1] + '.wikipedia.org/wiki/' +
                       m[2].replace(/ /g, '_') + (anchor ? ('#' + anchor) : ''));


### PR DESCRIPTION
If you paste a full Wikipedia URL into the Wikipedia preset field, iD tries to detect the Wikipedia language edition and normalize the tag value to the `xy:Foo` format. It also round-trips from this format back to a URL for the link button. This PR fixes a few edge cases around these normalization steps:

- Some Wikipedia subdomains contain hyphens, e.g. zh-min-nan.wikipedia.org.
- Some Wikipedia subdomains have variants, so paths such as zh.wikipedia.org/zh-hk/ are possible.
- When a map feature is covered by a section of a Wikipedia article, but not a full-blown article, the tag value can contain an anchor. MediaWiki has a special format for anchors that looks like URL encoding ([example](https://zh.wikipedia.org/zh-hk/%E8%8C%AB%E6%9B%B2%E9%95%87#.E8.A1.8C.E6.94.BF.E5.8C.BA.E5.88.92)), but the `wikipedia` tag value usually contains the unencoded form.

ref #2688