### PR TITLE
Add field "level" to preset vending_machine

### DIFF
--- a/data/presets/presets/amenity/vending_machine.json
+++ b/data/presets/presets/amenity/vending_machine.json
@@ -1,7 +1,8 @@
 {
     "fields": [
         "vending",
-        "operator"
+        "operator",
+        "level"
     ],
     "geometry": [
         "point"


### PR DESCRIPTION
I would suggest to add the field level to the amenity preset, as many vending_machines are in buildings at a defined level.