### PR TITLE
Allow for equals in background hash

### DIFF
--- a/js/id/util.js
+++ b/js/id/util.js
@@ -40,7 +40,8 @@ iD.util.displayType = function(id) {
 
 iD.util.stringQs = function(str) {
     return str.split('&').reduce(function(obj, pair){
-        var parts = pair.split('=');
+        var i = pair.indexOf('=');
+        var parts = i === -1 ? pair :[pair.slice(0, i), pair.slice(i + 1)];
         if (parts.length === 2) {
             obj[parts[0]] = (null === parts[1]) ? '' : decodeURIComponent(parts[1]);
         }


### PR DESCRIPTION
In a recent use case we needed to have query parameters for the background. Something like:

```
background=custom:http://a.tiles.mapbox.com/v4/astrodigital.LC81170532015080LGN00_bands_432/{z}/{x}/{y}.png?access_token=token_here
```
If you insert this string as a custom background source it works flawlessly but when it needs to be parsed from the url it breaks.

This happens because the `.split('=')` would convert this string to a 3 element array and that doesn't meet the criteria. This PR fixed the problem by allowing everything after the first `=` sign.