### PR TITLE
[Preset] Clarification: "Track" → "Two-Track Road (Primitive)"

### DIFF
--- a/data/presets/presets/highway/track.json
+++ b/data/presets/presets/highway/track.json
@@ -22,5 +22,5 @@
         "woods road",
         "fire road"
     ],
-    "name": "Track"
+    "name": "Two-Track Road (Primitive)"
 }


### PR DESCRIPTION
**Purpose:** to clarify that `highway=track` is not a trail / single-**track** trail.

I've noticed that particularly in the MTB community there's a trend of classifying trails as `highway=track` because "Track" is a common word to refer to single-track trails (e.g. [changeset/29897324](https://www.openstreetmap.org/changeset/29897324#map=16/37.6216/-119.0007))

Most of the road presets have a "Road" suffix that make it clear you're adding a road, but the track preset does not. In its current form it's too abstract, I feel. This PR aims to make it a little more clear what you're adding.

Relevant: [BLM Road Classifications](http://www.blm.gov/id/st/en/prog/planning/Travel_Management/Craters_of_the_Moon/Road_Trail_Classifications.print.html) (Class D)