### PR TITLE
FAQ.md: api url config in standalone iD

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -53,7 +53,7 @@ and [configure](https://github.com/openstreetmap/openstreetmap-website/blob/mast
 an instance of the Rails Port, the server that runs the OpenStreetMap website and API.
 
 Once you have the Rails Port running, you may edit as normal using the version of iD that
-is bundled with it. Your changes will be saved to your own database.
+is bundled with it. Your changes will be saved to your own database. To use a standalone iD with your own api, you may edit the [connection.js](https://github.com/openstreetmap/iD/blob/master/js/id/core/connection.js) file.
 
 Depending on your requirements, you may also want to set up [cgimap](https://github.com/openstreetmap/cgimap)
 and/or a tile rendering stack, but neither of these are required for editing with iD.


### PR DESCRIPTION
It took me a while to find it out. I guessed it would be in a separete config file, but it wasnt.

btw, I really wonder, how is the API url set up in the embeded iD in ruby-port. It uses correctly the my own server. Do you know how? :)