### PR TITLE
Fix iD.detect when navigator.languages is empty.

### DIFF
--- a/js/id/id.js
+++ b/js/id/id.js
@@ -380,7 +380,8 @@ iD.version = '1.8.0';
     // Added due to incomplete svg style support. See #715
     detected.opera = (detected.browser.toLowerCase() === 'opera' && parseFloat(detected.version) < 15 );
 
-    detected.locale = navigator.languages ? navigator.languages[0] : (navigator.language || navigator.userLanguage || 'en-US');
+    detected.locale = (navigator.languages && navigator.languages.length)
+        ? navigator.languages[0] : (navigator.language || navigator.userLanguage || 'en-US');
 
     detected.filedrop = (window.FileReader && 'ondrop' in window);
 


### PR DESCRIPTION
Fix iD.detect when navigator.languages is empty.