### PR TITLE
Add wikidata asynchronously based on wikipedia

### DIFF
--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -23,3599 +23,3599 @@ en:
         name: Water
     fields:
       access:
-        # 'access=*, foot=*, motor_vehicle=*, bicycle=*, horse=*'
         label: Access
-        options:
-          designated:
-            # access=designated
-            description: Access permitted according to signs or specific local laws
-            # access=designated
-            title: Designated
-          destination:
-            # access=destination
-            description: Access permitted only to reach a destination
-            # access=destination
-            title: Destination
-          'no':
-            # access=no
-            description: Access not permitted to the general public
-            # access=no
-            title: Prohibited
-          permissive:
-            # access=permissive
-            description: Access permitted until such time as the owner revokes the permission
-            # access=permissive
-            title: Permissive
-          private:
-            # access=private
-            description: Access permitted only with permission of the owner on an individual basis
-            # access=private
-            title: Private
-          'yes':
-            # access=yes
-            description: Access permitted by law; a right of way
-            # access=yes
-            title: Allowed
-        # access field placeholder
         placeholder: Unknown
         types:
           access: General
-          bicycle: Bicycles
           foot: Foot
-          horse: Horses
           motor_vehicle: Motor Vehicles
+          bicycle: Bicycles
+          horse: Horses
+        options:
+          "yes":
+            title: Allowed
+            description: Access permitted by law; a right of way
+            "description#": access=yes
+            "title#": access=yes
+          "no":
+            title: Prohibited
+            description: Access not permitted to the general public
+            "description#": access=no
+            "title#": access=no
+          permissive:
+            title: Permissive
+            description: Access permitted until such time as the owner revokes the permission
+            "description#": access=permissive
+            "title#": access=permissive
+          private:
+            title: Private
+            description: Access permitted only with permission of the owner on an individual basis
+            "description#": access=private
+            "title#": access=private
+          designated:
+            title: Designated
+            description: Access permitted according to signs or specific local laws
+            "description#": access=designated
+            "title#": access=designated
+          destination:
+            title: Destination
+            description: Access permitted only to reach a destination
+            "description#": access=destination
+            "title#": access=destination
+        "label#": "access=*, foot=*, motor_vehicle=*, bicycle=*, horse=*"
+        "placeholder#": access field placeholder
       access_simple:
-        # 'access=*'
         label: Access
-        # access_simple field placeholder
-        placeholder: 'yes'
+        placeholder: "yes"
+        "label#": "access=*"
+        "placeholder#": access_simple field placeholder
       access_toilets:
-        # 'access=*'
         label: Access
+        "label#": "access=*"
       address:
-        # 'addr:housename=*, addr:housenumber=*, addr:conscriptionnumber=*, addr:street=*, addr:city=*, addr:postcode=*, addr:place=*, addr:hamlet=*, addr:suburb=*, addr:subdistrict=*, addr:district=*, addr:province=*, addr:state=*, addr:country=*'
         label: Address
         placeholders:
-          city: City
-          conscriptionnumber: '123'
-          country: Country
-          district: District
-          hamlet: Hamlet
           housename: Housename
-          housenumber: '123'
-          place: Place
+          housenumber: "123"
+          conscriptionnumber: "123"
+          street: Street
+          city: City
           postcode: Postcode
+          place: Place
+          hamlet: Hamlet
+          suburb: Suburb
+          subdistrict: Subdistrict
+          district: District
           province: Province
           state: State
-          street: Street
-          subdistrict: Subdistrict
-          suburb: Suburb
+          country: Country
+        "label#": "addr:housename=*, addr:housenumber=*, addr:conscriptionnumber=*, addr:street=*, addr:city=*, addr:postcode=*, addr:place=*, addr:hamlet=*, addr:suburb=*, addr:subdistrict=*, addr:district=*, addr:province=*, addr:state=*, addr:country=*"
       admin_level:
-        # 'admin_level=*'
         label: Admin Level
+        "label#": "admin_level=*"
       aerialway:
-        # 'aerialway=*'
         label: Type
+        "label#": "aerialway=*"
       aerialway/access:
-        # 'aerialway:access=*'
         label: Access
         options:
-          # 'aerialway:access=both'
-          both: Both
-          # 'aerialway:access=entry'
           entry: Entry
-          # 'aerialway:access=exit'
           exit: Exit
+          both: Both
+          "entry#": "aerialway:access=entry"
+          "exit#": "aerialway:access=exit"
+          "both#": "aerialway:access=both"
+        "label#": "aerialway:access=*"
       aerialway/bubble:
-        # 'aerialway:bubble=*'
         label: Bubble
+        "label#": "aerialway:bubble=*"
       aerialway/capacity:
-        # 'aerialway:capacity=*'
         label: Capacity (per hour)
-        # aerialway/capacity field placeholder
-        placeholder: '500, 2500, 5000...'
+        placeholder: "500, 2500, 5000..."
+        "label#": "aerialway:capacity=*"
+        "placeholder#": aerialway/capacity field placeholder
       aerialway/duration:
-        # 'aerialway:duration=*'
         label: Duration (minutes)
-        # aerialway/duration field placeholder
-        placeholder: '1, 2, 3...'
+        placeholder: "1, 2, 3..."
+        "label#": "aerialway:duration=*"
+        "placeholder#": aerialway/duration field placeholder
       aerialway/heating:
-        # 'aerialway:heating=*'
         label: Heated
+        "label#": "aerialway:heating=*"
       aerialway/occupancy:
-        # 'aerialway:occupancy=*'
         label: Occupancy
-        # aerialway/occupancy field placeholder
-        placeholder: '2, 4, 8...'
+        placeholder: "2, 4, 8..."
+        "label#": "aerialway:occupancy=*"
+        "placeholder#": aerialway/occupancy field placeholder
       aerialway/summer/access:
-        # 'aerialway:summer:access=*'
         label: Access (summer)
         options:
-          # 'aerialway:summer:access=both'
-          both: Both
-          # 'aerialway:summer:access=entry'
           entry: Entry
-          # 'aerialway:summer:access=exit'
           exit: Exit
+          both: Both
+          "entry#": "aerialway:summer:access=entry"
+          "exit#": "aerialway:summer:access=exit"
+          "both#": "aerialway:summer:access=both"
+        "label#": "aerialway:summer:access=*"
       aeroway:
-        # 'aeroway=*'
         label: Type
+        "label#": "aeroway=*"
       amenity:
-        # 'amenity=*'
         label: Type
+        "label#": "amenity=*"
       area/highway:
-        # 'area:highway=*'
         label: Type
+        "label#": "area:highway=*"
       artist:
-        # 'artist_name=*'
         label: Artist
+        "label#": "artist_name=*"
       artwork_type:
-        # 'artwork_type=*'
         label: Type
+        "label#": "artwork_type=*"
       atm:
-        # 'atm=*'
         label: ATM
+        "label#": "atm=*"
       backrest:
-        # 'backrest=*'
         label: Backrest
+        "label#": "backrest=*"
       barrier:
-        # 'barrier=*'
         label: Type
+        "label#": "barrier=*"
       bench:
-        # 'bench=*'
         label: Bench
+        "label#": "bench=*"
       bicycle_parking:
-        # 'bicycle_parking=*'
         label: Type
+        "label#": "bicycle_parking=*"
       boundary:
-        # 'boundary=*'
         label: Type
+        "label#": "boundary=*"
       brand:
-        # 'brand=*'
         label: Brand
+        "label#": "brand=*"
       building:
-        # 'building=*'
         label: Building
+        "label#": "building=*"
       building_area:
-        # 'building=*'
         label: Building
+        "label#": "building=*"
       capacity:
-        # 'capacity=*'
         label: Capacity
-        # capacity field placeholder
-        placeholder: '50, 100, 200...'
+        placeholder: "50, 100, 200..."
+        "label#": "capacity=*"
+        "placeholder#": capacity field placeholder
       cardinal_direction:
-        # 'direction=*'
         label: Direction
         options:
-          # direction=E
+          "N": North
           E: East
-          # direction=ENE
-          ENE: East-northeast
-          # direction=ESE
-          ESE: East-southeast
-          # direction=N
-          'N': North
-          # direction=NE
-          NE: Northeast
-          # direction=NNE
-          NNE: North-northeast
-          # direction=NNW
-          NNW: North-northwest
-          # direction=NW
-          NW: Northwest
-          # direction=S
           S: South
-          # direction=SE
-          SE: Southeast
-          # direction=SSE
-          SSE: South-southeast
-          # direction=SSW
-          SSW: South-southwest
-          # direction=SW
-          SW: Southwest
-          # direction=W
           W: West
-          # direction=WNW
-          WNW: West-northwest
-          # direction=WSW
+          NE: Northeast
+          SE: Southeast
+          SW: Southwest
+          NW: Northwest
+          NNE: North-northeast
+          ENE: East-northeast
+          ESE: East-southeast
+          SSE: South-southeast
+          SSW: South-southwest
           WSW: West-southwest
+          WNW: West-northwest
+          NNW: North-northwest
+          "N#": direction=N
+          "E#": direction=E
+          "S#": direction=S
+          "W#": direction=W
+          "NE#": direction=NE
+          "SE#": direction=SE
+          "SW#": direction=SW
+          "NW#": direction=NW
+          "NNE#": direction=NNE
+          "ENE#": direction=ENE
+          "ESE#": direction=ESE
+          "SSE#": direction=SSE
+          "SSW#": direction=SSW
+          "WSW#": direction=WSW
+          "WNW#": direction=WNW
+          "NNW#": direction=NNW
+        "label#": "direction=*"
       clock_direction:
-        # 'direction=*'
         label: Direction
         options:
-          # direction=anticlockwise
-          anticlockwise: Counterclockwise
-          # direction=clockwise
           clockwise: Clockwise
+          anticlockwise: Counterclockwise
+          "clockwise#": direction=clockwise
+          "anticlockwise#": direction=anticlockwise
+        "label#": "direction=*"
       collection_times:
-        # 'collection_times=*'
         label: Collection Times
+        "label#": "collection_times=*"
       construction:
-        # 'construction=*'
         label: Type
+        "label#": "construction=*"
       content:
-        # 'content=*'
         label: Contents
+        "label#": "content=*"
       country:
-        # 'country=*'
         label: Country
+        "label#": "country=*"
       covered:
-        # 'covered=*'
         label: Covered
+        "label#": "covered=*"
       craft:
-        # 'craft=*'
         label: Type
+        "label#": "craft=*"
       crop:
-        # 'crop=*'
         label: Crop
+        "label#": "crop=*"
       crossing:
-        # 'crossing=*'
         label: Type
+        "label#": "crossing=*"
       cuisine:
-        # 'cuisine=*'
         label: Cuisine
+        "label#": "cuisine=*"
       cycleway:
-        # 'cycleway:left=*, cycleway:right=*'
         label: Bike Lanes
-        options:
-          # lane=yes
-          lane:
-            description: A bike lane separated from auto traffic by a painted line
-            title: Standard bike lane
-          # none=yes
-          none:
-            description: No bike lane
-            title: None
-          # opposite=yes
-          opposite:
-            description: A bike lane that travels in both directions on a one-way street
-            title: Contraflow bike lane
-          # opposite_lane=yes
-          opposite_lane:
-            description: A bike lane that travels in the opposite direction of traffic
-            title: Opposite bike lane
-          # share_busway=yes
-          share_busway:
-            description: A bike lane shared with a bus lane
-            title: Bike lane shared with bus
-          # shared_lane=yes
-          shared_lane:
-            description: A bike lane with no separation from auto traffic
-            title: Shared bike lane
-          # track=yes
-          track:
-            description: A bike lane separated from traffic by a physical barrier
-            title: Bike track
-        # cycleway field placeholder
         placeholder: none
         types:
-          'cycleway:left': Left side
-          'cycleway:right': Right side
+          "cycleway:left": Left side
+          "cycleway:right": Right side
+        options:
+          none:
+            title: None
+            description: No bike lane
+          lane:
+            title: Standard bike lane
+            description: A bike lane separated from auto traffic by a painted line
+          shared_lane:
+            title: Shared bike lane
+            description: A bike lane with no separation from auto traffic
+          track:
+            title: Bike track
+            description: A bike lane separated from traffic by a physical barrier
+          share_busway:
+            title: Bike lane shared with bus
+            description: A bike lane shared with a bus lane
+          opposite_lane:
+            title: Opposite bike lane
+            description: A bike lane that travels in the opposite direction of traffic
+          opposite:
+            title: Contraflow bike lane
+            description: A bike lane that travels in both directions on a one-way street
+          "none#": none=yes
+          "lane#": lane=yes
+          "shared_lane#": shared_lane=yes
+          "track#": track=yes
+          "share_busway#": share_busway=yes
+          "opposite_lane#": opposite_lane=yes
+          "opposite#": opposite=yes
+        "label#": "cycleway:left=*, cycleway:right=*"
+        "placeholder#": cycleway field placeholder
       delivery:
-        # 'delivery=*'
         label: Delivery
+        "label#": "delivery=*"
       denomination:
-        # 'denomination=*'
         label: Denomination
+        "label#": "denomination=*"
       denotation:
-        # 'denotation=*'
         label: Denotation
+        "label#": "denotation=*"
       description:
-        # 'description=*'
         label: Description
+        "label#": "description=*"
       drive_through:
-        # 'drive_through=*'
         label: Drive-Through
+        "label#": "drive_through=*"
       electrified:
-        # 'electrified=*'
         label: Electrification
+        placeholder: "Contact Line, Electrified Rail..."
         options:
-          # electrified=contact_line
           contact_line: Contact Line
-          # electrified=no
-          'no': 'No'
-          # electrified=rail
           rail: Electrified Rail
-          # electrified=yes
-          'yes': Yes (unspecified)
-        # electrified field placeholder
-        placeholder: 'Contact Line, Electrified Rail...'
+          "yes": Yes (unspecified)
+          "no": "No"
+          "contact_line#": electrified=contact_line
+          "rail#": electrified=rail
+          "yes#": electrified=yes
+          "no#": electrified=no
+        "label#": "electrified=*"
+        "placeholder#": electrified field placeholder
       elevation:
-        # 'ele=*'
         label: Elevation
+        "label#": "ele=*"
       emergency:
-        # 'emergency=*'
         label: Emergency
+        "label#": "emergency=*"
       entrance:
-        # 'entrance=*'
         label: Type
+        "label#": "entrance=*"
       except:
-        # 'except=*'
         label: Exceptions
+        "label#": "except=*"
       fax:
-        # 'fax=*'
         label: Fax
-        # fax field placeholder
         placeholder: +31 42 123 4567
+        "label#": "fax=*"
+        "placeholder#": fax field placeholder
       fee:
-        # 'fee=*'
         label: Fee
+        "label#": "fee=*"
       fire_hydrant/type:
-        # 'fire_hydrant:type=*'
         label: Type
         options:
-          # 'fire_hydrant:type=pillar'
           pillar: Pillar/Aboveground
-          # 'fire_hydrant:type=pond'
-          pond: Pond
-          # 'fire_hydrant:type=underground'
           underground: Underground
-          # 'fire_hydrant:type=wall'
           wall: Wall
+          pond: Pond
+          "pillar#": "fire_hydrant:type=pillar"
+          "underground#": "fire_hydrant:type=underground"
+          "wall#": "fire_hydrant:type=wall"
+          "pond#": "fire_hydrant:type=pond"
+        "label#": "fire_hydrant:type=*"
       fixme:
-        # 'fixme=*'
         label: Fix Me
+        "label#": "fixme=*"
       fuel:
-        # 'fuel=*'
         label: Fuel
+        "label#": "fuel=*"
       fuel/biodiesel:
-        # 'fuel:biodiesel=*'
         label: Sells Biodiesel
+        "label#": "fuel:biodiesel=*"
       fuel/diesel:
-        # 'fuel:diesel=*'
         label: Sells Diesel
+        "label#": "fuel:diesel=*"
       fuel/e10:
-        # 'fuel:e10=*'
         label: Sells E10
+        "label#": "fuel:e10=*"
       fuel/e85:
-        # 'fuel:e85=*'
         label: Sells E85
+        "label#": "fuel:e85=*"
       fuel/lpg:
-        # 'fuel:lpg=*'
         label: Sells Propane
+        "label#": "fuel:lpg=*"
       fuel/octane_100:
-        # 'fuel:octane_100=*'
         label: Sells Racing Gasoline
+        "label#": "fuel:octane_100=*"
       fuel/octane_91:
-        # 'fuel:octane_91=*'
         label: Sells Regular Gasoline
+        "label#": "fuel:octane_91=*"
       fuel/octane_95:
-        # 'fuel:octane_95=*'
         label: Sells Midgrade Gasoline
+        "label#": "fuel:octane_95=*"
       fuel/octane_98:
-        # 'fuel:octane_98=*'
         label: Sells Premium Gasoline
+        "label#": "fuel:octane_98=*"
       gauge:
-        # 'gauge=*'
         label: Gauge
+        "label#": "gauge=*"
       gender:
-        # 'male=*, female=*, unisex=*'
         label: Gender
-        options:
-          # female=yes
-          female: Female
-          # male=yes
-          male: Male
-          # unisex=yes
-          unisex: Unisex
-        # gender field placeholder
         placeholder: Unknown
+        options:
+          male: Male
+          female: Female
+          unisex: Unisex
+          "male#": male=yes
+          "female#": female=yes
+          "unisex#": unisex=yes
+        "label#": "male=*, female=*, unisex=*"
+        "placeholder#": gender field placeholder
       generator/method:
-        # 'generator:method=*'
         label: Method
+        "label#": "generator:method=*"
       generator/source:
-        # 'generator:source=*'
         label: Source
+        "label#": "generator:source=*"
       generator/type:
-        # 'generator:type=*'
         label: Type
+        "label#": "generator:type=*"
       golf_hole:
-        # 'ref=*'
         label: Reference
-        # golf_hole field placeholder
         placeholder: Hole number (1-18)
+        "label#": "ref=*"
+        "placeholder#": golf_hole field placeholder
       handicap:
-        # 'handicap=*'
         label: Handicap
-        # handicap field placeholder
         placeholder: 1-18
+        "label#": "handicap=*"
+        "placeholder#": handicap field placeholder
       highway:
-        # 'highway=*'
         label: Type
+        "label#": "highway=*"
       historic:
-        # 'historic=*'
         label: Type
+        "label#": "historic=*"
       hoops:
-        # 'hoops=*'
         label: Hoops
-        # hoops field placeholder
-        placeholder: '1, 2, 4...'
+        placeholder: "1, 2, 4..."
+        "label#": "hoops=*"
+        "placeholder#": hoops field placeholder
       iata:
-        # 'iata=*'
         label: IATA
+        "label#": "iata=*"
       icao:
-        # 'icao=*'
         label: ICAO
+        "label#": "icao=*"
       incline:
-        # 'incline=*'
         label: Incline
+        "label#": "incline=*"
       incline_steps:
-        # 'incline=*'
         label: Incline
         options:
-          # incline=down
-          down: Down
-          # incline=up
           up: Up
+          down: Down
+          "up#": incline=up
+          "down#": incline=down
+        "label#": "incline=*"
       information:
-        # 'information=*'
         label: Type
+        "label#": "information=*"
       internet_access:
-        # 'internet_access=*'
         label: Internet Access
         options:
-          # internet_access=no
-          'no': 'No'
-          # internet_access=terminal
-          terminal: Terminal
-          # internet_access=wired
-          wired: Wired
-          # internet_access=wlan
+          "yes": "Yes"
+          "no": "No"
           wlan: Wifi
-          # internet_access=yes
-          'yes': 'Yes'
+          wired: Wired
+          terminal: Terminal
+          "yes#": internet_access=yes
+          "no#": internet_access=no
+          "wlan#": internet_access=wlan
+          "wired#": internet_access=wired
+          "terminal#": internet_access=terminal
+        "label#": "internet_access=*"
       lamp_type:
-        # 'lamp_type=*'
         label: Type
+        "label#": "lamp_type=*"
       landuse:
-        # 'landuse=*'
         label: Type
+        "label#": "landuse=*"
       lanes:
-        # 'lanes=*'
         label: Lanes
-        # lanes field placeholder
-        placeholder: '1, 2, 3...'
+        placeholder: "1, 2, 3..."
+        "label#": "lanes=*"
+        "placeholder#": lanes field placeholder
       layer:
-        # 'layer=*'
         label: Layer
+        "label#": "layer=*"
       leaf_cycle:
-        # 'leaf_cycle=*'
         label: Leaf Cycle
         options:
-          # leaf_cycle=deciduous
-          deciduous: Deciduous
-          # leaf_cycle=evergreen
           evergreen: Evergreen
-          # leaf_cycle=mixed
-          mixed: Mixed
-          # leaf_cycle=semi_deciduous
-          semi_deciduous: Semi-Deciduous
-          # leaf_cycle=semi_evergreen
+          deciduous: Deciduous
           semi_evergreen: Semi-Evergreen
+          semi_deciduous: Semi-Deciduous
+          mixed: Mixed
+          "evergreen#": leaf_cycle=evergreen
+          "deciduous#": leaf_cycle=deciduous
+          "semi_evergreen#": leaf_cycle=semi_evergreen
+          "semi_deciduous#": leaf_cycle=semi_deciduous
+          "mixed#": leaf_cycle=mixed
+        "label#": "leaf_cycle=*"
       leaf_type:
-        # 'leaf_type=*'
         label: Leaf Type
         options:
-          # leaf_type=broadleaved
           broadleaved: Broadleaved
-          # leaf_type=leafless
-          leafless: Leafless
-          # leaf_type=mixed
-          mixed: Mixed
-          # leaf_type=needleleaved
           needleleaved: Needleleaved
+          mixed: Mixed
+          leafless: Leafless
+          "broadleaved#": leaf_type=broadleaved
+          "needleleaved#": leaf_type=needleleaved
+          "mixed#": leaf_type=mixed
+          "leafless#": leaf_type=leafless
+        "label#": "leaf_type=*"
       leisure:
-        # 'leisure=*'
         label: Type
+        "label#": "leisure=*"
       length:
-        # 'length=*'
         label: Length (Meters)
+        "label#": "length=*"
       level:
-        # 'level=*'
         label: Level
+        "label#": "level=*"
       levels:
-        # 'building:levels=*'
         label: Levels
-        # levels field placeholder
-        placeholder: '2, 4, 6...'
+        placeholder: "2, 4, 6..."
+        "label#": "building:levels=*"
+        "placeholder#": levels field placeholder
       lit:
-        # 'lit=*'
         label: Lit
+        "label#": "lit=*"
       location:
-        # 'location=*'
         label: Location
+        "label#": "location=*"
       man_made:
-        # 'man_made=*'
         label: Type
+        "label#": "man_made=*"
       maxspeed:
-        # 'maxspeed=*'
         label: Speed Limit
-        # maxspeed field placeholder
-        placeholder: '40, 50, 60...'
+        placeholder: "40, 50, 60..."
+        "label#": "maxspeed=*"
+        "placeholder#": maxspeed field placeholder
       mtb/scale:
-        # 'mtb:scale=*'
         label: Mountain Biking Difficulty
+        placeholder: "0, 1, 2, 3..."
         options:
-          # 'mtb:scale=0'
-          '0': '0: Solid gravel/packed earth, no obstacles, wide curves'
-          # 'mtb:scale=1'
-          '1': '1: Some loose surface, small obstacles, wide curves'
-          # 'mtb:scale=2'
-          '2': '2: Much loose surface, large obstacles, easy hairpins'
-          # 'mtb:scale=3'
-          '3': '3: Slippery surface, large obstacles, tight hairpins'
-          # 'mtb:scale=4'
-          '4': '4: Loose surface or boulders, dangerous hairpins'
-          # 'mtb:scale=5'
-          '5': '5: Maximum difficulty, boulder fields, landslides'
-          # 'mtb:scale=6'
-          '6': '6: Not rideable except by the very best mountain bikers'
-        # mtb/scale field placeholder
-        placeholder: '0, 1, 2, 3...'
+          "0": "0: Solid gravel/packed earth, no obstacles, wide curves"
+          "1": "1: Some loose surface, small obstacles, wide curves"
+          "2": "2: Much loose surface, large obstacles, easy hairpins"
+          "3": "3: Slippery surface, large obstacles, tight hairpins"
+          "4": "4: Loose surface or boulders, dangerous hairpins"
+          "5": "5: Maximum difficulty, boulder fields, landslides"
+          "6": "6: Not rideable except by the very best mountain bikers"
+          "0#": "mtb:scale=0"
+          "1#": "mtb:scale=1"
+          "2#": "mtb:scale=2"
+          "3#": "mtb:scale=3"
+          "4#": "mtb:scale=4"
+          "5#": "mtb:scale=5"
+          "6#": "mtb:scale=6"
+        "label#": "mtb:scale=*"
+        "placeholder#": mtb/scale field placeholder
       mtb/scale/imba:
-        # 'mtb:scale:imba=*'
         label: IMBA Trail Difficulty
+        placeholder: "Easy, Medium, Difficult..."
         options:
-          # 'mtb:scale:imba=0'
-          '0': Easiest (white circle)
-          # 'mtb:scale:imba=1'
-          '1': Easy (green circle)
-          # 'mtb:scale:imba=2'
-          '2': Medium (blue square)
-          # 'mtb:scale:imba=3'
-          '3': Difficult (black diamond)
-          # 'mtb:scale:imba=4'
-          '4': Extremely Difficult (double black diamond)
-        # mtb/scale/imba field placeholder
-        placeholder: 'Easy, Medium, Difficult...'
+          "0": Easiest (white circle)
+          "1": Easy (green circle)
+          "2": Medium (blue square)
+          "3": Difficult (black diamond)
+          "4": Extremely Difficult (double black diamond)
+          "0#": "mtb:scale:imba=0"
+          "1#": "mtb:scale:imba=1"
+          "2#": "mtb:scale:imba=2"
+          "3#": "mtb:scale:imba=3"
+          "4#": "mtb:scale:imba=4"
+        "label#": "mtb:scale:imba=*"
+        "placeholder#": mtb/scale/imba field placeholder
       mtb/scale/uphill:
-        # 'mtb:scale:uphill=*'
         label: Mountain Biking Uphill Difficulty
+        placeholder: "0, 1, 2, 3..."
         options:
-          # 'mtb:scale:uphill=0'
-          '0': '0: Avg. incline <10%, gravel/packed earth, no obstacles'
-          # 'mtb:scale:uphill=1'
-          '1': '1: Avg. incline <15%, gravel/packed earth, few small objects'
-          # 'mtb:scale:uphill=2'
-          '2': '2: Avg. incline <20%, stable surface, fistsize rocks/roots'
-          # 'mtb:scale:uphill=3'
-          '3': '3: Avg. incline <25%, variable surface, fistsize rocks/branches'
-          # 'mtb:scale:uphill=4'
-          '4': '4: Avg. incline <30%, poor condition, big rocks/branches'
-          # 'mtb:scale:uphill=5'
-          '5': '5: Very steep, bike generally needs to be pushed or carried'
-        # mtb/scale/uphill field placeholder
-        placeholder: '0, 1, 2, 3...'
+          "0": "0: Avg. incline <10%, gravel/packed earth, no obstacles"
+          "1": "1: Avg. incline <15%, gravel/packed earth, few small objects"
+          "2": "2: Avg. incline <20%, stable surface, fistsize rocks/roots"
+          "3": "3: Avg. incline <25%, variable surface, fistsize rocks/branches"
+          "4": "4: Avg. incline <30%, poor condition, big rocks/branches"
+          "5": "5: Very steep, bike generally needs to be pushed or carried"
+          "0#": "mtb:scale:uphill=0"
+          "1#": "mtb:scale:uphill=1"
+          "2#": "mtb:scale:uphill=2"
+          "3#": "mtb:scale:uphill=3"
+          "4#": "mtb:scale:uphill=4"
+          "5#": "mtb:scale:uphill=5"
+        "label#": "mtb:scale:uphill=*"
+        "placeholder#": mtb/scale/uphill field placeholder
       name:
-        # 'name=*'
         label: Name
-        # name field placeholder
         placeholder: Common name (if any)
+        "label#": "name=*"
+        "placeholder#": name field placeholder
       natural:
-        # 'natural=*'
         label: Natural
+        "label#": "natural=*"
       network:
-        # 'network=*'
         label: Network
+        "label#": "network=*"
       note:
-        # 'note=*'
         label: Note
+        "label#": "note=*"
       office:
-        # 'office=*'
         label: Type
+        "label#": "office=*"
       oneway:
-        # 'oneway=*'
         label: One Way
         options:
-          # oneway=no
-          'no': 'No'
-          # oneway=undefined
           undefined: Assumed to be No
-          # oneway=yes
-          'yes': 'Yes'
+          "yes": "Yes"
+          "no": "No"
+          "undefined#": oneway=undefined
+          "yes#": oneway=yes
+          "no#": oneway=no
+        "label#": "oneway=*"
       oneway_yes:
-        # 'oneway=*'
         label: One Way
         options:
-          # oneway=no
-          'no': 'No'
-          # oneway=undefined
           undefined: Assumed to be Yes
-          # oneway=yes
-          'yes': 'Yes'
+          "yes": "Yes"
+          "no": "No"
+          "undefined#": oneway=undefined
+          "yes#": oneway=yes
+          "no#": oneway=no
+        "label#": "oneway=*"
       opening_hours:
-        # 'opening_hours=*'
         label: Hours
+        "label#": "opening_hours=*"
       operator:
-        # 'operator=*'
         label: Operator
+        "label#": "operator=*"
       par:
-        # 'par=*'
         label: Par
-        # par field placeholder
-        placeholder: '3, 4, 5...'
+        placeholder: "3, 4, 5..."
+        "label#": "par=*"
+        "placeholder#": par field placeholder
       park_ride:
-        # 'park_ride=*'
         label: Park and Ride
+        "label#": "park_ride=*"
       parking:
-        # 'parking=*'
         label: Type
         options:
-          # parking=carports
-          carports: Carports
-          # parking=garage_boxes
-          garage_boxes: Garage Boxes
-          # parking=lane
-          lane: Roadside Lane
-          # parking=multi-storey
-          multi-storey: Multilevel
-          # parking=sheds
-          sheds: Sheds
-          # parking=surface
           surface: Surface
-          # parking=underground
+          multi-storey: Multilevel
           underground: Underground
+          sheds: Sheds
+          carports: Carports
+          garage_boxes: Garage Boxes
+          lane: Roadside Lane
+          "surface#": parking=surface
+          "multi-storey#": parking=multi-storey
+          "underground#": parking=underground
+          "sheds#": parking=sheds
+          "carports#": parking=carports
+          "garage_boxes#": parking=garage_boxes
+          "lane#": parking=lane
+        "label#": "parking=*"
       phone:
-        # 'phone=*'
         label: Phone
-        # phone field placeholder
         placeholder: +31 42 123 4567
+        "label#": "phone=*"
+        "placeholder#": phone field placeholder
       piste/difficulty:
-        # 'piste:difficulty=*'
         label: Difficulty
+        placeholder: "Easy, Intermediate, Advanced..."
         options:
-          # 'piste:difficulty=advanced'
-          advanced: Advanced (black diamond)
-          # 'piste:difficulty=easy'
-          easy: Easy (green circle)
-          # 'piste:difficulty=expert'
-          expert: Expert (double black diamond)
-          # 'piste:difficulty=extreme'
-          extreme: Extreme (climbing equipment required)
-          # 'piste:difficulty=freeride'
-          freeride: Freeride (off-piste)
-          # 'piste:difficulty=intermediate'
-          intermediate: Intermediate (blue square)
-          # 'piste:difficulty=novice'
           novice: Novice (instructional)
-        # piste/difficulty field placeholder
-        placeholder: 'Easy, Intermediate, Advanced...'
+          easy: Easy (green circle)
+          intermediate: Intermediate (blue square)
+          advanced: Advanced (black diamond)
+          expert: Expert (double black diamond)
+          freeride: Freeride (off-piste)
+          extreme: Extreme (climbing equipment required)
+          "novice#": "piste:difficulty=novice"
+          "easy#": "piste:difficulty=easy"
+          "intermediate#": "piste:difficulty=intermediate"
+          "advanced#": "piste:difficulty=advanced"
+          "expert#": "piste:difficulty=expert"
+          "freeride#": "piste:difficulty=freeride"
+          "extreme#": "piste:difficulty=extreme"
+        "label#": "piste:difficulty=*"
+        "placeholder#": piste/difficulty field placeholder
       piste/grooming:
-        # 'piste:grooming=*'
         label: Grooming
         options:
-          # 'piste:grooming=backcountry'
-          backcountry: Backcountry
-          # 'piste:grooming=classic'
           classic: Classic
-          # 'piste:grooming=classic+skating'
-          classic+skating: Classic and Skating
-          # 'piste:grooming=mogul'
           mogul: Mogul
-          # 'piste:grooming=scooter'
+          backcountry: Backcountry
+          classic+skating: Classic and Skating
           scooter: Scooter/Snowmobile
-          # 'piste:grooming=skating'
           skating: Skating
+          "classic#": "piste:grooming=classic"
+          "mogul#": "piste:grooming=mogul"
+          "backcountry#": "piste:grooming=backcountry"
+          "classic+skating#": "piste:grooming=classic+skating"
+          "scooter#": "piste:grooming=scooter"
+          "skating#": "piste:grooming=skating"
+        "label#": "piste:grooming=*"
       piste/type:
-        # 'piste:type=*'
         label: Type
         options:
-          # 'piste:type=downhill'
           downhill: Downhill
-          # 'piste:type=hike'
-          hike: Hike
-          # 'piste:type=ice_skate'
-          ice_skate: Ice Skate
-          # 'piste:type=nordic'
           nordic: Nordic
-          # 'piste:type=playground'
-          playground: Playground
-          # 'piste:type=skitour'
           skitour: Skitour
-          # 'piste:type=sled'
           sled: Sled
-          # 'piste:type=sleigh'
+          hike: Hike
           sleigh: Sleigh
-          # 'piste:type=snow_park'
+          ice_skate: Ice Skate
           snow_park: Snow Park
+          playground: Playground
+          "downhill#": "piste:type=downhill"
+          "nordic#": "piste:type=nordic"
+          "skitour#": "piste:type=skitour"
+          "sled#": "piste:type=sled"
+          "hike#": "piste:type=hike"
+          "sleigh#": "piste:type=sleigh"
+          "ice_skate#": "piste:type=ice_skate"
+          "snow_park#": "piste:type=snow_park"
+          "playground#": "piste:type=playground"
+        "label#": "piste:type=*"
       place:
-        # 'place=*'
         label: Type
+        "label#": "place=*"
       population:
-        # 'population=*'
         label: Population
+        "label#": "population=*"
       power:
-        # 'power=*'
         label: Type
+        "label#": "power=*"
       power_supply:
-        # 'power_supply=*'
         label: Power Supply
+        "label#": "power_supply=*"
       railway:
-        # 'railway=*'
         label: Type
+        "label#": "railway=*"
       recycling/cans:
-        # 'recycling:cans=*'
         label: Accepts Cans
+        "label#": "recycling:cans=*"
       recycling/clothes:
-        # 'recycling:clothes=*'
         label: Accepts Clothes
+        "label#": "recycling:clothes=*"
       recycling/glass:
-        # 'recycling:glass=*'
         label: Accepts Glass
+        "label#": "recycling:glass=*"
       recycling/paper:
-        # 'recycling:paper=*'
         label: Accepts Paper
+        "label#": "recycling:paper=*"
       recycling/type:
-        # 'recycling_type=*'
         label: Recycling Type
         options:
-          # recycling_type=centre
-          centre: Recycling Center
-          # recycling_type=container
           container: Container
+          centre: Recycling Center
+          "container#": recycling_type=container
+          "centre#": recycling_type=centre
+        "label#": "recycling_type=*"
       ref:
-        # 'ref=*'
         label: Reference
+        "label#": "ref=*"
       relation:
-        # 'type=*'
         label: Type
+        "label#": "type=*"
       religion:
-        # 'religion=*'
         label: Religion
+        "label#": "religion=*"
       restriction:
-        # 'restriction=*'
         label: Type
+        "label#": "restriction=*"
       restrictions:
         label: Turn Restrictions
       route:
-        # 'route=*'
         label: Type
+        "label#": "route=*"
       route_master:
-        # 'route_master=*'
         label: Type
+        "label#": "route_master=*"
       sac_scale:
-        # 'sac_scale=*'
         label: Hiking Difficulty
+        placeholder: "Mountain Hiking, Alpine Hiking..."
         options:
-          # sac_scale=alpine_hiking
-          alpine_hiking: 'T4: Alpine Hiking'
-          # sac_scale=demanding_alpine_hiking
-          demanding_alpine_hiking: 'T5: Demanding Alpine Hiking'
-          # sac_scale=demanding_mountain_hiking
-          demanding_mountain_hiking: 'T3: Demanding Mountain Hiking'
-          # sac_scale=difficult_alpine_hiking
-          difficult_alpine_hiking: 'T6: Difficult Alpine Hiking'
-          # sac_scale=hiking
-          hiking: 'T1: Hiking'
-          # sac_scale=mountain_hiking
-          mountain_hiking: 'T2: Mountain Hiking'
-        # sac_scale field placeholder
-        placeholder: 'Mountain Hiking, Alpine Hiking...'
+          hiking: "T1: Hiking"
+          mountain_hiking: "T2: Mountain Hiking"
+          demanding_mountain_hiking: "T3: Demanding Mountain Hiking"
+          alpine_hiking: "T4: Alpine Hiking"
+          demanding_alpine_hiking: "T5: Demanding Alpine Hiking"
+          difficult_alpine_hiking: "T6: Difficult Alpine Hiking"
+          "hiking#": sac_scale=hiking
+          "mountain_hiking#": sac_scale=mountain_hiking
+          "demanding_mountain_hiking#": sac_scale=demanding_mountain_hiking
+          "alpine_hiking#": sac_scale=alpine_hiking
+          "demanding_alpine_hiking#": sac_scale=demanding_alpine_hiking
+          "difficult_alpine_hiking#": sac_scale=difficult_alpine_hiking
+        "label#": "sac_scale=*"
+        "placeholder#": sac_scale field placeholder
       sanitary_dump_station:
-        # 'sanitary_dump_station=*'
         label: Toilet Disposal
+        "label#": "sanitary_dump_station=*"
       seasonal:
-        # 'seasonal=*'
         label: Seasonal
+        "label#": "seasonal=*"
       service:
-        # 'service=*'
         label: Type
+        "label#": "service=*"
       service/bicycle/chain_tool:
-        # 'service:bicycle:chain_tool=*'
         label: Chain Tool
         options:
-          # 'service:bicycle:chain_tool=no'
-          'no': 'No'
-          # 'service:bicycle:chain_tool=undefined'
           undefined: Assumed to be No
-          # 'service:bicycle:chain_tool=yes'
-          'yes': 'Yes'
+          "yes": "Yes"
+          "no": "No"
+          "undefined#": "service:bicycle:chain_tool=undefined"
+          "yes#": "service:bicycle:chain_tool=yes"
+          "no#": "service:bicycle:chain_tool=no"
+        "label#": "service:bicycle:chain_tool=*"
       service/bicycle/pump:
-        # 'service:bicycle:pump=*'
         label: Air Pump
         options:
-          # 'service:bicycle:pump=no'
-          'no': 'No'
-          # 'service:bicycle:pump=undefined'
           undefined: Assumed to be No
-          # 'service:bicycle:pump=yes'
-          'yes': 'Yes'
+          "yes": "Yes"
+          "no": "No"
+          "undefined#": "service:bicycle:pump=undefined"
+          "yes#": "service:bicycle:pump=yes"
+          "no#": "service:bicycle:pump=no"
+        "label#": "service:bicycle:pump=*"
       service_rail:
-        # 'service=*'
         label: Service Type
         options:
-          # service=crossover
-          crossover: Crossover
-          # service=siding
-          siding: Siding
-          # service=spur
           spur: Spur
-          # service=yard
           yard: Yard
+          siding: Siding
+          crossover: Crossover
+          "spur#": service=spur
+          "yard#": service=yard
+          "siding#": service=siding
+          "crossover#": service=crossover
+        "label#": "service=*"
       shelter:
-        # 'shelter=*'
         label: Shelter
+        "label#": "shelter=*"
       shelter_type:
-        # 'shelter_type=*'
         label: Type
+        "label#": "shelter_type=*"
       shop:
-        # 'shop=*'
         label: Type
+        "label#": "shop=*"
       sloped_curb:
-        # 'sloped_curb=*'
         label: Sloped Curb
+        "label#": "sloped_curb=*"
       smoking:
-        # 'smoking=*'
         label: Smoking
+        placeholder: "No, Separated, Yes..."
         options:
-          # smoking=dedicated
-          dedicated: "Dedicated to smokers (e.g. smokers' club)"
-          # smoking=isolated
-          isolated: 'In smoking areas, physically isolated'
-          # smoking=no
-          'no': No smoking anywhere
-          # smoking=outside
+          "no": No smoking anywhere
+          separated: "In smoking areas, not physically isolated"
+          isolated: "In smoking areas, physically isolated"
           outside: Allowed outside
-          # smoking=separated
-          separated: 'In smoking areas, not physically isolated'
-          # smoking=yes
-          'yes': Allowed everywhere
-        # smoking field placeholder
-        placeholder: 'No, Separated, Yes...'
+          "yes": Allowed everywhere
+          dedicated: "Dedicated to smokers (e.g. smokers' club)"
+          "no#": smoking=no
+          "separated#": smoking=separated
+          "isolated#": smoking=isolated
+          "outside#": smoking=outside
+          "yes#": smoking=yes
+          "dedicated#": smoking=dedicated
+        "label#": "smoking=*"
+        "placeholder#": smoking field placeholder
       smoothness:
-        # 'smoothness=*'
         label: Smoothness
+        placeholder: "Thin Rollers, Wheels, Off-Road..."
         options:
-          # smoothness=bad
-          bad: 'Robust Wheels: trekking bike, car, rickshaw'
-          # smoothness=excellent
-          excellent: 'Thin Rollers: rollerblade, skateboard'
-          # smoothness=good
-          good: 'Thin Wheels: racing bike'
-          # smoothness=horrible
-          horrible: 'Off-Road: heavy duty off-road vehicle'
-          # smoothness=impassable
+          excellent: "Thin Rollers: rollerblade, skateboard"
+          good: "Thin Wheels: racing bike"
+          intermediate: "Wheels: city bike, wheelchair, scooter"
+          bad: "Robust Wheels: trekking bike, car, rickshaw"
+          very_bad: "High Clearance: light duty off-road vehicle"
+          horrible: "Off-Road: heavy duty off-road vehicle"
+          very_horrible: "Specialized off-road: tractor, ATV"
           impassable: Impassable / No wheeled vehicle
-          # smoothness=intermediate
-          intermediate: 'Wheels: city bike, wheelchair, scooter'
-          # smoothness=very_bad
-          very_bad: 'High Clearance: light duty off-road vehicle'
-          # smoothness=very_horrible
-          very_horrible: 'Specialized off-road: tractor, ATV'
-        # smoothness field placeholder
-        placeholder: 'Thin Rollers, Wheels, Off-Road...'
+          "excellent#": smoothness=excellent
+          "good#": smoothness=good
+          "intermediate#": smoothness=intermediate
+          "bad#": smoothness=bad
+          "very_bad#": smoothness=very_bad
+          "horrible#": smoothness=horrible
+          "very_horrible#": smoothness=very_horrible
+          "impassable#": smoothness=impassable
+        "label#": "smoothness=*"
+        "placeholder#": smoothness field placeholder
       social_facility_for:
-        # 'social_facility:for=*'
         label: People served
-        # social_facility_for field placeholder
-        placeholder: 'Homeless, Disabled, Child, etc'
+        placeholder: "Homeless, Disabled, Child, etc"
+        "label#": "social_facility:for=*"
+        "placeholder#": social_facility_for field placeholder
       source:
-        # 'source=*'
         label: Source
+        "label#": "source=*"
       sport:
-        # 'sport=*'
         label: Sport
+        "label#": "sport=*"
       sport_ice:
-        # 'sport=*'
         label: Sport
+        "label#": "sport=*"
       sport_racing:
-        # 'sport=*'
         label: Sport
+        "label#": "sport=*"
       structure:
-        # 'bridge=*, tunnel=*, embankment=*, cutting=*, ford=*'
         label: Structure
-        options:
-          # bridge=yes
-          bridge: Bridge
-          # cutting=yes
-          cutting: Cutting
-          # embankment=yes
-          embankment: Embankment
-          # ford=yes
-          ford: Ford
-          # tunnel=yes
-          tunnel: Tunnel
-        # structure field placeholder
         placeholder: Unknown
-      studio_type:
-        # 'type=*'
-        label: Type
-      substation:
-        # 'substation=*'
-        label: Type
-      supervised:
-        # 'supervised=*'
-        label: Supervised
-      surface:
-        # 'surface=*'
-        label: Surface
-      tactile_paving:
-        # 'tactile_paving=*'
-        label: Tactile Paving
-      takeaway:
-        # 'takeaway=*'
-        label: Takeaway
         options:
-          # takeaway=no
-          'no': 'No'
-          # takeaway=only
+          bridge: Bridge
+          tunnel: Tunnel
+          embankment: Embankment
+          cutting: Cutting
+          ford: Ford
+          "bridge#": bridge=yes
+          "tunnel#": tunnel=yes
+          "embankment#": embankment=yes
+          "cutting#": cutting=yes
+          "ford#": ford=yes
+        "label#": "bridge=*, tunnel=*, embankment=*, cutting=*, ford=*"
+        "placeholder#": structure field placeholder
+      studio_type:
+        label: Type
+        "label#": "type=*"
+      substation:
+        label: Type
+        "label#": "substation=*"
+      supervised:
+        label: Supervised
+        "label#": "supervised=*"
+      surface:
+        label: Surface
+        "label#": "surface=*"
+      tactile_paving:
+        label: Tactile Paving
+        "label#": "tactile_paving=*"
+      takeaway:
+        label: Takeaway
+        placeholder: "Yes, No, Takeaway Only..."
+        options:
+          "yes": "Yes"
+          "no": "No"
           only: Takeaway Only
-          # takeaway=yes
-          'yes': 'Yes'
-        # takeaway field placeholder
-        placeholder: 'Yes, No, Takeaway Only...'
+          "yes#": takeaway=yes
+          "no#": takeaway=no
+          "only#": takeaway=only
+        "label#": "takeaway=*"
+        "placeholder#": takeaway field placeholder
       toilets/disposal:
-        # 'toilets:disposal=*'
         label: Disposal
         options:
-          # 'toilets:disposal=bucket'
-          bucket: Bucket
-          # 'toilets:disposal=chemical'
-          chemical: Chemical
-          # 'toilets:disposal=flush'
           flush: Flush
-          # 'toilets:disposal=pitlatrine'
           pitlatrine: Pit/Latrine
+          chemical: Chemical
+          bucket: Bucket
+          "flush#": "toilets:disposal=flush"
+          "pitlatrine#": "toilets:disposal=pitlatrine"
+          "chemical#": "toilets:disposal=chemical"
+          "bucket#": "toilets:disposal=bucket"
+        "label#": "toilets:disposal=*"
       tourism:
-        # 'tourism=*'
         label: Type
+        "label#": "tourism=*"
       towertype:
-        # 'tower:type=*'
         label: Tower type
+        "label#": "tower:type=*"
       tracktype:
-        # 'tracktype=*'
         label: Track Type
+        placeholder: "Solid, Mostly Solid, Soft..."
         options:
-          # tracktype=grade1
-          grade1: 'Solid: paved or heavily compacted hardcore surface'
-          # tracktype=grade2
-          grade2: 'Mostly Solid: gravel/rock with some soft material mixed in'
-          # tracktype=grade3
+          grade1: "Solid: paved or heavily compacted hardcore surface"
+          grade2: "Mostly Solid: gravel/rock with some soft material mixed in"
           grade3: Even mixture of hard and soft materials
-          # tracktype=grade4
-          grade4: 'Mostly Soft: soil/sand/grass with some hard material mixed in'
-          # tracktype=grade5
-          grade5: 'Soft: soil/sand/grass'
-        # tracktype field placeholder
-        placeholder: 'Solid, Mostly Solid, Soft...'
+          grade4: "Mostly Soft: soil/sand/grass with some hard material mixed in"
+          grade5: "Soft: soil/sand/grass"
+          "grade1#": tracktype=grade1
+          "grade2#": tracktype=grade2
+          "grade3#": tracktype=grade3
+          "grade4#": tracktype=grade4
+          "grade5#": tracktype=grade5
+        "label#": "tracktype=*"
+        "placeholder#": tracktype field placeholder
       trail_visibility:
-        # 'trail_visibility=*'
         label: Trail Visibility
+        placeholder: "Excellent, Good, Bad..."
         options:
-          # trail_visibility=bad
-          bad: 'Bad: no markers, path sometimes invisible/pathless'
-          # trail_visibility=excellent
-          excellent: 'Excellent: unambiguous path or markers everywhere'
-          # trail_visibility=good
-          good: 'Good: markers visible, sometimes require searching'
-          # trail_visibility=horrible
-          horrible: 'Horrible: often pathless, some orientation skills required'
-          # trail_visibility=intermediate
-          intermediate: 'Intermediate: few markers, path mostly visible'
-          # trail_visibility=no
-          'no': 'No: pathless, excellent orientation skills required'
-        # trail_visibility field placeholder
-        placeholder: 'Excellent, Good, Bad...'
+          excellent: "Excellent: unambiguous path or markers everywhere"
+          good: "Good: markers visible, sometimes require searching"
+          intermediate: "Intermediate: few markers, path mostly visible"
+          bad: "Bad: no markers, path sometimes invisible/pathless"
+          horrible: "Horrible: often pathless, some orientation skills required"
+          "no": "No: pathless, excellent orientation skills required"
+          "excellent#": trail_visibility=excellent
+          "good#": trail_visibility=good
+          "intermediate#": trail_visibility=intermediate
+          "bad#": trail_visibility=bad
+          "horrible#": trail_visibility=horrible
+          "no#": trail_visibility=no
+        "label#": "trail_visibility=*"
+        "placeholder#": trail_visibility field placeholder
       trees:
-        # 'trees=*'
         label: Trees
+        "label#": "trees=*"
       tunnel:
-        # 'tunnel=*'
         label: Tunnel
+        "label#": "tunnel=*"
       vending:
-        # 'vending=*'
         label: Type of Goods
+        "label#": "vending=*"
       water:
-        # 'water=*'
         label: Type
+        "label#": "water=*"
       water_point:
-        # 'water_point=*'
         label: Water Point
+        "label#": "water_point=*"
       waterway:
-        # 'waterway=*'
         label: Type
+        "label#": "waterway=*"
       website:
-        # 'website=*'
         label: Website
-        # website field placeholder
-        placeholder: 'http://example.com/'
+        placeholder: "http://example.com/"
+        "label#": "website=*"
+        "placeholder#": website field placeholder
       wetland:
-        # 'wetland=*'
         label: Type
+        "label#": "wetland=*"
       wheelchair:
-        # 'wheelchair=*'
         label: Wheelchair Access
+        "label#": "wheelchair=*"
       width:
-        # 'width=*'
         label: Width (Meters)
+        "label#": "width=*"
       wikipedia:
-        # 'wikipedia=*'
         label: Wikipedia
+        "label#": "wikipedia=*"
     presets:
       address:
-        # 'addr:housenumber=*'
         name: Address
         terms: "<translate with synonyms or related terms for 'Address', separated by commas>"
+        "name#": "addr:housenumber=*"
       aerialway:
-        # 'aerialway=*'
         name: Aerialway
-        # 'terms: ski lift,funifor,funitel'
         terms: "<translate with synonyms or related terms for 'Aerialway', separated by commas>"
+        "name#": "aerialway=*"
+        "terms#": "terms: ski lift,funifor,funitel"
       aerialway/cable_car:
-        # aerialway=cable_car
         name: Cable Car
-        # 'terms: tramway,ropeway'
         terms: "<translate with synonyms or related terms for 'Cable Car', separated by commas>"
+        "name#": aerialway=cable_car
+        "terms#": "terms: tramway,ropeway"
       aerialway/chair_lift:
-        # aerialway=chair_lift
         name: Chair Lift
         terms: "<translate with synonyms or related terms for 'Chair Lift', separated by commas>"
+        "name#": aerialway=chair_lift
       aerialway/gondola:
-        # aerialway=gondola
         name: Gondola
         terms: "<translate with synonyms or related terms for 'Gondola', separated by commas>"
+        "name#": aerialway=gondola
       aerialway/magic_carpet:
-        # aerialway=magic_carpet
         name: Magic Carpet Lift
         terms: "<translate with synonyms or related terms for 'Magic Carpet Lift', separated by commas>"
+        "name#": aerialway=magic_carpet
       aerialway/platter:
-        # aerialway=platter
         name: Platter Lift
-        # 'terms: button lift,poma lift'
         terms: "<translate with synonyms or related terms for 'Platter Lift', separated by commas>"
+        "name#": aerialway=platter
+        "terms#": "terms: button lift,poma lift"
       aerialway/pylon:
-        # aerialway=pylon
         name: Aerialway Pylon
         terms: "<translate with synonyms or related terms for 'Aerialway Pylon', separated by commas>"
+        "name#": aerialway=pylon
       aerialway/rope_tow:
-        # aerialway=rope_tow
         name: Rope Tow Lift
-        # 'terms: handle tow,bugel lift'
         terms: "<translate with synonyms or related terms for 'Rope Tow Lift', separated by commas>"
+        "name#": aerialway=rope_tow
+        "terms#": "terms: handle tow,bugel lift"
       aerialway/station:
-        # aerialway=station
         name: Aerialway Station
         terms: "<translate with synonyms or related terms for 'Aerialway Station', separated by commas>"
+        "name#": aerialway=station
       aerialway/t-bar:
-        # aerialway=t-bar
         name: T-bar Lift
         terms: "<translate with synonyms or related terms for 'T-bar Lift', separated by commas>"
+        "name#": aerialway=t-bar
       aeroway:
-        # 'aeroway=*'
         name: Aeroway
         terms: "<translate with synonyms or related terms for 'Aeroway', separated by commas>"
+        "name#": "aeroway=*"
       aeroway/aerodrome:
-        # aeroway=aerodrome
         name: Airport
-        # 'terms: airplane,airport,aerodrome'
         terms: "<translate with synonyms or related terms for 'Airport', separated by commas>"
+        "name#": aeroway=aerodrome
+        "terms#": "terms: airplane,airport,aerodrome"
       aeroway/apron:
-        # aeroway=apron
         name: Apron
-        # 'terms: ramp'
         terms: "<translate with synonyms or related terms for 'Apron', separated by commas>"
+        "name#": aeroway=apron
+        "terms#": "terms: ramp"
       aeroway/gate:
-        # aeroway=gate
         name: Airport gate
         terms: "<translate with synonyms or related terms for 'Airport gate', separated by commas>"
+        "name#": aeroway=gate
       aeroway/hangar:
-        # aeroway=hangar
         name: Hangar
         terms: "<translate with synonyms or related terms for 'Hangar', separated by commas>"
+        "name#": aeroway=hangar
       aeroway/helipad:
-        # aeroway=helipad
         name: Helipad
-        # 'terms: helicopter,helipad,heliport'
         terms: "<translate with synonyms or related terms for 'Helipad', separated by commas>"
+        "name#": aeroway=helipad
+        "terms#": "terms: helicopter,helipad,heliport"
       aeroway/runway:
-        # aeroway=runway
         name: Runway
-        # 'terms: landing strip'
         terms: "<translate with synonyms or related terms for 'Runway', separated by commas>"
+        "name#": aeroway=runway
+        "terms#": "terms: landing strip"
       aeroway/taxiway:
-        # aeroway=taxiway
         name: Taxiway
         terms: "<translate with synonyms or related terms for 'Taxiway', separated by commas>"
+        "name#": aeroway=taxiway
       aeroway/terminal:
-        # aeroway=terminal
         name: Airport terminal
-        # 'terms: airport,aerodrome'
         terms: "<translate with synonyms or related terms for 'Airport terminal', separated by commas>"
+        "name#": aeroway=terminal
+        "terms#": "terms: airport,aerodrome"
       amenity:
-        # 'amenity=*'
         name: Amenity
         terms: "<translate with synonyms or related terms for 'Amenity', separated by commas>"
+        "name#": "amenity=*"
       amenity/arts_centre:
-        # amenity=arts_centre
         name: Arts Center
         terms: "<translate with synonyms or related terms for 'Arts Center', separated by commas>"
+        "name#": amenity=arts_centre
       amenity/atm:
-        # amenity=atm
         name: ATM
-        # 'terms: money,cash,machine'
         terms: "<translate with synonyms or related terms for 'ATM', separated by commas>"
+        "name#": amenity=atm
+        "terms#": "terms: money,cash,machine"
       amenity/bank:
-        # amenity=bank
         name: Bank
-        # 'terms: credit union,check,deposit,fund,investment,repository,reserve,safe,savings,stock,treasury,trust,vault'
         terms: "<translate with synonyms or related terms for 'Bank', separated by commas>"
+        "name#": amenity=bank
+        "terms#": "terms: credit union,check,deposit,fund,investment,repository,reserve,safe,savings,stock,treasury,trust,vault"
       amenity/bar:
-        # amenity=bar
         name: Bar
-        # 'terms: dive,beer,bier,booze'
         terms: "<translate with synonyms or related terms for 'Bar', separated by commas>"
+        "name#": amenity=bar
+        "terms#": "terms: dive,beer,bier,booze"
       amenity/bbq:
-        # amenity=bbq
         name: Barbecue/Grill
-        # 'terms: bbq'
         terms: "<translate with synonyms or related terms for 'Barbecue/Grill', separated by commas>"
+        "name#": amenity=bbq
+        "terms#": "terms: bbq"
       amenity/bench:
-        # amenity=bench
         name: Bench
         terms: "<translate with synonyms or related terms for 'Bench', separated by commas>"
+        "name#": amenity=bench
       amenity/bicycle_parking:
-        # amenity=bicycle_parking
         name: Bicycle Parking
-        # 'terms: bike'
         terms: "<translate with synonyms or related terms for 'Bicycle Parking', separated by commas>"
+        "name#": amenity=bicycle_parking
+        "terms#": "terms: bike"
       amenity/bicycle_rental:
-        # amenity=bicycle_rental
         name: Bicycle Rental
-        # 'terms: bike'
         terms: "<translate with synonyms or related terms for 'Bicycle Rental', separated by commas>"
+        "name#": amenity=bicycle_rental
+        "terms#": "terms: bike"
       amenity/bicycle_repair_station:
-        # amenity=bicycle_repair_station
         name: Bicycle Repair Station
-        # 'terms: bike'
         terms: "<translate with synonyms or related terms for 'Bicycle Repair Station', separated by commas>"
+        "name#": amenity=bicycle_repair_station
+        "terms#": "terms: bike"
       amenity/biergarten:
-        # amenity=biergarten
         name: Beer Garden
-        # 'terms: beer,bier,booze'
         terms: "<translate with synonyms or related terms for 'Beer Garden', separated by commas>"
+        "name#": amenity=biergarten
+        "terms#": "terms: beer,bier,booze"
       amenity/boat_rental:
-        # amenity=boat_rental
         name: Boat Rental
         terms: "<translate with synonyms or related terms for 'Boat Rental', separated by commas>"
+        "name#": amenity=boat_rental
       amenity/bureau_de_change:
-        # amenity=bureau_de_change
         name: Currency Exchange
-        # 'terms: bureau de change,money changer'
         terms: "<translate with synonyms or related terms for 'Currency Exchange', separated by commas>"
+        "name#": amenity=bureau_de_change
+        "terms#": "terms: bureau de change,money changer"
       amenity/bus_station:
-        # amenity=bus_station
         name: Bus Station
         terms: "<translate with synonyms or related terms for 'Bus Station', separated by commas>"
+        "name#": amenity=bus_station
       amenity/cafe:
-        # amenity=cafe
         name: Cafe
-        # 'terms: coffee,tea'
         terms: "<translate with synonyms or related terms for 'Cafe', separated by commas>"
+        "name#": amenity=cafe
+        "terms#": "terms: coffee,tea"
       amenity/car_rental:
-        # amenity=car_rental
         name: Car Rental
         terms: "<translate with synonyms or related terms for 'Car Rental', separated by commas>"
+        "name#": amenity=car_rental
       amenity/car_sharing:
-        # amenity=car_sharing
         name: Car Sharing
         terms: "<translate with synonyms or related terms for 'Car Sharing', separated by commas>"
+        "name#": amenity=car_sharing
       amenity/car_wash:
-        # amenity=car_wash
         name: Car Wash
         terms: "<translate with synonyms or related terms for 'Car Wash', separated by commas>"
+        "name#": amenity=car_wash
       amenity/casino:
-        # amenity=casino
         name: Casino
-        # 'terms: gambling,roulette,craps,poker,blackjack'
         terms: "<translate with synonyms or related terms for 'Casino', separated by commas>"
+        "name#": amenity=casino
+        "terms#": "terms: gambling,roulette,craps,poker,blackjack"
       amenity/charging_station:
-        # amenity=charging_station
         name: Charging Station
-        # 'terms: EV,Electric Vehicle,Supercharger'
         terms: "<translate with synonyms or related terms for 'Charging Station', separated by commas>"
+        "name#": amenity=charging_station
+        "terms#": "terms: EV,Electric Vehicle,Supercharger"
       amenity/childcare:
-        # amenity=childcare
         name: Nursery/Childcare
-        # 'terms: daycare,orphanage,playgroup'
         terms: "<translate with synonyms or related terms for 'Nursery/Childcare', separated by commas>"
+        "name#": amenity=childcare
+        "terms#": "terms: daycare,orphanage,playgroup"
       amenity/cinema:
-        # amenity=cinema
         name: Cinema
-        # 'terms: drive-in,film,flick,movie,theater,picture,show,screen'
         terms: "<translate with synonyms or related terms for 'Cinema', separated by commas>"
+        "name#": amenity=cinema
+        "terms#": "terms: drive-in,film,flick,movie,theater,picture,show,screen"
       amenity/clinic:
-        # amenity=clinic
         name: Clinic
-        # 'terms: medical,urgentcare'
         terms: "<translate with synonyms or related terms for 'Clinic', separated by commas>"
+        "name#": amenity=clinic
+        "terms#": "terms: medical,urgentcare"
       amenity/clock:
-        # amenity=clock
         name: Clock
         terms: "<translate with synonyms or related terms for 'Clock', separated by commas>"
+        "name#": amenity=clock
       amenity/college:
-        # amenity=college
         name: College Grounds
-        # 'terms: university'
         terms: "<translate with synonyms or related terms for 'College Grounds', separated by commas>"
+        "name#": amenity=college
+        "terms#": "terms: university"
       amenity/community_centre:
-        # amenity=community_centre
         name: Community Center
-        # 'terms: event,hall'
         terms: "<translate with synonyms or related terms for 'Community Center', separated by commas>"
+        "name#": amenity=community_centre
+        "terms#": "terms: event,hall"
       amenity/compressed_air:
-        # amenity=compressed_air
         name: Compressed Air
         terms: "<translate with synonyms or related terms for 'Compressed Air', separated by commas>"
+        "name#": amenity=compressed_air
       amenity/courthouse:
-        # amenity=courthouse
         name: Courthouse
         terms: "<translate with synonyms or related terms for 'Courthouse', separated by commas>"
+        "name#": amenity=courthouse
       amenity/dentist:
-        # amenity=dentist
         name: Dentist
-        # 'terms: tooth,teeth'
         terms: "<translate with synonyms or related terms for 'Dentist', separated by commas>"
+        "name#": amenity=dentist
+        "terms#": "terms: tooth,teeth"
       amenity/doctor:
-        # amenity=doctors
         name: Doctor
-        # 'terms: medic*'
         terms: "<translate with synonyms or related terms for 'Doctor', separated by commas>"
+        "name#": amenity=doctors
+        "terms#": "terms: medic*"
       amenity/dojo:
-        # amenity=dojo
         name: Dojo / Martial Arts Academy
-        # 'terms: martial arts,dojang'
         terms: "<translate with synonyms or related terms for 'Dojo / Martial Arts Academy', separated by commas>"
+        "name#": amenity=dojo
+        "terms#": "terms: martial arts,dojang"
       amenity/drinking_water:
-        # amenity=drinking_water
         name: Drinking Water
-        # 'terms: fountain,potable'
         terms: "<translate with synonyms or related terms for 'Drinking Water', separated by commas>"
+        "name#": amenity=drinking_water
+        "terms#": "terms: fountain,potable"
       amenity/embassy:
-        # amenity=embassy
         name: Embassy
         terms: "<translate with synonyms or related terms for 'Embassy', separated by commas>"
+        "name#": amenity=embassy
       amenity/fast_food:
-        # amenity=fast_food
         name: Fast Food
-        # 'terms: restaurant'
         terms: "<translate with synonyms or related terms for 'Fast Food', separated by commas>"
+        "name#": amenity=fast_food
+        "terms#": "terms: restaurant"
       amenity/fire_station:
-        # amenity=fire_station
         name: Fire Station
         terms: "<translate with synonyms or related terms for 'Fire Station', separated by commas>"
+        "name#": amenity=fire_station
       amenity/fountain:
-        # amenity=fountain
         name: Fountain
         terms: "<translate with synonyms or related terms for 'Fountain', separated by commas>"
+        "name#": amenity=fountain
       amenity/fuel:
-        # amenity=fuel
         name: Gas Station
-        # 'terms: petrol,fuel,propane,diesel,lng,cng,biodiesel'
         terms: "<translate with synonyms or related terms for 'Gas Station', separated by commas>"
+        "name#": amenity=fuel
+        "terms#": "terms: petrol,fuel,propane,diesel,lng,cng,biodiesel"
       amenity/grave_yard:
-        # amenity=grave_yard
         name: Graveyard
         terms: "<translate with synonyms or related terms for 'Graveyard', separated by commas>"
+        "name#": amenity=grave_yard
       amenity/grit_bin:
-        # amenity=grit_bin
         name: Grit Bin
-        # 'terms: salt,sand'
         terms: "<translate with synonyms or related terms for 'Grit Bin', separated by commas>"
+        "name#": amenity=grit_bin
+        "terms#": "terms: salt,sand"
       amenity/hospital:
-        # amenity=hospital
         name: Hospital Grounds
-        # 'terms: clinic,doctor,emergency room,health service,hospice,infirmary,institution,nursing home,sanatorium,sanitarium,sick,surgery,ward'
         terms: "<translate with synonyms or related terms for 'Hospital Grounds', separated by commas>"
+        "name#": amenity=hospital
+        "terms#": "terms: clinic,doctor,emergency room,health service,hospice,infirmary,institution,nursing home,sanatorium,sanitarium,sick,surgery,ward"
       amenity/kindergarten:
-        # amenity=kindergarten
         name: Preschool/Kindergarten Grounds
-        # 'terms: kindergarden,pre-school'
         terms: "<translate with synonyms or related terms for 'Preschool/Kindergarten Grounds', separated by commas>"
+        "name#": amenity=kindergarten
+        "terms#": "terms: kindergarden,pre-school"
       amenity/library:
-        # amenity=library
         name: Library
-        # 'terms: book'
         terms: "<translate with synonyms or related terms for 'Library', separated by commas>"
+        "name#": amenity=library
+        "terms#": "terms: book"
       amenity/marketplace:
-        # amenity=marketplace
         name: Marketplace
         terms: "<translate with synonyms or related terms for 'Marketplace', separated by commas>"
+        "name#": amenity=marketplace
       amenity/nightclub:
-        # amenity=nightclub
         name: Nightclub
-        # 'terms: disco*,night club,dancing,dance club'
         terms: "<translate with synonyms or related terms for 'Nightclub', separated by commas>"
+        "name#": amenity=nightclub
+        "terms#": "terms: disco*,night club,dancing,dance club"
       amenity/parking:
-        # amenity=parking
         name: Car Parking
         terms: "<translate with synonyms or related terms for 'Car Parking', separated by commas>"
+        "name#": amenity=parking
       amenity/parking_entrance:
-        # amenity=parking_entrance
         name: Parking Garage Entrance/Exit
         terms: "<translate with synonyms or related terms for 'Parking Garage Entrance/Exit', separated by commas>"
+        "name#": amenity=parking_entrance
       amenity/pharmacy:
-        # amenity=pharmacy
         name: Pharmacy
-        # 'terms: drug,medicine'
         terms: "<translate with synonyms or related terms for 'Pharmacy', separated by commas>"
+        "name#": amenity=pharmacy
+        "terms#": "terms: drug,medicine"
       amenity/place_of_worship:
-        # amenity=place_of_worship
         name: Place of Worship
-        # 'terms: abbey,basilica,bethel,cathedral,chancel,chantry,chapel,church,fold,house of God,house of prayer,house of worship,minster,mission,mosque,oratory,parish,sacellum,sanctuary,shrine,synagogue,tabernacle,temple'
         terms: "<translate with synonyms or related terms for 'Place of Worship', separated by commas>"
+        "name#": amenity=place_of_worship
+        "terms#": "terms: abbey,basilica,bethel,cathedral,chancel,chantry,chapel,church,fold,house of God,house of prayer,house of worship,minster,mission,mosque,oratory,parish,sacellum,sanctuary,shrine,synagogue,tabernacle,temple"
       amenity/place_of_worship/buddhist:
-        # 'amenity=place_of_worship, religion=buddhist'
         name: Buddhist Temple
-        # 'terms: stupa,vihara,monastery,temple,pagoda,zendo,dojo'
         terms: "<translate with synonyms or related terms for 'Buddhist Temple', separated by commas>"
+        "name#": "amenity=place_of_worship, religion=buddhist"
+        "terms#": "terms: stupa,vihara,monastery,temple,pagoda,zendo,dojo"
       amenity/place_of_worship/christian:
-        # 'amenity=place_of_worship, religion=christian'
         name: Church
-        # 'terms: christian,abbey,basilica,bethel,cathedral,chancel,chantry,chapel,fold,house of God,house of prayer,house of worship,minster,mission,oratory,parish,sacellum,sanctuary,shrine,tabernacle,temple'
         terms: "<translate with synonyms or related terms for 'Church', separated by commas>"
+        "name#": "amenity=place_of_worship, religion=christian"
+        "terms#": "terms: christian,abbey,basilica,bethel,cathedral,chancel,chantry,chapel,fold,house of God,house of prayer,house of worship,minster,mission,oratory,parish,sacellum,sanctuary,shrine,tabernacle,temple"
       amenity/place_of_worship/jewish:
-        # 'amenity=place_of_worship, religion=jewish'
         name: Synagogue
-        # 'terms: jewish'
         terms: "<translate with synonyms or related terms for 'Synagogue', separated by commas>"
+        "name#": "amenity=place_of_worship, religion=jewish"
+        "terms#": "terms: jewish"
       amenity/place_of_worship/muslim:
-        # 'amenity=place_of_worship, religion=muslim'
         name: Mosque
-        # 'terms: muslim'
         terms: "<translate with synonyms or related terms for 'Mosque', separated by commas>"
+        "name#": "amenity=place_of_worship, religion=muslim"
+        "terms#": "terms: muslim"
       amenity/police:
-        # amenity=police
         name: Police
-        # 'terms: badge,constable,constabulary,cop,detective,fed,law,enforcement,officer,patrol'
         terms: "<translate with synonyms or related terms for 'Police', separated by commas>"
+        "name#": amenity=police
+        "terms#": "terms: badge,constable,constabulary,cop,detective,fed,law,enforcement,officer,patrol"
       amenity/post_box:
-        # amenity=post_box
         name: Mailbox
-        # 'terms: letter,post'
         terms: "<translate with synonyms or related terms for 'Mailbox', separated by commas>"
+        "name#": amenity=post_box
+        "terms#": "terms: letter,post"
       amenity/post_office:
-        # amenity=post_office
         name: Post Office
-        # 'terms: letter,mail'
         terms: "<translate with synonyms or related terms for 'Post Office', separated by commas>"
+        "name#": amenity=post_office
+        "terms#": "terms: letter,mail"
       amenity/pub:
-        # amenity=pub
         name: Pub
-        # 'terms: dive,beer,bier,booze'
         terms: "<translate with synonyms or related terms for 'Pub', separated by commas>"
+        "name#": amenity=pub
+        "terms#": "terms: dive,beer,bier,booze"
       amenity/public_bookcase:
-        # amenity=public_bookcase
         name: Public Bookcase
-        # 'terms: library,bookcrossing'
         terms: "<translate with synonyms or related terms for 'Public Bookcase', separated by commas>"
+        "name#": amenity=public_bookcase
+        "terms#": "terms: library,bookcrossing"
       amenity/ranger_station:
-        # amenity=ranger_station
         name: Ranger Station
-        # 'terms: visitor center,visitor centre,permit center,permit centre,backcountry office,warden office,warden center'
         terms: "<translate with synonyms or related terms for 'Ranger Station', separated by commas>"
+        "name#": amenity=ranger_station
+        "terms#": "terms: visitor center,visitor centre,permit center,permit centre,backcountry office,warden office,warden center"
       amenity/recycling:
-        # amenity=recycling
         name: Recycling
-        # 'terms: can,bottle,garbage,scrap,trash'
         terms: "<translate with synonyms or related terms for 'Recycling', separated by commas>"
+        "name#": amenity=recycling
+        "terms#": "terms: can,bottle,garbage,scrap,trash"
       amenity/register_office:
-        # amenity=register_office
         name: Register Office
         terms: "<translate with synonyms or related terms for 'Register Office', separated by commas>"
+        "name#": amenity=register_office
       amenity/restaurant:
-        # amenity=restaurant
         name: Restaurant
-        # 'terms: bar,breakfast,cafe,café,canteen,coffee,dine,dining,dinner,drive-in,eat,grill,lunch,table'
         terms: "<translate with synonyms or related terms for 'Restaurant', separated by commas>"
+        "name#": amenity=restaurant
+        "terms#": "terms: bar,breakfast,cafe,café,canteen,coffee,dine,dining,dinner,drive-in,eat,grill,lunch,table"
       amenity/sanitary_dump_station:
-        # amenity=sanitary_dump_station
         name: RV Toilet Disposal
-        # 'terms: Motor Home,Camper,Sanitary,Dump Station,Elsan,CDP,CTDP,Chemical Toilet'
         terms: "<translate with synonyms or related terms for 'RV Toilet Disposal', separated by commas>"
+        "name#": amenity=sanitary_dump_station
+        "terms#": "terms: Motor Home,Camper,Sanitary,Dump Station,Elsan,CDP,CTDP,Chemical Toilet"
       amenity/school:
-        # amenity=school
         name: School Grounds
-        # 'terms: academy,elementary school,middle school,high school'
         terms: "<translate with synonyms or related terms for 'School Grounds', separated by commas>"
+        "name#": amenity=school
+        "terms#": "terms: academy,elementary school,middle school,high school"
       amenity/shelter:
-        # amenity=shelter
         name: Shelter
-        # 'terms: lean-to,gazebo,picnic'
         terms: "<translate with synonyms or related terms for 'Shelter', separated by commas>"
+        "name#": amenity=shelter
+        "terms#": "terms: lean-to,gazebo,picnic"
       amenity/social_facility:
-        # amenity=social_facility
         name: Social Facility
         terms: "<translate with synonyms or related terms for 'Social Facility', separated by commas>"
+        "name#": amenity=social_facility
       amenity/social_facility/food_bank:
-        # 'amenity=social_facility, social_facility=food_bank'
         name: Food Bank
         terms: "<translate with synonyms or related terms for 'Food Bank', separated by commas>"
+        "name#": "amenity=social_facility, social_facility=food_bank"
       amenity/social_facility/group_home:
-        # 'amenity=social_facility, social_facility=group_home, social_facility:for=senior'
         name: Elderly Group Home
-        # 'terms: old,senior,living'
         terms: "<translate with synonyms or related terms for 'Elderly Group Home', separated by commas>"
+        "name#": "amenity=social_facility, social_facility=group_home, social_facility:for=senior"
+        "terms#": "terms: old,senior,living"
       amenity/social_facility/homeless_shelter:
-        # 'amenity=social_facility, social_facility=shelter, social_facility:for=homeless'
         name: Homeless Shelter
-        # 'terms: houseless,unhoused,displaced'
         terms: "<translate with synonyms or related terms for 'Homeless Shelter', separated by commas>"
+        "name#": "amenity=social_facility, social_facility=shelter, social_facility:for=homeless"
+        "terms#": "terms: houseless,unhoused,displaced"
       amenity/studio:
-        # amenity=studio
         name: Studio
-        # 'terms: recording,radio,television'
         terms: "<translate with synonyms or related terms for 'Studio', separated by commas>"
+        "name#": amenity=studio
+        "terms#": "terms: recording,radio,television"
       amenity/swimming_pool:
-        # amenity=swimming_pool
         name: Swimming Pool
         terms: "<translate with synonyms or related terms for 'Swimming Pool', separated by commas>"
+        "name#": amenity=swimming_pool
       amenity/taxi:
-        # amenity=taxi
         name: Taxi Stand
-        # 'terms: cab'
         terms: "<translate with synonyms or related terms for 'Taxi Stand', separated by commas>"
+        "name#": amenity=taxi
+        "terms#": "terms: cab"
       amenity/telephone:
-        # amenity=telephone
         name: Telephone
-        # 'terms: phone'
         terms: "<translate with synonyms or related terms for 'Telephone', separated by commas>"
+        "name#": amenity=telephone
+        "terms#": "terms: phone"
       amenity/theatre:
-        # amenity=theatre
         name: Theater
-        # 'terms: theatre,performance,play,musical'
         terms: "<translate with synonyms or related terms for 'Theater', separated by commas>"
+        "name#": amenity=theatre
+        "terms#": "terms: theatre,performance,play,musical"
       amenity/toilets:
-        # amenity=toilets
         name: Toilets
-        # 'terms: bathroom,restroom,outhouse,privy,head,lavatory,latrine,water closet,WC,W.C.'
         terms: "<translate with synonyms or related terms for 'Toilets', separated by commas>"
+        "name#": amenity=toilets
+        "terms#": "terms: bathroom,restroom,outhouse,privy,head,lavatory,latrine,water closet,WC,W.C."
       amenity/townhall:
-        # amenity=townhall
         name: Town Hall
-        # 'terms: village,city,government,courthouse,municipal'
         terms: "<translate with synonyms or related terms for 'Town Hall', separated by commas>"
+        "name#": amenity=townhall
+        "terms#": "terms: village,city,government,courthouse,municipal"
       amenity/university:
-        # amenity=university
         name: University Grounds
-        # 'terms: college'
         terms: "<translate with synonyms or related terms for 'University Grounds', separated by commas>"
+        "name#": amenity=university
+        "terms#": "terms: college"
       amenity/vending_machine:
-        # amenity=vending_machine
         name: Vending Machine
-        # 'terms: snack,soda,ticket'
         terms: "<translate with synonyms or related terms for 'Vending Machine', separated by commas>"
+        "name#": amenity=vending_machine
+        "terms#": "terms: snack,soda,ticket"
       amenity/veterinary:
-        # amenity=veterinary
         name: Veterinary
-        # 'terms: pet clinic,veterinarian,animal hospital,pet doctor'
         terms: "<translate with synonyms or related terms for 'Veterinary', separated by commas>"
+        "name#": amenity=veterinary
+        "terms#": "terms: pet clinic,veterinarian,animal hospital,pet doctor"
       amenity/waste_basket:
-        # amenity=waste_basket
         name: Waste Basket
-        # 'terms: rubbish,litter,trash,garbage'
         terms: "<translate with synonyms or related terms for 'Waste Basket', separated by commas>"
+        "name#": amenity=waste_basket
+        "terms#": "terms: rubbish,litter,trash,garbage"
       area:
-        # area=yes
         name: Area
         terms: "<translate with synonyms or related terms for 'Area', separated by commas>"
+        "name#": area=yes
       area/highway:
-        # 'area:highway=*'
         name: Road Surface
         terms: "<translate with synonyms or related terms for 'Road Surface', separated by commas>"
+        "name#": "area:highway=*"
       barrier:
-        # 'barrier=*'
         name: Barrier
         terms: "<translate with synonyms or related terms for 'Barrier', separated by commas>"
+        "name#": "barrier=*"
       barrier/block:
-        # barrier=block
         name: Block
         terms: "<translate with synonyms or related terms for 'Block', separated by commas>"
+        "name#": barrier=block
       barrier/bollard:
-        # barrier=bollard
         name: Bollard
         terms: "<translate with synonyms or related terms for 'Bollard', separated by commas>"
+        "name#": barrier=bollard
       barrier/cattle_grid:
-        # barrier=cattle_grid
         name: Cattle Grid
         terms: "<translate with synonyms or related terms for 'Cattle Grid', separated by commas>"
+        "name#": barrier=cattle_grid
       barrier/city_wall:
-        # barrier=city_wall
         name: City Wall
         terms: "<translate with synonyms or related terms for 'City Wall', separated by commas>"
+        "name#": barrier=city_wall
       barrier/cycle_barrier:
-        # barrier=cycle_barrier
         name: Cycle Barrier
         terms: "<translate with synonyms or related terms for 'Cycle Barrier', separated by commas>"
+        "name#": barrier=cycle_barrier
       barrier/ditch:
-        # barrier=ditch
         name: Ditch
         terms: "<translate with synonyms or related terms for 'Ditch', separated by commas>"
+        "name#": barrier=ditch
       barrier/entrance:
-        # barrier=entrance
         name: Entrance
         terms: "<translate with synonyms or related terms for 'Entrance', separated by commas>"
+        "name#": barrier=entrance
       barrier/fence:
-        # barrier=fence
         name: Fence
         terms: "<translate with synonyms or related terms for 'Fence', separated by commas>"
+        "name#": barrier=fence
       barrier/gate:
-        # barrier=gate
         name: Gate
         terms: "<translate with synonyms or related terms for 'Gate', separated by commas>"
+        "name#": barrier=gate
       barrier/hedge:
-        # barrier=hedge
         name: Hedge
         terms: "<translate with synonyms or related terms for 'Hedge', separated by commas>"
+        "name#": barrier=hedge
       barrier/kissing_gate:
-        # barrier=kissing_gate
         name: Kissing Gate
         terms: "<translate with synonyms or related terms for 'Kissing Gate', separated by commas>"
+        "name#": barrier=kissing_gate
       barrier/lift_gate:
-        # barrier=lift_gate
         name: Lift Gate
         terms: "<translate with synonyms or related terms for 'Lift Gate', separated by commas>"
+        "name#": barrier=lift_gate
       barrier/retaining_wall:
-        # barrier=retaining_wall
         name: Retaining Wall
         terms: "<translate with synonyms or related terms for 'Retaining Wall', separated by commas>"
+        "name#": barrier=retaining_wall
       barrier/stile:
-        # barrier=stile
         name: Stile
         terms: "<translate with synonyms or related terms for 'Stile', separated by commas>"
+        "name#": barrier=stile
       barrier/toll_booth:
-        # barrier=toll_booth
         name: Toll Booth
         terms: "<translate with synonyms or related terms for 'Toll Booth', separated by commas>"
+        "name#": barrier=toll_booth
       barrier/wall:
-        # barrier=wall
         name: Wall
         terms: "<translate with synonyms or related terms for 'Wall', separated by commas>"
+        "name#": barrier=wall
       boundary/administrative:
-        # boundary=administrative
         name: Administrative Boundary
         terms: "<translate with synonyms or related terms for 'Administrative Boundary', separated by commas>"
+        "name#": boundary=administrative
       building:
-        # 'building=*'
         name: Building
         terms: "<translate with synonyms or related terms for 'Building', separated by commas>"
+        "name#": "building=*"
       building/apartments:
-        # building=apartments
         name: Apartments
         terms: "<translate with synonyms or related terms for 'Apartments', separated by commas>"
+        "name#": building=apartments
       building/barn:
-        # building=barn
         name: Barn
         terms: "<translate with synonyms or related terms for 'Barn', separated by commas>"
+        "name#": building=barn
       building/bunker:
-        # building=bunker
         name: Bunker
         terms: "<translate with synonyms or related terms for 'Bunker', separated by commas>"
+        "name#": building=bunker
       building/cabin:
-        # building=cabin
         name: Cabin
         terms: "<translate with synonyms or related terms for 'Cabin', separated by commas>"
+        "name#": building=cabin
       building/cathedral:
-        # building=cathedral
         name: Cathedral
         terms: "<translate with synonyms or related terms for 'Cathedral', separated by commas>"
+        "name#": building=cathedral
       building/chapel:
-        # building=chapel
         name: Chapel
         terms: "<translate with synonyms or related terms for 'Chapel', separated by commas>"
+        "name#": building=chapel
       building/church:
-        # building=church
         name: Church
         terms: "<translate with synonyms or related terms for 'Church', separated by commas>"
+        "name#": building=church
       building/college:
-        # building=college
         name: College Building
-        # 'terms: university'
         terms: "<translate with synonyms or related terms for 'College Building', separated by commas>"
+        "name#": building=college
+        "terms#": "terms: university"
       building/commercial:
-        # building=commercial
         name: Commercial Building
         terms: "<translate with synonyms or related terms for 'Commercial Building', separated by commas>"
+        "name#": building=commercial
       building/construction:
-        # building=construction
         name: Building Under Construction
         terms: "<translate with synonyms or related terms for 'Building Under Construction', separated by commas>"
+        "name#": building=construction
       building/detached:
-        # building=detached
         name: Detached Home
         terms: "<translate with synonyms or related terms for 'Detached Home', separated by commas>"
+        "name#": building=detached
       building/dormitory:
-        # building=dormitory
         name: Dormitory
         terms: "<translate with synonyms or related terms for 'Dormitory', separated by commas>"
+        "name#": building=dormitory
       building/entrance:
-        # building=entrance
         name: Entrance/Exit
         terms: "<translate with synonyms or related terms for 'Entrance/Exit', separated by commas>"
+        "name#": building=entrance
       building/garage:
-        # building=garage
         name: Garage
         terms: "<translate with synonyms or related terms for 'Garage', separated by commas>"
+        "name#": building=garage
       building/garages:
-        # building=garages
         name: Garages
         terms: "<translate with synonyms or related terms for 'Garages', separated by commas>"
+        "name#": building=garages
       building/greenhouse:
-        # building=greenhouse
         name: Greenhouse
         terms: "<translate with synonyms or related terms for 'Greenhouse', separated by commas>"
+        "name#": building=greenhouse
       building/hospital:
-        # building=hospital
         name: Hospital Building
         terms: "<translate with synonyms or related terms for 'Hospital Building', separated by commas>"
+        "name#": building=hospital
       building/hotel:
-        # building=hotel
         name: Hotel Building
         terms: "<translate with synonyms or related terms for 'Hotel Building', separated by commas>"
+        "name#": building=hotel
       building/house:
-        # building=house
         name: House
         terms: "<translate with synonyms or related terms for 'House', separated by commas>"
+        "name#": building=house
       building/hut:
-        # building=hut
         name: Hut
         terms: "<translate with synonyms or related terms for 'Hut', separated by commas>"
+        "name#": building=hut
       building/industrial:
-        # building=industrial
         name: Industrial Building
         terms: "<translate with synonyms or related terms for 'Industrial Building', separated by commas>"
+        "name#": building=industrial
       building/kindergarten:
-        # building=kindergarten
         name: Preschool/Kindergarten Building
-        # 'terms: kindergarden,pre-school'
         terms: "<translate with synonyms or related terms for 'Preschool/Kindergarten Building', separated by commas>"
+        "name#": building=kindergarten
+        "terms#": "terms: kindergarden,pre-school"
       building/public:
-        # building=public
         name: Public Building
         terms: "<translate with synonyms or related terms for 'Public Building', separated by commas>"
+        "name#": building=public
       building/residential:
-        # building=residential
         name: Residential Building
         terms: "<translate with synonyms or related terms for 'Residential Building', separated by commas>"
+        "name#": building=residential
       building/retail:
-        # building=retail
         name: Retail Building
         terms: "<translate with synonyms or related terms for 'Retail Building', separated by commas>"
+        "name#": building=retail
       building/roof:
-        # building=roof
         name: Roof
         terms: "<translate with synonyms or related terms for 'Roof', separated by commas>"
+        "name#": building=roof
       building/school:
-        # building=school
         name: School Building
-        # 'terms: academy,elementary school,middle school,high school'
         terms: "<translate with synonyms or related terms for 'School Building', separated by commas>"
+        "name#": building=school
+        "terms#": "terms: academy,elementary school,middle school,high school"
       building/shed:
-        # building=shed
         name: Shed
         terms: "<translate with synonyms or related terms for 'Shed', separated by commas>"
+        "name#": building=shed
       building/stable:
-        # building=stable
         name: Stable
         terms: "<translate with synonyms or related terms for 'Stable', separated by commas>"
+        "name#": building=stable
       building/static_caravan:
-        # building=static_caravan
         name: Static Mobile Home
         terms: "<translate with synonyms or related terms for 'Static Mobile Home', separated by commas>"
+        "name#": building=static_caravan
       building/terrace:
-        # building=terrace
         name: Row Houses
         terms: "<translate with synonyms or related terms for 'Row Houses', separated by commas>"
+        "name#": building=terrace
       building/train_station:
-        # building=train_station
         name: Train Station
         terms: "<translate with synonyms or related terms for 'Train Station', separated by commas>"
+        "name#": building=train_station
       building/university:
-        # building=university
         name: University Building
-        # 'terms: college'
         terms: "<translate with synonyms or related terms for 'University Building', separated by commas>"
+        "name#": building=university
+        "terms#": "terms: college"
       building/warehouse:
-        # building=warehouse
         name: Warehouse
         terms: "<translate with synonyms or related terms for 'Warehouse', separated by commas>"
+        "name#": building=warehouse
       craft:
-        # 'craft=*'
         name: Craft
         terms: "<translate with synonyms or related terms for 'Craft', separated by commas>"
+        "name#": "craft=*"
       craft/basket_maker:
-        # craft=basket_maker
         name: Basket Maker
         terms: "<translate with synonyms or related terms for 'Basket Maker', separated by commas>"
+        "name#": craft=basket_maker
       craft/beekeeper:
-        # craft=beekeeper
         name: Beekeeper
         terms: "<translate with synonyms or related terms for 'Beekeeper', separated by commas>"
+        "name#": craft=beekeeper
       craft/blacksmith:
-        # craft=blacksmith
         name: Blacksmith
         terms: "<translate with synonyms or related terms for 'Blacksmith', separated by commas>"
+        "name#": craft=blacksmith
       craft/boatbuilder:
-        # craft=boatbuilder
         name: Boat Builder
         terms: "<translate with synonyms or related terms for 'Boat Builder', separated by commas>"
+        "name#": craft=boatbuilder
       craft/bookbinder:
-        # craft=bookbinder
         name: Bookbinder
-        # 'terms: book repair'
         terms: "<translate with synonyms or related terms for 'Bookbinder', separated by commas>"
+        "name#": craft=bookbinder
+        "terms#": "terms: book repair"
       craft/brewery:
-        # craft=brewery
         name: Brewery
-        # 'terms: beer,bier'
         terms: "<translate with synonyms or related terms for 'Brewery', separated by commas>"
+        "name#": craft=brewery
+        "terms#": "terms: beer,bier"
       craft/carpenter:
-        # craft=carpenter
         name: Carpenter
-        # 'terms: woodworker'
         terms: "<translate with synonyms or related terms for 'Carpenter', separated by commas>"
+        "name#": craft=carpenter
+        "terms#": "terms: woodworker"
       craft/carpet_layer:
-        # craft=carpet_layer
         name: Carpet Layer
         terms: "<translate with synonyms or related terms for 'Carpet Layer', separated by commas>"
+        "name#": craft=carpet_layer
       craft/caterer:
-        # craft=caterer
         name: Caterer
         terms: "<translate with synonyms or related terms for 'Caterer', separated by commas>"
+        "name#": craft=caterer
       craft/clockmaker:
-        # craft=clockmaker
         name: Clockmaker
         terms: "<translate with synonyms or related terms for 'Clockmaker', separated by commas>"
+        "name#": craft=clockmaker
       craft/confectionery:
-        # craft=confectionery
         name: Confectionery
-        # 'terms: sweets,candy'
         terms: "<translate with synonyms or related terms for 'Confectionery', separated by commas>"
+        "name#": craft=confectionery
+        "terms#": "terms: sweets,candy"
       craft/dressmaker:
-        # craft=dressmaker
         name: Dressmaker
-        # 'terms: seamstress'
         terms: "<translate with synonyms or related terms for 'Dressmaker', separated by commas>"
+        "name#": craft=dressmaker
+        "terms#": "terms: seamstress"
       craft/electrician:
-        # craft=electrician
         name: Electrician
-        # 'terms: power,wire'
         terms: "<translate with synonyms or related terms for 'Electrician', separated by commas>"
+        "name#": craft=electrician
+        "terms#": "terms: power,wire"
       craft/gardener:
-        # craft=gardener
         name: Gardener
-        # 'terms: landscaper,grounds keeper'
         terms: "<translate with synonyms or related terms for 'Gardener', separated by commas>"
+        "name#": craft=gardener
+        "terms#": "terms: landscaper,grounds keeper"
       craft/glaziery:
-        # craft=glaziery
         name: Glaziery
-        # 'terms: glass,stained-glass,window'
         terms: "<translate with synonyms or related terms for 'Glaziery', separated by commas>"
+        "name#": craft=glaziery
+        "terms#": "terms: glass,stained-glass,window"
       craft/handicraft:
-        # craft=handicraft
         name: Handicraft
         terms: "<translate with synonyms or related terms for 'Handicraft', separated by commas>"
+        "name#": craft=handicraft
       craft/hvac:
-        # craft=hvac
         name: HVAC
-        # 'terms: heat*,vent*,air conditioning'
         terms: "<translate with synonyms or related terms for 'HVAC', separated by commas>"
+        "name#": craft=hvac
+        "terms#": "terms: heat*,vent*,air conditioning"
       craft/insulator:
-        # craft=insulation
         name: Insulator
         terms: "<translate with synonyms or related terms for 'Insulator', separated by commas>"
+        "name#": craft=insulation
       craft/jeweler:
-        # craft=jeweler
         name: Jeweler
         terms: "<translate with synonyms or related terms for 'Jeweler', separated by commas>"
+        "name#": craft=jeweler
       craft/key_cutter:
-        # craft=key_cutter
         name: Key Cutter
         terms: "<translate with synonyms or related terms for 'Key Cutter', separated by commas>"
+        "name#": craft=key_cutter
       craft/locksmith:
-        # craft=locksmith
         name: Locksmith
         terms: "<translate with synonyms or related terms for 'Locksmith', separated by commas>"
+        "name#": craft=locksmith
       craft/metal_construction:
-        # craft=metal_construction
         name: Metal Construction
         terms: "<translate with synonyms or related terms for 'Metal Construction', separated by commas>"
+        "name#": craft=metal_construction
       craft/optician:
-        # craft=optician
         name: Optician
         terms: "<translate with synonyms or related terms for 'Optician', separated by commas>"
+        "name#": craft=optician
       craft/painter:
-        # craft=painter
         name: Painter
         terms: "<translate with synonyms or related terms for 'Painter', separated by commas>"
+        "name#": craft=painter
       craft/photographer:
-        # craft=photographer
         name: Photographer
         terms: "<translate with synonyms or related terms for 'Photographer', separated by commas>"
+        "name#": craft=photographer
       craft/photographic_laboratory:
-        # craft=photographic_laboratory
         name: Photographic Laboratory
-        # 'terms: film'
         terms: "<translate with synonyms or related terms for 'Photographic Laboratory', separated by commas>"
+        "name#": craft=photographic_laboratory
+        "terms#": "terms: film"
       craft/plasterer:
-        # craft=plasterer
         name: Plasterer
         terms: "<translate with synonyms or related terms for 'Plasterer', separated by commas>"
+        "name#": craft=plasterer
       craft/plumber:
-        # craft=plumber
         name: Plumber
-        # 'terms: pipe'
         terms: "<translate with synonyms or related terms for 'Plumber', separated by commas>"
+        "name#": craft=plumber
+        "terms#": "terms: pipe"
       craft/pottery:
-        # craft=pottery
         name: Pottery
-        # 'terms: ceramic'
         terms: "<translate with synonyms or related terms for 'Pottery', separated by commas>"
+        "name#": craft=pottery
+        "terms#": "terms: ceramic"
       craft/rigger:
-        # craft=rigger
         name: Rigger
         terms: "<translate with synonyms or related terms for 'Rigger', separated by commas>"
+        "name#": craft=rigger
       craft/roofer:
-        # craft=roofer
         name: Roofer
         terms: "<translate with synonyms or related terms for 'Roofer', separated by commas>"
+        "name#": craft=roofer
       craft/saddler:
-        # craft=saddler
         name: Saddler
         terms: "<translate with synonyms or related terms for 'Saddler', separated by commas>"
+        "name#": craft=saddler
       craft/sailmaker:
-        # craft=sailmaker
         name: Sailmaker
         terms: "<translate with synonyms or related terms for 'Sailmaker', separated by commas>"
+        "name#": craft=sailmaker
       craft/sawmill:
-        # craft=sawmill
         name: Sawmill
-        # 'terms: lumber'
         terms: "<translate with synonyms or related terms for 'Sawmill', separated by commas>"
+        "name#": craft=sawmill
+        "terms#": "terms: lumber"
       craft/scaffolder:
-        # craft=scaffolder
         name: Scaffolder
         terms: "<translate with synonyms or related terms for 'Scaffolder', separated by commas>"
+        "name#": craft=scaffolder
       craft/sculpter:
-        # craft=sculpter
         name: Sculpter
         terms: "<translate with synonyms or related terms for 'Sculpter', separated by commas>"
+        "name#": craft=sculpter
       craft/shoemaker:
-        # craft=shoemaker
         name: Shoemaker
-        # 'terms: cobbler'
         terms: "<translate with synonyms or related terms for 'Shoemaker', separated by commas>"
+        "name#": craft=shoemaker
+        "terms#": "terms: cobbler"
       craft/stonemason:
-        # craft=stonemason
         name: Stonemason
-        # 'terms: masonry'
         terms: "<translate with synonyms or related terms for 'Stonemason', separated by commas>"
+        "name#": craft=stonemason
+        "terms#": "terms: masonry"
       craft/sweep:
-        # craft=sweep
         name: Chimney Sweep
         terms: "<translate with synonyms or related terms for 'Chimney Sweep', separated by commas>"
+        "name#": craft=sweep
       craft/tailor:
-        # craft=tailor
         name: Tailor
-        # 'terms: clothes,suit'
         terms: "<translate with synonyms or related terms for 'Tailor', separated by commas>"
+        "name#": craft=tailor
+        "terms#": "terms: clothes,suit"
       craft/tiler:
-        # craft=tiler
         name: Tiler
         terms: "<translate with synonyms or related terms for 'Tiler', separated by commas>"
+        "name#": craft=tiler
       craft/tinsmith:
-        # craft=tinsmith
         name: Tinsmith
         terms: "<translate with synonyms or related terms for 'Tinsmith', separated by commas>"
+        "name#": craft=tinsmith
       craft/upholsterer:
-        # craft=upholsterer
         name: Upholsterer
         terms: "<translate with synonyms or related terms for 'Upholsterer', separated by commas>"
+        "name#": craft=upholsterer
       craft/watchmaker:
-        # craft=watchmaker
         name: Watchmaker
         terms: "<translate with synonyms or related terms for 'Watchmaker', separated by commas>"
+        "name#": craft=watchmaker
       craft/window_construction:
-        # craft=window_construction
         name: Window Construction
-        # 'terms: glass'
         terms: "<translate with synonyms or related terms for 'Window Construction', separated by commas>"
+        "name#": craft=window_construction
+        "terms#": "terms: glass"
       craft/winery:
-        # craft=winery
         name: Winery
         terms: "<translate with synonyms or related terms for 'Winery', separated by commas>"
+        "name#": craft=winery
       embankment:
-        # embankment=yes
         name: Embankment
         terms: "<translate with synonyms or related terms for 'Embankment', separated by commas>"
+        "name#": embankment=yes
       emergency/ambulance_station:
-        # emergency=ambulance_station
         name: Ambulance Station
-        # 'terms: EMS,EMT,rescue'
         terms: "<translate with synonyms or related terms for 'Ambulance Station', separated by commas>"
+        "name#": emergency=ambulance_station
+        "terms#": "terms: EMS,EMT,rescue"
       emergency/fire_hydrant:
-        # emergency=fire_hydrant
         name: Fire Hydrant
         terms: "<translate with synonyms or related terms for 'Fire Hydrant', separated by commas>"
+        "name#": emergency=fire_hydrant
       emergency/phone:
-        # emergency=phone
         name: Emergency Phone
         terms: "<translate with synonyms or related terms for 'Emergency Phone', separated by commas>"
+        "name#": emergency=phone
       entrance:
-        # 'entrance=*'
         name: Entrance/Exit
         terms: "<translate with synonyms or related terms for 'Entrance/Exit', separated by commas>"
+        "name#": "entrance=*"
       footway/crossing:
-        # 'highway=footway, footway=crossing'
         name: Street Crossing
         terms: "<translate with synonyms or related terms for 'Street Crossing', separated by commas>"
+        "name#": "highway=footway, footway=crossing"
       footway/crosswalk:
-        # 'highway=footway, footway=crossing, crossing=zebra'
         name: Pedestrian Crosswalk
-        # 'terms: zebra crossing'
         terms: "<translate with synonyms or related terms for 'Pedestrian Crosswalk', separated by commas>"
+        "name#": "highway=footway, footway=crossing, crossing=zebra"
+        "terms#": "terms: zebra crossing"
       footway/sidewalk:
-        # 'highway=footway, footway=sidewalk'
         name: Sidewalk
         terms: "<translate with synonyms or related terms for 'Sidewalk', separated by commas>"
+        "name#": "highway=footway, footway=sidewalk"
       ford:
-        # ford=yes
         name: Ford
         terms: "<translate with synonyms or related terms for 'Ford', separated by commas>"
+        "name#": ford=yes
       golf/bunker:
-        # 'golf=bunker, natural=sand'
         name: Sand Trap
-        # 'terms: hazard,bunker'
         terms: "<translate with synonyms or related terms for 'Sand Trap', separated by commas>"
+        "name#": "golf=bunker, natural=sand"
+        "terms#": "terms: hazard,bunker"
       golf/fairway:
-        # 'golf=fairway, landuse=grass'
         name: Fairway
         terms: "<translate with synonyms or related terms for 'Fairway', separated by commas>"
+        "name#": "golf=fairway, landuse=grass"
       golf/green:
-        # 'golf=green, landuse=grass, leisure=pitch, sport=golf'
         name: Putting Green
         terms: "<translate with synonyms or related terms for 'Putting Green', separated by commas>"
+        "name#": "golf=green, landuse=grass, leisure=pitch, sport=golf"
       golf/hole:
-        # golf=hole
         name: Golf Hole
         terms: "<translate with synonyms or related terms for 'Golf Hole', separated by commas>"
+        "name#": golf=hole
       golf/lateral_water_hazard:
-        # 'golf=lateral_water_hazard, natural=water'
         name: Lateral Water Hazard
         terms: "<translate with synonyms or related terms for 'Lateral Water Hazard', separated by commas>"
+        "name#": "golf=lateral_water_hazard, natural=water"
       golf/rough:
-        # 'golf=rough, landuse=grass'
         name: Rough
         terms: "<translate with synonyms or related terms for 'Rough', separated by commas>"
+        "name#": "golf=rough, landuse=grass"
       golf/tee:
-        # 'golf=tee, landuse=grass'
         name: Tee Box
-        # 'terms: teeing ground'
         terms: "<translate with synonyms or related terms for 'Tee Box', separated by commas>"
+        "name#": "golf=tee, landuse=grass"
+        "terms#": "terms: teeing ground"
       golf/water_hazard:
-        # 'golf=water_hazard, natural=water'
         name: Water Hazard
         terms: "<translate with synonyms or related terms for 'Water Hazard', separated by commas>"
+        "name#": "golf=water_hazard, natural=water"
       highway:
-        # 'highway=*'
         name: Highway
         terms: "<translate with synonyms or related terms for 'Highway', separated by commas>"
+        "name#": "highway=*"
       highway/bridleway:
-        # highway=bridleway
         name: Bridle Path
-        # 'terms: bridleway,equestrian,horse'
         terms: "<translate with synonyms or related terms for 'Bridle Path', separated by commas>"
+        "name#": highway=bridleway
+        "terms#": "terms: bridleway,equestrian,horse"
       highway/bus_stop:
-        # highway=bus_stop
         name: Bus Stop
         terms: "<translate with synonyms or related terms for 'Bus Stop', separated by commas>"
+        "name#": highway=bus_stop
       highway/corridor:
-        # highway=corridor
         name: Indoor Corridor
-        # 'terms: gallery,hall,hallway,indoor,passage,passageway'
         terms: "<translate with synonyms or related terms for 'Indoor Corridor', separated by commas>"
+        "name#": highway=corridor
+        "terms#": "terms: gallery,hall,hallway,indoor,passage,passageway"
       highway/crossing:
-        # highway=crossing
         name: Street Crossing
         terms: "<translate with synonyms or related terms for 'Street Crossing', separated by commas>"
+        "name#": highway=crossing
       highway/crosswalk:
-        # 'highway=crossing, crossing=zebra'
         name: Pedestrian Crosswalk
-        # 'terms: zebra crossing'
         terms: "<translate with synonyms or related terms for 'Pedestrian Crosswalk', separated by commas>"
+        "name#": "highway=crossing, crossing=zebra"
+        "terms#": "terms: zebra crossing"
       highway/cycleway:
-        # highway=cycleway
         name: Cycle Path
-        # 'terms: bike'
         terms: "<translate with synonyms or related terms for 'Cycle Path', separated by commas>"
+        "name#": highway=cycleway
+        "terms#": "terms: bike"
       highway/footway:
-        # highway=footway
         name: Foot Path
-        # 'terms: hike,hiking,trackway,trail,walk'
         terms: "<translate with synonyms or related terms for 'Foot Path', separated by commas>"
+        "name#": highway=footway
+        "terms#": "terms: hike,hiking,trackway,trail,walk"
       highway/living_street:
-        # highway=living_street
         name: Living Street
         terms: "<translate with synonyms or related terms for 'Living Street', separated by commas>"
+        "name#": highway=living_street
       highway/mini_roundabout:
-        # highway=mini_roundabout
         name: Mini-Roundabout
         terms: "<translate with synonyms or related terms for 'Mini-Roundabout', separated by commas>"
+        "name#": highway=mini_roundabout
       highway/motorway:
-        # highway=motorway
         name: Motorway
         terms: "<translate with synonyms or related terms for 'Motorway', separated by commas>"
+        "name#": highway=motorway
       highway/motorway_junction:
-        # highway=motorway_junction
         name: Motorway Junction / Exit
         terms: "<translate with synonyms or related terms for 'Motorway Junction / Exit', separated by commas>"
+        "name#": highway=motorway_junction
       highway/motorway_link:
-        # highway=motorway_link
         name: Motorway Link
-        # 'terms: ramp,on ramp,off ramp'
         terms: "<translate with synonyms or related terms for 'Motorway Link', separated by commas>"
+        "name#": highway=motorway_link
+        "terms#": "terms: ramp,on ramp,off ramp"
       highway/path:
-        # highway=path
         name: Path
-        # 'terms: hike,hiking,trackway,trail,walk'
         terms: "<translate with synonyms or related terms for 'Path', separated by commas>"
+        "name#": highway=path
+        "terms#": "terms: hike,hiking,trackway,trail,walk"
       highway/pedestrian:
-        # highway=pedestrian
         name: Pedestrian Street
         terms: "<translate with synonyms or related terms for 'Pedestrian Street', separated by commas>"
+        "name#": highway=pedestrian
       highway/primary:
-        # highway=primary
         name: Primary Road
         terms: "<translate with synonyms or related terms for 'Primary Road', separated by commas>"
+        "name#": highway=primary
       highway/primary_link:
-        # highway=primary_link
         name: Primary Link
-        # 'terms: ramp,on ramp,off ramp'
         terms: "<translate with synonyms or related terms for 'Primary Link', separated by commas>"
+        "name#": highway=primary_link
+        "terms#": "terms: ramp,on ramp,off ramp"
       highway/raceway:
-        # highway=raceway
         name: Motor Raceway
-        # 'terms: auto*,race*,nascar'
         terms: "<translate with synonyms or related terms for 'Motor Raceway', separated by commas>"
+        "name#": highway=raceway
+        "terms#": "terms: auto*,race*,nascar"
       highway/residential:
-        # highway=residential
         name: Residential Road
         terms: "<translate with synonyms or related terms for 'Residential Road', separated by commas>"
+        "name#": highway=residential
       highway/rest_area:
-        # highway=rest_area
         name: Rest Area
-        # 'terms: rest stop'
         terms: "<translate with synonyms or related terms for 'Rest Area', separated by commas>"
+        "name#": highway=rest_area
+        "terms#": "terms: rest stop"
       highway/road:
-        # highway=road
         name: Unknown Road
         terms: "<translate with synonyms or related terms for 'Unknown Road', separated by commas>"
+        "name#": highway=road
       highway/secondary:
-        # highway=secondary
         name: Secondary Road
         terms: "<translate with synonyms or related terms for 'Secondary Road', separated by commas>"
+        "name#": highway=secondary
       highway/secondary_link:
-        # highway=secondary_link
         name: Secondary Link
-        # 'terms: ramp,on ramp,off ramp'
         terms: "<translate with synonyms or related terms for 'Secondary Link', separated by commas>"
+        "name#": highway=secondary_link
+        "terms#": "terms: ramp,on ramp,off ramp"
       highway/service:
-        # highway=service
         name: Service Road
         terms: "<translate with synonyms or related terms for 'Service Road', separated by commas>"
+        "name#": highway=service
       highway/service/alley:
-        # 'highway=service, service=alley'
         name: Alley
         terms: "<translate with synonyms or related terms for 'Alley', separated by commas>"
+        "name#": "highway=service, service=alley"
       highway/service/drive-through:
-        # 'highway=service, service=drive-through'
         name: Drive-Through
         terms: "<translate with synonyms or related terms for 'Drive-Through', separated by commas>"
+        "name#": "highway=service, service=drive-through"
       highway/service/driveway:
-        # 'highway=service, service=driveway'
         name: Driveway
         terms: "<translate with synonyms or related terms for 'Driveway', separated by commas>"
+        "name#": "highway=service, service=driveway"
       highway/service/emergency_access:
-        # 'highway=service, service=emergency_access'
         name: Emergency Access
         terms: "<translate with synonyms or related terms for 'Emergency Access', separated by commas>"
+        "name#": "highway=service, service=emergency_access"
       highway/service/parking_aisle:
-        # 'highway=service, service=parking_aisle'
         name: Parking Aisle
         terms: "<translate with synonyms or related terms for 'Parking Aisle', separated by commas>"
+        "name#": "highway=service, service=parking_aisle"
       highway/services:
-        # highway=services
         name: Service Area
-        # 'terms: services,travel plaza,service station'
         terms: "<translate with synonyms or related terms for 'Service Area', separated by commas>"
+        "name#": highway=services
+        "terms#": "terms: services,travel plaza,service station"
       highway/steps:
-        # highway=steps
         name: Steps
-        # 'terms: stairs,staircase'
         terms: "<translate with synonyms or related terms for 'Steps', separated by commas>"
+        "name#": highway=steps
+        "terms#": "terms: stairs,staircase"
       highway/stop:
-        # highway=stop
         name: Stop Sign
-        # 'terms: stop sign'
         terms: "<translate with synonyms or related terms for 'Stop Sign', separated by commas>"
+        "name#": highway=stop
+        "terms#": "terms: stop sign"
       highway/street_lamp:
-        # highway=street_lamp
         name: Street Lamp
-        # 'terms: streetlight,street light,lamp,light,gaslight'
         terms: "<translate with synonyms or related terms for 'Street Lamp', separated by commas>"
+        "name#": highway=street_lamp
+        "terms#": "terms: streetlight,street light,lamp,light,gaslight"
       highway/tertiary:
-        # highway=tertiary
         name: Tertiary Road
         terms: "<translate with synonyms or related terms for 'Tertiary Road', separated by commas>"
+        "name#": highway=tertiary
       highway/tertiary_link:
-        # highway=tertiary_link
         name: Tertiary Link
-        # 'terms: ramp,on ramp,off ramp'
         terms: "<translate with synonyms or related terms for 'Tertiary Link', separated by commas>"
+        "name#": highway=tertiary_link
+        "terms#": "terms: ramp,on ramp,off ramp"
       highway/track:
-        # highway=track
         name: Track
-        # 'terms: woods road,fire road'
         terms: "<translate with synonyms or related terms for 'Track', separated by commas>"
+        "name#": highway=track
+        "terms#": "terms: woods road,fire road"
       highway/traffic_signals:
-        # highway=traffic_signals
         name: Traffic Signals
-        # 'terms: light,stoplight,traffic light'
         terms: "<translate with synonyms or related terms for 'Traffic Signals', separated by commas>"
+        "name#": highway=traffic_signals
+        "terms#": "terms: light,stoplight,traffic light"
       highway/trunk:
-        # highway=trunk
         name: Trunk Road
         terms: "<translate with synonyms or related terms for 'Trunk Road', separated by commas>"
+        "name#": highway=trunk
       highway/trunk_link:
-        # highway=trunk_link
         name: Trunk Link
-        # 'terms: ramp,on ramp,off ramp'
         terms: "<translate with synonyms or related terms for 'Trunk Link', separated by commas>"
+        "name#": highway=trunk_link
+        "terms#": "terms: ramp,on ramp,off ramp"
       highway/turning_circle:
-        # highway=turning_circle
         name: Turning Circle
-        # 'terms: cul-de-sac'
         terms: "<translate with synonyms or related terms for 'Turning Circle', separated by commas>"
+        "name#": highway=turning_circle
+        "terms#": "terms: cul-de-sac"
       highway/unclassified:
-        # highway=unclassified
         name: Unclassified Road
         terms: "<translate with synonyms or related terms for 'Unclassified Road', separated by commas>"
+        "name#": highway=unclassified
       historic:
-        # 'historic=*'
         name: Historic Site
         terms: "<translate with synonyms or related terms for 'Historic Site', separated by commas>"
+        "name#": "historic=*"
       historic/archaeological_site:
-        # historic=archaeological_site
         name: Archaeological Site
         terms: "<translate with synonyms or related terms for 'Archaeological Site', separated by commas>"
+        "name#": historic=archaeological_site
       historic/boundary_stone:
-        # historic=boundary_stone
         name: Boundary Stone
         terms: "<translate with synonyms or related terms for 'Boundary Stone', separated by commas>"
+        "name#": historic=boundary_stone
       historic/castle:
-        # historic=castle
         name: Castle
         terms: "<translate with synonyms or related terms for 'Castle', separated by commas>"
+        "name#": historic=castle
       historic/memorial:
-        # historic=memorial
         name: Memorial
         terms: "<translate with synonyms or related terms for 'Memorial', separated by commas>"
+        "name#": historic=memorial
       historic/monument:
-        # historic=monument
         name: Monument
         terms: "<translate with synonyms or related terms for 'Monument', separated by commas>"
+        "name#": historic=monument
       historic/ruins:
-        # historic=ruins
         name: Ruins
         terms: "<translate with synonyms or related terms for 'Ruins', separated by commas>"
+        "name#": historic=ruins
       historic/wayside_cross:
-        # historic=wayside_cross
         name: Wayside Cross
         terms: "<translate with synonyms or related terms for 'Wayside Cross', separated by commas>"
+        "name#": historic=wayside_cross
       historic/wayside_shrine:
-        # historic=wayside_shrine
         name: Wayside Shrine
         terms: "<translate with synonyms or related terms for 'Wayside Shrine', separated by commas>"
+        "name#": historic=wayside_shrine
       junction:
-        # junction=yes
         name: Junction
         terms: "<translate with synonyms or related terms for 'Junction', separated by commas>"
+        "name#": junction=yes
       landuse:
-        # 'landuse=*'
         name: Landuse
         terms: "<translate with synonyms or related terms for 'Landuse', separated by commas>"
+        "name#": "landuse=*"
       landuse/allotments:
-        # landuse=allotments
         name: Allotments
         terms: "<translate with synonyms or related terms for 'Allotments', separated by commas>"
+        "name#": landuse=allotments
       landuse/basin:
-        # landuse=basin
         name: Basin
         terms: "<translate with synonyms or related terms for 'Basin', separated by commas>"
+        "name#": landuse=basin
       landuse/cemetery:
-        # landuse=cemetery
         name: Cemetery
         terms: "<translate with synonyms or related terms for 'Cemetery', separated by commas>"
+        "name#": landuse=cemetery
       landuse/churchyard:
-        # landuse=churchyard
         name: Churchyard
         terms: "<translate with synonyms or related terms for 'Churchyard', separated by commas>"
+        "name#": landuse=churchyard
       landuse/commercial:
-        # landuse=commercial
         name: Commercial Area
         terms: "<translate with synonyms or related terms for 'Commercial Area', separated by commas>"
+        "name#": landuse=commercial
       landuse/construction:
-        # landuse=construction
         name: Construction
         terms: "<translate with synonyms or related terms for 'Construction', separated by commas>"
+        "name#": landuse=construction
       landuse/farm:
-        # landuse=farm
         name: Farmland
         terms: "<translate with synonyms or related terms for 'Farmland', separated by commas>"
+        "name#": landuse=farm
       landuse/farmland:
-        # landuse=farmland
         name: Farmland
         terms: "<translate with synonyms or related terms for 'Farmland', separated by commas>"
+        "name#": landuse=farmland
       landuse/farmyard:
-        # landuse=farmyard
         name: Farmyard
         terms: "<translate with synonyms or related terms for 'Farmyard', separated by commas>"
+        "name#": landuse=farmyard
       landuse/forest:
-        # landuse=forest
         name: Forest
-        # 'terms: tree'
         terms: "<translate with synonyms or related terms for 'Forest', separated by commas>"
+        "name#": landuse=forest
+        "terms#": "terms: tree"
       landuse/garages:
-        # landuse=garages
         name: Garages
         terms: "<translate with synonyms or related terms for 'Garages', separated by commas>"
+        "name#": landuse=garages
       landuse/grass:
-        # landuse=grass
         name: Grass
         terms: "<translate with synonyms or related terms for 'Grass', separated by commas>"
+        "name#": landuse=grass
       landuse/industrial:
-        # landuse=industrial
         name: Industrial Area
         terms: "<translate with synonyms or related terms for 'Industrial Area', separated by commas>"
+        "name#": landuse=industrial
       landuse/landfill:
-        # landuse=landfill
         name: Landfill
-        # 'terms: dump'
         terms: "<translate with synonyms or related terms for 'Landfill', separated by commas>"
+        "name#": landuse=landfill
+        "terms#": "terms: dump"
       landuse/meadow:
-        # landuse=meadow
         name: Meadow
         terms: "<translate with synonyms or related terms for 'Meadow', separated by commas>"
+        "name#": landuse=meadow
       landuse/military:
-        # landuse=military
         name: Military Area
         terms: "<translate with synonyms or related terms for 'Military Area', separated by commas>"
+        "name#": landuse=military
       landuse/orchard:
-        # landuse=orchard
         name: Orchard
         terms: "<translate with synonyms or related terms for 'Orchard', separated by commas>"
+        "name#": landuse=orchard
       landuse/plant_nursery:
-        # landuse=plant_nursery
         name: Plant Nursery
-        # 'terms: vivero'
         terms: "<translate with synonyms or related terms for 'Plant Nursery', separated by commas>"
+        "name#": landuse=plant_nursery
+        "terms#": "terms: vivero"
       landuse/quarry:
-        # landuse=quarry
         name: Quarry
         terms: "<translate with synonyms or related terms for 'Quarry', separated by commas>"
+        "name#": landuse=quarry
       landuse/residential:
-        # landuse=residential
         name: Residential Area
         terms: "<translate with synonyms or related terms for 'Residential Area', separated by commas>"
+        "name#": landuse=residential
       landuse/retail:
-        # landuse=retail
         name: Retail Area
         terms: "<translate with synonyms or related terms for 'Retail Area', separated by commas>"
+        "name#": landuse=retail
       landuse/vineyard:
-        # landuse=vineyard
         name: Vineyard
         terms: "<translate with synonyms or related terms for 'Vineyard', separated by commas>"
+        "name#": landuse=vineyard
       leisure:
-        # 'leisure=*'
         name: Leisure
         terms: "<translate with synonyms or related terms for 'Leisure', separated by commas>"
+        "name#": "leisure=*"
       leisure/adult_gaming_centre:
-        # leisure=adult_gaming_centre
         name: Adult Gaming Center
-        # 'terms: gambling,slot machine'
         terms: "<translate with synonyms or related terms for 'Adult Gaming Center', separated by commas>"
+        "name#": leisure=adult_gaming_centre
+        "terms#": "terms: gambling,slot machine"
       leisure/common:
-        # leisure=common
         name: Common
-        # 'terms: open space'
         terms: "<translate with synonyms or related terms for 'Common', separated by commas>"
+        "name#": leisure=common
+        "terms#": "terms: open space"
       leisure/dog_park:
-        # leisure=dog_park
         name: Dog Park
         terms: "<translate with synonyms or related terms for 'Dog Park', separated by commas>"
+        "name#": leisure=dog_park
       leisure/firepit:
-        # leisure=firepit
         name: Firepit
-        # 'terms: fireplace,campfire'
         terms: "<translate with synonyms or related terms for 'Firepit', separated by commas>"
+        "name#": leisure=firepit
+        "terms#": "terms: fireplace,campfire"
       leisure/garden:
-        # leisure=garden
         name: Garden
         terms: "<translate with synonyms or related terms for 'Garden', separated by commas>"
+        "name#": leisure=garden
       leisure/golf_course:
-        # leisure=golf_course
         name: Golf Course
-        # 'terms: links'
         terms: "<translate with synonyms or related terms for 'Golf Course', separated by commas>"
+        "name#": leisure=golf_course
+        "terms#": "terms: links"
       leisure/ice_rink:
-        # leisure=ice_rink
         name: Ice Rink
-        # 'terms: hockey,skating,curling'
         terms: "<translate with synonyms or related terms for 'Ice Rink', separated by commas>"
+        "name#": leisure=ice_rink
+        "terms#": "terms: hockey,skating,curling"
       leisure/marina:
-        # leisure=marina
         name: Marina
-        # 'terms: boat'
         terms: "<translate with synonyms or related terms for 'Marina', separated by commas>"
+        "name#": leisure=marina
+        "terms#": "terms: boat"
       leisure/nature_reserve:
-        # leisure=nature_reserve
         name: Nature Reserve
-        # 'terms: protected,wildlife'
         terms: "<translate with synonyms or related terms for 'Nature Reserve', separated by commas>"
+        "name#": leisure=nature_reserve
+        "terms#": "terms: protected,wildlife"
       leisure/park:
-        # leisure=park
         name: Park
-        # 'terms: esplanade,estate,forest,garden,grass,green,grounds,lawn,lot,meadow,parkland,place,playground,plaza,pleasure garden,recreation area,square,tract,village green,woodland'
         terms: "<translate with synonyms or related terms for 'Park', separated by commas>"
+        "name#": leisure=park
+        "terms#": "terms: esplanade,estate,forest,garden,grass,green,grounds,lawn,lot,meadow,parkland,place,playground,plaza,pleasure garden,recreation area,square,tract,village green,woodland"
       leisure/picnic_table:
-        # leisure=picnic_table
         name: Picnic Table
-        # 'terms: bench'
         terms: "<translate with synonyms or related terms for 'Picnic Table', separated by commas>"
+        "name#": leisure=picnic_table
+        "terms#": "terms: bench"
       leisure/pitch:
-        # leisure=pitch
         name: Sport Pitch
-        # 'terms: field'
         terms: "<translate with synonyms or related terms for 'Sport Pitch', separated by commas>"
+        "name#": leisure=pitch
+        "terms#": "terms: field"
       leisure/pitch/american_football:
-        # 'leisure=pitch, sport=american_football'
         name: American Football Field
         terms: "<translate with synonyms or related terms for 'American Football Field', separated by commas>"
+        "name#": "leisure=pitch, sport=american_football"
       leisure/pitch/baseball:
-        # 'leisure=pitch, sport=baseball'
         name: Baseball Diamond
         terms: "<translate with synonyms or related terms for 'Baseball Diamond', separated by commas>"
+        "name#": "leisure=pitch, sport=baseball"
       leisure/pitch/basketball:
-        # 'leisure=pitch, sport=basketball'
         name: Basketball Court
         terms: "<translate with synonyms or related terms for 'Basketball Court', separated by commas>"
+        "name#": "leisure=pitch, sport=basketball"
       leisure/pitch/skateboard:
-        # 'leisure=pitch, sport=skateboard'
         name: Skate Park
         terms: "<translate with synonyms or related terms for 'Skate Park', separated by commas>"
+        "name#": "leisure=pitch, sport=skateboard"
       leisure/pitch/soccer:
-        # 'leisure=pitch, sport=soccer'
         name: Soccer Field
         terms: "<translate with synonyms or related terms for 'Soccer Field', separated by commas>"
+        "name#": "leisure=pitch, sport=soccer"
       leisure/pitch/tennis:
-        # 'leisure=pitch, sport=tennis'
         name: Tennis Court
         terms: "<translate with synonyms or related terms for 'Tennis Court', separated by commas>"
+        "name#": "leisure=pitch, sport=tennis"
       leisure/pitch/volleyball:
-        # 'leisure=pitch, sport=volleyball'
         name: Volleyball Court
         terms: "<translate with synonyms or related terms for 'Volleyball Court', separated by commas>"
+        "name#": "leisure=pitch, sport=volleyball"
       leisure/playground:
-        # leisure=playground
         name: Playground
-        # 'terms: jungle gym,play area'
         terms: "<translate with synonyms or related terms for 'Playground', separated by commas>"
+        "name#": leisure=playground
+        "terms#": "terms: jungle gym,play area"
       leisure/running_track:
-        # 'leisure=track, sport=running'
         name: Running Track
         terms: "<translate with synonyms or related terms for 'Running Track', separated by commas>"
+        "name#": "leisure=track, sport=running"
       leisure/slipway:
-        # leisure=slipway
         name: Slipway
-        # 'terms: boat launch,boat ramp'
         terms: "<translate with synonyms or related terms for 'Slipway', separated by commas>"
+        "name#": leisure=slipway
+        "terms#": "terms: boat launch,boat ramp"
       leisure/sports_center:
-        # leisure=sports_centre
         name: Sports Center / Gym
-        # 'terms: gym'
         terms: "<translate with synonyms or related terms for 'Sports Center / Gym', separated by commas>"
+        "name#": leisure=sports_centre
+        "terms#": "terms: gym"
       leisure/stadium:
-        # leisure=stadium
         name: Stadium
         terms: "<translate with synonyms or related terms for 'Stadium', separated by commas>"
+        "name#": leisure=stadium
       leisure/swimming_pool:
-        # leisure=swimming_pool
         name: Swimming Pool
         terms: "<translate with synonyms or related terms for 'Swimming Pool', separated by commas>"
+        "name#": leisure=swimming_pool
       leisure/track:
-        # leisure=track
         name: Racetrack (non-Motorsport)
         terms: "<translate with synonyms or related terms for 'Racetrack (non-Motorsport)', separated by commas>"
+        "name#": leisure=track
       line:
         name: Line
         terms: "<translate with synonyms or related terms for 'Line', separated by commas>"
       man_made:
-        # 'man_made=*'
         name: Man Made
         terms: "<translate with synonyms or related terms for 'Man Made', separated by commas>"
+        "name#": "man_made=*"
       man_made/adit:
-        # man_made=adit
         name: Adit
-        # 'terms: entrance,underground,mine,cave'
         terms: "<translate with synonyms or related terms for 'Adit', separated by commas>"
+        "name#": man_made=adit
+        "terms#": "terms: entrance,underground,mine,cave"
       man_made/breakwater:
-        # man_made=breakwater
         name: Breakwater
         terms: "<translate with synonyms or related terms for 'Breakwater', separated by commas>"
+        "name#": man_made=breakwater
       man_made/cutline:
-        # man_made=cutline
         name: Cut line
         terms: "<translate with synonyms or related terms for 'Cut line', separated by commas>"
+        "name#": man_made=cutline
       man_made/embankment:
-        # man_made=embankment
         name: Embankment
         terms: "<translate with synonyms or related terms for 'Embankment', separated by commas>"
+        "name#": man_made=embankment
       man_made/flagpole:
-        # man_made=flagpole
         name: Flagpole
         terms: "<translate with synonyms or related terms for 'Flagpole', separated by commas>"
+        "name#": man_made=flagpole
       man_made/lighthouse:
-        # man_made=lighthouse
         name: Lighthouse
         terms: "<translate with synonyms or related terms for 'Lighthouse', separated by commas>"
+        "name#": man_made=lighthouse
       man_made/mast:
-        # man_made=mast
         name: Radio Mast
-        # 'terms: broadcast tower,cell phone tower,cell tower,guyed tower,mobile phone tower,radio tower,television tower,transmission mast,transmission tower,tv tower'
         terms: "<translate with synonyms or related terms for 'Radio Mast', separated by commas>"
+        "name#": man_made=mast
+        "terms#": "terms: broadcast tower,cell phone tower,cell tower,guyed tower,mobile phone tower,radio tower,television tower,transmission mast,transmission tower,tv tower"
       man_made/observation:
-        # 'man_made=tower, tower:type=observation'
         name: Observation Tower
-        # 'terms: lookout tower,fire tower'
         terms: "<translate with synonyms or related terms for 'Observation Tower', separated by commas>"
+        "name#": "man_made=tower, tower:type=observation"
+        "terms#": "terms: lookout tower,fire tower"
       man_made/petroleum_well:
-        # man_made=petroleum_well
         name: Oil Well
-        # 'terms: drilling rig,oil derrick,oil drill,oil horse,oil rig,oil pump,petroleum well,pumpjack'
         terms: "<translate with synonyms or related terms for 'Oil Well', separated by commas>"
+        "name#": man_made=petroleum_well
+        "terms#": "terms: drilling rig,oil derrick,oil drill,oil horse,oil rig,oil pump,petroleum well,pumpjack"
       man_made/pier:
-        # man_made=pier
         name: Pier
         terms: "<translate with synonyms or related terms for 'Pier', separated by commas>"
+        "name#": man_made=pier
       man_made/pipeline:
-        # man_made=pipeline
         name: Pipeline
         terms: "<translate with synonyms or related terms for 'Pipeline', separated by commas>"
+        "name#": man_made=pipeline
       man_made/silo:
-        # man_made=silo
         name: Silo
-        # 'terms: grain,corn,wheat'
         terms: "<translate with synonyms or related terms for 'Silo', separated by commas>"
+        "name#": man_made=silo
+        "terms#": "terms: grain,corn,wheat"
       man_made/storage_tank:
-        # man_made=storage_tank
         name: Storage Tank
-        # 'terms: water,oil,gas,petrol'
         terms: "<translate with synonyms or related terms for 'Storage Tank', separated by commas>"
+        "name#": man_made=storage_tank
+        "terms#": "terms: water,oil,gas,petrol"
       man_made/survey_point:
-        # man_made=survey_point
         name: Survey Point
         terms: "<translate with synonyms or related terms for 'Survey Point', separated by commas>"
+        "name#": man_made=survey_point
       man_made/tower:
-        # man_made=tower
         name: Tower
         terms: "<translate with synonyms or related terms for 'Tower', separated by commas>"
+        "name#": man_made=tower
       man_made/wastewater_plant:
-        # man_made=wastewater_plant
         name: Wastewater Plant
-        # 'terms: sewage*,water treatment plant,reclamation plant'
         terms: "<translate with synonyms or related terms for 'Wastewater Plant', separated by commas>"
+        "name#": man_made=wastewater_plant
+        "terms#": "terms: sewage*,water treatment plant,reclamation plant"
       man_made/water_tower:
-        # man_made=water_tower
         name: Water Tower
         terms: "<translate with synonyms or related terms for 'Water Tower', separated by commas>"
+        "name#": man_made=water_tower
       man_made/water_well:
-        # man_made=water_well
         name: Water Well
         terms: "<translate with synonyms or related terms for 'Water Well', separated by commas>"
+        "name#": man_made=water_well
       man_made/water_works:
-        # man_made=water_works
         name: Water Works
         terms: "<translate with synonyms or related terms for 'Water Works', separated by commas>"
+        "name#": man_made=water_works
       military/airfield:
-        # military=airfield
         name: Airfield
         terms: "<translate with synonyms or related terms for 'Airfield', separated by commas>"
+        "name#": military=airfield
       military/barracks:
-        # military=barracks
         name: Barracks
         terms: "<translate with synonyms or related terms for 'Barracks', separated by commas>"
+        "name#": military=barracks
       military/bunker:
-        # military=bunker
         name: Bunker
         terms: "<translate with synonyms or related terms for 'Bunker', separated by commas>"
+        "name#": military=bunker
       military/range:
-        # military=range
         name: Military Range
         terms: "<translate with synonyms or related terms for 'Military Range', separated by commas>"
+        "name#": military=range
       natural:
-        # 'natural=*'
         name: Natural
         terms: "<translate with synonyms or related terms for 'Natural', separated by commas>"
+        "name#": "natural=*"
       natural/bay:
-        # natural=bay
         name: Bay
         terms: "<translate with synonyms or related terms for 'Bay', separated by commas>"
+        "name#": natural=bay
       natural/beach:
-        # natural=beach
         name: Beach
         terms: "<translate with synonyms or related terms for 'Beach', separated by commas>"
+        "name#": natural=beach
       natural/cave_entrance:
-        # natural=cave_entrance
         name: Cave Entrance
-        # 'terms: cavern,hollow,grotto,shelter,cavity'
         terms: "<translate with synonyms or related terms for 'Cave Entrance', separated by commas>"
+        "name#": natural=cave_entrance
+        "terms#": "terms: cavern,hollow,grotto,shelter,cavity"
       natural/cliff:
-        # natural=cliff
         name: Cliff
         terms: "<translate with synonyms or related terms for 'Cliff', separated by commas>"
+        "name#": natural=cliff
       natural/coastline:
-        # natural=coastline
         name: Coastline
-        # 'terms: shore'
         terms: "<translate with synonyms or related terms for 'Coastline', separated by commas>"
+        "name#": natural=coastline
+        "terms#": "terms: shore"
       natural/fell:
-        # natural=fell
         name: Fell
         terms: "<translate with synonyms or related terms for 'Fell', separated by commas>"
+        "name#": natural=fell
       natural/glacier:
-        # natural=glacier
         name: Glacier
         terms: "<translate with synonyms or related terms for 'Glacier', separated by commas>"
+        "name#": natural=glacier
       natural/grassland:
-        # natural=grassland
         name: Grassland
         terms: "<translate with synonyms or related terms for 'Grassland', separated by commas>"
+        "name#": natural=grassland
       natural/heath:
-        # natural=heath
         name: Heath
         terms: "<translate with synonyms or related terms for 'Heath', separated by commas>"
+        "name#": natural=heath
       natural/peak:
-        # natural=peak
         name: Peak
-        # 'terms: acme,aiguille,alp,climax,crest,crown,hill,mount,mountain,pinnacle,summit,tip,top'
         terms: "<translate with synonyms or related terms for 'Peak', separated by commas>"
+        "name#": natural=peak
+        "terms#": "terms: acme,aiguille,alp,climax,crest,crown,hill,mount,mountain,pinnacle,summit,tip,top"
       natural/saddle:
-        # natural=saddle
         name: Saddle
-        # 'terms: pass,mountain pass,top'
         terms: "<translate with synonyms or related terms for 'Saddle', separated by commas>"
+        "name#": natural=saddle
+        "terms#": "terms: pass,mountain pass,top"
       natural/scree:
-        # natural=scree
         name: Scree
-        # 'terms: loose rocks'
         terms: "<translate with synonyms or related terms for 'Scree', separated by commas>"
+        "name#": natural=scree
+        "terms#": "terms: loose rocks"
       natural/scrub:
-        # natural=scrub
         name: Scrub
-        # 'terms: bush,shrubs'
         terms: "<translate with synonyms or related terms for 'Scrub', separated by commas>"
+        "name#": natural=scrub
+        "terms#": "terms: bush,shrubs"
       natural/spring:
-        # natural=spring
         name: Spring
         terms: "<translate with synonyms or related terms for 'Spring', separated by commas>"
+        "name#": natural=spring
       natural/tree:
-        # natural=tree
         name: Tree
         terms: "<translate with synonyms or related terms for 'Tree', separated by commas>"
+        "name#": natural=tree
       natural/tree_row:
-        # natural=tree_row
         name: Tree row
         terms: "<translate with synonyms or related terms for 'Tree row', separated by commas>"
+        "name#": natural=tree_row
       natural/volcano:
-        # natural=volcano
         name: Volcano
-        # 'terms: mountain,crater'
         terms: "<translate with synonyms or related terms for 'Volcano', separated by commas>"
+        "name#": natural=volcano
+        "terms#": "terms: mountain,crater"
       natural/water:
-        # natural=water
         name: Water
         terms: "<translate with synonyms or related terms for 'Water', separated by commas>"
+        "name#": natural=water
       natural/water/lake:
-        # 'natural=water, water=lake'
         name: Lake
-        # 'terms: lakelet,loch,mere'
         terms: "<translate with synonyms or related terms for 'Lake', separated by commas>"
+        "name#": "natural=water, water=lake"
+        "terms#": "terms: lakelet,loch,mere"
       natural/water/pond:
-        # 'natural=water, water=pond'
         name: Pond
-        # 'terms: lakelet,millpond,tarn,pool,mere'
         terms: "<translate with synonyms or related terms for 'Pond', separated by commas>"
+        "name#": "natural=water, water=pond"
+        "terms#": "terms: lakelet,millpond,tarn,pool,mere"
       natural/water/reservoir:
-        # 'natural=water, water=reservoir'
         name: Reservoir
         terms: "<translate with synonyms or related terms for 'Reservoir', separated by commas>"
+        "name#": "natural=water, water=reservoir"
       natural/wetland:
-        # natural=wetland
         name: Wetland
         terms: "<translate with synonyms or related terms for 'Wetland', separated by commas>"
+        "name#": natural=wetland
       natural/wood:
-        # natural=wood
         name: Wood
-        # 'terms: tree'
         terms: "<translate with synonyms or related terms for 'Wood', separated by commas>"
+        "name#": natural=wood
+        "terms#": "terms: tree"
       office:
-        # 'office=*'
         name: Office
         terms: "<translate with synonyms or related terms for 'Office', separated by commas>"
+        "name#": "office=*"
       office/accountant:
-        # office=accountant
         name: Accountant
         terms: "<translate with synonyms or related terms for 'Accountant', separated by commas>"
+        "name#": office=accountant
       office/administrative:
-        # office=administrative
         name: Administrative Office
         terms: "<translate with synonyms or related terms for 'Administrative Office', separated by commas>"
+        "name#": office=administrative
       office/architect:
-        # office=architect
         name: Architect
         terms: "<translate with synonyms or related terms for 'Architect', separated by commas>"
+        "name#": office=architect
       office/company:
-        # office=company
         name: Company Office
         terms: "<translate with synonyms or related terms for 'Company Office', separated by commas>"
+        "name#": office=company
       office/educational_institution:
-        # office=educational_institution
         name: Educational Institution
         terms: "<translate with synonyms or related terms for 'Educational Institution', separated by commas>"
+        "name#": office=educational_institution
       office/employment_agency:
-        # office=employment_agency
         name: Employment Agency
-        # 'terms: job'
         terms: "<translate with synonyms or related terms for 'Employment Agency', separated by commas>"
+        "name#": office=employment_agency
+        "terms#": "terms: job"
       office/estate_agent:
-        # office=estate_agent
         name: Real Estate Office
         terms: "<translate with synonyms or related terms for 'Real Estate Office', separated by commas>"
+        "name#": office=estate_agent
       office/financial:
-        # office=financial
         name: Financial Office
         terms: "<translate with synonyms or related terms for 'Financial Office', separated by commas>"
+        "name#": office=financial
       office/government:
-        # office=government
         name: Government Office
         terms: "<translate with synonyms or related terms for 'Government Office', separated by commas>"
+        "name#": office=government
       office/insurance:
-        # office=insurance
         name: Insurance Office
         terms: "<translate with synonyms or related terms for 'Insurance Office', separated by commas>"
+        "name#": office=insurance
       office/it:
-        # office=it
         name: IT Office
         terms: "<translate with synonyms or related terms for 'IT Office', separated by commas>"
+        "name#": office=it
       office/lawyer:
-        # office=lawyer
         name: Law Office
         terms: "<translate with synonyms or related terms for 'Law Office', separated by commas>"
+        "name#": office=lawyer
       office/newspaper:
-        # office=newspaper
         name: Newspaper
         terms: "<translate with synonyms or related terms for 'Newspaper', separated by commas>"
+        "name#": office=newspaper
       office/ngo:
-        # office=ngo
         name: NGO Office
         terms: "<translate with synonyms or related terms for 'NGO Office', separated by commas>"
+        "name#": office=ngo
       office/physician:
-        # office=physician
         name: Physician
         terms: "<translate with synonyms or related terms for 'Physician', separated by commas>"
+        "name#": office=physician
       office/political_party:
-        # office=political_party
         name: Political Party
         terms: "<translate with synonyms or related terms for 'Political Party', separated by commas>"
+        "name#": office=political_party
       office/research:
-        # office=research
         name: Research Office
         terms: "<translate with synonyms or related terms for 'Research Office', separated by commas>"
+        "name#": office=research
       office/telecommunication:
-        # office=telecommunication
         name: Telecom Office
         terms: "<translate with synonyms or related terms for 'Telecom Office', separated by commas>"
+        "name#": office=telecommunication
       office/therapist:
-        # office=therapist
         name: Therapist
         terms: "<translate with synonyms or related terms for 'Therapist', separated by commas>"
+        "name#": office=therapist
       office/travel_agent:
-        # office=travel_agent
         name: Travel Agency
         terms: "<translate with synonyms or related terms for 'Travel Agency', separated by commas>"
+        "name#": office=travel_agent
       piste:
-        # 'piste:type=*'
         name: Piste/Ski Trail
-        # 'terms: ski,sled,sleigh,snowboard,nordic,downhill,snowmobile'
         terms: "<translate with synonyms or related terms for 'Piste/Ski Trail', separated by commas>"
+        "name#": "piste:type=*"
+        "terms#": "terms: ski,sled,sleigh,snowboard,nordic,downhill,snowmobile"
       place:
-        # 'place=*'
         name: Place
         terms: "<translate with synonyms or related terms for 'Place', separated by commas>"
+        "name#": "place=*"
       place/city:
-        # place=city
         name: City
         terms: "<translate with synonyms or related terms for 'City', separated by commas>"
+        "name#": place=city
       place/farm:
-        # place=farm
         name: Farm
         terms: "<translate with synonyms or related terms for 'Farm', separated by commas>"
+        "name#": place=farm
       place/hamlet:
-        # place=hamlet
         name: Hamlet
         terms: "<translate with synonyms or related terms for 'Hamlet', separated by commas>"
+        "name#": place=hamlet
       place/island:
-        # place=island
         name: Island
-        # 'terms: archipelago,atoll,bar,cay,isle,islet,key,reef'
         terms: "<translate with synonyms or related terms for 'Island', separated by commas>"
+        "name#": place=island
+        "terms#": "terms: archipelago,atoll,bar,cay,isle,islet,key,reef"
       place/isolated_dwelling:
-        # place=isolated_dwelling
         name: Isolated Dwelling
         terms: "<translate with synonyms or related terms for 'Isolated Dwelling', separated by commas>"
+        "name#": place=isolated_dwelling
       place/locality:
-        # place=locality
         name: Locality
         terms: "<translate with synonyms or related terms for 'Locality', separated by commas>"
+        "name#": place=locality
       place/neighbourhood:
-        # place=neighbourhood
         name: Neighborhood
-        # 'terms: neighbourhood'
         terms: "<translate with synonyms or related terms for 'Neighborhood', separated by commas>"
+        "name#": place=neighbourhood
+        "terms#": "terms: neighbourhood"
       place/suburb:
-        # place=suburb
         name: Borough
-        # 'terms: Boro,Quarter'
         terms: "<translate with synonyms or related terms for 'Borough', separated by commas>"
+        "name#": place=suburb
+        "terms#": "terms: Boro,Quarter"
       place/town:
-        # place=town
         name: Town
         terms: "<translate with synonyms or related terms for 'Town', separated by commas>"
+        "name#": place=town
       place/village:
-        # place=village
         name: Village
         terms: "<translate with synonyms or related terms for 'Village', separated by commas>"
+        "name#": place=village
       point:
         name: Point
         terms: "<translate with synonyms or related terms for 'Point', separated by commas>"
       power:
-        # 'power=*'
         name: Power
         terms: "<translate with synonyms or related terms for 'Power', separated by commas>"
+        "name#": "power=*"
       power/generator:
-        # power=generator
         name: Power Generator
         terms: "<translate with synonyms or related terms for 'Power Generator', separated by commas>"
+        "name#": power=generator
       power/line:
-        # power=line
         name: Power Line
         terms: "<translate with synonyms or related terms for 'Power Line', separated by commas>"
+        "name#": power=line
       power/minor_line:
-        # power=minor_line
         name: Minor Power Line
         terms: "<translate with synonyms or related terms for 'Minor Power Line', separated by commas>"
+        "name#": power=minor_line
       power/pole:
-        # power=pole
         name: Power Pole
         terms: "<translate with synonyms or related terms for 'Power Pole', separated by commas>"
+        "name#": power=pole
       power/sub_station:
-        # power=sub_station
         name: Substation
         terms: "<translate with synonyms or related terms for 'Substation', separated by commas>"
+        "name#": power=sub_station
       power/substation:
-        # power=substation
         name: Substation
         terms: "<translate with synonyms or related terms for 'Substation', separated by commas>"
+        "name#": power=substation
       power/tower:
-        # power=tower
         name: High-Voltage Tower
         terms: "<translate with synonyms or related terms for 'High-Voltage Tower', separated by commas>"
+        "name#": power=tower
       power/transformer:
-        # power=transformer
         name: Transformer
         terms: "<translate with synonyms or related terms for 'Transformer', separated by commas>"
+        "name#": power=transformer
       public_transport/platform:
-        # public_transport=platform
         name: Platform
         terms: "<translate with synonyms or related terms for 'Platform', separated by commas>"
+        "name#": public_transport=platform
       public_transport/stop_position:
-        # public_transport=stop_position
         name: Stop Position
         terms: "<translate with synonyms or related terms for 'Stop Position', separated by commas>"
+        "name#": public_transport=stop_position
       railway:
-        # 'railway=*'
         name: Railway
         terms: "<translate with synonyms or related terms for 'Railway', separated by commas>"
+        "name#": "railway=*"
       railway/abandoned:
-        # railway=abandoned
         name: Abandoned Railway
         terms: "<translate with synonyms or related terms for 'Abandoned Railway', separated by commas>"
+        "name#": railway=abandoned
       railway/disused:
-        # railway=disused
         name: Disused Railway
         terms: "<translate with synonyms or related terms for 'Disused Railway', separated by commas>"
+        "name#": railway=disused
       railway/funicular:
-        # railway=funicular
         name: Funicular
-        # 'terms: venicular,cliff railway,cable car,cable railway,funicular railway'
         terms: "<translate with synonyms or related terms for 'Funicular', separated by commas>"
+        "name#": railway=funicular
+        "terms#": "terms: venicular,cliff railway,cable car,cable railway,funicular railway"
       railway/halt:
-        # railway=halt
         name: Railway Halt
-        # 'terms: break,interrupt,rest,wait,interruption'
         terms: "<translate with synonyms or related terms for 'Railway Halt', separated by commas>"
+        "name#": railway=halt
+        "terms#": "terms: break,interrupt,rest,wait,interruption"
       railway/level_crossing:
-        # railway=level_crossing
         name: Railway Crossing
-        # 'terms: crossing,railroad crossing,level crossing,grade crossing,road through railroad,train crossing'
         terms: "<translate with synonyms or related terms for 'Railway Crossing', separated by commas>"
+        "name#": railway=level_crossing
+        "terms#": "terms: crossing,railroad crossing,level crossing,grade crossing,road through railroad,train crossing"
       railway/monorail:
-        # railway=monorail
         name: Monorail
         terms: "<translate with synonyms or related terms for 'Monorail', separated by commas>"
+        "name#": railway=monorail
       railway/narrow_gauge:
-        # railway=narrow_gauge
         name: Narrow Gauge Rail
-        # 'terms: narrow gauge railway,narrow gauge railroad'
         terms: "<translate with synonyms or related terms for 'Narrow Gauge Rail', separated by commas>"
+        "name#": railway=narrow_gauge
+        "terms#": "terms: narrow gauge railway,narrow gauge railroad"
       railway/platform:
-        # railway=platform
         name: Railway Platform
         terms: "<translate with synonyms or related terms for 'Railway Platform', separated by commas>"
+        "name#": railway=platform
       railway/rail:
-        # railway=rail
         name: Rail
         terms: "<translate with synonyms or related terms for 'Rail', separated by commas>"
+        "name#": railway=rail
       railway/station:
-        # railway=station
         name: Railway Station
-        # 'terms: train station,station'
         terms: "<translate with synonyms or related terms for 'Railway Station', separated by commas>"
+        "name#": railway=station
+        "terms#": "terms: train station,station"
       railway/subway:
-        # railway=subway
         name: Subway
         terms: "<translate with synonyms or related terms for 'Subway', separated by commas>"
+        "name#": railway=subway
       railway/subway_entrance:
-        # railway=subway_entrance
         name: Subway Entrance
         terms: "<translate with synonyms or related terms for 'Subway Entrance', separated by commas>"
+        "name#": railway=subway_entrance
       railway/tram:
-        # railway=tram
         name: Tram
-        # 'terms: streetcar'
         terms: "<translate with synonyms or related terms for 'Tram', separated by commas>"
+        "name#": railway=tram
+        "terms#": "terms: streetcar"
       relation:
         name: Relation
         terms: "<translate with synonyms or related terms for 'Relation', separated by commas>"
       roundabout:
-        # junction=roundabout
         name: Roundabout
         terms: "<translate with synonyms or related terms for 'Roundabout', separated by commas>"
+        "name#": junction=roundabout
       route/ferry:
-        # route=ferry
         name: Ferry Route
         terms: "<translate with synonyms or related terms for 'Ferry Route', separated by commas>"
+        "name#": route=ferry
       shop:
-        # 'shop=*'
         name: Shop
         terms: "<translate with synonyms or related terms for 'Shop', separated by commas>"
+        "name#": "shop=*"
       shop/alcohol:
-        # shop=alcohol
         name: Liquor Store
-        # 'terms: alcohol,beer,booze,wine'
         terms: "<translate with synonyms or related terms for 'Liquor Store', separated by commas>"
+        "name#": shop=alcohol
+        "terms#": "terms: alcohol,beer,booze,wine"
       shop/anime:
-        # shop=anime
         name: Anime Shop
         terms: "<translate with synonyms or related terms for 'Anime Shop', separated by commas>"
+        "name#": shop=anime
       shop/antiques:
-        # shop=antiques
         name: Antiques Shop
         terms: "<translate with synonyms or related terms for 'Antiques Shop', separated by commas>"
+        "name#": shop=antiques
       shop/art:
-        # shop=art
         name: Art Gallery
         terms: "<translate with synonyms or related terms for 'Art Gallery', separated by commas>"
+        "name#": shop=art
       shop/baby_goods:
-        # shop=baby_goods
         name: Baby Goods Store
         terms: "<translate with synonyms or related terms for 'Baby Goods Store', separated by commas>"
+        "name#": shop=baby_goods
       shop/bag:
-        # shop=bag
         name: Bag/Luggage Store
-        # 'terms: handbag,purse'
         terms: "<translate with synonyms or related terms for 'Bag/Luggage Store', separated by commas>"
+        "name#": shop=bag
+        "terms#": "terms: handbag,purse"
       shop/bakery:
-        # shop=bakery
         name: Bakery
         terms: "<translate with synonyms or related terms for 'Bakery', separated by commas>"
+        "name#": shop=bakery
       shop/bathroom_furnishing:
-        # shop=bathroom_furnishing
         name: Bathroom Furnishing Store
         terms: "<translate with synonyms or related terms for 'Bathroom Furnishing Store', separated by commas>"
+        "name#": shop=bathroom_furnishing
       shop/beauty:
-        # shop=beauty
         name: Beauty Shop
-        # 'terms: nail spa,spa,salon,tanning'
         terms: "<translate with synonyms or related terms for 'Beauty Shop', separated by commas>"
+        "name#": shop=beauty
+        "terms#": "terms: nail spa,spa,salon,tanning"
       shop/bed:
-        # shop=bed
         name: Bedding/Mattress Store
         terms: "<translate with synonyms or related terms for 'Bedding/Mattress Store', separated by commas>"
+        "name#": shop=bed
       shop/beverages:
-        # shop=beverages
         name: Beverage Store
         terms: "<translate with synonyms or related terms for 'Beverage Store', separated by commas>"
+        "name#": shop=beverages
       shop/bicycle:
-        # shop=bicycle
         name: Bicycle Shop
         terms: "<translate with synonyms or related terms for 'Bicycle Shop', separated by commas>"
+        "name#": shop=bicycle
       shop/bookmaker:
-        # shop=bookmaker
         name: Bookmaker
         terms: "<translate with synonyms or related terms for 'Bookmaker', separated by commas>"
+        "name#": shop=bookmaker
       shop/books:
-        # shop=books
         name: Book Store
         terms: "<translate with synonyms or related terms for 'Book Store', separated by commas>"
+        "name#": shop=books
       shop/boutique:
-        # shop=boutique
         name: Boutique
         terms: "<translate with synonyms or related terms for 'Boutique', separated by commas>"
+        "name#": shop=boutique
       shop/butcher:
-        # shop=butcher
         name: Butcher
-        # 'terms: meat'
         terms: "<translate with synonyms or related terms for 'Butcher', separated by commas>"
+        "name#": shop=butcher
+        "terms#": "terms: meat"
       shop/candles:
-        # shop=candles
         name: Candle Shop
         terms: "<translate with synonyms or related terms for 'Candle Shop', separated by commas>"
+        "name#": shop=candles
       shop/car:
-        # shop=car
         name: Car Dealership
-        # 'terms: auto'
         terms: "<translate with synonyms or related terms for 'Car Dealership', separated by commas>"
+        "name#": shop=car
+        "terms#": "terms: auto"
       shop/car_parts:
-        # shop=car_parts
         name: Car Parts Store
-        # 'terms: auto'
         terms: "<translate with synonyms or related terms for 'Car Parts Store', separated by commas>"
+        "name#": shop=car_parts
+        "terms#": "terms: auto"
       shop/car_repair:
-        # shop=car_repair
         name: Car Repair Shop
-        # 'terms: auto'
         terms: "<translate with synonyms or related terms for 'Car Repair Shop', separated by commas>"
+        "name#": shop=car_repair
+        "terms#": "terms: auto"
       shop/carpet:
-        # shop=carpet
         name: Carpet Store
-        # 'terms: rug'
         terms: "<translate with synonyms or related terms for 'Carpet Store', separated by commas>"
+        "name#": shop=carpet
+        "terms#": "terms: rug"
       shop/cheese:
-        # shop=cheese
         name: Cheese Store
         terms: "<translate with synonyms or related terms for 'Cheese Store', separated by commas>"
+        "name#": shop=cheese
       shop/chemist:
-        # shop=chemist
         name: Chemist
         terms: "<translate with synonyms or related terms for 'Chemist', separated by commas>"
+        "name#": shop=chemist
       shop/chocolate:
-        # shop=chocolate
         name: Chocolate Store
         terms: "<translate with synonyms or related terms for 'Chocolate Store', separated by commas>"
+        "name#": shop=chocolate
       shop/clothes:
-        # shop=clothes
         name: Clothing Store
         terms: "<translate with synonyms or related terms for 'Clothing Store', separated by commas>"
+        "name#": shop=clothes
       shop/computer:
-        # shop=computer
         name: Computer Store
         terms: "<translate with synonyms or related terms for 'Computer Store', separated by commas>"
+        "name#": shop=computer
       shop/confectionery:
-        # shop=confectionery
         name: Candy Store
         terms: "<translate with synonyms or related terms for 'Candy Store', separated by commas>"
+        "name#": shop=confectionery
       shop/convenience:
-        # shop=convenience
         name: Convenience Store
         terms: "<translate with synonyms or related terms for 'Convenience Store', separated by commas>"
+        "name#": shop=convenience
       shop/copyshop:
-        # shop=copyshop
         name: Copy Store
         terms: "<translate with synonyms or related terms for 'Copy Store', separated by commas>"
+        "name#": shop=copyshop
       shop/cosmetics:
-        # shop=cosmetics
         name: Cosmetics Store
         terms: "<translate with synonyms or related terms for 'Cosmetics Store', separated by commas>"
+        "name#": shop=cosmetics
       shop/craft:
-        # shop=craft
         name: Arts and Crafts Store
         terms: "<translate with synonyms or related terms for 'Arts and Crafts Store', separated by commas>"
+        "name#": shop=craft
       shop/curtain:
-        # shop=curtain
         name: Curtain Store
-        # 'terms: drape*,window'
         terms: "<translate with synonyms or related terms for 'Curtain Store', separated by commas>"
+        "name#": shop=curtain
+        "terms#": "terms: drape*,window"
       shop/dairy:
-        # shop=dairy
         name: Dairy Store
-        # 'terms: milk,egg,cheese'
         terms: "<translate with synonyms or related terms for 'Dairy Store', separated by commas>"
+        "name#": shop=dairy
+        "terms#": "terms: milk,egg,cheese"
       shop/deli:
-        # shop=deli
         name: Deli
-        # 'terms: lunch,meat,sandwich'
         terms: "<translate with synonyms or related terms for 'Deli', separated by commas>"
+        "name#": shop=deli
+        "terms#": "terms: lunch,meat,sandwich"
       shop/department_store:
-        # shop=department_store
         name: Department Store
         terms: "<translate with synonyms or related terms for 'Department Store', separated by commas>"
+        "name#": shop=department_store
       shop/doityourself:
-        # shop=doityourself
         name: DIY Store
         terms: "<translate with synonyms or related terms for 'DIY Store', separated by commas>"
+        "name#": shop=doityourself
       shop/dry_cleaning:
-        # shop=dry_cleaning
         name: Dry Cleaner
         terms: "<translate with synonyms or related terms for 'Dry Cleaner', separated by commas>"
+        "name#": shop=dry_cleaning
       shop/electronics:
-        # shop=electronics
         name: Electronics Store
-        # 'terms: appliance,audio,computer,tv'
         terms: "<translate with synonyms or related terms for 'Electronics Store', separated by commas>"
+        "name#": shop=electronics
+        "terms#": "terms: appliance,audio,computer,tv"
       shop/erotic:
-        # shop=erotic
         name: Erotic Store
-        # 'terms: sex,porn'
         terms: "<translate with synonyms or related terms for 'Erotic Store', separated by commas>"
+        "name#": shop=erotic
+        "terms#": "terms: sex,porn"
       shop/fabric:
-        # shop=fabric
         name: Fabric Store
-        # 'terms: sew'
         terms: "<translate with synonyms or related terms for 'Fabric Store', separated by commas>"
+        "name#": shop=fabric
+        "terms#": "terms: sew"
       shop/farm:
-        # shop=farm
         name: Produce Stand
-        # 'terms: farm shop,farm stand'
         terms: "<translate with synonyms or related terms for 'Produce Stand', separated by commas>"
+        "name#": shop=farm
+        "terms#": "terms: farm shop,farm stand"
       shop/fashion:
-        # shop=fashion
         name: Fashion Store
         terms: "<translate with synonyms or related terms for 'Fashion Store', separated by commas>"
+        "name#": shop=fashion
       shop/fishmonger:
-        # shop=fishmonger
         name: Fishmonger
         terms: "<translate with synonyms or related terms for 'Fishmonger', separated by commas>"
+        "name#": shop=fishmonger
       shop/florist:
-        # shop=florist
         name: Florist
-        # 'terms: flower'
         terms: "<translate with synonyms or related terms for 'Florist', separated by commas>"
+        "name#": shop=florist
+        "terms#": "terms: flower"
       shop/frame:
-        # shop=frame
         name: Framing Shop
         terms: "<translate with synonyms or related terms for 'Framing Shop', separated by commas>"
+        "name#": shop=frame
       shop/funeral_directors:
-        # shop=funeral_directors
         name: Funeral Home
-        # 'terms: undertaker,memorial home'
         terms: "<translate with synonyms or related terms for 'Funeral Home', separated by commas>"
+        "name#": shop=funeral_directors
+        "terms#": "terms: undertaker,memorial home"
       shop/furnace:
-        # shop=furnace
         name: Furnace Store
-        # 'terms: oven,stove'
         terms: "<translate with synonyms or related terms for 'Furnace Store', separated by commas>"
+        "name#": shop=furnace
+        "terms#": "terms: oven,stove"
       shop/furniture:
-        # shop=furniture
         name: Furniture Store
-        # 'terms: chair,sofa,table'
         terms: "<translate with synonyms or related terms for 'Furniture Store', separated by commas>"
+        "name#": shop=furniture
+        "terms#": "terms: chair,sofa,table"
       shop/garden_centre:
-        # shop=garden_centre
         name: Garden Center
-        # 'terms: landscape,mulch,shrub,tree'
         terms: "<translate with synonyms or related terms for 'Garden Center', separated by commas>"
+        "name#": shop=garden_centre
+        "terms#": "terms: landscape,mulch,shrub,tree"
       shop/gift:
-        # shop=gift
         name: Gift Shop
         terms: "<translate with synonyms or related terms for 'Gift Shop', separated by commas>"
+        "name#": shop=gift
       shop/greengrocer:
-        # shop=greengrocer
         name: Greengrocer
-        # 'terms: fruit,vegetable'
         terms: "<translate with synonyms or related terms for 'Greengrocer', separated by commas>"
+        "name#": shop=greengrocer
+        "terms#": "terms: fruit,vegetable"
       shop/hairdresser:
-        # shop=hairdresser
         name: Hairdresser
         terms: "<translate with synonyms or related terms for 'Hairdresser', separated by commas>"
+        "name#": shop=hairdresser
       shop/hardware:
-        # shop=hardware
         name: Hardware Store
         terms: "<translate with synonyms or related terms for 'Hardware Store', separated by commas>"
+        "name#": shop=hardware
       shop/hearing_aids:
-        # shop=hearing_aids
         name: Hearing Aids Store
         terms: "<translate with synonyms or related terms for 'Hearing Aids Store', separated by commas>"
+        "name#": shop=hearing_aids
       shop/herbalist:
-        # shop=herbalist
         name: Herbalist
         terms: "<translate with synonyms or related terms for 'Herbalist', separated by commas>"
+        "name#": shop=herbalist
       shop/hifi:
-        # shop=hifi
         name: Hifi Store
-        # 'terms: stereo,video'
         terms: "<translate with synonyms or related terms for 'Hifi Store', separated by commas>"
+        "name#": shop=hifi
+        "terms#": "terms: stereo,video"
       shop/houseware:
-        # shop=houseware
         name: Houseware Store
-        # 'terms: home,household'
         terms: "<translate with synonyms or related terms for 'Houseware Store', separated by commas>"
+        "name#": shop=houseware
+        "terms#": "terms: home,household"
       shop/interior_decoration:
-        # shop=interior_decoration
         name: Interior Decoration Store
         terms: "<translate with synonyms or related terms for 'Interior Decoration Store', separated by commas>"
+        "name#": shop=interior_decoration
       shop/jewelry:
-        # shop=jewelry
         name: Jeweler
-        # 'terms: diamond,gem,ring'
         terms: "<translate with synonyms or related terms for 'Jeweler', separated by commas>"
+        "name#": shop=jewelry
+        "terms#": "terms: diamond,gem,ring"
       shop/kiosk:
-        # shop=kiosk
         name: News Kiosk
         terms: "<translate with synonyms or related terms for 'News Kiosk', separated by commas>"
+        "name#": shop=kiosk
       shop/kitchen:
-        # shop=kitchen
         name: Kitchen Design Store
         terms: "<translate with synonyms or related terms for 'Kitchen Design Store', separated by commas>"
+        "name#": shop=kitchen
       shop/laundry:
-        # shop=laundry
         name: Laundry
         terms: "<translate with synonyms or related terms for 'Laundry', separated by commas>"
+        "name#": shop=laundry
       shop/leather:
-        # shop=leather
         name: Leather Store
         terms: "<translate with synonyms or related terms for 'Leather Store', separated by commas>"
+        "name#": shop=leather
       shop/locksmith:
-        # shop=locksmith
         name: Locksmith
-        # 'terms: key,lockpick'
         terms: "<translate with synonyms or related terms for 'Locksmith', separated by commas>"
+        "name#": shop=locksmith
+        "terms#": "terms: key,lockpick"
       shop/lottery:
-        # shop=lottery
         name: Lottery Shop
         terms: "<translate with synonyms or related terms for 'Lottery Shop', separated by commas>"
+        "name#": shop=lottery
       shop/mall:
-        # shop=mall
         name: Mall
         terms: "<translate with synonyms or related terms for 'Mall', separated by commas>"
+        "name#": shop=mall
       shop/massage:
-        # shop=massage
         name: Massage Shop
         terms: "<translate with synonyms or related terms for 'Massage Shop', separated by commas>"
+        "name#": shop=massage
       shop/medical_supply:
-        # shop=medical_supply
         name: Medical Supply Store
         terms: "<translate with synonyms or related terms for 'Medical Supply Store', separated by commas>"
+        "name#": shop=medical_supply
       shop/mobile_phone:
-        # shop=mobile_phone
         name: Mobile Phone Store
         terms: "<translate with synonyms or related terms for 'Mobile Phone Store', separated by commas>"
+        "name#": shop=mobile_phone
       shop/money_lender:
-        # shop=money_lender
         name: Money Lender
         terms: "<translate with synonyms or related terms for 'Money Lender', separated by commas>"
+        "name#": shop=money_lender
       shop/motorcycle:
-        # shop=motorcycle
         name: Motorcycle Dealership
         terms: "<translate with synonyms or related terms for 'Motorcycle Dealership', separated by commas>"
+        "name#": shop=motorcycle
       shop/music:
-        # shop=music
         name: Music Store
-        # 'terms: CD,vinyl'
         terms: "<translate with synonyms or related terms for 'Music Store', separated by commas>"
+        "name#": shop=music
+        "terms#": "terms: CD,vinyl"
       shop/musical_instrument:
-        # shop=musical_instrument
         name: Musical Instrument Store
         terms: "<translate with synonyms or related terms for 'Musical Instrument Store', separated by commas>"
+        "name#": shop=musical_instrument
       shop/newsagent:
-        # shop=newsagent
         name: Newspaper/Magazine Shop
         terms: "<translate with synonyms or related terms for 'Newspaper/Magazine Shop', separated by commas>"
+        "name#": shop=newsagent
       shop/optician:
-        # shop=optician
         name: Optician
-        # 'terms: eye,glasses'
         terms: "<translate with synonyms or related terms for 'Optician', separated by commas>"
+        "name#": shop=optician
+        "terms#": "terms: eye,glasses"
       shop/organic:
-        # 'shop=supermarket, organic=only'
         name: Organic Goods Store
         terms: "<translate with synonyms or related terms for 'Organic Goods Store', separated by commas>"
+        "name#": "shop=supermarket, organic=only"
       shop/outdoor:
-        # shop=outdoor
         name: Outdoors Store
-        # 'terms: camping,climbing,hiking'
         terms: "<translate with synonyms or related terms for 'Outdoors Store', separated by commas>"
+        "name#": shop=outdoor
+        "terms#": "terms: camping,climbing,hiking"
       shop/paint:
-        # shop=paint
         name: Paint Store
         terms: "<translate with synonyms or related terms for 'Paint Store', separated by commas>"
+        "name#": shop=paint
       shop/pawnbroker:
-        # shop=pawnbroker
         name: Pawn Shop
         terms: "<translate with synonyms or related terms for 'Pawn Shop', separated by commas>"
+        "name#": shop=pawnbroker
       shop/pet:
-        # shop=pet
         name: Pet Store
-        # 'terms: cat,dog,fish'
         terms: "<translate with synonyms or related terms for 'Pet Store', separated by commas>"
+        "name#": shop=pet
+        "terms#": "terms: cat,dog,fish"
       shop/photo:
-        # shop=photo
         name: Photography Store
-        # 'terms: camera,film'
         terms: "<translate with synonyms or related terms for 'Photography Store', separated by commas>"
+        "name#": shop=photo
+        "terms#": "terms: camera,film"
       shop/pyrotechnics:
-        # shop=pyrotechnics
         name: Fireworks Store
         terms: "<translate with synonyms or related terms for 'Fireworks Store', separated by commas>"
+        "name#": shop=pyrotechnics
       shop/radiotechnics:
-        # shop=radiotechnics
         name: Radio/Electronic Component Store
         terms: "<translate with synonyms or related terms for 'Radio/Electronic Component Store', separated by commas>"
+        "name#": shop=radiotechnics
       shop/religion:
-        # shop=religion
         name: Religious Store
         terms: "<translate with synonyms or related terms for 'Religious Store', separated by commas>"
+        "name#": shop=religion
       shop/scuba_diving:
-        # shop=scuba_diving
         name: Scuba Diving Shop
         terms: "<translate with synonyms or related terms for 'Scuba Diving Shop', separated by commas>"
+        "name#": shop=scuba_diving
       shop/seafood:
-        # shop=seafood
         name: Seafood Shop
-        # 'terms: fishmonger'
         terms: "<translate with synonyms or related terms for 'Seafood Shop', separated by commas>"
+        "name#": shop=seafood
+        "terms#": "terms: fishmonger"
       shop/second_hand:
-        # shop=second_hand
         name: Consignment/Thrift Store
-        # 'terms: secondhand,second hand,resale,thrift,used'
         terms: "<translate with synonyms or related terms for 'Consignment/Thrift Store', separated by commas>"
+        "name#": shop=second_hand
+        "terms#": "terms: secondhand,second hand,resale,thrift,used"
       shop/shoes:
-        # shop=shoes
         name: Shoe Store
         terms: "<translate with synonyms or related terms for 'Shoe Store', separated by commas>"
+        "name#": shop=shoes
       shop/sports:
-        # shop=sports
         name: Sporting Goods Store
         terms: "<translate with synonyms or related terms for 'Sporting Goods Store', separated by commas>"
+        "name#": shop=sports
       shop/stationery:
-        # shop=stationery
         name: Stationery Store
-        # 'terms: card,paper'
         terms: "<translate with synonyms or related terms for 'Stationery Store', separated by commas>"
+        "name#": shop=stationery
+        "terms#": "terms: card,paper"
       shop/supermarket:
-        # shop=supermarket
         name: Supermarket
-        # 'terms: grocery,store,shop'
         terms: "<translate with synonyms or related terms for 'Supermarket', separated by commas>"
+        "name#": shop=supermarket
+        "terms#": "terms: grocery,store,shop"
       shop/tailor:
-        # shop=tailor
         name: Tailor
-        # 'terms: clothes,suit'
         terms: "<translate with synonyms or related terms for 'Tailor', separated by commas>"
+        "name#": shop=tailor
+        "terms#": "terms: clothes,suit"
       shop/tattoo:
-        # shop=tattoo
         name: Tattoo Parlor
         terms: "<translate with synonyms or related terms for 'Tattoo Parlor', separated by commas>"
+        "name#": shop=tattoo
       shop/tea:
-        # shop=tea
         name: Tea Store
         terms: "<translate with synonyms or related terms for 'Tea Store', separated by commas>"
+        "name#": shop=tea
       shop/ticket:
-        # shop=ticket
         name: Ticket Seller
         terms: "<translate with synonyms or related terms for 'Ticket Seller', separated by commas>"
+        "name#": shop=ticket
       shop/tobacco:
-        # shop=tobacco
         name: Tobacco Shop
         terms: "<translate with synonyms or related terms for 'Tobacco Shop', separated by commas>"
+        "name#": shop=tobacco
       shop/toys:
-        # shop=toys
         name: Toy Store
         terms: "<translate with synonyms or related terms for 'Toy Store', separated by commas>"
+        "name#": shop=toys
       shop/travel_agency:
-        # shop=travel_agency
         name: Travel Agency
         terms: "<translate with synonyms or related terms for 'Travel Agency', separated by commas>"
+        "name#": shop=travel_agency
       shop/tyres:
-        # shop=tyres
         name: Tire Store
         terms: "<translate with synonyms or related terms for 'Tire Store', separated by commas>"
+        "name#": shop=tyres
       shop/vacant:
-        # shop=vacant
         name: Vacant Shop
         terms: "<translate with synonyms or related terms for 'Vacant Shop', separated by commas>"
+        "name#": shop=vacant
       shop/vacuum_cleaner:
-        # shop=vacuum_cleaner
         name: Vacuum Cleaner Store
         terms: "<translate with synonyms or related terms for 'Vacuum Cleaner Store', separated by commas>"
+        "name#": shop=vacuum_cleaner
       shop/variety_store:
-        # shop=variety_store
         name: Variety Store
         terms: "<translate with synonyms or related terms for 'Variety Store', separated by commas>"
+        "name#": shop=variety_store
       shop/video:
-        # shop=video
         name: Video Store
-        # 'terms: DVD'
         terms: "<translate with synonyms or related terms for 'Video Store', separated by commas>"
+        "name#": shop=video
+        "terms#": "terms: DVD"
       shop/video_games:
-        # shop=video_games
         name: Video Game Store
         terms: "<translate with synonyms or related terms for 'Video Game Store', separated by commas>"
+        "name#": shop=video_games
       shop/water_sports:
-        # shop=water_sports
         name: Watersport/Swim Shop
         terms: "<translate with synonyms or related terms for 'Watersport/Swim Shop', separated by commas>"
+        "name#": shop=water_sports
       shop/weapons:
-        # shop=weapons
         name: Weapon Shop
-        # 'terms: ammo,gun,knife,knives'
         terms: "<translate with synonyms or related terms for 'Weapon Shop', separated by commas>"
+        "name#": shop=weapons
+        "terms#": "terms: ammo,gun,knife,knives"
       shop/window_blind:
-        # shop=window_blind
         name: Window Blind Store
         terms: "<translate with synonyms or related terms for 'Window Blind Store', separated by commas>"
+        "name#": shop=window_blind
       shop/wine:
-        # shop=wine
         name: Wine Shop
         terms: "<translate with synonyms or related terms for 'Wine Shop', separated by commas>"
+        "name#": shop=wine
       tourism:
-        # 'tourism=*'
         name: Tourism
         terms: "<translate with synonyms or related terms for 'Tourism', separated by commas>"
+        "name#": "tourism=*"
       tourism/alpine_hut:
-        # tourism=alpine_hut
         name: Alpine Hut
         terms: "<translate with synonyms or related terms for 'Alpine Hut', separated by commas>"
+        "name#": tourism=alpine_hut
       tourism/artwork:
-        # tourism=artwork
         name: Artwork
-        # 'terms: mural,sculpture,statue'
         terms: "<translate with synonyms or related terms for 'Artwork', separated by commas>"
+        "name#": tourism=artwork
+        "terms#": "terms: mural,sculpture,statue"
       tourism/attraction:
-        # tourism=attraction
         name: Tourist Attraction
         terms: "<translate with synonyms or related terms for 'Tourist Attraction', separated by commas>"
+        "name#": tourism=attraction
       tourism/camp_site:
-        # tourism=camp_site
         name: Camp Site
-        # 'terms: Tent'
         terms: "<translate with synonyms or related terms for 'Camp Site', separated by commas>"
+        "name#": tourism=camp_site
+        "terms#": "terms: Tent"
       tourism/caravan_site:
-        # tourism=caravan_site
         name: RV Park
-        # 'terms: Motor Home,Camper'
         terms: "<translate with synonyms or related terms for 'RV Park', separated by commas>"
+        "name#": tourism=caravan_site
+        "terms#": "terms: Motor Home,Camper"
       tourism/chalet:
-        # tourism=chalet
         name: Chalet
         terms: "<translate with synonyms or related terms for 'Chalet', separated by commas>"
+        "name#": tourism=chalet
       tourism/guest_house:
-        # tourism=guest_house
         name: Guest House
-        # 'terms: B&B,Bed and Breakfast'
         terms: "<translate with synonyms or related terms for 'Guest House', separated by commas>"
+        "name#": tourism=guest_house
+        "terms#": "terms: B&B,Bed and Breakfast"
       tourism/hostel:
-        # tourism=hostel
         name: Hostel
         terms: "<translate with synonyms or related terms for 'Hostel', separated by commas>"
+        "name#": tourism=hostel
       tourism/hotel:
-        # tourism=hotel
         name: Hotel
         terms: "<translate with synonyms or related terms for 'Hotel', separated by commas>"
+        "name#": tourism=hotel
       tourism/information:
-        # tourism=information
         name: Information
         terms: "<translate with synonyms or related terms for 'Information', separated by commas>"
+        "name#": tourism=information
       tourism/motel:
-        # tourism=motel
         name: Motel
         terms: "<translate with synonyms or related terms for 'Motel', separated by commas>"
+        "name#": tourism=motel
       tourism/museum:
-        # tourism=museum
         name: Museum
-        # 'terms: exhibition,foundation,gallery,hall,institution'
         terms: "<translate with synonyms or related terms for 'Museum', separated by commas>"
+        "name#": tourism=museum
+        "terms#": "terms: exhibition,foundation,gallery,hall,institution"
       tourism/picnic_site:
-        # tourism=picnic_site
         name: Picnic Site
-        # 'terms: camp'
         terms: "<translate with synonyms or related terms for 'Picnic Site', separated by commas>"
+        "name#": tourism=picnic_site
+        "terms#": "terms: camp"
       tourism/theme_park:
-        # tourism=theme_park
         name: Theme Park
         terms: "<translate with synonyms or related terms for 'Theme Park', separated by commas>"
+        "name#": tourism=theme_park
       tourism/viewpoint:
-        # tourism=viewpoint
         name: Viewpoint
         terms: "<translate with synonyms or related terms for 'Viewpoint', separated by commas>"
+        "name#": tourism=viewpoint
       tourism/zoo:
-        # tourism=zoo
         name: Zoo
         terms: "<translate with synonyms or related terms for 'Zoo', separated by commas>"
+        "name#": tourism=zoo
       traffic_calming/bump:
-        # traffic_calming=bump
         name: Speed Bump
-        # 'terms: speed hump'
         terms: "<translate with synonyms or related terms for 'Speed Bump', separated by commas>"
+        "name#": traffic_calming=bump
+        "terms#": "terms: speed hump"
       traffic_calming/hump:
-        # traffic_calming=hump
         name: Speed Hump
-        # 'terms: speed bump'
         terms: "<translate with synonyms or related terms for 'Speed Hump', separated by commas>"
+        "name#": traffic_calming=hump
+        "terms#": "terms: speed bump"
       traffic_calming/rumble_strip:
-        # traffic_calming=rumble_strip
         name: Rumble Strip
-        # 'terms: sleeper lines,audible lines,growlers'
         terms: "<translate with synonyms or related terms for 'Rumble Strip', separated by commas>"
+        "name#": traffic_calming=rumble_strip
+        "terms#": "terms: sleeper lines,audible lines,growlers"
       traffic_calming/table:
-        # 'highway=crossing, traffic_calming=table'
         name: Raised Pedestrian Crossing
-        # 'terms: speed table,flat top hump'
         terms: "<translate with synonyms or related terms for 'Raised Pedestrian Crossing', separated by commas>"
+        "name#": "highway=crossing, traffic_calming=table"
+        "terms#": "terms: speed table,flat top hump"
       type/boundary:
-        # type=boundary
         name: Boundary
         terms: "<translate with synonyms or related terms for 'Boundary', separated by commas>"
+        "name#": type=boundary
       type/boundary/administrative:
-        # 'type=boundary, boundary=administrative'
         name: Administrative Boundary
         terms: "<translate with synonyms or related terms for 'Administrative Boundary', separated by commas>"
+        "name#": "type=boundary, boundary=administrative"
       type/multipolygon:
-        # type=multipolygon
         name: Multipolygon
         terms: "<translate with synonyms or related terms for 'Multipolygon', separated by commas>"
+        "name#": type=multipolygon
       type/restriction:
-        # type=restriction
         name: Restriction
         terms: "<translate with synonyms or related terms for 'Restriction', separated by commas>"
+        "name#": type=restriction
       type/restriction/no_left_turn:
-        # 'type=restriction, restriction=no_left_turn'
         name: No Left Turn
         terms: "<translate with synonyms or related terms for 'No Left Turn', separated by commas>"
+        "name#": "type=restriction, restriction=no_left_turn"
       type/restriction/no_right_turn:
-        # 'type=restriction, restriction=no_right_turn'
         name: No Right Turn
         terms: "<translate with synonyms or related terms for 'No Right Turn', separated by commas>"
+        "name#": "type=restriction, restriction=no_right_turn"
       type/restriction/no_straight_on:
-        # 'type=restriction, restriction=no_straight_on'
         name: No Straight On
         terms: "<translate with synonyms or related terms for 'No Straight On', separated by commas>"
+        "name#": "type=restriction, restriction=no_straight_on"
       type/restriction/no_u_turn:
-        # 'type=restriction, restriction=no_u_turn'
         name: No U-turn
         terms: "<translate with synonyms or related terms for 'No U-turn', separated by commas>"
+        "name#": "type=restriction, restriction=no_u_turn"
       type/restriction/only_left_turn:
-        # 'type=restriction, restriction=only_left_turn'
         name: Left Turn Only
         terms: "<translate with synonyms or related terms for 'Left Turn Only', separated by commas>"
+        "name#": "type=restriction, restriction=only_left_turn"
       type/restriction/only_right_turn:
-        # 'type=restriction, restriction=only_right_turn'
         name: Right Turn Only
         terms: "<translate with synonyms or related terms for 'Right Turn Only', separated by commas>"
+        "name#": "type=restriction, restriction=only_right_turn"
       type/restriction/only_straight_on:
-        # 'type=restriction, restriction=only_straight_on'
         name: No Turns
         terms: "<translate with synonyms or related terms for 'No Turns', separated by commas>"
+        "name#": "type=restriction, restriction=only_straight_on"
       type/route:
-        # type=route
         name: Route
         terms: "<translate with synonyms or related terms for 'Route', separated by commas>"
+        "name#": type=route
       type/route/bicycle:
-        # 'type=route, route=bicycle'
         name: Cycle Route
         terms: "<translate with synonyms or related terms for 'Cycle Route', separated by commas>"
+        "name#": "type=route, route=bicycle"
       type/route/bus:
-        # 'type=route, route=bus'
         name: Bus Route
         terms: "<translate with synonyms or related terms for 'Bus Route', separated by commas>"
+        "name#": "type=route, route=bus"
       type/route/detour:
-        # 'type=route, route=detour'
         name: Detour Route
         terms: "<translate with synonyms or related terms for 'Detour Route', separated by commas>"
+        "name#": "type=route, route=detour"
       type/route/ferry:
-        # 'type=route, route=ferry'
         name: Ferry Route
         terms: "<translate with synonyms or related terms for 'Ferry Route', separated by commas>"
+        "name#": "type=route, route=ferry"
       type/route/foot:
-        # 'type=route, route=foot'
         name: Foot Route
         terms: "<translate with synonyms or related terms for 'Foot Route', separated by commas>"
+        "name#": "type=route, route=foot"
       type/route/hiking:
-        # 'type=route, route=hiking'
         name: Hiking Route
         terms: "<translate with synonyms or related terms for 'Hiking Route', separated by commas>"
+        "name#": "type=route, route=hiking"
       type/route/pipeline:
-        # 'type=route, route=pipeline'
         name: Pipeline Route
         terms: "<translate with synonyms or related terms for 'Pipeline Route', separated by commas>"
+        "name#": "type=route, route=pipeline"
       type/route/power:
-        # 'type=route, route=power'
         name: Power Route
         terms: "<translate with synonyms or related terms for 'Power Route', separated by commas>"
+        "name#": "type=route, route=power"
       type/route/road:
-        # 'type=route, route=road'
         name: Road Route
         terms: "<translate with synonyms or related terms for 'Road Route', separated by commas>"
+        "name#": "type=route, route=road"
       type/route/train:
-        # 'type=route, route=train'
         name: Train Route
         terms: "<translate with synonyms or related terms for 'Train Route', separated by commas>"
+        "name#": "type=route, route=train"
       type/route/tram:
-        # 'type=route, route=tram'
         name: Tram Route
         terms: "<translate with synonyms or related terms for 'Tram Route', separated by commas>"
+        "name#": "type=route, route=tram"
       type/route_master:
-        # type=route_master
         name: Route Master
         terms: "<translate with synonyms or related terms for 'Route Master', separated by commas>"
+        "name#": type=route_master
       vertex:
         name: Other
         terms: "<translate with synonyms or related terms for 'Other', separated by commas>"
       waterway:
-        # 'waterway=*'
         name: Waterway
         terms: "<translate with synonyms or related terms for 'Waterway', separated by commas>"
+        "name#": "waterway=*"
       waterway/canal:
-        # waterway=canal
         name: Canal
         terms: "<translate with synonyms or related terms for 'Canal', separated by commas>"
+        "name#": waterway=canal
       waterway/dam:
-        # waterway=dam
         name: Dam
         terms: "<translate with synonyms or related terms for 'Dam', separated by commas>"
+        "name#": waterway=dam
       waterway/ditch:
-        # waterway=ditch
         name: Ditch
         terms: "<translate with synonyms or related terms for 'Ditch', separated by commas>"
+        "name#": waterway=ditch
       waterway/drain:
-        # waterway=drain
         name: Drain
         terms: "<translate with synonyms or related terms for 'Drain', separated by commas>"
+        "name#": waterway=drain
       waterway/fuel:
-        # waterway=fuel
         name: Marine Fuel Station
-        # 'terms: petrol,gas,diesel,boat'
         terms: "<translate with synonyms or related terms for 'Marine Fuel Station', separated by commas>"
+        "name#": waterway=fuel
+        "terms#": "terms: petrol,gas,diesel,boat"
       waterway/river:
-        # waterway=river
         name: River
-        # 'terms: beck,branch,brook,course,creek,estuary,rill,rivulet,run,runnel,stream,tributary,watercourse'
         terms: "<translate with synonyms or related terms for 'River', separated by commas>"
+        "name#": waterway=river
+        "terms#": "terms: beck,branch,brook,course,creek,estuary,rill,rivulet,run,runnel,stream,tributary,watercourse"
       waterway/riverbank:
-        # waterway=riverbank
         name: Riverbank
         terms: "<translate with synonyms or related terms for 'Riverbank', separated by commas>"
+        "name#": waterway=riverbank
       waterway/sanitary_dump_station:
-        # waterway=sanitary_dump_station
         name: Marine Toilet Disposal
-        # 'terms: Boat,Watercraft,Sanitary,Dump Station,Pumpout,Pump out,Elsan,CDP,CTDP,Chemical Toilet'
         terms: "<translate with synonyms or related terms for 'Marine Toilet Disposal', separated by commas>"
+        "name#": waterway=sanitary_dump_station
+        "terms#": "terms: Boat,Watercraft,Sanitary,Dump Station,Pumpout,Pump out,Elsan,CDP,CTDP,Chemical Toilet"
       waterway/stream:
-        # waterway=stream
         name: Stream
-        # 'terms: beck,branch,brook,burn,course,creek,current,drift,flood,flow,freshet,race,rill,rindle,rivulet,run,runnel,rush,spate,spritz,surge,tide,torrent,tributary,watercourse'
         terms: "<translate with synonyms or related terms for 'Stream', separated by commas>"
+        "name#": waterway=stream
+        "terms#": "terms: beck,branch,brook,burn,course,creek,current,drift,flood,flow,freshet,race,rill,rindle,rivulet,run,runnel,rush,spate,spritz,surge,tide,torrent,tributary,watercourse"
       waterway/weir:
-        # waterway=weir
         name: Weir
         terms: "<translate with synonyms or related terms for 'Weir', separated by commas>"
+        "name#": waterway=weir

--- a/index.html
+++ b/index.html
@@ -44,6 +44,7 @@
 
         <script src='js/id/services/countrycode.js'></script>
         <script src='js/id/services/taginfo.js'></script>
+        <script src='js/id/services/wikidata.js'></script>
         <script src='js/id/services/wikipedia.js'></script>
 
         <script src='data/data_dev.js'></script>

--- a/js/id/services/wikidata.js
+++ b/js/id/services/wikidata.js
@@ -1,0 +1,22 @@
+iD.wikidata = function() {
+    var wiki = {},
+        endpoint = 'https://www.wikidata.org/w/api.php?';
+
+    // Given a Wikipedia language and article title, return an array of
+    // corresponding Wikidata entities.
+    wiki.itemsByTitle = function(lang, title, callback) {
+        lang = lang || 'en';
+        d3.jsonp(endpoint + iD.util.qsString({
+            action: 'wbgetentities',
+            format: 'json',
+            sites: lang.replace(/-/g, '_') + 'wiki',
+            titles: title,
+            languages: 'en', // shrink response by filtering to one language
+            callback: '{callback}'
+        }), function(data) {
+            callback(title, data.entities || {});
+        });
+    };
+
+    return wiki;
+};

--- a/js/id/ui/preset/wikipedia.js
+++ b/js/id/ui/preset/wikipedia.js
@@ -113,11 +113,15 @@ iD.ui.preset.wikipedia = function(field, context) {
         if (value && language()[2]) {
             wikidata.itemsByTitle(language()[2], value, function (title, entities) {
                 var qids = entities && Object.keys(entities),
-                    asyncTags = {};
-                asyncTags.wikidata = qids && _.find(qids, function (id) {
+                    qid = qids && _.find(qids, function (id) {
                     return id.match(/^Q\d+$/);
-                });
-                event.change(asyncTags);
+                }),
+                    selectedIDs = context.selectedIDs();
+                if (selectedIDs.length === 1 && selectedIDs[0] === entity.id) {
+                    event.change({wikidata: qid});
+                } else {
+                    context.entity(entity.id).tags.wikidata = qid;
+                }
             });
         }
     }

--- a/js/id/ui/preset/wikipedia.js
+++ b/js/id/ui/preset/wikipedia.js
@@ -116,7 +116,7 @@ iD.ui.preset.wikipedia = function(field, context) {
                     qid = qids && _.find(qids, function (id) {
                     return id.match(/^Q\d+$/);
                 }),
-                    selectedIDs = context.selectedIDs();
+                    selectedIDs = context.selectedIDs && context.selectedIDs();
                 if (selectedIDs.length === 1 && selectedIDs[0] === entity.id) {
                     event.change({wikidata: qid});
                 } else {

--- a/js/id/ui/preset/wikipedia.js
+++ b/js/id/ui/preset/wikipedia.js
@@ -117,7 +117,7 @@ iD.ui.preset.wikipedia = function(field, context) {
                     return id.match(/^Q\d+$/);
                 }),
                     selectedIDs = context.selectedIDs && context.selectedIDs();
-                if (selectedIDs.length === 1 && selectedIDs[0] === entity.id) {
+                if (selectedIDs && selectedIDs.length === 1 && selectedIDs[0] === entity.id) {
                     event.change({wikidata: qid});
                 } else {
                     context.entity(entity.id).tags.wikidata = qid;

--- a/test/index.html
+++ b/test/index.html
@@ -41,6 +41,7 @@
 
     <script src='../js/id/services/countrycode.js'></script>
     <script src='../js/id/services/taginfo.js'></script>
+    <script src='../js/id/services/wikidata.js'></script>
     <script src='../js/id/services/wikipedia.js'></script>
 
     <script src='../data/data_dev.js'></script>

--- a/test/spec/ui/preset/wikipedia.js
+++ b/test/spec/ui/preset/wikipedia.js
@@ -27,7 +27,9 @@ describe('iD.ui.preset.wikipedia', function() {
         happen.once(selection.selectAll('.wiki-lang').node(), {type: 'change'});
 
         wikipedia.on('change', function(tags) {
-            expect(tags).to.eql({wikipedia: 'de:Title'});
+            expect(tags).to.satisfy(function (tags) {
+                return tags.wikipedia === 'de:Title' || 'wikidata' in tags;
+            });
         });
 
         selection.selectAll('.wiki-title').value('Title');


### PR DESCRIPTION
As a first step towards #2680, when the user enters a Wikipedia article title using the Wikipedia preset field, pair the resulting `wikipedia` tag with a `wikidata` tag. The query is asynchronous using JSONP, because neither wikidata.org nor wqt.wmflabs.org supports XmlHttpRequests from any hosted iD instance.

Also [tracked in Phabricator](https://phabricator.wikimedia.org/T106094) as part of the Wikimanía 2015 Hackathon.

/cc @pigsonthewing @bhousel