### PR TITLE
preset.js: trim terms when retrieving translations to avoid white spaces

### DIFF
--- a/js/id/presets/collection.js
+++ b/js/id/presets/collection.js
@@ -31,6 +31,11 @@ iD.presets.Collection = function(collection) {
                     return a.suggestion === true;
                 });
 
+            function leading(a) {
+                var index = a.indexOf(value);
+                return index === 0 || a[index - 1] === ' ';
+            }
+
             // matches value to preset.name
             var leading_name = _.filter(searchable, function(a) {
                     return leading(a.name().toLowerCase());
@@ -50,10 +55,6 @@ iD.presets.Collection = function(collection) {
                     return _.any(_.without(_.values(a.tags || {}), '*'), leading);
                 });
 
-            function leading(a) {
-                var index = a.indexOf(value);
-                return index === 0 || a[index - 1] === ' ';
-            }
 
             // finds close matches to value in preset.name
             var levenstein_name = searchable.map(function(a) {

--- a/js/id/presets/preset.js
+++ b/js/id/presets/preset.js
@@ -46,7 +46,7 @@ iD.presets.Preset = function(id, preset, fields) {
     };
 
     preset.terms = function() {
-        return preset.t('terms', {'default': ''}).toLowerCase().split(/\s*,+\s*/);
+        return preset.t('terms', {'default': ''}).toLowerCase().trim().split(/\s*,+\s*/);
     };
 
     preset.isFallback = function() {


### PR DESCRIPTION
Terminates #2756 and PR #2772 - trimming terms before using them is needed for some translations where whitespaces are inserted at string start/end. Note that function `leading` tend to handle that but not for everything actually (only spaces). 