### PR TITLE
Make raw tag editor show docs for key=value

### DIFF
--- a/js/id/services/taginfo.js
+++ b/js/id/services/taginfo.js
@@ -122,8 +122,21 @@ iD.taginfo = function() {
         if (parameters.value) path = 'tag/wiki_pages?';
         else if (parameters.rtype) path = 'relation/wiki_pages?';
 
+        var decoratedCallback;
+        if (parameters.value) {
+            decoratedCallback = function(err, data) {
+                // The third argument to callback is the softfail flag, to
+                // make the callback function not show a message to the end
+                // user when no docs are found but just return false.
+                var docsFound = callback(err, data, true);
+                if (!docsFound) {
+                    taginfo.docs(_.omit(parameters, 'value'), callback);
+                }
+            }
+        }
+
         request(endpoint + path +
-            iD.util.qsString(parameters), debounce, callback);
+            iD.util.qsString(parameters), debounce, decoratedCallback||callback);
     };
 
     taginfo.endpoint = function(_) {

--- a/js/id/services/taginfo.js
+++ b/js/id/services/taginfo.js
@@ -132,11 +132,11 @@ iD.taginfo = function() {
                 if (!docsFound) {
                     taginfo.docs(_.omit(parameters, 'value'), callback);
                 }
-            }
+            };
         }
 
         request(endpoint + path +
-            iD.util.qsString(parameters), debounce, decoratedCallback||callback);
+            iD.util.qsString(parameters), debounce, decoratedCallback || callback);
     };
 
     taginfo.endpoint = function(_) {

--- a/js/id/ui/raw_tag_editor.js
+++ b/js/id/ui/raw_tag_editor.js
@@ -85,7 +85,7 @@ iD.ui.RawTagEditor = function(context) {
         $items.order();
 
         $items.each(function(tag) {
-            var reference = iD.ui.TagReference({key: tag.key}, context);
+            var reference = iD.ui.TagReference({key: tag.key, value: tag.value}, context);
 
             if (state === 'hover') {
                 reference.showing(false);

--- a/js/id/ui/tag_reference.js
+++ b/js/id/ui/tag_reference.js
@@ -33,7 +33,7 @@ iD.ui.TagReference = function(tag, context) {
     function load() {
         button.classed('tag-reference-loading', true);
 
-        context.taginfo().docs(tag, function(err, docs) {
+        context.taginfo().docs(tag, function(err, docs, softfail) {
             if (!err && docs) {
                 docs = findLocal(docs);
             }
@@ -41,9 +41,11 @@ iD.ui.TagReference = function(tag, context) {
             body.html('');
 
             if (!docs || !docs.description) {
-                body.append('p').text(t('inspector.no_documentation_key'));
-                show();
-                return;
+                if (!softfail) {
+                    body.append('p').text(t('inspector.no_documentation_key'));
+                    show();
+                }
+                return false;
             }
 
             if (docs.image && docs.image.thumb_url_prefix) {
@@ -71,6 +73,8 @@ iD.ui.TagReference = function(tag, context) {
 
             wikiLink.append('span')
                 .text(t('inspector.reference'));
+
+            return true;
         });
     }
 


### PR DESCRIPTION
instead of just key.

* Pass the value to iD.ui.TagReference in the `context` function of iD.ui.RawTagEditor
* Let iD.taginfo query the docs for the key when its callback returns false.
* Let the callback function defined inside iD.ui.TagReference return false when both of these are met:
  * it isn't happy with the docs results AND
  * it was called with its softfail argument set to true.

Closes #2754.