### PR TITLE
Preventing the jumping of point markers

### DIFF
--- a/js/id/modes/drag_node.js
+++ b/js/id/modes/drag_node.js
@@ -8,6 +8,7 @@ iD.modes.DragNode = function(context) {
         activeIDs,
         wasMidpoint,
         cancelled,
+        nodeOffset,
         selectedIDs = [],
         hover = iD.behavior.Hover(context)
             .altDisables(true)
@@ -103,6 +104,12 @@ iD.modes.DragNode = function(context) {
         var loc = context.map().mouseCoordinates();
 
         var d = datum();
+
+        // save the offset as difference between loc and d.loc during start of drag
+        nodeOffset = nodeOffset || [loc[0] - d.loc[0], loc[1] - d.loc[1]];
+        // use this offset to prevent jumping of POI marker (node)
+        loc = [loc[0] - nodeOffset[0], loc[1] - nodeOffset[1]];
+
         if (d.type === 'node' && d.id !== entity.id) {
             loc = d.loc;
         } else if (d.type === 'way' && !d3.select(d3.event.sourceEvent.target).classed('fill')) {


### PR DESCRIPTION
In this patch, I am saving the difference between mouse coordinates and the node.
and then using this offset to compensate for jumping.

However, I am not really sure whether to put it before or after the `if else` clause in the subsequent lines.

**drag_node.js: 112**
``` Javascript
if (d.type === 'node' && d.id !== entity.id) {
    loc = d.loc;
} else if (d.type === 'way' && !d3.select(d3.event.sourceEvent.target).classed('fill')) {
    loc = iD.geo.chooseEdge(context.childNodes(d), context.mouse(), context.projection).loc;
}
```

Are there any edge cases I should look into?