### PR TITLE
Set PATH appropriately

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 # See the README for installation instructions.
+PATH := $(PATH):node_modules/.bin
 
 all: \
 	$(BUILDJS_TARGETS) \


### PR DESCRIPTION
This fixes the following error (because `svg-sprite` isn't in my `PATH`):

```
svg-sprite --symbol --symbol-dest . --symbol-sprite dist/img/maki-sprite.svg node_modules/maki/src/*.svg
/bin/sh: svg-sprite: command not found
make: *** [dist/img/maki-sprite.svg] Error 12
```