### PR TITLE
add a warning to the changeset page if a user mentions google

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -206,6 +206,8 @@ en:
     created: Created
     about_changeset_comments: About changeset comments
     about_changeset_comments_link: //wiki.openstreetmap.org/wiki/Good_changeset_comments
+    google_warning: "You mentioned Google in this comment: remember that copying from Google Maps is strictly forbidden."
+    google_warning_link: http://www.openstreetmap.org/copyright
   contributors:
     list: "Edits by {users}"
     truncated_list: "Edits by {users} and {count} others"

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -253,7 +253,9 @@
         "deleted": "Deleted",
         "created": "Created",
         "about_changeset_comments": "About changeset comments",
-        "about_changeset_comments_link": "//wiki.openstreetmap.org/wiki/Good_changeset_comments"
+        "about_changeset_comments_link": "//wiki.openstreetmap.org/wiki/Good_changeset_comments",
+        "google_warning": "You mentioned Google in this comment: remember that copying from Google Maps is strictly forbidden.",
+        "google_warning_link": "http://www.openstreetmap.org/copyright"
     },
     "contributors": {
         "list": "Edits by {users}",

--- a/js/id/ui/commit.js
+++ b/js/id/ui/commit.js
@@ -40,6 +40,8 @@ iD.ui.Commit = function(context) {
             .property('value', context.storage('comment') || '')
             .on('input.save', enableDisableSaveButton)
             .on('change.save', enableDisableSaveButton)
+            .on('input.save', detectForClippy)
+            .on('change.save', detectForClippy)
             .on('blur.save', function() {
                 context.storage('comment', this.value);
             });
@@ -47,6 +49,22 @@ iD.ui.Commit = function(context) {
         function enableDisableSaveButton() {
             d3.selectAll('.save-section .save-button')
                 .attr('disabled', (this.value.length ? null : true));
+        }
+
+        function detectForClippy() {
+           var googleWarning = clippyArea
+             .html('')
+             .selectAll('a')
+             .data(this.value.match(/google/i) ? [true] : []);
+            googleWarning.exit().remove();
+            googleWarning.enter()
+             .append('a')
+             .attr('target', '_blank')
+             .attr('tabindex', -1)
+             .call(iD.svg.Icon('#icon-alert', 'inline'))
+             .attr('href', t('commit.google_warning_link'))
+             .append('span')
+             .text(t('commit.google_warning'));
         }
 
         commentField.node().select();
@@ -67,6 +85,10 @@ iD.ui.Commit = function(context) {
 
             commentField.call(d3.combobox().data(comments));
         });
+
+        var clippyArea = commentSection.append('div')
+            .attr('class', 'clippy-area');
+
 
         var changeSetInfo = commentSection.append('div')
             .attr('class', 'changeset-info');
@@ -251,6 +273,11 @@ iD.ui.Commit = function(context) {
                         .suppressMenu(true));
             }
         }
+
+        // Call the enableDisableSaveButton and detectForClippy methods
+        // off the bat, in case a changeset comment is recovered from
+        // localStorage
+        commentField.trigger('input');
     }
 
     return d3.rebind(commit, dispatch, 'on');


### PR DESCRIPTION
![google](https://cloud.githubusercontent.com/assets/32314/14558141/5ef38330-031e-11e6-8fdf-62ec30993548.gif)

Fixes #3063

This moves a check that's very common in our post-changeset validation up before the user even makes the mistake. This _doesn't_ prevent the user from saving the changeset yet. We may want to do that in a second pass, but there are innocuous ways to mention Google, like "This feature isn't in Google Maps, but it does exist.", so blocking save entirely is probably _too_ strong.

cc @geohacker @bhousel for the review