### PR TITLE
Fix member argument to ChangeMember when using raw member editor

### DIFF
--- a/js/id/ui/raw_member_editor.js
+++ b/js/id/ui/raw_member_editor.js
@@ -8,8 +8,9 @@ iD.ui.RawMemberEditor = function(context) {
 
     function changeRole(d) {
         var role = d3.select(this).property('value');
+        var member = {id: d.id, type: d.type, role: role};
         context.perform(
-            iD.actions.ChangeMember(d.relation.id, _.extend({}, d.id, {role: role}), d.index),
+            iD.actions.ChangeMember(d.relation.id, member, d.index),
             t('operations.change_role.annotation'));
     }
 
@@ -31,6 +32,7 @@ iD.ui.RawMemberEditor = function(context) {
             memberships.push({
                 index: index,
                 id: member.id,
+                type: member.type,
                 role: member.role,
                 relation: entity,
                 member: context.hasEntity(member.id)


### PR DESCRIPTION
There is a nasty bug when using the Raw Member Editor to set the "role" of a relation member.  The `member` argument to `iD.actions.ChangeMember` was constructed wrong, causing the relation to become corrupted. 

I'm not 100% sure that this caused https://github.com/openstreetmap/iD/issues/2739#issuecomment-210112137 but it seems possible.

:eyes: @jfirebaugh 
