### PR TITLE
Fix a typo

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -21,7 +21,7 @@ please open a request there with the link and license details.
 Using canvas rather than SVG would require implementing a scenegraph, hit-testing,
 event dispatch, animation, and other features provided natively by SVG. All that is
 a significant amount of work, would have meant a longer time for the initial release
-of iD, and would likely increase the ongoing costs of maintenence and new features.
+of iD, and would likely increase the ongoing costs of maintenance and new features.
 
 On the other hand, SVG is already fast enough in many or most hardware/browser/OS/editing
 region combinations, and will only get faster as hardware improves and browser vendors


### PR DESCRIPTION
`maintenence` → `maintenance`