### PR TITLE
Add Irish postcode field

### DIFF
--- a/data/address-formats.json
+++ b/data/address-formats.json
@@ -8,7 +8,7 @@
     },
     {
         "countryCodes": ["ie"],
-        "format": [["housename"], ["housenumber", "street"], ["city"]]
+        "format": [["housename"], ["housenumber", "street"], ["city"], ["postcode"]]
     },
     {
         "countryCodes": ["ad", "at", "ba", "be", "ch", "cz", "de", "dk", "es", "fi", "gr", "hr", "is", "it", "li", "nl", "no", "pl", "pt", "se", "si", "sk", "sm", "va"],


### PR DESCRIPTION
Ireland got postcodes (aka 'eircode') today. This (untested) patch adds the "postcode" field to Irish address format using the method recommended.

See the example here: http://www.irishtimes.com/news/ireland/irish-news/eircode-q-a-things-you-need-to-know-about-the-new-system-1.2283200