### PR TITLE
Reorder categories by popularity according to taginfo

### DIFF
--- a/data/presets/categories.json
+++ b/data/presets/categories.json
@@ -48,12 +48,12 @@
         "name": "Path",
         "icon": "category-path",
         "members": [
-            "highway/pedestrian",
             "highway/footway",
-            "highway/cycleway",
-            "highway/bridleway",
             "highway/path",
-            "highway/steps"
+            "highway/cycleway",
+            "highway/steps",
+            "highway/pedestrian",
+            "highway/bridleway"
         ]
     },
     "category-rail": {
@@ -90,20 +90,20 @@
         "icon": "category-roads",
         "members": [
             "highway/residential",
-            "highway/motorway",
-            "highway/trunk",
-            "highway/primary",
-            "highway/secondary",
-            "highway/tertiary",
             "highway/service",
+            "highway/track",
+            "highway/unclassified",
+            "highway/tertiary",
+            "highway/secondary",
+            "highway/primary",
+            "highway/trunk",
+            "highway/motorway",
             "highway/motorway_link",
+            "highway/road",
             "highway/trunk_link",
             "highway/primary_link",
             "highway/secondary_link",
-            "highway/tertiary_link",
-            "highway/unclassified",
-            "highway/track",
-            "highway/road"
+            "highway/tertiary_link"
         ]
     },
     "category-route": {
@@ -112,15 +112,14 @@
         "icon": "route",
         "members": [
             "type/route/road",
+            "type/route/bus",
+            "type/route/hiking",
             "type/route/bicycle",
             "type/route/foot",
-            "type/route/hiking",
-            "type/route/bus",
-            "type/route/train",
-            "type/route/tram",
             "type/route/ferry",
             "type/route/power",
-            "type/route/pipeline",
+            "type/route/train",
+            "type/route/tram",
             "type/route/detour",
             "type/route_master",
             "type/route"
@@ -131,8 +130,8 @@
         "name": "Water",
         "icon": "water",
         "members": [
-            "natural/water/lake",
             "natural/water/pond",
+            "natural/water/lake",
             "natural/water/reservoir",
             "natural/water"
         ]


### PR DESCRIPTION
Basically this PR reorders category-route, category-road and category-path according to taginfo most used values.

The previous order was problematic because most important roads were the firsts in the list. But as a mapper, you do not often map motorways - it's often the inverse. That's why you have now tertiary road then secondary road then primary road and finally motorway (basically the order is inverted).

I also removed `type/route/pipeline` since taginfo reports it only used 34 times worldwide.