### PR TITLE
Corrected some brands to match ad copy

### DIFF
--- a/data/name-suggestions.json
+++ b/data/name-suggestions.json
@@ -115,9 +115,6 @@
             "Shell Express": {
                 "count": 131
             },
-            "Hess": {
-                "count": 127
-            },
             "Flying V": {
                 "count": 129
             },
@@ -897,8 +894,8 @@
             "Робин Сдобин": {
                 "count": 82
             },
-            "Baskin Robbins": {
-                "count": 74
+            "Baskin-Robbins": {
+                "count": 57
             },
             "ケンタッキーフライドチキン": {
                 "count": 164,
@@ -2447,8 +2444,8 @@
             "Second Cup": {
                 "count": 193
             },
-            "Dunkin Donuts": {
-                "count": 428,
+            "Dunkin' Donuts": {
+                "count": 1596,
                 "tags": {
                     "cuisine": "donut"
                 }
@@ -3870,7 +3867,7 @@
             "OBI": {
                 "count": 422
             },
-            "Lowes": {
+            "Lowe's": {
                 "count": 1152
             },
             "Wickes": {


### PR DESCRIPTION
Removed Hess gas station
The Hess brand is no longer used in retail fuel sales. Signs may still exist, but are being converted to Speedway brand.
http://www.usatoday.com/story/money/business/2014/05/25/hess-stations-name-change/9445589/

Dunkin' Donuts
http://news.dunkindonuts.com/

Lowe's
http://media.lowes.com/about-lowes/

Baskin-Robbins
http://news.baskinrobbins.com/about