### PR TITLE
Add right-to-left language layout to CSS

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -3399,6 +3399,16 @@ img.tile-removing {
   border-radius: 3px 0 0 3px;
 }
 
+/* search */
+[dir='rtl'] .feature-list-item .label {
+  text-align: right;
+}
+
+[dir='rtl'] .feature-list-item .entity-name {
+  padding-left: 0;
+  padding-right: 10px;
+}
+
 /* preset form */
 [dir='rtl'] .form-label {
   padding: 5px 10px 5px 0;

--- a/css/app.css
+++ b/css/app.css
@@ -3318,8 +3318,6 @@ img.tile-removing {
     margin: auto;
 }
 
-/* Mapillary
-------------------------------------------------------- */
 .mapillary-wrap {
     position: absolute;
     bottom: 30px;
@@ -3357,4 +3355,286 @@ img.tile-removing {
 
 .mly-wrapper.active {
   visibility: visible;
+
+/* Right-to-left localization settings */
+
+/* sidebar */
+[dir='rtl'] #sidebar {
+  float: right;
+}
+
+#sidebar .search-header .icon {
+  left: auto;
+  right: 10px;
+}
+
+/* header */
+[dir='rtl'] .header h3 {
+  text-align: right;
+  padding: 20px 40px 20px 20px;
+}
+
+[dir='rtl'] .entity-editor-pane .header button.preset-choose {
+  left: auto;
+  right: 0;
+}
+
+[dir='rtl'] .entity-editor-pane .header button.preset-close, [dir='rtl'] .preset-list-pane .header button.preset-choose {
+  left: 0;
+  right: auto;
+}
+
+[dir='rtl'] .map-data-control .layer-list button, [dir='rtl'] .background-control .layer-list button {
+  float: left;
+  border-left: none;
+  border-right: 1px solid #CCC;
+}
+
+[dir='rtl'] .map-data-control .layer-list button:first-of-type, [dir='rtl'] .background-control .layer-list button:first-of-type {
+  border-radius: 3px 0 0 3px;
+}
+
+/* preset form */
+[dir='rtl'] .form-label {
+  padding: 5px 10px 5px 0;
+}
+
+[dir='rtl'] .form-label button {
+  border-left: none;
+  border-right: 1px solid #CCC;
+}
+
+[dir='rtl'] .more-fields label {
+  padding: 5px 0 5px 10px;
+}
+
+[dir='rtl'] .form-label-button-wrap {
+  text-align: left;
+}
+
+[dir='rtl'] button.minor {
+  left: 0;
+  right: auto;
+}
+
+[dir='rtl'] .form-field .localized-main {
+  padding-left: 10%;
+  padding-right: 10px;
+}
+
+[dir='rtl'] .combobox-caret {
+  margin-left: 0;
+  margin-right: -30px;
+}
+
+[dir='rtl'] .form-field .button-input-action {
+  margin-left: 0;
+  margin-right: -10%;
+}
+
+[dir='rtl'] .icon.pre-text {
+  margin-left: 3px;
+  margin-right: 0;
+}
+
+[dir='rtl'] .notice .zoom-to .icon {
+  margin-left: 10px;
+  margin-right: 0;
+}
+
+[dir='rtl'] .preset-list-button .label {
+  text-align: right;
+  left: 0;
+  right: 60px;
+  border-left: none;
+  border-right: 1px solid rgba(0, 0, 0, .1);
+  border-radius: 3px 0 0 3px;
+}
+
+[dir='rtl'] .preset-icon-frame {
+  left: auto;
+  right: 7px;
+}
+
+[dir='rtl'] .preset-list-item button.tag-reference-button {
+  left: 0;
+  right: auto;
+  border-radius: 3px 0 0 3px;
+}
+
+[dir='rtl'] .preset-list-button-wrap .preset-icon {
+  left: auto;
+  right: auto;
+}
+
+[dir='rtl'] .preset-list-button-wrap .preset-icon-32 {
+  right: 13px;
+}
+
+[dir='rtl'] .form-field .maxspeed-unit {
+  border-radius: 0 0 0 4px;
+}
+
+[dir='rtl'] input[type="checkbox"], [dir='rtl'] input[type="radio"] {
+  float: right;
+  margin-left: 5px;
+  margin-right: 0;
+}
+
+[dir='rtl'] .preset-input-wrap .col6 {
+  float: right;
+}
+
+/* tags form */
+[dir='rtl'] .tag-row .key-wrap, [dir='rtl'] .tag-row .input-wrap-position {
+  float: right;
+}
+
+[dir='rtl'] .tag-row input {
+  border-left: none;
+  border-right: 1px solid #CCC;
+}
+
+[dir='rtl'] .tag-row:first-child input.key {
+  border-top-left-radius: 0;
+  border-top-right-radius: 4px;
+}
+
+[dir='rtl'] .tag-row button {
+  left: 10%;
+  border-left-width: 1px;
+}
+
+[dir='rtl'] .tag-row .tag-reference-button {
+  left: auto;
+  right: auto;
+  margin-right: 35px;
+  border-left-width: 1px;
+  border-right-width: 0;
+}
+
+[dir='rtl'] .tag-row:first-child .tag-reference-button {
+  border-top-left-radius: 4px;
+  border-top-right-radius: 0;
+}
+
+[dir='rtl'] .tag-row:last-child .tag-reference-button {
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 0;
+}
+
+/* map control buttons */
+[dir='rtl'] .map-controls {
+  left: 0;
+  right: auto;
+}
+
+[dir='rtl'] .background-control button, [dir='rtl'] .zoombuttons button.zoom-in {
+  border-radius: 0 4px 0 0;
+}
+
+[dir='rtl'] .help-control button, [dir='rtl'] .geolocate-control button {
+  border-radius: 0 0 4px 0;
+}
+
+/* map control button overlays */
+[dir='rtl'] .map-overlay {
+  padding: 20px 20px 20px 50px;
+  left: 0;
+  right: auto !important;
+}
+
+[dir='rtl'] .opacity-options {
+  left: 50px;
+  right: auto;
+}
+
+[dir='rtl'] .hide-toggle {
+  padding-left: 0;
+  padding-right: 12px;
+}
+
+[dir='rtl'] .hide-toggle:before {
+  left: auto;
+  right: 0;
+  border-left: none;
+  border-right: 8px solid #7092ff;
+}
+
+[dir='rtl'] .hide-toggle.expanded:before {
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+}
+
+/* navbar */
+[dir='rtl'] #bar .spacer, [dir='rtl'] #bar .button-wrap, [dir='rtl'] #bar .button-wrap button {
+  float: right;
+}
+
+[dir='rtl'] .add-point .tooltip {
+  left: inherit !important;
+}
+
+[dir='rtl'] .button-wrap:last-of-type {
+  padding-left: 0;
+  padding-right: 10px;
+}
+
+[dir='rtl'] button.save.has-count .count {
+  margin-left: auto;
+  margin-right: 8%;
+}
+
+[dir='rtl'] button.save.has-count .count::before {
+  border-left: 6px solid rgba(255,255,255,.5);
+  border-right: none;
+  left: auto;
+  right: -6px;
+}
+
+[dir='rtl'] .joined button {
+  border-left: 1px solid rgba(0,0,0,.5);
+  border-right: none;
+}
+
+[dir='rtl'] .joined button:first-child {
+  border-radius: 0 4px 4px 0;
+}
+
+[dir='rtl'] .joined button:last-child {
+  border-radius: 4px 0 0 4px;
+}
+
+/* footer */
+[dir='rtl'] #scale-block {
+  float: right;
+  clear: right;
+}
+
+[dir='rtl'] #info-block {
+  clear: left;
+}
+
+[dir='rtl'] #about-list {
+  text-align: left;
+  clear: left;
+  margin-left: 10px;
+  margin-right: 0;
+}
+
+[dir='rtl'] #about-list li {
+  float: left;
+  border-left: none;
+  border-right: 1px solid rgba(255,255,255,.5);
+  margin-left: 0;
+  margin-right: 5px;
+  padding: 5px 5px 5px 0;
+}
+
+[dir='rtl'] #about-list li:last-child {
+  border-right: none;
+}
+
+[dir='rtl'] #scale text {
+  text-anchor: end;
 }

--- a/css/app.css
+++ b/css/app.css
@@ -3384,6 +3384,11 @@ img.tile-removing {
   right: auto;
 }
 
+[dir='rtl'] .preset-icon-fill-area {
+  left: auto;
+  right: 10px;
+}
+
 [dir='rtl'] .map-data-control .layer-list button, [dir='rtl'] .background-control .layer-list button {
   float: left;
   border-left: none;

--- a/css/app.css
+++ b/css/app.css
@@ -3537,6 +3537,10 @@ img.tile-removing {
   border-radius: 0 0 4px 0;
 }
 
+[dir='rtl'] .geolocate-control button svg, [dir='rtl'] .list-item-gpx-browse svg {
+  transform: rotateY(180deg);
+}
+
 /* map control button overlays */
 [dir='rtl'] .map-overlay {
   padding: 20px 20px 20px 50px;

--- a/css/app.css
+++ b/css/app.css
@@ -3647,3 +3647,20 @@ img.tile-removing {
 [dir='rtl'] #scale text {
   text-anchor: end;
 }
+
+/* increment / decrement control - code by Naoufel Razouane */
+
+[dir='rtl'] .spin-control{
+  margin-left: 0;
+  margin-right: -20%;
+}
+[dir='rtl'] .spin-control button{
+  border-left: 0;
+  border-right: 1px solid #CCC;
+}
+[dir='rtl'] .spin-control button.decrement{
+  border-bottom-right-radius: 0;
+}
+[dir='rtl'] .spin-control button.increment{
+  border-bottom-left-radius: 3px;
+}

--- a/css/app.css
+++ b/css/app.css
@@ -3355,15 +3355,15 @@ img.tile-removing {
 
 .mly-wrapper.active {
   visibility: visible;
+}
 
 /* Right-to-left localization settings */
 
-/* sidebar */
 [dir='rtl'] #sidebar {
   float: right;
 }
 
-#sidebar .search-header .icon {
+[dir='rtl'] #sidebar .search-header .icon {
   left: auto;
   right: 10px;
 }
@@ -3542,7 +3542,7 @@ img.tile-removing {
   border-radius: 0 0 4px 0;
 }
 
-[dir='rtl'] .geolocate-control button svg, [dir='rtl'] .list-item-gpx-browse svg {
+[dir='rtl'] .list-item-gpx-browse svg {
   transform: rotateY(180deg);
 }
 

--- a/modules/ui/background.js
+++ b/modules/ui/background.js
@@ -378,7 +378,8 @@ export function uiBackground(context) {
         /* background switcher */
 
         var backgroundList = content.append('ul')
-            .attr('class', 'layer-list');
+            .attr('class', 'layer-list')
+            .attr('dir', 'auto');
 
         var custom = backgroundList.append('li')
             .attr('class', 'custom_layer')

--- a/modules/ui/background.js
+++ b/modules/ui/background.js
@@ -1,7 +1,7 @@
 import * as d3 from 'd3';
 import _ from 'lodash';
 import { d3keybinding } from '../lib/d3.keybinding.js';
-import { t } from '../util/locale';
+import { t, textDirection } from '../util/locale';
 import { rendererBackgroundSource } from '../renderer/index';
 import { geoMetersToOffset, geoOffsetToMeters } from '../geo/index';
 import { utilDetect } from '../util/detect';
@@ -150,7 +150,7 @@ export function uiBackground(context) {
                 .attr('class', 'best')
                 .call(tooltip()
                     .title(t('background.best_imagery'))
-                    .placement((iD.detect().textDirection === 'rtl') ? 'right' : 'left'))
+                    .placement((textDirection === 'rtl') ? 'right' : 'left'))
                 .append('span')
                 .html('&#9733;');
 
@@ -337,7 +337,7 @@ export function uiBackground(context) {
         var content = selection.append('div')
                 .attr('class', 'fillL map-overlay col3 content hide'),
             tooltipBehavior = tooltip()
-                .placement((iD.detect().textDirection === 'rtl') ? 'right' : 'left')
+                .placement((textDirection === 'rtl') ? 'right' : 'left')
                 .html(true)
                 .title(uiTooltipHtml(t('background.description'), key)),
             button = selection.append('button')
@@ -369,7 +369,7 @@ export function uiBackground(context) {
             .on('click.set-opacity', setOpacity)
             .html('<div class="select-box"></div>')
             .call(tooltip()
-                .placement((iD.detect().textDirection === 'rtl') ? 'right' : 'left'))
+                .placement((textDirection === 'rtl') ? 'right' : 'left'))
             .append('div')
             .attr('class', 'opacity')
             .style('opacity', function(d) { return 1.25 - d; });
@@ -388,7 +388,7 @@ export function uiBackground(context) {
             .attr('class', 'layer-browse')
             .call(tooltip()
                 .title(t('background.custom_button'))
-                .placement((iD.detect().textDirection === 'rtl') ? 'right' : 'left'))
+                .placement((textDirection === 'rtl') ? 'right' : 'left'))
             .on('click', editCustom)
             .call(svgIcon('#icon-search'));
 
@@ -498,7 +498,7 @@ export function uiBackground(context) {
             .attr('class', 'nudge-reset disabled')
             .on('click', resetOffset)
             .call(
-              (iD.detect().textDirection === 'rtl') ? svgIcon('#icon-redo') : svgIcon('#icon-undo')
+                (textDirection === 'rtl') ? svgIcon('#icon-redo') : svgIcon('#icon-undo')
             );
 
         context.map()

--- a/modules/ui/background.js
+++ b/modules/ui/background.js
@@ -150,7 +150,7 @@ export function uiBackground(context) {
                 .attr('class', 'best')
                 .call(tooltip()
                     .title(t('background.best_imagery'))
-                    .placement('left'))
+                    .placement((iD.detect().textDirection === 'rtl') ? 'right' : 'left'))
                 .append('span')
                 .html('&#9733;');
 
@@ -337,7 +337,7 @@ export function uiBackground(context) {
         var content = selection.append('div')
                 .attr('class', 'fillL map-overlay col3 content hide'),
             tooltipBehavior = tooltip()
-                .placement('left')
+                .placement((iD.detect().textDirection === 'rtl') ? 'right' : 'left')
                 .html(true)
                 .title(uiTooltipHtml(t('background.description'), key)),
             button = selection.append('button')
@@ -369,7 +369,7 @@ export function uiBackground(context) {
             .on('click.set-opacity', setOpacity)
             .html('<div class="select-box"></div>')
             .call(tooltip()
-                .placement('left'))
+                .placement((iD.detect().textDirection === 'rtl') ? 'right' : 'left'))
             .append('div')
             .attr('class', 'opacity')
             .style('opacity', function(d) { return 1.25 - d; });
@@ -388,7 +388,7 @@ export function uiBackground(context) {
             .attr('class', 'layer-browse')
             .call(tooltip()
                 .title(t('background.custom_button'))
-                .placement('left'))
+                .placement((iD.detect().textDirection === 'rtl') ? 'right' : 'left'))
             .on('click', editCustom)
             .call(svgIcon('#icon-search'));
 

--- a/modules/ui/background.js
+++ b/modules/ui/background.js
@@ -497,7 +497,9 @@ export function uiBackground(context) {
             .attr('title', t('background.reset'))
             .attr('class', 'nudge-reset disabled')
             .on('click', resetOffset)
-            .call(svgIcon('#icon-undo'));
+            .call(
+              (iD.detect().textDirection === 'rtl') ? svgIcon('#icon-redo') : svgIcon('#icon-undo')
+            );
 
         context.map()
             .on('move.background-update', _.debounce(update, 1000));

--- a/modules/ui/entity_editor.js
+++ b/modules/ui/entity_editor.js
@@ -46,7 +46,7 @@ export function uiEntityEditor(context) {
             .attr('class', 'fl preset-reset preset-choose')
             .on('click', function() { dispatch.call('choose', this, activePreset); })
             .append('span')
-            .html('&#9668;');
+            .html((iD.detect().textDirection === 'rtl') ? '&#9658;' : '&#9668;');
 
         enter
             .append('button')

--- a/modules/ui/entity_editor.js
+++ b/modules/ui/entity_editor.js
@@ -1,6 +1,6 @@
 import * as d3 from 'd3';
 import _ from 'lodash';
-import { t } from '../util/locale';
+import { t, textDirection } from '../util/locale';
 import { tooltip } from '../util/tooltip';
 import { actionChangeTags } from '../actions/index';
 import { modeBrowse } from '../modes/index';
@@ -46,7 +46,7 @@ export function uiEntityEditor(context) {
             .attr('class', 'fl preset-reset preset-choose')
             .on('click', function() { dispatch.call('choose', this, activePreset); })
             .append('span')
-            .html((iD.detect().textDirection === 'rtl') ? '&#9658;' : '&#9668;');
+            .html((textDirection === 'rtl') ? '&#9658;' : '&#9668;');
 
         enter
             .append('button')

--- a/modules/ui/geolocate.js
+++ b/modules/ui/geolocate.js
@@ -54,6 +54,7 @@ export function uiGeolocate(context) {
             .attr('title', t('geolocate.title'))
             .on('click', click)
             .call(svgIcon('#icon-geolocate', 'light'))
-            .call(tooltip().placement('left'));
+            .call(tooltip()
+                .placement((iD.detect().textDirection === 'rtl') ? 'right' : 'left'));
     };
 }

--- a/modules/ui/geolocate.js
+++ b/modules/ui/geolocate.js
@@ -1,4 +1,4 @@
-import { t } from '../util/locale';
+import { t, textDirection } from '../util/locale';
 import { tooltip } from '../util/tooltip';
 import { modeBrowse } from '../modes/index';
 import { geoExtent } from '../geo/index';
@@ -55,6 +55,6 @@ export function uiGeolocate(context) {
             .on('click', click)
             .call(svgIcon('#icon-geolocate', 'light'))
             .call(tooltip()
-                .placement((iD.detect().textDirection === 'rtl') ? 'right' : 'left'));
+                .placement((textDirection === 'rtl') ? 'right' : 'left'));
     };
 }

--- a/modules/ui/help.js
+++ b/modules/ui/help.js
@@ -113,7 +113,7 @@ export function uiHelp(context) {
         var pane = selection.append('div')
                 .attr('class', 'help-wrap map-overlay fillL col5 content hide'),
             tooltipBehavior = tooltip()
-                .placement('left')
+                .placement((iD.detect().textDirection === 'rtl') ? 'right' : 'left')
                 .html(true)
                 .title(uiTooltipHtml(t('help.title'), key)),
             button = selection.append('button')

--- a/modules/ui/help.js
+++ b/modules/ui/help.js
@@ -1,7 +1,7 @@
 import * as d3 from 'd3';
 import marked from 'marked';
 import { d3keybinding } from '../lib/d3.keybinding.js';
-import { t } from '../util/locale';
+import { t, textDirection } from '../util/locale';
 import { svgIcon } from '../svg/index';
 import { uiIntro } from './intro/index';
 import { uiTooltipHtml } from './tooltipHtml';
@@ -113,7 +113,7 @@ export function uiHelp(context) {
         var pane = selection.append('div')
                 .attr('class', 'help-wrap map-overlay fillL col5 content hide'),
             tooltipBehavior = tooltip()
-                .placement((iD.detect().textDirection === 'rtl') ? 'right' : 'left')
+                .placement((textDirection === 'rtl') ? 'right' : 'left')
                 .html(true)
                 .title(uiTooltipHtml(t('help.title'), key)),
             button = selection.append('button')

--- a/modules/ui/init.js
+++ b/modules/ui/init.js
@@ -1,6 +1,6 @@
 import * as d3 from 'd3';
 import { d3keybinding } from '../lib/d3.keybinding.js';
-import { t } from '../util/locale';
+import { t, textDirection } from '../util/locale';
 import { tooltip } from '../util/tooltip';
 import { utilDetect } from '../util/detect';
 import { utilSetDimensions } from '../util/dimensions';
@@ -73,11 +73,11 @@ export function uiInit(context) {
         content
             .append('div')
             .attr('id', 'map')
-            .attr('dir', 'auto')
+            .attr('dir', 'ltr')
             .call(map);
 
-        if (iD.detect().textDirection === 'rtl') {
-          d3.select('body').attr('dir', 'rtl');
+        if (textDirection === 'rtl') {
+            d3.select('body').attr('dir', 'rtl');
         }
 
         content

--- a/modules/ui/init.js
+++ b/modules/ui/init.js
@@ -73,7 +73,12 @@ export function uiInit(context) {
         content
             .append('div')
             .attr('id', 'map')
+            .attr('dir', 'auto')
             .call(map);
+
+        if (iD.detect().textDirection === 'rtl') {
+          d3.select('body').attr('dir', 'rtl');
+        }
 
         content
             .call(uiMapInMap(context));
@@ -150,6 +155,7 @@ export function uiInit(context) {
         about
             .append('div')
             .attr('id', 'attrib')
+            .attr('dir', 'ltr')
             .call(uiAttribution(context));
 
         var footer = about

--- a/modules/ui/map_data.js
+++ b/modules/ui/map_data.js
@@ -1,7 +1,7 @@
 import * as d3 from 'd3';
 import _ from 'lodash';
 import { d3keybinding } from '../lib/d3.keybinding.js';
-import { t } from '../util/locale';
+import { t, textDirection } from '../util/locale';
 import { svgIcon } from '../svg/index';
 import { uiTooltipHtml } from './tooltipHtml';
 import { tooltip } from '../util/tooltip';
@@ -216,7 +216,7 @@ export function uiMapData(context) {
                 .attr('class', 'list-item-gpx-extent')
                 .call(tooltip()
                     .title(t('gpx.zoom'))
-                    .placement((iD.detect().textDirection === 'rtl') ? 'right' : 'left'))
+                    .placement((textDirection === 'rtl') ? 'right' : 'left'))
                 .on('click', function() {
                     d3.event.preventDefault();
                     d3.event.stopPropagation();
@@ -229,7 +229,7 @@ export function uiMapData(context) {
                 .attr('class', 'list-item-gpx-browse')
                 .call(tooltip()
                     .title(t('gpx.browse'))
-                    .placement((iD.detect().textDirection === 'rtl') ? 'right' : 'left'))
+                    .placement((textDirection === 'rtl') ? 'right' : 'left'))
                 .on('click', function() {
                     d3.select(document.createElement('input'))
                         .attr('type', 'file')
@@ -388,7 +388,7 @@ export function uiMapData(context) {
                 .append('div')
                 .attr('class', 'fillL map-overlay col3 content hide'),
             tooltipBehavior = tooltip()
-                .placement((iD.detect().textDirection === 'rtl') ? 'right' : 'left')
+                .placement((textDirection === 'rtl') ? 'right' : 'left')
                 .html(true)
                 .title(uiTooltipHtml(t('map_data.description'), key)),
             button = selection

--- a/modules/ui/map_data.js
+++ b/modules/ui/map_data.js
@@ -216,7 +216,7 @@ export function uiMapData(context) {
                 .attr('class', 'list-item-gpx-extent')
                 .call(tooltip()
                     .title(t('gpx.zoom'))
-                    .placement('left'))
+                    .placement((iD.detect().textDirection === 'rtl') ? 'right' : 'left'))
                 .on('click', function() {
                     d3.event.preventDefault();
                     d3.event.stopPropagation();
@@ -229,7 +229,7 @@ export function uiMapData(context) {
                 .attr('class', 'list-item-gpx-browse')
                 .call(tooltip()
                     .title(t('gpx.browse'))
-                    .placement('left'))
+                    .placement((iD.detect().textDirection === 'rtl') ? 'right' : 'left'))
                 .on('click', function() {
                     d3.select(document.createElement('input'))
                         .attr('type', 'file')
@@ -388,7 +388,7 @@ export function uiMapData(context) {
                 .append('div')
                 .attr('class', 'fillL map-overlay col3 content hide'),
             tooltipBehavior = tooltip()
-                .placement('left')
+                .placement((iD.detect().textDirection === 'rtl') ? 'right' : 'left')
                 .html(true)
                 .title(uiTooltipHtml(t('map_data.description'), key)),
             button = selection

--- a/modules/ui/preset.js
+++ b/modules/ui/preset.js
@@ -1,7 +1,7 @@
 import * as d3 from 'd3';
 import _ from 'lodash';
 import { d3combobox } from '../lib/d3.combobox.js';
-import { t } from '../util/locale';
+import { t, textDirection } from '../util/locale';
 import { modeBrowse } from '../modes/index';
 import { svgIcon } from '../svg/index';
 import { uiDisclosure } from './disclosure';
@@ -161,7 +161,7 @@ export function uiPreset(context) {
             .attr('class', 'modified-icon')
             .attr('tabindex', -1)
             .call(
-              (iD.detect().textDirection === 'rtl') ? svgIcon('#icon-redo') : svgIcon('#icon-undo')
+                (textDirection === 'rtl') ? svgIcon('#icon-redo') : svgIcon('#icon-undo')
             );
 
 

--- a/modules/ui/preset.js
+++ b/modules/ui/preset.js
@@ -160,7 +160,9 @@ export function uiPreset(context) {
         wrap.append('button')
             .attr('class', 'modified-icon')
             .attr('tabindex', -1)
-            .call(svgIcon('#icon-undo'));
+            .call(
+              (iD.detect().textDirection === 'rtl') ? svgIcon('#icon-redo') : svgIcon('#icon-undo')
+            );
 
 
         // Update

--- a/modules/ui/preset_list.js
+++ b/modules/ui/preset_list.js
@@ -44,7 +44,7 @@ export function uiPresetList(context) {
                 .attr('class', 'preset-choose')
                 .on('click', function() { dispatch.call('choose', this, currentPreset); })
                 .append('span')
-                .html('&#9658;');
+                .html((iD.detect().textDirection === 'rtl') ? '&#9668;' : '&#9658;');
         } else {
             messagewrap
                 .append('button')

--- a/modules/ui/preset_list.js
+++ b/modules/ui/preset_list.js
@@ -1,7 +1,7 @@
 import * as d3 from 'd3';
 import { utilRebind } from '../util/rebind';
 import { d3keybinding } from '../lib/d3.keybinding.js';
-import { t } from '../util/locale';
+import { t, textDirection } from '../util/locale';
 import { actionChangePreset } from '../actions/index';
 import { operationDelete } from '../operations/index';
 import { modeBrowse } from '../modes/index';
@@ -44,7 +44,7 @@ export function uiPresetList(context) {
                 .attr('class', 'preset-choose')
                 .on('click', function() { dispatch.call('choose', this, currentPreset); })
                 .append('span')
-                .html((iD.detect().textDirection === 'rtl') ? '&#9668;' : '&#9658;');
+                .html((textDirection === 'rtl') ? '&#9668;' : '&#9658;');
         } else {
             messagewrap
                 .append('button')

--- a/modules/ui/undo_redo.js
+++ b/modules/ui/undo_redo.js
@@ -1,6 +1,6 @@
 import * as d3 from 'd3';
 import { d3keybinding } from '../lib/d3.keybinding.js';
-import { t } from '../util/locale';
+import { t, textDirection } from '../util/locale';
 import { svgIcon } from '../svg/index';
 import { uiCmd } from './cmd';
 import { uiTooltipHtml } from './tooltipHtml';
@@ -46,12 +46,12 @@ export function uiUndoRedo(context) {
 
         buttons.each(function(d) {
             var iconName = d.id;
-            if (iD.detect().textDirection === 'rtl') {
-              if (iconName === 'undo') {
-                iconName = 'redo';
-              } else if (iconName === 'redo') {
-                iconName = 'undo';
-              }
+            if (textDirection === 'rtl') {
+                if (iconName === 'undo') {
+                    iconName = 'redo';
+                } else if (iconName === 'redo') {
+                    iconName = 'undo';
+                }
             }
             d3.select(this)
                 .call(svgIcon('#icon-' + iconName));

--- a/modules/ui/undo_redo.js
+++ b/modules/ui/undo_redo.js
@@ -44,11 +44,18 @@ export function uiUndoRedo(context) {
             .on('click', function(d) { return d.action(); })
             .call(tooltipBehavior);
 
-        buttons
-            .each(function(d) {
-                d3.select(this)
-                    .call(svgIcon('#icon-' + d.id));
-            });
+        buttons.each(function(d) {
+            var iconName = d.id;
+            if (iD.detect().textDirection === 'rtl') {
+              if (iconName === 'undo') {
+                iconName = 'redo';
+              } else if (iconName === 'redo') {
+                iconName = 'undo';
+              }
+            }
+            d3.select(this)
+                .call(svgIcon('#icon-' + iconName));
+        });
 
         var keybinding = d3keybinding('undo')
             .on(commands[0].cmd, function() { d3.event.preventDefault(); commands[0].action(); })

--- a/modules/ui/zoom.js
+++ b/modules/ui/zoom.js
@@ -57,7 +57,7 @@ export function uiZoom(context) {
             .attr('class', function(d) { return d.id; })
             .on('click.editor', function(d) { d.action(); })
             .call(tooltip()
-                .placement('left')
+                .placement((iD.detect().textDirection === 'rtl') ? 'right' : 'left')
                 .html(true)
                 .title(function(d) {
                     return uiTooltipHtml(d.title, d.key);

--- a/modules/ui/zoom.js
+++ b/modules/ui/zoom.js
@@ -1,7 +1,7 @@
 import * as d3 from 'd3';
 import _ from 'lodash';
 import { d3keybinding } from '../lib/d3.keybinding.js';
-import { t } from '../util/locale';
+import { t, textDirection } from '../util/locale';
 import { svgIcon } from '../svg/index';
 import { uiCmd } from './cmd';
 import { uiTooltipHtml } from './tooltipHtml';
@@ -57,7 +57,7 @@ export function uiZoom(context) {
             .attr('class', function(d) { return d.id; })
             .on('click.editor', function(d) { d.action(); })
             .call(tooltip()
-                .placement((iD.detect().textDirection === 'rtl') ? 'right' : 'left')
+                .placement((textDirection === 'rtl') ? 'right' : 'left')
                 .html(true)
                 .title(function(d) {
                     return uiTooltipHtml(d.title, d.key);

--- a/modules/util/detect.js
+++ b/modules/util/detect.js
@@ -1,4 +1,4 @@
-import { currentLocale } from './locale';
+import { currentLocale, setTextDirection } from './locale';
 
 export function utilDetect() {
     var detected = {};
@@ -63,6 +63,13 @@ export function utilDetect() {
     if (loadedLocale !== 'en') {
         detected.locale = loadedLocale;
     }
+
+    if (['ar', 'fa', 'iw', 'dv'].indexOf(detected.locale.split('-')[0]) > -1 || window.location.href.indexOf('rtl-test-rtl') > -1) {
+        detected.textDirection = 'rtl';
+    } else {
+        detected.textDirection = 'ltr';
+    }
+    setTextDirection(detected.textDirection);
 
     detected.host = window.location && (window.location.origin + window.location.pathname);
 

--- a/modules/util/locale.js
+++ b/modules/util/locale.js
@@ -1,6 +1,7 @@
 var translations = Object.create(null);
 
 export var currentLocale = 'en';
+export var textDirection = 'ltr';
 
 export function setLocale(_) {
     if (translations[_] !== undefined) {
@@ -46,4 +47,14 @@ export function t(s, o, loc) {
     if (typeof console !== 'undefined') console.error(missing); // eslint-disable-line
 
     return missing;
+}
+
+/**
+ * Given string 'ltr' or 'rtl', save that setting
+ *
+ * @param {string} s ltr or rtl
+ */
+
+export function setTextDirection(dir) {
+    textDirection = dir;
 }

--- a/modules/util/util.js
+++ b/modules/util/util.js
@@ -1,6 +1,6 @@
 import * as d3 from 'd3';
 import _ from 'lodash';
-import { t } from './locale';
+import { t, textDirection } from './locale';
 import { utilDetect } from './detect';
 import { remove as removeDiacritics } from 'diacritics';
 
@@ -174,8 +174,8 @@ export function utilFastMouse(container) {
         rectTop = rect.top,
         clientLeft = +container.clientLeft,
         clientTop = +container.clientTop;
-    if (iD.detect().textDirection === 'rtl') {
-      rectLeft = 0;
+    if (textDirection === 'rtl') {
+        rectLeft = 0;
     }
     return function(e) {
         return [

--- a/modules/util/util.js
+++ b/modules/util/util.js
@@ -174,6 +174,9 @@ export function utilFastMouse(container) {
         rectTop = rect.top,
         clientLeft = +container.clientLeft,
         clientTop = +container.clientTop;
+    if (iD.detect().textDirection === 'rtl') {
+      rectLeft = 0;
+    }
     return function(e) {
         return [
             e.clientX - rectLeft - clientLeft,


### PR DESCRIPTION
Addresses #3007 - right-to-left languages (Arabic and Persian are available in iD editor)

Here's what it looks like (using English locale and ```?rtl-test-rtl``` in the URL)

![screen shot 2016-04-25 at 4 25 01 pm](https://cloud.githubusercontent.com/assets/643918/14801942/740025a8-0b02-11e6-9109-6831dae34eed.png)

I might be missing some tooltips... if someone is an Arabic or Persian speaker and can check this out with the language locale on, that'd be great