### PR TITLE
Change "Access" to "Legal access"

### DIFF
--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -71,7 +71,7 @@ en:
           motor_vehicle: Motor Vehicles
       access_simple:
         # 'access=*'
-        label: Access
+        label: Legal access
         # access_simple field placeholder
         placeholder: 'yes'
       access_toilets:

--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -24,7 +24,7 @@ en:
     fields:
       access:
         # 'access=*, foot=*, motor_vehicle=*, bicycle=*, horse=*'
-        label: Access
+        label: Legal access
         options:
           designated:
             # access=designated


### PR DESCRIPTION
to avoid mappers tagging suitability for a transportation mode instead of legal access.

Fixes #2761.