### PR TITLE
Look up languages by English or local names [closes #3023]

### DIFF
--- a/js/id/ui/preset/localized.js
+++ b/js/id/ui/preset/localized.js
@@ -127,7 +127,7 @@ iD.ui.preset.localized = function(field, context) {
         innerWrap.attr('class', 'entry')
             .each(function() {
                 var wrap = d3.select(this);
-                var langcombo = d3.combobox().fetcher(fetcher);
+                var langcombo = d3.combobox().fetcher(fetcher).minItems(0);
 
                 var label = wrap.append('label')
                     .attr('class','form-label')


### PR DESCRIPTION
This was partly implemented on the placenames feature (adding a placename in "Chinese" shows you a list of localized options such as 中文)

The issue is that the box closes if it falls below d3.combobox minItems threshold . So if you start typing "ta" for Tamil, you will see many results whose English names contain "ta" (Tibetan at the top, Tamil close to the bottom if you scroll down). When you type "tam", there is only one matching option, so the combobox hides and your string cannot be completed.

This PR sets the minItems to zero, so you will see தமிழ் left over. If there are no results, the box will disappear.  Fix for #3023