### PR TITLE
Fetch proper tag-references for relation types in raw tag editor

### DIFF
--- a/js/id/ui/raw_tag_editor.js
+++ b/js/id/ui/raw_tag_editor.js
@@ -85,7 +85,12 @@ iD.ui.RawTagEditor = function(context) {
         $items.order();
 
         $items.each(function(tag) {
-            var reference = iD.ui.TagReference({key: tag.key, value: tag.value}, context);
+            var isRelation = (context.entity(id).type === 'relation'),
+                reference;
+            if (isRelation && tag.key === 'type')
+                reference = iD.ui.TagReference({rtype: tag.value}, context);
+            else
+                reference = iD.ui.TagReference({key: tag.key, value: tag.value}, context);
 
             if (state === 'hover') {
                 reference.showing(false);


### PR DESCRIPTION
Implements special casing of relation type tags as described in https://github.com/openstreetmap/iD/issues/2797#issuecomment-145907014. Fixes #2797