### PR TITLE
Fix "terms" translations (closes #2756)

### DIFF
--- a/js/id/presets/preset.js
+++ b/js/id/presets/preset.js
@@ -46,7 +46,7 @@ iD.presets.Preset = function(id, preset, fields) {
     };
 
     preset.terms = function() {
-        return preset.t('terms', {'default': ''}).split(',');
+        return preset.t('terms', {'default': ''}).toLowerCase().split(/\s*,+\s*/);
     };
 
     preset.isFallback = function() {


### PR DESCRIPTION
"terms" lists that are not fully lowercase or used combinations of whitespace and commas as separators (instead of just commas) could not be handled properly. This PR fixes that.

Improved version of #2767 after feedback there.