### PR TITLE
better support for browser language preferences

### DIFF
--- a/js/id/id.js
+++ b/js/id/id.js
@@ -380,7 +380,7 @@ iD.version = '1.7.4';
     // Added due to incomplete svg style support. See #715
     detected.opera = (detected.browser.toLowerCase() === 'opera' && parseFloat(detected.version) < 15 );
 
-    detected.locale = navigator.language || navigator.userLanguage || 'en-US';
+    detected.locale = navigator.languages ? navigator.languages[0] : (navigator.language || navigator.userLanguage || 'en-US');
 
     detected.filedrop = (window.FileReader && 'ondrop' in window);
 


### PR DESCRIPTION
Use navigator.languages preferences when available. This allows a preferred language to be set in Chrome without needing to change the primary language of the OS.  This appears to only apply when iD is running outside of openstreetmap.org, as we are doing for the loggingroads.org project. When it is framed inside osm, the osm user profile language settings appear to override the browser settings.

also see: https://alicoding.com/detect-browser-language-preference-in-firefox-and-chrome-using-javascript/ and http://www.w3.org/html/wg/drafts/html/master/webappapis.html#dom-navigator-languages