### PR TITLE
Data layer refactor

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -296,7 +296,7 @@ correspondence with entities:
   two vertices.
 * `iD.svg.Labels` renders the textual
   [labels](http://mapbox.com/osmdev/2013/02/12/labeling-id/).
-* `iD.svg.Surface` sets up a number of layers that ensure that map elements
+* `iD.svg.Layers` sets up a number of layers that ensure that map elements
   appear in an appropriate z-order.
 
 ## Other UI

--- a/css/app.css
+++ b/css/app.css
@@ -2132,7 +2132,7 @@ div.full-screen > button:hover {
     user-select: none;
 }
 
-#supersurface, .layer-layer {
+#supersurface, .layer {
     position: absolute;
     top: 0;
     left: 0;

--- a/css/app.css
+++ b/css/app.css
@@ -2208,7 +2208,7 @@ div.full-screen > button:hover {
     border-bottom: 1px solid black;
 }
 
-.infobox .selection-heading {
+.infobox .infobox-heading {
     display: block;
     border-radius: 4px 0 0 0;
     padding: 5px 10px;

--- a/css/map.css
+++ b/css/map.css
@@ -24,11 +24,11 @@ img.tile-removing {
 use { pointer-events: none; }
 
 /* base styles */
-.layer path:not(.oneway) { fill: none; }     /* IE needs :not(.oneway) */
+.layer-osm path:not(.oneway) { fill: none; }     /* IE needs :not(.oneway) */
 
 /* the above fill: none rule affects paths in <use> shadow dom only in Firefox */
-.layer use.icon path { fill: #333; }                       /* FF svg Maki icons */
-.layer .turn use path { fill: #000; }                      /* FF turn restriction icons */
+.layer-osm use.icon path { fill: #333; }                       /* FF svg Maki icons */
+.layer-osm .turn use path { fill: #000; }                      /* FF turn restriction icons */
 #turn-only-shape2, #turn-only-u-shape2 { fill: #7092FF; }  /* FF turn-only, turn-only-u */
 #turn-no-shape2, #turn-no-u-shape2     { fill: #E06D5F; }  /* FF turn-no, turn-no-u */
 #turn-yes-shape2, #turn-yes-u-shape2   { fill: #8CD05F; }  /* FF turn-yes, turn-yes-u */
@@ -1500,7 +1500,7 @@ g.turn circle {
 }
 
 /* GPX Paths */
-div.layer-gpx {
+.layer-gpx {
     pointer-events: none;
 }
 

--- a/css/map.css
+++ b/css/map.css
@@ -1268,7 +1268,7 @@ path.shadow.tag-cutting {
 
 /* Surface - unpaved */
 path.casing.tag-unpaved {
-    stroke: #eaeaea;
+    stroke: #ccc;
     stroke-linecap: butt;
     stroke-dasharray: 4, 3;
 }

--- a/index.html
+++ b/index.html
@@ -56,18 +56,18 @@
         <script src='js/id/renderer/background.js'></script>
         <script src='js/id/renderer/background_source.js'></script>
         <script src='js/id/renderer/features.js'></script>
-        <script src='js/id/renderer/gpx_layer.js'></script>
-        <script src='js/id/renderer/tile_layer.js'></script>
         <script src='js/id/renderer/map.js'></script>
-        <script src='js/id/renderer/mapillary_image_layer.js'></script>
-        <script src='js/id/renderer/mapillary_sign_layer.js'></script>
+        <script src='js/id/renderer/tile_layer.js'></script>
 
         <script src="js/id/svg.js"></script>
         <script src="js/id/svg/areas.js"></script>
         <script src="js/id/svg/defs.js"></script>
+        <script src='js/id/svg/gpx.js'></script>
         <script src="js/id/svg/icon.js"></script>
         <script src="js/id/svg/labels.js"></script>
         <script src="js/id/svg/lines.js"></script>
+        <script src='js/id/svg/mapillary_images.js'></script>
+        <script src='js/id/svg/mapillary_signs.js'></script>
         <script src="js/id/svg/midpoints.js"></script>
         <script src="js/id/svg/points.js"></script>
         <script src="js/id/svg/surface.js"></script>

--- a/index.html
+++ b/index.html
@@ -69,6 +69,7 @@
         <script src='js/id/svg/mapillary_images.js'></script>
         <script src='js/id/svg/mapillary_signs.js'></script>
         <script src="js/id/svg/midpoints.js"></script>
+        <script src="js/id/svg/osm.js"></script>
         <script src="js/id/svg/points.js"></script>
         <script src="js/id/svg/surface.js"></script>
         <script src="js/id/svg/tag_classes.js"></script>

--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
         <script src="js/id/svg/midpoints.js"></script>
         <script src="js/id/svg/osm.js"></script>
         <script src="js/id/svg/points.js"></script>
-        <script src="js/id/svg/surface.js"></script>
+        <script src="js/id/svg/layers.js"></script>
         <script src="js/id/svg/tag_classes.js"></script>
         <script src="js/id/svg/turns.js"></script>
         <script src="js/id/svg/vertices.js"></script>

--- a/js/id/renderer/background.js
+++ b/js/id/renderer/background.js
@@ -55,19 +55,21 @@ iD.Background = function(context) {
     }
 
     function background(selection) {
-        var base = selection.selectAll('.background-layer')
+        var base = selection.selectAll('.layer-background')
             .data([0]);
 
-        base.enter().insert('div', '.layer-data')
-            .attr('class', 'layer-layer background-layer');
+        base.enter()
+            .insert('div', '.layer-data')
+            .attr('class', 'layer layer-background');
 
         base.call(baseLayer);
 
         var overlays = selection.selectAll('.layer-overlay')
             .data(overlayLayers, function(d) { return d.source().name(); });
 
-        overlays.enter().insert('div', '.layer-data')
-            .attr('class', 'layer-layer layer-overlay');
+        overlays.enter()
+            .insert('div', '.layer-data')
+            .attr('class', 'layer layer-overlay');
 
         overlays.each(function(layer) {
             d3.select(this).call(layer);

--- a/js/id/renderer/background.js
+++ b/js/id/renderer/background.js
@@ -1,9 +1,6 @@
 iD.Background = function(context) {
     var dispatch = d3.dispatch('change'),
         baseLayer = iD.TileLayer().projection(context.projection),
-        gpxLayer = iD.svg.Gpx(context.projection, context),
-        mapillaryImageLayer,
-        mapillarySignLayer,
         overlayLayers = [];
 
     var backgroundSources;
@@ -47,7 +44,8 @@ iD.Background = function(context) {
             }
         });
 
-        if (background.showsGpxLayer()) {
+        var gpx = context.layers().layer('gpx');
+        if (gpx && gpx.enabled() && gpx.hasGpx()) {
             imageryUsed.push('Local GPX');
         }
 
@@ -77,51 +75,6 @@ iD.Background = function(context) {
 
         overlays.exit()
             .remove();
-
-
-
-        // selection.selectAll('#surface')
-        //     .call(gpxLayer);
-
-
-
-
-        // var mapillary = iD.services.mapillary,
-        //     supportsMapillaryImages = !!mapillary,
-        //     supportsMapillarySigns = !!mapillary && mapillary().signsSupported();
-
-        // var mapillaryImages = selection.selectAll('.layer-mapillary-images')
-        //     .data(supportsMapillaryImages ? [0] : []);
-
-        // mapillaryImages.enter().insert('div')
-        //     .attr('class', 'layer-layer layer-mapillary-images');
-
-        // if (supportsMapillaryImages) {
-        //     if (!mapillaryImageLayer) { mapillaryImageLayer = iD.svg.MapillaryImages(context); }
-        //     mapillaryImages.call(mapillaryImageLayer);
-        // } else {
-        //     mapillaryImageLayer = null;
-        // }
-
-        // mapillaryImages.exit()
-        //     .remove();
-
-
-        // var mapillarySigns = selection.selectAll('.layer-mapillary-signs')
-        //     .data(supportsMapillarySigns ? [0] : []);
-
-        // mapillarySigns.enter().insert('div')
-        //     .attr('class', 'layer-layer layer-mapillary-signs');
-
-        // if (supportsMapillarySigns) {
-        //     if (!mapillarySignLayer) { mapillarySignLayer = iD.svg.MapillarySigns(context); }
-        //     mapillarySigns.call(mapillarySignLayer);
-        // } else {
-        //     mapillarySignLayer = null;
-        // }
-
-        // mapillarySigns.exit()
-        //     .remove();
     }
 
     background.sources = function(extent) {
@@ -132,8 +85,6 @@ iD.Background = function(context) {
 
     background.dimensions = function(_) {
         baseLayer.dimensions(_);
-        if (mapillaryImageLayer) mapillaryImageLayer.dimensions(_);
-        if (mapillarySignLayer) mapillarySignLayer.dimensions(_);
 
         overlayLayers.forEach(function(layer) {
             layer.dimensions(_);
@@ -152,43 +103,6 @@ iD.Background = function(context) {
 
     background.bing = function() {
         background.baseLayerSource(findSource('Bing'));
-    };
-
-    background.gpxLayer = function() {
-        return gpxLayer;
-    };
-
-    background.hasGpxLayer = function() {
-        return !_.isEmpty(gpxLayer.geojson());
-    };
-
-    background.showsGpxLayer = function() {
-        return background.hasGpxLayer() && gpxLayer.enabled();
-    };
-
-    background.toggleGpxLayer = function() {
-        gpxLayer.enabled(!gpxLayer.enabled());
-        dispatch.change();
-    };
-
-    background.showsMapillaryImageLayer = function() {
-        return mapillaryImageLayer && mapillaryImageLayer.enable();
-    };
-
-    background.showsMapillarySignLayer = function() {
-        return mapillarySignLayer && mapillarySignLayer.enable();
-    };
-
-    background.toggleMapillaryImageLayer = function() {
-        if (!mapillaryImageLayer) return;
-        mapillaryImageLayer.enable(!mapillaryImageLayer.enable());
-        dispatch.change();
-    };
-
-    background.toggleMapillarySignLayer = function() {
-        if (!mapillarySignLayer) return;
-        mapillarySignLayer.enable(!mapillarySignLayer.enable());
-        dispatch.change();
     };
 
     background.showsLayer = function(d) {
@@ -285,7 +199,8 @@ iD.Background = function(context) {
         });
 
         if (q.gpx) {
-            gpxLayer.url(q.gpx);
+            var gpx = context.layers().layer('gpx');
+            if (gpx) { gpx.url(q.gpx); }
         }
     };
 

--- a/js/id/renderer/background.js
+++ b/js/id/renderer/background.js
@@ -2,7 +2,7 @@ iD.Background = function(context) {
     var dispatch = d3.dispatch('change'),
         baseLayer = iD.TileLayer()
             .projection(context.projection),
-        gpxLayer = iD.GpxLayer(context, dispatch)
+        gpxLayer = iD.svg.Gpx(context, dispatch)
             .projection(context.projection),
         mapillaryImageLayer,
         mapillarySignLayer,
@@ -98,7 +98,7 @@ iD.Background = function(context) {
             .attr('class', 'layer-layer layer-mapillary-images');
 
         if (supportsMapillaryImages) {
-            if (!mapillaryImageLayer) { mapillaryImageLayer = iD.MapillaryImageLayer(context); }
+            if (!mapillaryImageLayer) { mapillaryImageLayer = iD.svg.MapillaryImages(context); }
             mapillaryImages.call(mapillaryImageLayer);
         } else {
             mapillaryImageLayer = null;
@@ -115,7 +115,7 @@ iD.Background = function(context) {
             .attr('class', 'layer-layer layer-mapillary-signs');
 
         if (supportsMapillarySigns) {
-            if (!mapillarySignLayer) { mapillarySignLayer = iD.MapillarySignLayer(context); }
+            if (!mapillarySignLayer) { mapillarySignLayer = iD.svg.MapillarySigns(context); }
             mapillarySigns.call(mapillarySignLayer);
         } else {
             mapillarySignLayer = null;

--- a/js/id/renderer/background.js
+++ b/js/id/renderer/background.js
@@ -78,56 +78,48 @@ iD.Background = function(context) {
 
 
 
-        // var gpx = selection.selectAll('.layer-gpx')
-        //     .data([0]);
-
-        // gpx.enter().insert('div')
-        //     .attr('class', 'layer-layer layer-gpx');
-
-        // gpx.call(gpxLayer);
-
-        selection.selectAll('#surface')
-            .call(gpxLayer);
+        // selection.selectAll('#surface')
+        //     .call(gpxLayer);
 
 
 
 
-        var mapillary = iD.services.mapillary,
-            supportsMapillaryImages = !!mapillary,
-            supportsMapillarySigns = !!mapillary && mapillary().signsSupported();
+        // var mapillary = iD.services.mapillary,
+        //     supportsMapillaryImages = !!mapillary,
+        //     supportsMapillarySigns = !!mapillary && mapillary().signsSupported();
 
-        var mapillaryImages = selection.selectAll('.layer-mapillary-images')
-            .data(supportsMapillaryImages ? [0] : []);
+        // var mapillaryImages = selection.selectAll('.layer-mapillary-images')
+        //     .data(supportsMapillaryImages ? [0] : []);
 
-        mapillaryImages.enter().insert('div')
-            .attr('class', 'layer-layer layer-mapillary-images');
+        // mapillaryImages.enter().insert('div')
+        //     .attr('class', 'layer-layer layer-mapillary-images');
 
-        if (supportsMapillaryImages) {
-            if (!mapillaryImageLayer) { mapillaryImageLayer = iD.svg.MapillaryImages(context); }
-            mapillaryImages.call(mapillaryImageLayer);
-        } else {
-            mapillaryImageLayer = null;
-        }
+        // if (supportsMapillaryImages) {
+        //     if (!mapillaryImageLayer) { mapillaryImageLayer = iD.svg.MapillaryImages(context); }
+        //     mapillaryImages.call(mapillaryImageLayer);
+        // } else {
+        //     mapillaryImageLayer = null;
+        // }
 
-        mapillaryImages.exit()
-            .remove();
+        // mapillaryImages.exit()
+        //     .remove();
 
 
-        var mapillarySigns = selection.selectAll('.layer-mapillary-signs')
-            .data(supportsMapillarySigns ? [0] : []);
+        // var mapillarySigns = selection.selectAll('.layer-mapillary-signs')
+        //     .data(supportsMapillarySigns ? [0] : []);
 
-        mapillarySigns.enter().insert('div')
-            .attr('class', 'layer-layer layer-mapillary-signs');
+        // mapillarySigns.enter().insert('div')
+        //     .attr('class', 'layer-layer layer-mapillary-signs');
 
-        if (supportsMapillarySigns) {
-            if (!mapillarySignLayer) { mapillarySignLayer = iD.svg.MapillarySigns(context); }
-            mapillarySigns.call(mapillarySignLayer);
-        } else {
-            mapillarySignLayer = null;
-        }
+        // if (supportsMapillarySigns) {
+        //     if (!mapillarySignLayer) { mapillarySignLayer = iD.svg.MapillarySigns(context); }
+        //     mapillarySigns.call(mapillarySignLayer);
+        // } else {
+        //     mapillarySignLayer = null;
+        // }
 
-        mapillarySigns.exit()
-            .remove();
+        // mapillarySigns.exit()
+        //     .remove();
     }
 
     background.sources = function(extent) {

--- a/js/id/renderer/map.js
+++ b/js/id/renderer/map.js
@@ -19,8 +19,9 @@ iD.Map = function(context) {
         drawAreas = iD.svg.Areas(projection),
         drawMidpoints = iD.svg.Midpoints(projection, context),
         drawLabels = iD.svg.Labels(projection, context),
-        surface,
         supersurface,
+        wrapper,
+        surface,
         mouse,
         mousemove;
 
@@ -42,13 +43,11 @@ iD.Map = function(context) {
 
         // Need a wrapper div because Opera can't cope with an absolutely positioned
         // SVG element: http://bl.ocks.org/jfirebaugh/6fbfbd922552bf776c16
-        var wrap = supersurface
+        wrapper = supersurface
             .append('div')
             .attr('class', 'layer layer-data');
 
-        map.layers = drawLayers;
-
-        map.surface = surface = wrap
+        map.surface = surface = wrapper
             .call(drawLayers)
             .selectAll('.surface')
             .attr('id', 'surface');
@@ -226,7 +225,7 @@ iD.Map = function(context) {
             editOff();
         }
 
-        surface
+        wrapper
             .call(drawLayers);
 
         transformStart = [
@@ -483,6 +482,8 @@ iD.Map = function(context) {
         minzoom = _;
         return map;
     };
+
+    map.layers = drawLayers;
 
     return d3.rebind(map, dispatch, 'on');
 };

--- a/js/id/renderer/map.js
+++ b/js/id/renderer/map.js
@@ -138,7 +138,7 @@ iD.Map = function(context) {
             .call(areas, graph, data, filter)
             .call(midpoints, graph, data, filter, map.trimmedExtent())
             .call(labels, graph, data, filter, dimensions, !difference && !extent)
-            .call(points, data, filter);
+            .call(points, graph, data, filter);
 
         dispatch.drawn({full: true});
     }

--- a/js/id/renderer/map.js
+++ b/js/id/renderer/map.js
@@ -145,7 +145,7 @@ iD.Map = function(context) {
 
     function editOff() {
         context.features().resetStats();
-        surface.selectAll('.layer *').remove();
+        surface.selectAll('.layer-osm *').remove();
         dispatch.drawn({full: true});
     }
 

--- a/js/id/renderer/map.js
+++ b/js/id/renderer/map.js
@@ -190,6 +190,8 @@ iD.Map = function(context) {
 
     function resetTransform() {
         if (!transformed) return false;
+
+        surface.selectAll('.radial-menu').interrupt().remove();
         iD.util.setTransform(supersurface, 0, 0);
         transformed = false;
         return true;

--- a/js/id/renderer/map.js
+++ b/js/id/renderer/map.js
@@ -56,7 +56,7 @@ iD.Map = function(context) {
                 if (resetTransform()) redraw();
             })
             .attr('id', 'surface')
-            .call(iD.svg.Surface(context));
+            .call(iD.svg.Surface(projection, context));
 
         supersurface.call(context.background());
 

--- a/js/id/svg/areas.js
+++ b/js/id/svg/areas.js
@@ -82,7 +82,7 @@ iD.svg.Areas = function(projection) {
            .remove();
 
         var areagroup = surface
-            .select('.layer-areas')
+            .selectAll('.layer-areas')
             .selectAll('g.areagroup')
             .data(['fill', 'shadow', 'stroke']);
 

--- a/js/id/svg/defs.js
+++ b/js/id/svg/defs.js
@@ -15,7 +15,7 @@ iD.svg.Defs = function(context) {
         };
     }
 
-    return function (selection) {
+    return function drawDefs(selection) {
         var defs = selection.append('defs');
 
         // marker

--- a/js/id/svg/gpx.js
+++ b/js/id/svg/gpx.js
@@ -93,6 +93,9 @@ iD.svg.Gpx = function(projection, context) {
         return (new DOMParser()).parseFromString(x, 'text/xml');
     }
 
+    function redraw() {
+        context.pan([0,0]);
+    }
 
     gpx.showLabels = function(_) {
         if (!arguments.length) return showLabels;
@@ -117,7 +120,7 @@ iD.svg.Gpx = function(projection, context) {
         d3.text(url, function(err, data) {
             if (!err) {
                 gpx.geojson(toGeoJSON.gpx(toDom(data)));
-                // dispatch.change();
+                redraw();
             }
         });
         return gpx;
@@ -129,7 +132,7 @@ iD.svg.Gpx = function(projection, context) {
 
         reader.onload = function(e) {
             gpx.geojson(toGeoJSON.gpx(toDom(e.target.result))).fitZoom();
-            // dispatch.change();
+            redraw();
         };
 
         reader.readAsText(f);

--- a/js/id/svg/gpx.js
+++ b/js/id/svg/gpx.js
@@ -40,7 +40,7 @@ iD.svg.Gpx = function(projection, context) {
 
         layer.enter()
             .append('g')
-            .attr('class', 'layer layer-gpx');
+            .attr('class', 'layer-gpx');
 
         layer.exit()
             .remove();

--- a/js/id/svg/gpx.js
+++ b/js/id/svg/gpx.js
@@ -99,30 +99,35 @@ iD.svg.Gpx = function(projection, context) {
     drawGpx.showLabels = function(_) {
         if (!arguments.length) return showLabels;
         showLabels = _;
-        return drawGpx;
+        return this;
     };
 
     drawGpx.enabled = function(_) {
         if (!arguments.length) return iD.svg.Gpx.enabled;
         iD.svg.Gpx.enabled = _;
-        return drawGpx;
+        return this;
+    };
+
+    drawGpx.hasGpx = function() {
+        var geojson = iD.svg.Gpx.geojson;
+        return (!(_.isEmpty(geojson) || _.isEmpty(geojson.features)));
     };
 
     drawGpx.geojson = function(gj) {
         if (!arguments.length) return iD.svg.Gpx.geojson;
-        if (_.isEmpty(gj) || _.isEmpty(gj.features)) return drawGpx;
+        if (_.isEmpty(gj) || _.isEmpty(gj.features)) return this;
         iD.svg.Gpx.geojson = gj;
-        return drawGpx;
+        return this;
     };
 
     drawGpx.url = function(url) {
         d3.text(url, function(err, data) {
             if (!err) {
-                drawGpx.geojson(toGeoJSON.gpx(toDom(data)));
+                this.geojson(toGeoJSON.gpx(toDom(data)));
                 redraw();
             }
         });
-        return drawGpx;
+        return this;
     };
 
     drawGpx.files = function(fileList) {
@@ -130,17 +135,17 @@ iD.svg.Gpx = function(projection, context) {
             reader = new FileReader();
 
         reader.onload = function(e) {
-            drawGpx.geojson(toGeoJSON.gpx(toDom(e.target.result))).fitZoom();
+            this.geojson(toGeoJSON.gpx(toDom(e.target.result))).fitZoom();
             redraw();
         };
 
         reader.readAsText(f);
-        return drawGpx;
+        return this;
     };
 
     drawGpx.fitZoom = function() {
+        if (!this.hasGpx()) return this;
         var geojson = iD.svg.Gpx.geojson;
-        if (_.isEmpty(geojson) || _.isEmpty(geojson.features)) return drawGpx;
 
         var map = context.map(),
             viewport = map.trimmedExtent().polygon(),
@@ -154,7 +159,7 @@ iD.svg.Gpx = function(projection, context) {
             map.centerZoom(extent.center(), map.trimmedExtentZoom(extent));
         }
 
-        return drawGpx;
+        return this;
     };
 
     init();

--- a/js/id/svg/gpx.js
+++ b/js/id/svg/gpx.js
@@ -2,7 +2,6 @@ iD.svg.Gpx = function(projection, context) {
     var showLabels = true,
         layer;
 
-
     function init() {
         if (iD.svg.Gpx.initialized) return;  // run once
 
@@ -21,7 +20,7 @@ iD.svg.Gpx = function(projection, context) {
                 d3.event.stopPropagation();
                 d3.event.preventDefault();
                 if (!iD.detect().filedrop) return;
-                gpx.files(d3.event.dataTransfer.files);
+                drawGpx.files(d3.event.dataTransfer.files);
             })
             .on('dragenter.localgpx', over)
             .on('dragexit.localgpx', over)
@@ -31,7 +30,7 @@ iD.svg.Gpx = function(projection, context) {
     }
 
 
-    function gpx(surface) {
+    function drawGpx(surface) {
         var geojson = iD.svg.Gpx.geojson,
             enabled = iD.svg.Gpx.enabled;
 
@@ -97,51 +96,51 @@ iD.svg.Gpx = function(projection, context) {
         context.pan([0,0]);
     }
 
-    gpx.showLabels = function(_) {
+    drawGpx.showLabels = function(_) {
         if (!arguments.length) return showLabels;
         showLabels = _;
-        return gpx;
+        return drawGpx;
     };
 
-    gpx.enabled = function(_) {
+    drawGpx.enabled = function(_) {
         if (!arguments.length) return iD.svg.Gpx.enabled;
         iD.svg.Gpx.enabled = _;
-        return gpx;
+        return drawGpx;
     };
 
-    gpx.geojson = function(gj) {
+    drawGpx.geojson = function(gj) {
         if (!arguments.length) return iD.svg.Gpx.geojson;
-        if (_.isEmpty(gj) || _.isEmpty(gj.features)) return gpx;
+        if (_.isEmpty(gj) || _.isEmpty(gj.features)) return drawGpx;
         iD.svg.Gpx.geojson = gj;
-        return gpx;
+        return drawGpx;
     };
 
-    gpx.url = function(url) {
+    drawGpx.url = function(url) {
         d3.text(url, function(err, data) {
             if (!err) {
-                gpx.geojson(toGeoJSON.gpx(toDom(data)));
+                drawGpx.geojson(toGeoJSON.gpx(toDom(data)));
                 redraw();
             }
         });
-        return gpx;
+        return drawGpx;
     };
 
-    gpx.files = function(fileList) {
+    drawGpx.files = function(fileList) {
         var f = fileList[0],
             reader = new FileReader();
 
         reader.onload = function(e) {
-            gpx.geojson(toGeoJSON.gpx(toDom(e.target.result))).fitZoom();
+            drawGpx.geojson(toGeoJSON.gpx(toDom(e.target.result))).fitZoom();
             redraw();
         };
 
         reader.readAsText(f);
-        return gpx;
+        return drawGpx;
     };
 
-    gpx.fitZoom = function() {
+    drawGpx.fitZoom = function() {
         var geojson = iD.svg.Gpx.geojson;
-        if (_.isEmpty(geojson) || _.isEmpty(geojson.features)) return gpx;
+        if (_.isEmpty(geojson) || _.isEmpty(geojson.features)) return drawGpx;
 
         var map = context.map(),
             viewport = map.trimmedExtent().polygon(),
@@ -155,9 +154,9 @@ iD.svg.Gpx = function(projection, context) {
             map.centerZoom(extent.center(), map.trimmedExtentZoom(extent));
         }
 
-        return gpx;
+        return drawGpx;
     };
 
     init();
-    return gpx;
+    return drawGpx;
 };

--- a/js/id/svg/gpx.js
+++ b/js/id/svg/gpx.js
@@ -1,4 +1,4 @@
-iD.GpxLayer = function(context) {
+iD.svg.Gpx = function(context) {
     var projection,
         gj = {},
         enable = true,

--- a/js/id/svg/icon.js
+++ b/js/id/svg/icon.js
@@ -1,5 +1,5 @@
 iD.svg.Icon = function(name, svgklass, useklass) {
-    return function (selection) {
+    return function drawIcon(selection) {
         selection.selectAll('svg')
             .data([0])
             .enter()

--- a/js/id/svg/labels.js
+++ b/js/id/svg/labels.js
@@ -131,7 +131,6 @@ iD.svg.Labels = function(projection, context) {
     }
 
     function drawPointLabels(group, entities, filter, classes, labels) {
-
         var texts = group.selectAll('text.' + classes)
             .filter(filter)
             .data(entities, iD.Entity.key);
@@ -248,8 +247,7 @@ iD.svg.Labels = function(projection, context) {
     var rtree = rbush(),
         rectangles = {};
 
-    function labels(surface, graph, entities, filter, dimensions, fullRedraw) {
-
+    function drawLabels(surface, graph, entities, filter, dimensions, fullRedraw) {
         var hidePoints = !surface.select('.node.point').node();
 
         var labelable = [], i, k, entity;
@@ -427,7 +425,7 @@ iD.svg.Labels = function(projection, context) {
         drawAreaIcons(label, labelled.area, filter, 'arealabel-icon', positions.area);
     }
 
-    labels.supersurface = function(supersurface) {
+    drawLabels.supersurface = function(supersurface) {
         supersurface
             .on('mousemove.hidelabels', hideOnMouseover)
             .on('mousedown.hidelabels', function () {
@@ -438,5 +436,5 @@ iD.svg.Labels = function(projection, context) {
             });
     };
 
-    return labels;
+    return drawLabels;
 };

--- a/js/id/svg/labels.js
+++ b/js/id/svg/labels.js
@@ -248,7 +248,7 @@ iD.svg.Labels = function(projection, context) {
         rectangles = {};
 
     function drawLabels(surface, graph, entities, filter, dimensions, fullRedraw) {
-        var hidePoints = !surface.select('.node.point').node();
+        var hidePoints = !surface.selectAll('.node.point').node();
 
         var labelable = [], i, k, entity;
         for (i = 0; i < label_stack.length; i++) labelable.push([]);
@@ -407,8 +407,8 @@ iD.svg.Labels = function(projection, context) {
             return v;
         }
 
-        var label = surface.select('.layer-label'),
-            halo = surface.select('.layer-halo');
+        var label = surface.selectAll('.layer-label'),
+            halo = surface.selectAll('.layer-halo');
 
         // points
         drawPointLabels(label, labelled.point, filter, 'pointlabel', positions.point);

--- a/js/id/svg/layers.js
+++ b/js/id/svg/layers.js
@@ -1,4 +1,4 @@
-iD.svg.Surface = function(projection, context) {
+iD.svg.Layers = function(projection, context) {
     var svg = d3.select(null),
         layers = [
             { id: 'osm', render: iD.svg.Osm(projection, context) },
@@ -8,7 +8,7 @@ iD.svg.Surface = function(projection, context) {
         ];
 
 
-    function surface(selection) {
+    function drawLayers(selection) {
         svg = selection.selectAll('.surface')
             .data([0]);
 
@@ -31,32 +31,39 @@ iD.svg.Surface = function(projection, context) {
             .remove();
     }
 
-
-    surface.only = function(what) {
-        var arr = [].concat(what);
-        surface.remove(_.difference(_.pluck(layers, 'id'), arr));
-        return surface;
+    drawLayers.all = function() {
+        return layers;
     };
 
-    surface.remove = function(what) {
+    drawLayers.layer = function(id) {
+        return _.find(layers, 'id', id);
+    };
+
+    drawLayers.only = function(what) {
+        var arr = [].concat(what);
+        drawLayers.remove(_.difference(_.pluck(layers, 'id'), arr));
+        return drawLayers;
+    };
+
+    drawLayers.remove = function(what) {
         var arr = [].concat(what);
         arr.forEach(function(id) {
-            layers = _.reject(layers, function(d) { return d.id === id; });
+            layers = _.reject(layers, 'id', id);
         });
-        return surface;
+        return drawLayers;
     };
 
-    surface.add = function(what) {
+    drawLayers.add = function(what) {
         var arr = [].concat(what);
         arr.forEach(function(obj) {
             if ('id' in obj && 'render' in obj) {
                 layers.push(obj);
             }
         });
-        return surface;
+        return drawLayers;
     };
 
-    surface.dimensions = function(_) {
+    drawLayers.dimensions = function(_) {
         if (!arguments.length) return svg.dimensions();
         svg.dimensions(_);
         layers.forEach(function(layer) {
@@ -64,9 +71,9 @@ iD.svg.Surface = function(projection, context) {
                 layer.render.dimensions(_);
             }
         });
-        return surface;
+        return drawLayers;
     };
 
 
-    return surface;
+    return drawLayers;
 };

--- a/js/id/svg/layers.js
+++ b/js/id/svg/layers.js
@@ -1,10 +1,10 @@
 iD.svg.Layers = function(projection, context) {
     var svg = d3.select(null),
         layers = [
-            { id: 'osm', render: iD.svg.Osm(projection, context) },
-            { id: 'gpx', render: iD.svg.Gpx(projection, context) },
-            { id: 'mapillary-images', render: iD.svg.MapillaryImages(projection, context) },
-            { id: 'mapillary-signs',  render: iD.svg.MapillarySigns(projection, context) }
+            { id: 'osm', layer: iD.svg.Osm(projection, context) },
+            { id: 'gpx', layer: iD.svg.Gpx(projection, context) },
+            { id: 'mapillary-images', layer: iD.svg.MapillaryImages(projection, context) },
+            { id: 'mapillary-signs',  layer: iD.svg.MapillarySigns(projection, context) }
         ];
 
 
@@ -25,7 +25,7 @@ iD.svg.Layers = function(projection, context) {
             .attr('class', function(d) { return 'data-layer data-layer-' + d.id; });
 
         groups
-            .each(function(d) { d3.select(this).call(d.render); });
+            .each(function(d) { d3.select(this).call(d.layer); });
 
         groups.exit()
             .remove();
@@ -36,13 +36,14 @@ iD.svg.Layers = function(projection, context) {
     };
 
     drawLayers.layer = function(id) {
-        return _.find(layers, 'id', id);
+        var obj = _.find(layers, 'id', id);
+        return obj && obj.layer;
     };
 
     drawLayers.only = function(what) {
         var arr = [].concat(what);
         drawLayers.remove(_.difference(_.pluck(layers, 'id'), arr));
-        return drawLayers;
+        return this;
     };
 
     drawLayers.remove = function(what) {
@@ -50,28 +51,28 @@ iD.svg.Layers = function(projection, context) {
         arr.forEach(function(id) {
             layers = _.reject(layers, 'id', id);
         });
-        return drawLayers;
+        return this;
     };
 
     drawLayers.add = function(what) {
         var arr = [].concat(what);
         arr.forEach(function(obj) {
-            if ('id' in obj && 'render' in obj) {
+            if ('id' in obj && 'layer' in obj) {
                 layers.push(obj);
             }
         });
-        return drawLayers;
+        return this;
     };
 
     drawLayers.dimensions = function(_) {
         if (!arguments.length) return svg.dimensions();
         svg.dimensions(_);
-        layers.forEach(function(layer) {
-            if (layer.render.dimensions) {
-                layer.render.dimensions(_);
+        layers.forEach(function(obj) {
+            if (obj.layer.dimensions) {
+                obj.layer.dimensions(_);
             }
         });
-        return drawLayers;
+        return this;
     };
 
 

--- a/js/id/svg/lines.js
+++ b/js/id/svg/lines.js
@@ -50,7 +50,7 @@ iD.svg.Lines = function(projection) {
         });
 
         var layergroup = surface
-            .select('.layer-lines')
+            .selectAll('.layer-lines')
             .selectAll('g.layergroup')
             .data(d3.range(-10, 11));
 

--- a/js/id/svg/mapillary_images.js
+++ b/js/id/svg/mapillary_images.js
@@ -110,13 +110,13 @@ iD.svg.MapillaryImages = function(projection, context) {
     function render(selection) {
         var mapillary = getMapillary();
 
-        layer = selection.selectAll('svg')
+        layer = selection.selectAll('.layer-mapillary-images')
             .data(mapillary ? [0] : []);
 
         layer.enter()
-            .append('svg')
+            .append('g')
+            .attr('class', 'layer-mapillary-images')
             .style('display', enabled ? 'block' : 'none')
-            .dimensions(context.map().dimensions())
             .on('click', function() {   // deselect/select
                 var mapillary = getMapillary();
                 if (!mapillary) return;
@@ -172,7 +172,6 @@ iD.svg.MapillaryImages = function(projection, context) {
     };
 
     render.dimensions = function(_) {
-        if (layer.empty()) return null;
         if (!arguments.length) return layer.dimensions();
         layer.dimensions(_);
         return render;

--- a/js/id/svg/mapillary_images.js
+++ b/js/id/svg/mapillary_images.js
@@ -1,4 +1,4 @@
-iD.svg.MapillaryImages = function(context) {
+iD.svg.MapillaryImages = function(projection, context) {
     var debouncedRedraw = _.debounce(function () { context.pan([0,0]); }, 1000),
         enabled = false,
         minZoom = 12,
@@ -19,7 +19,7 @@ iD.svg.MapillaryImages = function(context) {
         if (!mapillary) return;
 
         var thumb = mapillary.selectedThumbnail(),
-            posX = context.projection(image.loc)[0],
+            posX = projection(image.loc)[0],
             width = layer.dimensions()[0],
             position = (posX < width / 2) ? 'right' : 'left';
 
@@ -71,14 +71,14 @@ iD.svg.MapillaryImages = function(context) {
     }
 
     function transform(d) {
-        var t = iD.svg.PointTransform(context.projection)(d);
+        var t = iD.svg.PointTransform(projection)(d);
         if (d.ca) t += ' rotate(' + Math.floor(d.ca) + ',0,0)';
         return t;
     }
 
     function drawMarkers() {
         var mapillary = getMapillary(),
-            data = (mapillary ? mapillary.images(context.projection, layer.dimensions()) : []);
+            data = (mapillary ? mapillary.images(projection, layer.dimensions()) : []);
 
         var markers = layer.selectAll('.viewfield-group')
             .data(data, function(d) { return d.key; });
@@ -153,7 +153,7 @@ iD.svg.MapillaryImages = function(context) {
             if (mapillary && ~~context.map().zoom() >= minZoom) {
                 editOn();
                 drawMarkers();
-                mapillary.loadImages(context.projection, layer.dimensions());
+                mapillary.loadImages(projection, layer.dimensions());
             } else {
                 editOff();
             }

--- a/js/id/svg/mapillary_images.js
+++ b/js/id/svg/mapillary_images.js
@@ -1,9 +1,15 @@
 iD.svg.MapillaryImages = function(projection, context) {
     var debouncedRedraw = _.debounce(function () { context.pan([0,0]); }, 1000),
-        enabled = false,
         minZoom = 12,
         layer = d3.select(null),
         _mapillary;
+
+
+    function init() {
+        if (iD.svg.MapillaryImages.initialized) return;  // run once
+        iD.svg.MapillaryImages.enabled = false;
+        iD.svg.MapillaryImages.initialized = true;
+    }
 
     function getMapillary() {
         if (iD.services.mapillary && !_mapillary) {
@@ -108,7 +114,8 @@ iD.svg.MapillaryImages = function(projection, context) {
     }
 
     function drawImages(selection) {
-        var mapillary = getMapillary();
+        var enabled = iD.svg.MapillaryImages.enabled,
+            mapillary = getMapillary();
 
         layer = selection.selectAll('.layer-mapillary-images')
             .data(mapillary ? [0] : []);
@@ -160,22 +167,27 @@ iD.svg.MapillaryImages = function(projection, context) {
         }
     }
 
-    drawImages.enable = function(_) {
-        if (!arguments.length) return enabled;
-        enabled = _;
-        if (enabled) {
+    drawImages.enabled = function(_) {
+        if (!arguments.length) return iD.svg.MapillaryImages.enabled;
+        iD.svg.MapillaryImages.enabled = _;
+        if (iD.svg.MapillaryImages.enabled) {
             showLayer();
         } else {
             hideLayer();
         }
-        return drawImages;
+        return this;
+    };
+
+    drawImages.supported = function() {
+        return !!getMapillary();
     };
 
     drawImages.dimensions = function(_) {
         if (!arguments.length) return layer.dimensions();
         layer.dimensions(_);
-        return drawImages;
+        return this;
     };
 
+    init();
     return drawImages;
 };

--- a/js/id/svg/mapillary_images.js
+++ b/js/id/svg/mapillary_images.js
@@ -76,7 +76,7 @@ iD.svg.MapillaryImages = function(projection, context) {
         return t;
     }
 
-    function drawMarkers() {
+    function update() {
         var mapillary = getMapillary(),
             data = (mapillary ? mapillary.images(projection, layer.dimensions()) : []);
 
@@ -107,7 +107,7 @@ iD.svg.MapillaryImages = function(projection, context) {
             .attr('transform', transform);
     }
 
-    function render(selection) {
+    function drawImages(selection) {
         var mapillary = getMapillary();
 
         layer = selection.selectAll('.layer-mapillary-images')
@@ -152,7 +152,7 @@ iD.svg.MapillaryImages = function(projection, context) {
         if (enabled) {
             if (mapillary && ~~context.map().zoom() >= minZoom) {
                 editOn();
-                drawMarkers();
+                update();
                 mapillary.loadImages(projection, layer.dimensions());
             } else {
                 editOff();
@@ -160,7 +160,7 @@ iD.svg.MapillaryImages = function(projection, context) {
         }
     }
 
-    render.enable = function(_) {
+    drawImages.enable = function(_) {
         if (!arguments.length) return enabled;
         enabled = _;
         if (enabled) {
@@ -168,14 +168,14 @@ iD.svg.MapillaryImages = function(projection, context) {
         } else {
             hideLayer();
         }
-        return render;
+        return drawImages;
     };
 
-    render.dimensions = function(_) {
+    drawImages.dimensions = function(_) {
         if (!arguments.length) return layer.dimensions();
         layer.dimensions(_);
-        return render;
+        return drawImages;
     };
 
-    return render;
+    return drawImages;
 };

--- a/js/id/svg/mapillary_signs.js
+++ b/js/id/svg/mapillary_signs.js
@@ -1,4 +1,4 @@
-iD.svg.MapillarySigns = function(context) {
+iD.svg.MapillarySigns = function(projection, context) {
     var debouncedRedraw = _.debounce(function () { context.pan([0,0]); }, 1000),
         enabled = false,
         minZoom = 12,
@@ -19,7 +19,7 @@ iD.svg.MapillarySigns = function(context) {
         if (!mapillary) return;
 
         var thumb = mapillary.selectedThumbnail(),
-            posX = context.projection(image.loc)[0],
+            posX = projection(image.loc)[0],
             width = layer.dimensions()[0],
             position = (posX < width / 2) ? 'right' : 'left';
 
@@ -63,7 +63,7 @@ iD.svg.MapillarySigns = function(context) {
 
     function drawSigns() {
         var mapillary = getMapillary(),
-            data = (mapillary ? mapillary.signs(context.projection, layer.dimensions()) : []);
+            data = (mapillary ? mapillary.signs(projection, layer.dimensions()) : []);
 
         var signs = layer.select('.mapillary-sign-offset')
             .selectAll('.icon-sign')
@@ -111,7 +111,7 @@ iD.svg.MapillarySigns = function(context) {
 
         // Update
         signs
-            .attr('transform', iD.svg.PointTransform(context.projection));
+            .attr('transform', iD.svg.PointTransform(projection));
     }
 
     function render(selection) {
@@ -135,7 +135,7 @@ iD.svg.MapillarySigns = function(context) {
             if (mapillary && ~~context.map().zoom() >= minZoom) {
                 editOn();
                 drawSigns();
-                mapillary.loadSigns(context, context.projection, layer.dimensions());
+                mapillary.loadSigns(context, projection, layer.dimensions());
             } else {
                 editOff();
             }

--- a/js/id/svg/mapillary_signs.js
+++ b/js/id/svg/mapillary_signs.js
@@ -1,4 +1,4 @@
-iD.MapillaryImageLayer = function(context) {
+iD.svg.MapillarySigns = function(context) {
     var debouncedRedraw = _.debounce(function () { context.pan([0,0]); }, 1000),
         enabled = false,
         minZoom = 12,
@@ -7,7 +7,7 @@ iD.MapillaryImageLayer = function(context) {
 
     function getMapillary() {
         if (iD.services.mapillary && !_mapillary) {
-            _mapillary = iD.services.mapillary().on('loadedImages', debouncedRedraw);
+            _mapillary = iD.services.mapillary().on('loadedSigns', debouncedRedraw);
         } else if (!iD.services.mapillary && _mapillary) {
             _mapillary = null;
         }
@@ -43,22 +43,13 @@ iD.MapillaryImageLayer = function(context) {
 
     function showLayer() {
         editOn();
-        layer
-            .style('opacity', 0)
-            .transition()
-            .duration(500)
-            .style('opacity', 1)
-            .each('end', debouncedRedraw);
+        debouncedRedraw();
     }
 
     function hideLayer() {
         debouncedRedraw.cancel();
         hideThumbnail();
-        layer
-            .transition()
-            .duration(500)
-            .style('opacity', 0)
-            .each('end', editOff);
+        editOff();
     }
 
     function editOn() {
@@ -66,45 +57,61 @@ iD.MapillaryImageLayer = function(context) {
     }
 
     function editOff() {
-        layer.selectAll('.viewfield-group').remove();
+        layer.selectAll('.icon-sign').remove();
         layer.style('display', 'none');
     }
 
-    function transform(d) {
-        var t = iD.svg.PointTransform(context.projection)(d);
-        if (d.ca) t += ' rotate(' + Math.floor(d.ca) + ',0,0)';
-        return t;
-    }
-
-    function drawMarkers() {
+    function drawSigns() {
         var mapillary = getMapillary(),
-            data = (mapillary ? mapillary.images(context.projection, layer.dimensions()) : []);
+            data = (mapillary ? mapillary.signs(context.projection, layer.dimensions()) : []);
 
-        var markers = layer.selectAll('.viewfield-group')
+        var signs = layer.select('.mapillary-sign-offset')
+            .selectAll('.icon-sign')
             .data(data, function(d) { return d.key; });
 
         // Enter
-        var enter = markers.enter()
-            .append('g')
-            .attr('class', 'viewfield-group');
+        var enter = signs.enter()
+            .append('foreignObject')
+            .attr('class', 'icon-sign')
+            .attr('width', '32px')      // for Firefox
+            .attr('height', '32px');    // for Firefox
 
-        enter.append('path')
-            .attr('class', 'viewfield')
-            .attr('transform', 'scale(1.5,1.5),translate(-8, -13)')
-            .attr('d', 'M 6,9 C 8,8.4 8,8.4 10,9 L 16,-2 C 12,-5 4,-5 0,-2 z');
+        enter
+            .append('xhtml:body')
+            .html(mapillary.signHTML);
 
-        enter.append('circle')
-            .attr('dx', '0')
-            .attr('dy', '0')
-            .attr('r', '6');
+        enter
+            .on('click', function(d) {   // deselect/select
+                var mapillary = getMapillary();
+                if (!mapillary) return;
+                var thumb = mapillary.selectedThumbnail();
+                if (thumb && thumb.key === d.key) {
+                    hideThumbnail();
+                } else {
+                    mapillary.selectedThumbnail(d);
+                    context.map().centerEase(d.loc);
+                    showThumbnail(d);
+                }
+            })
+            .on('mouseover', showThumbnail)
+            .on('mouseout', function() {
+                var mapillary = getMapillary();
+                if (!mapillary) return;
+                var thumb = mapillary.selectedThumbnail();
+                if (thumb) {
+                    showThumbnail(thumb);
+                } else {
+                    hideThumbnail();
+                }
+            });
 
         // Exit
-        markers.exit()
+        signs.exit()
             .remove();
 
         // Update
-        markers
-            .attr('transform', transform);
+        signs
+            .attr('transform', iD.svg.PointTransform(context.projection));
     }
 
     function render(selection) {
@@ -117,34 +124,9 @@ iD.MapillaryImageLayer = function(context) {
             .append('svg')
             .style('display', enabled ? 'block' : 'none')
             .dimensions(context.map().dimensions())
-            .on('click', function() {   // deselect/select
-                var mapillary = getMapillary();
-                if (!mapillary) return;
-                var d = d3.event.target.__data__,
-                    thumb = mapillary.selectedThumbnail();
-                if (thumb && thumb.key === d.key) {
-                    hideThumbnail();
-                } else {
-                    mapillary.selectedThumbnail(d);
-                    context.map().centerEase(d.loc);
-                    showThumbnail(d);
-                }
-            })
-            .on('mouseover', function() {
-                var mapillary = getMapillary();
-                if (!mapillary) return;
-                showThumbnail(d3.event.target.__data__);
-            })
-            .on('mouseout', function() {
-                var mapillary = getMapillary();
-                if (!mapillary) return;
-                var thumb = mapillary.selectedThumbnail();
-                if (thumb) {
-                    showThumbnail(thumb);
-                } else {
-                    hideThumbnail();
-                }
-            });
+            .append('g')
+            .attr('class', 'mapillary-sign-offset')
+            .attr('transform', 'translate(-16, -16)');  // center signs on loc
 
         layer.exit()
             .remove();
@@ -152,8 +134,8 @@ iD.MapillaryImageLayer = function(context) {
         if (enabled) {
             if (mapillary && ~~context.map().zoom() >= minZoom) {
                 editOn();
-                drawMarkers();
-                mapillary.loadImages(context.projection, layer.dimensions());
+                drawSigns();
+                mapillary.loadSigns(context, context.projection, layer.dimensions());
             } else {
                 editOff();
             }

--- a/js/id/svg/mapillary_signs.js
+++ b/js/id/svg/mapillary_signs.js
@@ -61,7 +61,7 @@ iD.svg.MapillarySigns = function(projection, context) {
         layer.style('display', 'none');
     }
 
-    function drawSigns() {
+    function update() {
         var mapillary = getMapillary(),
             data = (mapillary ? mapillary.signs(projection, layer.dimensions()) : []);
 
@@ -114,7 +114,7 @@ iD.svg.MapillarySigns = function(projection, context) {
             .attr('transform', iD.svg.PointTransform(projection));
     }
 
-    function render(selection) {
+    function drawSigns(selection) {
         var mapillary = getMapillary();
 
         layer = selection.selectAll('.layer-mapillary-signs')
@@ -132,7 +132,7 @@ iD.svg.MapillarySigns = function(projection, context) {
         if (enabled) {
             if (mapillary && ~~context.map().zoom() >= minZoom) {
                 editOn();
-                drawSigns();
+                update();
                 mapillary.loadSigns(context, projection, layer.dimensions());
             } else {
                 editOff();
@@ -140,7 +140,7 @@ iD.svg.MapillarySigns = function(projection, context) {
         }
     }
 
-    render.enable = function(_) {
+    drawSigns.enable = function(_) {
         if (!arguments.length) return enabled;
         enabled = _;
         if (enabled) {
@@ -148,14 +148,14 @@ iD.svg.MapillarySigns = function(projection, context) {
         } else {
             hideLayer();
         }
-        return render;
+        return drawSigns;
     };
 
-    render.dimensions = function(_) {
+    drawSigns.dimensions = function(_) {
         if (!arguments.length) return layer.dimensions();
         layer.dimensions(_);
-        return render;
+        return drawSigns;
     };
 
-    return render;
+    return drawSigns;
 };

--- a/js/id/svg/mapillary_signs.js
+++ b/js/id/svg/mapillary_signs.js
@@ -65,7 +65,7 @@ iD.svg.MapillarySigns = function(projection, context) {
         var mapillary = getMapillary(),
             data = (mapillary ? mapillary.signs(projection, layer.dimensions()) : []);
 
-        var signs = layer.select('.mapillary-sign-offset')
+        var signs = layer.select('.layer-mapillary-signs')
             .selectAll('.icon-sign')
             .data(data, function(d) { return d.key; });
 
@@ -117,15 +117,13 @@ iD.svg.MapillarySigns = function(projection, context) {
     function render(selection) {
         var mapillary = getMapillary();
 
-        layer = selection.selectAll('svg')
+        layer = selection.selectAll('.layer-mapillary-signs')
             .data(mapillary ? [0] : []);
 
         layer.enter()
-            .append('svg')
-            .style('display', enabled ? 'block' : 'none')
-            .dimensions(context.map().dimensions())
             .append('g')
-            .attr('class', 'mapillary-sign-offset')
+            .attr('class', 'layer-mapillary-signs')
+            .style('display', enabled ? 'block' : 'none')
             .attr('transform', 'translate(-16, -16)');  // center signs on loc
 
         layer.exit()
@@ -154,7 +152,6 @@ iD.svg.MapillarySigns = function(projection, context) {
     };
 
     render.dimensions = function(_) {
-        if (layer.empty()) return null;
         if (!arguments.length) return layer.dimensions();
         layer.dimensions(_);
         return render;

--- a/js/id/svg/midpoints.js
+++ b/js/id/svg/midpoints.js
@@ -67,7 +67,7 @@ iD.svg.Midpoints = function(projection, context) {
             return false;
         }
 
-        var groups = surface.select('.layer-hit').selectAll('g.midpoint')
+        var groups = surface.selectAll('.layer-hit').selectAll('g.midpoint')
             .filter(midpointFilter)
             .data(_.values(midpoints), function(d) { return d.id; });
 

--- a/js/id/svg/osm.js
+++ b/js/id/svg/osm.js
@@ -1,5 +1,5 @@
 iD.svg.Osm = function() {
-    return function (selection) {
+    return function drawOsm(selection) {
         var layers = selection.selectAll('.layer-osm')
             .data(['areas', 'lines', 'hit', 'halo', 'label']);
 

--- a/js/id/svg/osm.js
+++ b/js/id/svg/osm.js
@@ -4,6 +4,6 @@ iD.svg.Osm = function() {
             .data(['areas', 'lines', 'hit', 'halo', 'label']);
 
         layers.enter().append('g')
-            .attr('class', function(d) { return 'layer layer-osm layer-' + d; });
+            .attr('class', function(d) { return 'layer-osm layer-' + d; });
     };
 };

--- a/js/id/svg/osm.js
+++ b/js/id/svg/osm.js
@@ -1,0 +1,9 @@
+iD.svg.Osm = function() {
+    return function (selection) {
+        var layers = selection.selectAll('.layer-osm')
+            .data(['areas', 'lines', 'hit', 'halo', 'label']);
+
+        layers.enter().append('g')
+            .attr('class', function(d) { return 'layer layer-osm layer-' + d; });
+    };
+};

--- a/js/id/svg/points.js
+++ b/js/id/svg/points.js
@@ -18,7 +18,7 @@ iD.svg.Points = function(projection, context) {
 
         points.sort(sortY);
 
-        var groups = surface.select('.layer-hit').selectAll('g.point')
+        var groups = surface.selectAll('.layer-hit').selectAll('g.point')
             .filter(filter)
             .data(points, iD.Entity.key);
 

--- a/js/id/svg/points.js
+++ b/js/id/svg/points.js
@@ -10,9 +10,8 @@ iD.svg.Points = function(projection, context) {
         return b.loc[1] - a.loc[1];
     }
 
-    return function drawPoints(surface, entities, filter) {
-        var graph = context.graph(),
-            wireframe = surface.classed('fill-wireframe'),
+    return function drawPoints(surface, graph, entities, filter) {
+        var wireframe = surface.classed('fill-wireframe'),
             points = wireframe ? [] : _.filter(entities, function(e) {
                 return e.geometry(graph) === 'point';
             });
@@ -49,7 +48,7 @@ iD.svg.Points = function(projection, context) {
         groups.select('.stroke');
         groups.select('.icon')
             .attr('xlink:href', function(entity) {
-                var preset = context.presets().match(entity, context.graph());
+                var preset = context.presets().match(entity, graph);
                 return preset.icon ? '#' + preset.icon + '-12' : '';
             });
 

--- a/js/id/svg/surface.js
+++ b/js/id/svg/surface.js
@@ -1,14 +1,58 @@
-iD.svg.Surface = function() {
-    return function (selection) {
+iD.svg.Surface = function (projection, context) {
+    var all = [
+        { order: 1, id: 'osm', render: iD.svg.Osm(projection, context) },
+        { order: 2, id: 'gpx', render: iD.svg.Gpx(projection, context) },
+        { order: 3, id: 'mapillary-images', render: iD.svg.MapillaryImages(projection, context) },
+        { order: 4, id: 'mapillary-signs',  render: iD.svg.MapillarySigns(projection, context) }
+    ];
+
+
+    function surface (selection) {
         selection.selectAll('defs')
             .data([0])
             .enter()
             .append('defs');
 
-        var layers = selection.selectAll('.layer')
-            .data(['areas', 'lines', 'hit', 'halo', 'label']);
+        var groups = selection.selectAll('.data-layer')
+            .data(all);
 
-        layers.enter().append('g')
-            .attr('class', function(d) { return 'layer layer-osm layer-' + d; });
+        groups.enter()
+            .append('g')
+            .attr('class', function(d) { return 'layer data-layer data-layer-' + d.id; });
+
+        groups
+            .sort(function(a, b) { return a.order - b.order; })
+            .each(function(d) { d3.select(this).call(d.render); });
+
+        groups.exit()
+            .remove();
+    }
+
+
+    surface.only = function (what) {
+        var arr = [].concat(what);
+        surface.remove(_.difference(_.pluck(all, 'id'), arr));
+        return surface;
     };
+
+    surface.remove = function (what) {
+        var arr = [].concat(what);
+        _.each(arr, function(id) {
+            all = _.reject(all, function(d) { return d.id === id; });
+        });
+        return surface;
+    };
+
+    surface.add = function (what) {
+        var arr = [].concat(what);
+        _.each(arr, function(obj) {
+            if ('order' in obj && 'id' in obj && 'render' in obj) {
+                all.push(obj);
+            }
+        });
+        return surface;
+    };
+
+
+    return surface;
 };

--- a/js/id/svg/surface.js
+++ b/js/id/svg/surface.js
@@ -9,6 +9,6 @@ iD.svg.Surface = function() {
             .data(['areas', 'lines', 'hit', 'halo', 'label']);
 
         layers.enter().append('g')
-            .attr('class', function(d) { return 'layer layer-' + d; });
+            .attr('class', function(d) { return 'layer layer-osm layer-' + d; });
     };
 };

--- a/js/id/svg/surface.js
+++ b/js/id/svg/surface.js
@@ -1,27 +1,30 @@
-iD.svg.Surface = function (projection, context) {
-    var all = [
-        { order: 1, id: 'osm', render: iD.svg.Osm(projection, context) },
-        { order: 2, id: 'gpx', render: iD.svg.Gpx(projection, context) },
-        { order: 3, id: 'mapillary-images', render: iD.svg.MapillaryImages(projection, context) },
-        { order: 4, id: 'mapillary-signs',  render: iD.svg.MapillarySigns(projection, context) }
-    ];
+iD.svg.Surface = function(projection, context) {
+    var svg = d3.select(null),
+        layers = [
+            { id: 'osm', render: iD.svg.Osm(projection, context) },
+            { id: 'gpx', render: iD.svg.Gpx(projection, context) },
+            { id: 'mapillary-images', render: iD.svg.MapillaryImages(projection, context) },
+            { id: 'mapillary-signs',  render: iD.svg.MapillarySigns(projection, context) }
+        ];
 
 
-    function surface (selection) {
-        selection.selectAll('defs')
-            .data([0])
-            .enter()
+    function surface(selection) {
+        svg = selection.selectAll('.surface')
+            .data([0]);
+
+        svg.enter()
+            .append('svg')
+            .attr('class', 'surface')
             .append('defs');
 
-        var groups = selection.selectAll('.data-layer')
-            .data(all);
+        var groups = svg.selectAll('.data-layer')
+            .data(layers);
 
         groups.enter()
             .append('g')
-            .attr('class', function(d) { return 'layer data-layer data-layer-' + d.id; });
+            .attr('class', function(d) { return 'data-layer data-layer-' + d.id; });
 
         groups
-            .sort(function(a, b) { return a.order - b.order; })
             .each(function(d) { d3.select(this).call(d.render); });
 
         groups.exit()
@@ -29,25 +32,36 @@ iD.svg.Surface = function (projection, context) {
     }
 
 
-    surface.only = function (what) {
+    surface.only = function(what) {
         var arr = [].concat(what);
-        surface.remove(_.difference(_.pluck(all, 'id'), arr));
+        surface.remove(_.difference(_.pluck(layers, 'id'), arr));
         return surface;
     };
 
-    surface.remove = function (what) {
+    surface.remove = function(what) {
         var arr = [].concat(what);
-        _.each(arr, function(id) {
-            all = _.reject(all, function(d) { return d.id === id; });
+        arr.forEach(function(id) {
+            layers = _.reject(layers, function(d) { return d.id === id; });
         });
         return surface;
     };
 
-    surface.add = function (what) {
+    surface.add = function(what) {
         var arr = [].concat(what);
-        _.each(arr, function(obj) {
-            if ('order' in obj && 'id' in obj && 'render' in obj) {
-                all.push(obj);
+        arr.forEach(function(obj) {
+            if ('id' in obj && 'render' in obj) {
+                layers.push(obj);
+            }
+        });
+        return surface;
+    };
+
+    surface.dimensions = function(_) {
+        if (!arguments.length) return svg.dimensions();
+        svg.dimensions(_);
+        layers.forEach(function(layer) {
+            if (layer.render.dimensions) {
+                layer.render.dimensions(_);
             }
         });
         return surface;

--- a/js/id/svg/turns.js
+++ b/js/id/svg/turns.js
@@ -1,5 +1,5 @@
 iD.svg.Turns = function(projection) {
-    return function(surface, graph, turns) {
+    return function drawTurns(surface, graph, turns) {
         function key(turn) {
             return [turn.from.node + turn.via.node + turn.to.node].join('-');
         }

--- a/js/id/svg/turns.js
+++ b/js/id/svg/turns.js
@@ -13,7 +13,7 @@ iD.svg.Turns = function(projection) {
                 (!turn.indirect_restriction && /^only_/.test(restriction) ? 'only' : 'no') + u;
         }
 
-        var groups = surface.select('.layer-hit').selectAll('g.turn')
+        var groups = surface.selectAll('.layer-hit').selectAll('g.turn')
             .data(turns, key);
 
         // Enter

--- a/js/id/svg/vertices.js
+++ b/js/id/svg/vertices.js
@@ -48,19 +48,10 @@ iD.svg.Vertices = function(projection, context) {
 
     function draw(selection, vertices, klass, graph, zoom) {
         var icons = {},
-            z;
+            z = (zoom < 17 ? 0 : zoom < 18 ? 1 : 2);
 
-        if (zoom < 17) {
-            z = 0;
-        } else if (zoom < 18) {
-            z = 1;
-        } else {
-            z = 2;
-        }
-
-        var groups = selection.data(vertices, function(entity) {
-            return iD.Entity.key(entity);
-        });
+        var groups = selection
+            .data(vertices, iD.Entity.key);
 
         function icon(entity) {
             if (entity.id in icons) return icons[entity.id];
@@ -162,7 +153,7 @@ iD.svg.Vertices = function(projection, context) {
             }
         }
 
-        surface.select('.layer-hit').selectAll('g.vertex.vertex-persistent')
+        surface.selectAll('.layer-hit').selectAll('g.vertex.vertex-persistent')
             .filter(filter)
             .call(draw, vertices, 'vertex-persistent', graph, zoom);
 
@@ -172,15 +163,14 @@ iD.svg.Vertices = function(projection, context) {
     function drawHover(surface, graph, extent, zoom) {
         var hovered = hover ? siblingAndChildVertices([hover.id], graph, extent) : {};
 
-        surface.select('.layer-hit').selectAll('g.vertex.vertex-hover')
+        surface.selectAll('.layer-hit').selectAll('g.vertex.vertex-hover')
             .call(draw, d3.values(hovered), 'vertex-hover', graph, zoom);
     }
 
-    drawVertices.drawHover = function(surface, graph, _, extent, zoom) {
-        if (hover !== _) {
-            hover = _;
-            drawHover(surface, graph, extent, zoom);
-        }
+    drawVertices.drawHover = function(surface, graph, target, extent, zoom) {
+        if (target === hover) return;
+        hover = target;
+        drawHover(surface, graph, extent, zoom);
     };
 
     return drawVertices;

--- a/js/id/ui.js
+++ b/js/id/ui.js
@@ -32,14 +32,10 @@ iD.ui = function(context) {
             .attr('id', 'map')
             .call(map);
 
-        content.append('div')
-            .attr('class', 'map-in-map')
-            .style('display', 'none')
+        content
             .call(iD.ui.MapInMap(context));
 
         content.append('div')
-            .attr('class', 'infobox fillD2')
-            .style('display', 'none')
             .call(iD.ui.Info(context));
 
         bar.append('div')

--- a/js/id/ui.js
+++ b/js/id/ui.js
@@ -28,7 +28,7 @@ iD.ui = function(context) {
             .attr('id', 'bar')
             .attr('class', 'fillD');
 
-        var m = content.append('div')
+        content.append('div')
             .attr('id', 'map')
             .call(map);
 
@@ -169,8 +169,8 @@ iD.ui = function(context) {
         var mapDimensions = map.dimensions();
 
         d3.select(window).on('resize.editor', function() {
-            mapDimensions = m.dimensions();
-            map.dimensions(m.dimensions());
+            mapDimensions = content.dimensions(null);
+            map.dimensions(mapDimensions);
         });
 
         function pan(d) {

--- a/js/id/ui/background.js
+++ b/js/id/ui/background.js
@@ -24,7 +24,7 @@ iD.ui.Background = function(context) {
         }
 
         function setOpacity(d) {
-            var bg = context.container().selectAll('.background-layer')
+            var bg = context.container().selectAll('.layer-background')
                 .transition()
                 .style('opacity', d)
                 .attr('data-opacity', d);

--- a/js/id/ui/info.js
+++ b/js/id/ui/info.js
@@ -1,6 +1,7 @@
 iD.ui.Info = function(context) {
     var key = iD.ui.cmd('⌘I'),
-        imperial = (iD.detect().locale.toLowerCase() === 'en-us');
+        imperial = (iD.detect().locale.toLowerCase() === 'en-us'),
+        hidden = true;
 
     function info(selection) {
         function radiansToMeters(r) {
@@ -95,7 +96,7 @@ iD.ui.Info = function(context) {
 
 
         function redraw() {
-            if (hidden()) return;
+            if (hidden) return;
 
             var resolver = context.graph(),
                 selected = _.filter(context.selectedIDs(), function(e) { return context.hasEntity(e); }),
@@ -103,9 +104,9 @@ iD.ui.Info = function(context) {
                 extent = iD.geo.Extent(),
                 entity;
 
-            selection.html('');
-            selection.append('h4')
-                .attr('class', 'selection-heading fillD')
+            wrap.html('');
+            wrap.append('h4')
+                .attr('class', 'infobox-heading fillD')
                 .text(singular || t('infobox.selected', { n: selected.length }));
 
             if (!selected.length) return;
@@ -118,16 +119,16 @@ iD.ui.Info = function(context) {
             center = extent.center();
 
 
-            var list = selection.append('ul');
+            var list = wrap.append('ul');
 
-            // multiple selection, just display extent center..
+            // multiple wrap, just display extent center..
             if (!singular) {
                 list.append('li')
                     .text(t('infobox.center') + ': ' + center[0].toFixed(5) + ', ' + center[1].toFixed(5));
                 return;
             }
 
-            // single selection, display details..
+            // single wrap, display details..
             if (!entity) return;
             var geometry = entity.geometry(resolver);
 
@@ -156,7 +157,7 @@ iD.ui.Info = function(context) {
 
 
                 var toggle  = imperial ? 'imperial' : 'metric';
-                selection.append('a')
+                wrap.append('a')
                     .text(t('infobox.' + toggle))
                     .attr('href', '#')
                     .attr('class', 'button')
@@ -178,26 +179,13 @@ iD.ui.Info = function(context) {
         }
 
 
-        function hidden() {
-            return selection.style('display') === 'none';
-        }
-
-
         function toggle() {
             if (d3.event) d3.event.preventDefault();
 
-            if (hidden()) {
-                selection
-                    .style('display', 'block')
-                    .style('opacity', 0)
-                    .transition()
-                    .duration(200)
-                    .style('opacity', 1);
+            hidden = !hidden;
 
-                redraw();
-
-            } else {
-                selection
+            if (hidden) {
+                wrap
                     .style('display', 'block')
                     .style('opacity', 1)
                     .transition()
@@ -206,8 +194,26 @@ iD.ui.Info = function(context) {
                     .each('end', function() {
                         d3.select(this).style('display', 'none');
                     });
+            } else {
+                wrap
+                    .style('display', 'block')
+                    .style('opacity', 0)
+                    .transition()
+                    .duration(200)
+                    .style('opacity', 1);
+
+                redraw();
             }
         }
+
+
+        var wrap = selection.selectAll('.infobox')
+            .data([0]);
+
+        wrap.enter()
+            .append('div')
+            .attr('class', 'infobox fillD2')
+            .style('display', (hidden ? 'none' : 'block'));
 
         context.map()
             .on('drawn.info', redraw);

--- a/js/id/ui/map_data.js
+++ b/js/id/ui/map_data.js
@@ -1,6 +1,7 @@
 iD.ui.MapData = function(context) {
     var key = 'F',
         features = context.features().keys(),
+        layers = context.layers(),
         fills = ['wireframe', 'partial', 'full'],
         fillDefault = context.storage('area-fill') || 'partial',
         fillSelected = fillDefault;
@@ -38,30 +39,38 @@ iD.ui.MapData = function(context) {
             update();
         }
 
+        function toggleLayer(which) {
+            var layer = layers.layer(which);
+            if (layer) {
+                layer.enabled(!layer.enabled());
+                update();
+            }
+        }
+
         function clickGpx() {
-            context.background().toggleGpxLayer();
-            update();
+            toggleLayer('gpx');
         }
 
         function clickMapillaryImages() {
-            context.background().toggleMapillaryImageLayer();
-            update();
+            toggleLayer('mapillary-images');
         }
 
         function clickMapillarySigns() {
-            context.background().toggleMapillarySignLayer();
-            update();
+            toggleLayer('mapillary-signs');
         }
 
 
         function drawMapillaryItems(selection) {
-            var mapillary = iD.services.mapillary,
-                supportsMapillaryImages = !!mapillary,
-                supportsMapillarySigns = !!mapillary && mapillary().signsSupported();
+            var mapillaryImages = layers.layer('mapillary-images'),
+                mapillarySigns = layers.layer('mapillary-signs'),
+                supportsMapillaryImages = mapillaryImages && mapillaryImages.supported(),
+                supportsMapillarySigns = mapillarySigns && mapillarySigns.supported(),
+                showsMapillaryImages = supportsMapillaryImages && mapillaryImages.enabled(),
+                showsMapillarySigns = supportsMapillarySigns && mapillarySigns.enabled();
 
             var mapillaryList = selection
-                    .selectAll('.mapillary-list')
-                    .data([0]);
+                .selectAll('.mapillary-list')
+                .data([0]);
 
             // Enter
             mapillaryList
@@ -70,8 +79,8 @@ iD.ui.MapData = function(context) {
                 .attr('class', 'layer-list mapillary-list');
 
             var mapillaryImageLayerItem = mapillaryList
-                    .selectAll('.item-mapillary-images')
-                    .data(supportsMapillaryImages ? [0] : []);
+                .selectAll('.item-mapillary-images')
+                .data(supportsMapillaryImages ? [0] : []);
 
             var enterImages = mapillaryImageLayerItem.enter()
                 .append('li')
@@ -91,8 +100,8 @@ iD.ui.MapData = function(context) {
 
 
             var mapillarySignLayerItem = mapillaryList
-                    .selectAll('.item-mapillary-signs')
-                    .data(supportsMapillarySigns ? [0] : []);
+                .selectAll('.item-mapillary-signs')
+                .data(supportsMapillarySigns ? [0] : []);
 
             var enterSigns = mapillarySignLayerItem.enter()
                 .append('li')
@@ -111,9 +120,6 @@ iD.ui.MapData = function(context) {
                 .text(t('mapillary_signs.title'));
 
             // Update
-            var showsMapillaryImages = supportsMapillaryImages && context.background().showsMapillaryImageLayer(),
-                showsMapillarySigns = supportsMapillarySigns && context.background().showsMapillarySignLayer();
-
             mapillaryImageLayerItem
                 .classed('active', showsMapillaryImages)
                 .selectAll('input')
@@ -133,9 +139,13 @@ iD.ui.MapData = function(context) {
 
 
         function drawGpxItem(selection) {
+            var gpx = layers.layer('gpx'),
+                hasGpx = gpx && gpx.hasGpx(),
+                showsGpx = hasGpx && gpx.enabled();
+
             var gpxLayerItem = selection
                 .selectAll('.layer-gpx')
-                .data([0]);
+                .data(gpx ? [0] : []);
 
             // Enter
             var enter = gpxLayerItem.enter()
@@ -152,7 +162,7 @@ iD.ui.MapData = function(context) {
                 .on('click', function() {
                     d3.event.preventDefault();
                     d3.event.stopPropagation();
-                    context.background().gpxLayer().fitZoom();
+                    gpx.fitZoom();
                 })
                 .call(iD.svg.Icon('#icon-search'));
 
@@ -165,7 +175,7 @@ iD.ui.MapData = function(context) {
                     d3.select(document.createElement('input'))
                         .attr('type', 'file')
                         .on('change', function() {
-                            context.background().gpxLayer().files(d3.event.target.files);
+                            gpx.files(d3.event.target.files);
                         })
                         .node().click();
                 })
@@ -184,9 +194,6 @@ iD.ui.MapData = function(context) {
                 .text(t('gpx.local_layer'));
 
             // Update
-            var hasGpx = context.background().hasGpxLayer(),
-                showsGpx = context.background().showsGpxLayer();
-
             gpxLayerItem
                 .classed('active', showsGpx)
                 .selectAll('input')

--- a/js/id/ui/map_data.js
+++ b/js/id/ui/map_data.js
@@ -133,10 +133,9 @@ iD.ui.MapData = function(context) {
 
 
         function drawGpxItem(selection) {
-            var supportsGpx = iD.detect().filedrop,
-                gpxLayerItem = selection
-                    .selectAll('.layer-gpx')
-                    .data(supportsGpx ? [0] : []);
+            var gpxLayerItem = selection
+                .selectAll('.layer-gpx')
+                .data([0]);
 
             // Enter
             var enter = gpxLayerItem.enter()
@@ -153,7 +152,7 @@ iD.ui.MapData = function(context) {
                 .on('click', function() {
                     d3.event.preventDefault();
                     d3.event.stopPropagation();
-                    context.background().zoomToGpxLayer();
+                    context.background().gpxLayer().fitZoom();
                 })
                 .call(iD.svg.Icon('#icon-search'));
 
@@ -166,7 +165,7 @@ iD.ui.MapData = function(context) {
                     d3.select(document.createElement('input'))
                         .attr('type', 'file')
                         .on('change', function() {
-                            context.background().gpxLayerFiles(d3.event.target.files);
+                            context.background().gpxLayer().files(d3.event.target.files);
                         })
                         .node().click();
                 })
@@ -185,8 +184,8 @@ iD.ui.MapData = function(context) {
                 .text(t('gpx.local_layer'));
 
             // Update
-            var hasGpx = supportsGpx && context.background().hasGpxLayer(),
-                showsGpx = supportsGpx && context.background().showsGpxLayer();
+            var hasGpx = context.background().hasGpxLayer(),
+                showsGpx = context.background().showsGpxLayer();
 
             gpxLayerItem
                 .classed('active', showsGpx)

--- a/js/id/ui/map_in_map.js
+++ b/js/id/ui/map_in_map.js
@@ -11,6 +11,7 @@ iD.ui.MapInMap = function(context) {
                 .on('zoom', zoomPan),
             transformed = false,
             panning = false,
+            hidden = true,
             zDiff = 6,    // by default, minimap renders at (main zoom - 6)
             tStart, tLast, tCurr, kLast, kCurr, tiles, svg, timeoutId;
 
@@ -68,7 +69,7 @@ iD.ui.MapInMap = function(context) {
             panning = false;
 
             if (tCurr[0] !== tStart[0] && tCurr[1] !== tStart[1]) {
-                var dMini = selection.dimensions(),
+                var dMini = wrap.dimensions(),
                     cMini = [ dMini[0] / 2, dMini[1] / 2 ];
 
                 context.map().center(projection.invert(cMini));
@@ -78,7 +79,7 @@ iD.ui.MapInMap = function(context) {
 
         function updateProjection() {
             var loc = context.map().center(),
-                dMini = selection.dimensions(),
+                dMini = wrap.dimensions(),
                 cMini = [ dMini[0] / 2, dMini[1] / 2 ],
                 tMain = context.projection.translate(),
                 kMain = context.projection.scale(),
@@ -118,15 +119,15 @@ iD.ui.MapInMap = function(context) {
 
 
         function redraw() {
-            if (hidden()) return;
+            if (hidden) return;
 
             updateProjection();
 
-            var dMini = selection.dimensions(),
+            var dMini = wrap.dimensions(),
                 zMini = ktoz(projection.scale() * 2 * Math.PI);
 
             // setup tile container
-            tiles = selection
+            tiles = wrap
                 .selectAll('.map-in-map-tiles')
                 .data([0]);
 
@@ -206,7 +207,7 @@ iD.ui.MapInMap = function(context) {
                 var getPath = d3.geo.path().projection(projection),
                     bbox = { type: 'Polygon', coordinates: [context.map().extent().polygon()] };
 
-                svg = selection.selectAll('.map-in-map-svg')
+                svg = wrap.selectAll('.map-in-map-svg')
                     .data([0]);
 
                 svg.enter()
@@ -233,31 +234,17 @@ iD.ui.MapInMap = function(context) {
         }
 
 
-        function hidden() {
-            return selection.style('display') === 'none';
-        }
-
-
         function toggle() {
             if (d3.event) d3.event.preventDefault();
 
+            hidden = !hidden;
+
             var label = d3.select('.minimap-toggle');
+            label.classed('active', !hidden)
+                .select('input').property('checked', !hidden);
 
-            if (hidden()) {
-                selection
-                    .style('display', 'block')
-                    .style('opacity', 0)
-                    .transition()
-                    .duration(200)
-                    .style('opacity', 1);
-
-                label.classed('active', true)
-                    .select('input').property('checked', true);
-
-                redraw();
-
-            } else {
-                selection
+            if (hidden) {
+                wrap
                     .style('display', 'block')
                     .style('opacity', 1)
                     .transition()
@@ -266,19 +253,29 @@ iD.ui.MapInMap = function(context) {
                     .each('end', function() {
                         d3.select(this).style('display', 'none');
                     });
+            } else {
+                wrap
+                    .style('display', 'block')
+                    .style('opacity', 0)
+                    .transition()
+                    .duration(200)
+                    .style('opacity', 1);
 
-                label.classed('active', false)
-                    .select('input').property('checked', false);
+                redraw();
             }
         }
 
         iD.ui.MapInMap.toggle = toggle;
 
-        selection
-            .on('mousedown.map-in-map', startMouse)
-            .on('mouseup.map-in-map', endMouse);
+        var wrap = selection.selectAll('.map-in-map')
+            .data([0]);
 
-        selection
+        wrap.enter()
+            .append('div')
+            .attr('class', 'map-in-map')
+            .style('display', (hidden ? 'none' : 'block'))
+            .on('mousedown.map-in-map', startMouse)
+            .on('mouseup.map-in-map', endMouse)
             .call(zoom)
             .on('dblclick.zoom', null);
 

--- a/js/id/ui/map_in_map.js
+++ b/js/id/ui/map_in_map.js
@@ -4,18 +4,15 @@ iD.ui.MapInMap = function(context) {
     function map_in_map(selection) {
         var backgroundLayer = iD.TileLayer(),
             overlayLayers = {},
-            dispatch = d3.dispatch('change'),
-            gpxLayer = iD.svg.Gpx(context, dispatch),
             projection = iD.geo.RawMercator(),
+            gpxLayer = iD.svg.Gpx(projection, context).showLabels(false),
             zoom = d3.behavior.zoom()
                 .scaleExtent([ztok(0.5), ztok(24)])
                 .on('zoom', zoomPan),
             transformed = false,
             panning = false,
             zDiff = 6,    // by default, minimap renders at (main zoom - 6)
-            tStart, tLast, tCurr, kLast, kCurr, tiles, svg, gpx, timeoutId;
-
-        iD.ui.MapInMap.gpxLayer = gpxLayer;
+            tStart, tLast, tCurr, kLast, kCurr, tiles, svg, timeoutId;
 
         function ztok(z) { return 256 * Math.pow(2, z); }
         function ktoz(k) { return Math.log(k) / Math.LN2 - 8; }
@@ -155,6 +152,7 @@ iD.ui.MapInMap = function(context) {
             background
                 .call(backgroundLayer);
 
+
             // redraw overlay
             var overlaySources = context.background().overlayLayerSources();
             var activeOverlayLayers = [];
@@ -188,20 +186,20 @@ iD.ui.MapInMap = function(context) {
             overlays.exit()
                 .remove();
 
-            // redraw gpx overlay
-            gpxLayer
-                .projection(projection);
 
-            gpx = tiles
+            var gpx = tiles
                 .selectAll('.map-in-map-gpx')
-                .data([0]);
+                .data(gpxLayer.enabled() ? [0] : []);
 
             gpx.enter()
-                .append('div')
+                .append('svg')
                 .attr('class', 'map-in-map-gpx');
 
+            gpx.exit()
+                .remove();
+
             gpx.call(gpxLayer);
-            gpx.dimensions(dMini);
+
 
             // redraw bounding box
             if (!panning) {

--- a/js/id/ui/map_in_map.js
+++ b/js/id/ui/map_in_map.js
@@ -2,11 +2,10 @@ iD.ui.MapInMap = function(context) {
     var key = '/';
 
     function map_in_map(selection) {
-
         var backgroundLayer = iD.TileLayer(),
             overlayLayers = {},
             dispatch = d3.dispatch('change'),
-            gpxLayer = iD.GpxLayer(context, dispatch),
+            gpxLayer = iD.svg.Gpx(context, dispatch),
             projection = iD.geo.RawMercator(),
             zoom = d3.behavior.zoom()
                 .scaleExtent([ztok(0.5), ztok(24)])

--- a/js/id/ui/preset/restrictions.js
+++ b/js/id/ui/preset/restrictions.js
@@ -7,21 +7,19 @@ iD.ui.preset.restrictions = function(field, context) {
         var wrap = selection.selectAll('.preset-input-wrap')
             .data([0]);
 
-        var enter = wrap.enter().append('div')
+        var enter = wrap.enter()
+            .append('div')
             .attr('class', 'preset-input-wrap');
 
-        enter.append('div')
+        enter
+            .append('div')
             .attr('class', 'restriction-help');
 
-        enter.append('svg')
-            .call(iD.svg.Surface(context))
-            .call(iD.behavior.Hover(context));
 
         var intersection = iD.geo.Intersection(context.graph(), vertexID),
             graph = intersection.graph,
             vertex = graph.entity(vertexID),
-            surface = wrap.selectAll('svg'),
-            filter = function () { return true; },
+            filter = d3.functor(true),
             extent = iD.geo.Extent(),
             projection = iD.geo.RawMercator(),
             lines = iD.svg.Lines(projection, context),
@@ -30,7 +28,7 @@ iD.ui.preset.restrictions = function(field, context) {
 
         var d = wrap.dimensions(),
             c = [d[0] / 2, d[1] / 2],
-            z = 21;
+            z = 24;
 
         projection
             .scale(256 * Math.pow(2, z) / (2 * Math.PI));
@@ -40,6 +38,13 @@ iD.ui.preset.restrictions = function(field, context) {
         projection
             .translate([c[0] - s[0], c[1] - s[1]])
             .clipExtent([[0, 0], d]);
+
+        enter
+            .append('svg')
+            .call(iD.svg.Surface(projection, context).only('osm'))
+            .call(iD.behavior.Hover(context));
+
+        var surface = wrap.selectAll('svg');
 
         surface
             .call(vertices, graph, [vertex], filter, extent, z)

--- a/js/id/ui/preset/restrictions.js
+++ b/js/id/ui/preset/restrictions.js
@@ -39,14 +39,17 @@ iD.ui.preset.restrictions = function(field, context) {
             .translate([c[0] - s[0], c[1] - s[1]])
             .clipExtent([[0, 0], d]);
 
+
         enter
-            .append('svg')
-            .call(iD.svg.Surface(projection, context).only('osm'))
+            .call(iD.svg.Surface(projection, context).only('osm').dimensions(d))
+            .select('.surface')
             .call(iD.behavior.Hover(context));
 
-        var surface = wrap.selectAll('svg');
+
+        var surface = wrap.select('.surface');
 
         surface
+            .dimensions(d)
             .call(vertices, graph, [vertex], filter, extent, z)
             .call(lines, graph, intersection.ways, filter)
             .call(turns, graph, intersection.turns(fromNodeID));
@@ -72,7 +75,10 @@ iD.ui.preset.restrictions = function(field, context) {
             .on('change.restrictions', render);
 
         d3.select(window)
-            .on('resize.restrictions', render);
+            .on('resize.restrictions', function() {
+                wrap.dimensions(null);
+                render();
+            });
 
         function click() {
             var datum = d3.event.target.__data__;

--- a/js/id/ui/preset/restrictions.js
+++ b/js/id/ui/preset/restrictions.js
@@ -1,9 +1,17 @@
 iD.ui.preset.restrictions = function(field, context) {
     var dispatch = d3.dispatch('change'),
+        hover = iD.behavior.Hover(context),
         vertexID,
         fromNodeID;
 
+
     function restrictions(selection) {
+        // if form field is hidden or has detached from dom, clean up.
+        if (!d3.select('.inspector-wrap.inspector-hidden').empty() || !selection.node().parentNode) {
+            selection.call(restrictions.off);
+            return;
+        }
+
         var wrap = selection.selectAll('.preset-input-wrap')
             .data([0]);
 
@@ -44,10 +52,10 @@ iD.ui.preset.restrictions = function(field, context) {
         enter
             .call(drawLayers)
             .selectAll('.surface')
-            .call(iD.behavior.Hover(context));
+            .call(hover);
 
 
-        var surface = wrap.select('.surface');
+        var surface = wrap.selectAll('.surface');
 
         surface
             .dimensions(d)
@@ -147,6 +155,20 @@ iD.ui.preset.restrictions = function(field, context) {
 
     restrictions.tags = function() {};
     restrictions.focus = function() {};
+
+    restrictions.off = function(selection) {
+        selection.selectAll('.surface')
+            .call(hover.off)
+            .on('click.restrictions', null)
+            .on('mouseover.restrictions', null)
+            .on('mouseout.restrictions', null);
+
+        context.history()
+            .on('change.restrictions', null);
+
+        d3.select(window)
+            .on('resize.restrictions', null);
+    };
 
     return d3.rebind(restrictions, dispatch, 'on');
 };

--- a/js/id/ui/preset/restrictions.js
+++ b/js/id/ui/preset/restrictions.js
@@ -43,7 +43,7 @@ iD.ui.preset.restrictions = function(field, context) {
 
         enter
             .call(drawLayers)
-            .select('.surface')
+            .selectAll('.surface')
             .call(iD.behavior.Hover(context));
 
 

--- a/js/id/ui/preset/restrictions.js
+++ b/js/id/ui/preset/restrictions.js
@@ -21,10 +21,7 @@ iD.ui.preset.restrictions = function(field, context) {
             vertex = graph.entity(vertexID),
             filter = d3.functor(true),
             extent = iD.geo.Extent(),
-            projection = iD.geo.RawMercator(),
-            lines = iD.svg.Lines(projection, context),
-            vertices = iD.svg.Vertices(projection, context),
-            turns = iD.svg.Turns(projection, context);
+            projection = iD.geo.RawMercator();
 
         var d = wrap.dimensions(),
             c = [d[0] / 2, d[1] / 2],
@@ -39,9 +36,13 @@ iD.ui.preset.restrictions = function(field, context) {
             .translate([c[0] - s[0], c[1] - s[1]])
             .clipExtent([[0, 0], d]);
 
+        var drawLayers = iD.svg.Layers(projection, context).only('osm').dimensions(d),
+            drawVertices = iD.svg.Vertices(projection, context),
+            drawLines = iD.svg.Lines(projection, context),
+            drawTurns = iD.svg.Turns(projection, context);
 
         enter
-            .call(iD.svg.Surface(projection, context).only('osm').dimensions(d))
+            .call(drawLayers)
             .select('.surface')
             .call(iD.behavior.Hover(context));
 
@@ -50,9 +51,9 @@ iD.ui.preset.restrictions = function(field, context) {
 
         surface
             .dimensions(d)
-            .call(vertices, graph, [vertex], filter, extent, z)
-            .call(lines, graph, intersection.ways, filter)
-            .call(turns, graph, intersection.turns(fromNodeID));
+            .call(drawVertices, graph, [vertex], filter, extent, z)
+            .call(drawLines, graph, intersection.ways, filter)
+            .call(drawTurns, graph, intersection.turns(fromNodeID));
 
         surface
             .on('click.restrictions', click)

--- a/js/lib/d3.dimensions.js
+++ b/js/lib/d3.dimensions.js
@@ -1,17 +1,23 @@
 d3.selection.prototype.dimensions = function (dimensions) {
-    if (!arguments.length) {
-        var node = this.node();
-        if (!node) return;
-
-        var prop = this.property('__dimensions__');
-        if (!prop) {
-            var cr = node.getBoundingClientRect();
-            prop = [cr.width, cr.height];
-            this.property('__dimensions__', prop);
-        }
+    var refresh = (function(node) {
+        var cr = node.getBoundingClientRect();
+        prop = [cr.width, cr.height];
+        this.property('__dimensions__', prop);
         return prop;
+    }).bind(this);
+
+    var node = this.node();
+
+    if (!arguments.length) {
+        if (!node) return [0,0];
+        return this.property('__dimensions__') || refresh(node);
+    }
+    if (dimensions === null) {
+        if (!node) return [0,0];
+        return refresh(node);
     }
 
-    this.property('__dimensions__', [dimensions[0], dimensions[1]]);
-    return this.attr({width: dimensions[0], height: dimensions[1]});
+    return this
+        .property('__dimensions__', [dimensions[0], dimensions[1]])
+        .attr({width: dimensions[0], height: dimensions[1]});
 };

--- a/test/index.html
+++ b/test/index.html
@@ -76,7 +76,7 @@
     <script src="../js/id/svg/midpoints.js"></script>
     <script src="../js/id/svg/osm.js"></script>
     <script src="../js/id/svg/points.js"></script>
-    <script src="../js/id/svg/surface.js"></script>
+    <script src="../js/id/svg/layers.js"></script>
     <script src="../js/id/svg/tag_classes.js"></script>
     <script src="../js/id/svg/turns.js"></script>
     <script src="../js/id/svg/vertices.js"></script>

--- a/test/index.html
+++ b/test/index.html
@@ -62,17 +62,17 @@
     <script src='../js/id/renderer/background_source.js'></script>
     <script src='../js/id/renderer/features.js'></script>
     <script src='../js/id/renderer/map.js'></script>
-    <script src='../js/id/renderer/gpx_layer.js'></script>
     <script src='../js/id/renderer/tile_layer.js'></script>
-    <script src='../js/id/renderer/mapillary_image_layer.js'></script>
-    <script src='../js/id/renderer/mapillary_sign_layer.js'></script>
 
     <script src="../js/id/svg.js"></script>
     <script src="../js/id/svg/areas.js"></script>
     <script src="../js/id/svg/defs.js"></script>
+    <script src='../js/id/svg/gpx.js'></script>
     <script src="../js/id/svg/icon.js"></script>
     <script src="../js/id/svg/labels.js"></script>
     <script src="../js/id/svg/lines.js"></script>
+    <script src='../js/id/svg/mapillary_images.js'></script>
+    <script src='../js/id/svg/mapillary_signs.js'></script>
     <script src="../js/id/svg/midpoints.js"></script>
     <script src="../js/id/svg/points.js"></script>
     <script src="../js/id/svg/surface.js"></script>

--- a/test/index.html
+++ b/test/index.html
@@ -74,6 +74,7 @@
     <script src='../js/id/svg/mapillary_images.js'></script>
     <script src='../js/id/svg/mapillary_signs.js'></script>
     <script src="../js/id/svg/midpoints.js"></script>
+    <script src="../js/id/svg/osm.js"></script>
     <script src="../js/id/svg/points.js"></script>
     <script src="../js/id/svg/surface.js"></script>
     <script src="../js/id/svg/tag_classes.js"></script>

--- a/test/rendering.html
+++ b/test/rendering.html
@@ -21,6 +21,7 @@
     <script src="../js/id/svg/icon.js"></script>
     <script src="../js/id/svg/lines.js"></script>
     <script src="../js/id/svg/midpoints.js"></script>
+    <script src="../js/id/svg/osm.js"></script>
     <script src="../js/id/svg/points.js"></script>
     <script src="../js/id/svg/surface.js"></script>
     <script src="../js/id/svg/tag_classes.js"></script>

--- a/test/rendering.html
+++ b/test/rendering.html
@@ -23,7 +23,7 @@
     <script src="../js/id/svg/midpoints.js"></script>
     <script src="../js/id/svg/osm.js"></script>
     <script src="../js/id/svg/points.js"></script>
-    <script src="../js/id/svg/surface.js"></script>
+    <script src="../js/id/svg/layers.js"></script>
     <script src="../js/id/svg/tag_classes.js"></script>
     <script src="../js/id/svg/vertices.js"></script>
 
@@ -147,7 +147,7 @@
             .attr('width', 30)
             .attr('height', 40)
             .attr('data-zoom', function (d) { return d.zoom; })
-            .call(iD.svg.Surface(context))
+            .call(iD.svg.Layers(context))
             .each(function (d) {
                 var n = node.update({tags: d}),
                     graph = iD.Graph([n]);
@@ -215,7 +215,7 @@
             .attr('width', 30)
             .attr('height', 30)
             .attr('data-zoom', function (d) { return d.zoom; })
-            .call(iD.svg.Surface(context))
+            .call(iD.svg.Layers(context))
             .each(function (d) {
                 var n = node.update({tags: d.tags}),
                     graph = iD.Graph([n, way]);
@@ -303,7 +303,7 @@
             .attr('width', 200)
             .attr('height', 30)
             .attr('data-zoom', function (d) { return d.zoom; })
-            .call(iD.svg.Surface(context))
+            .call(iD.svg.Layers(context))
             .each(function (d) {
                 var highway = way.update({tags: d.tags}),
                     graph = iD.Graph([a, b, highway]);
@@ -365,7 +365,7 @@
             .append('svg')
             .attr('width', 100)
             .attr('height', 100)
-            .call(iD.svg.Surface(context))
+            .call(iD.svg.Layers(context))
             .each(function (datum) {
                 var area = way.update({tags: datum.tags}),
                     graph = iD.Graph([a, b, c, d, area]);

--- a/test/spec/behavior/select.js
+++ b/test/spec/behavior/select.js
@@ -15,7 +15,7 @@ describe("iD.behavior.Select", function() {
             .append('div')
             .attr('class', 'inspector-wrap');
 
-        context.surface().selectAll('circle')
+        context.surface().select('.data-layer-osm').selectAll('circle')
             .data([a, b])
             .enter().append('circle')
             .attr('class', function(d) { return d.id; });
@@ -33,7 +33,7 @@ describe("iD.behavior.Select", function() {
     });
 
     specify("click on entity selects the entity", function() {
-        happen.click(context.surface().select('.' + a.id).node());
+        happen.click(context.surface().selectAll('.' + a.id).node());
         expect(context.selectedIDs()).to.eql([a.id]);
     });
 
@@ -45,19 +45,19 @@ describe("iD.behavior.Select", function() {
 
     specify("shift-click on unselected entity adds it to the selection", function() {
         context.enter(iD.modes.Select(context, [a.id]));
-        happen.click(context.surface().select('.' + b.id).node(), {shiftKey: true});
+        happen.click(context.surface().selectAll('.' + b.id).node(), {shiftKey: true});
         expect(context.selectedIDs()).to.eql([a.id, b.id]);
     });
 
     specify("shift-click on selected entity removes it from the selection", function() {
         context.enter(iD.modes.Select(context, [a.id, b.id]));
-        happen.click(context.surface().select('.' + b.id).node(), {shiftKey: true});
+        happen.click(context.surface().selectAll('.' + b.id).node(), {shiftKey: true});
         expect(context.selectedIDs()).to.eql([a.id]);
     });
 
     specify("shift-click on last selected entity clears the selection", function() {
         context.enter(iD.modes.Select(context, [a.id]));
-        happen.click(context.surface().select('.' + a.id).node(), {shiftKey: true});
+        happen.click(context.surface().selectAll('.' + a.id).node(), {shiftKey: true});
         expect(context.mode().id).to.eql('browse');
     });
 

--- a/test/spec/svg/areas.js
+++ b/test/spec/svg/areas.js
@@ -7,7 +7,7 @@ describe("iD.svg.Areas", function () {
 
     beforeEach(function () {
         surface = d3.select(document.createElementNS('http://www.w3.org/2000/svg', 'svg'))
-            .call(iD.svg.Surface(iD()));
+            .call(iD.svg.Layers(iD()));
     });
 
     it("adds way and area classes", function () {

--- a/test/spec/svg/lines.js
+++ b/test/spec/svg/lines.js
@@ -7,7 +7,7 @@ describe("iD.svg.Lines", function () {
 
     beforeEach(function () {
         surface = d3.select(document.createElementNS('http://www.w3.org/2000/svg', 'svg'))
-            .call(iD.svg.Surface(iD()));
+            .call(iD.svg.Layers(iD()));
     });
 
     it("adds way and line classes", function () {

--- a/test/spec/svg/midpoints.js
+++ b/test/spec/svg/midpoints.js
@@ -7,7 +7,7 @@ describe("iD.svg.Midpoints", function () {
     beforeEach(function () {
         context = iD();
         surface = d3.select(document.createElementNS('http://www.w3.org/2000/svg', 'svg'))
-            .call(iD.svg.Surface(context));
+            .call(iD.svg.Layers(context));
     });
 
     it("creates midpoint on segment completely within the extent", function () {

--- a/test/spec/svg/points.js
+++ b/test/spec/svg/points.js
@@ -6,7 +6,7 @@ describe("iD.svg.Points", function () {
     beforeEach(function () {
         context = iD().presets(iD.data.presets);
         surface = d3.select(document.createElementNS('http://www.w3.org/2000/svg', 'svg'))
-            .call(iD.svg.Surface(context));
+            .call(iD.svg.Layers(context));
     });
 
     it("adds tag classes", function () {

--- a/test/spec/svg/points.js
+++ b/test/spec/svg/points.js
@@ -10,9 +10,10 @@ describe("iD.svg.Points", function () {
     });
 
     it("adds tag classes", function () {
-        var point = iD.Node({tags: {amenity: "cafe"}, loc: [0, 0]});
+        var point = iD.Node({tags: {amenity: "cafe"}, loc: [0, 0]}),
+            graph = iD.Graph([point]);
 
-        surface.call(iD.svg.Points(projection, context), [point]);
+        surface.call(iD.svg.Points(projection, context), graph, [point]);
 
         expect(surface.select('.point')).to.be.classed('tag-amenity');
         expect(surface.select('.point')).to.be.classed('tag-amenity-cafe');

--- a/test/spec/svg/vertices.js
+++ b/test/spec/svg/vertices.js
@@ -6,7 +6,7 @@ describe("iD.svg.Vertices", function () {
     beforeEach(function () {
         context = iD();
         surface = d3.select(document.createElementNS('http://www.w3.org/2000/svg', 'svg'))
-            .call(iD.svg.Surface(context));
+            .call(iD.svg.Layers(context));
     });
 
     it("adds the .shared class to vertices that are members of two or more ways", function () {


### PR DESCRIPTION
This primarily addresses #2994 but also eliminates bunch of accumulated technical debt.

* `iD.svg.Surface` is now `iD.svg.Layers` and provides access to whatever vector layers we want to draw on top of the raster tiles.
* layers can be dynamically added or removed, or I suppose reordered if you want to get crazy.
* `iD.Background` now draws just the background and nothing else

Why now? 
Because Mapillary proved how useful it is to draw data layers on top of the OSM data, and we want anyone else to be able to do that cleanly (not by hacking up `iD.Background`).   Next stop: OSM notes.

As simple as shuffling some layers around seems, this is in fact a big nasty refactor, but I'm feeling ok about it.  I'm going to do a bunch of editing with it tonight and see if anything else is terribly broken.

There are a few other low hanging performance/usability things I'll probably sneak in:
- [X] The turn restrictions editor should go away when it's not visible.  Or at least, stop listening to history change and mousemove events and redrawing to its secret svg surface. a866856

- [ ] ~~When dragging POI markers, they jump slightly when you start to drag them.  So we probably need to adjust the drag origin so that it matches the pointy part of the marker, not the center.~~  Just realized this is broken in master, not something I broke in the refactor, so tracking on a new issue #3003 

- [X] Make sure radial menu ~~position gets updated~~ immediately goes away when resetting the surface transform.  It currently does a funny thing: dragging makes the menu transition away, but if you do a quick drag and the surface has time to redraw, you can see it flicker to the wrong place just before it disappears. 34901d1