### PR TITLE
Indoor mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,6 +196,7 @@ dist/iD.js: \
 	js/id/ui/full_screen.js \
 	js/id/ui/geolocate.js \
 	js/id/ui/help.js \
+	js/id/ui/indoor_mode.js \
 	js/id/ui/info.js \
 	js/id/ui/inspector.js \
 	js/id/ui/intro.js \

--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,7 @@ dist/iD.js: \
 	js/id/renderer/background.js \
 	js/id/renderer/background_source.js \
 	js/id/renderer/features.js \
+	js/id/renderer/indoor.js \
 	js/id/renderer/map.js \
 	js/id/renderer/tile_layer.js \
 	js/id/svg.js \

--- a/Makefile
+++ b/Makefile
@@ -238,6 +238,7 @@ dist/iD.js: \
 	js/id/ui/preset/localized.js \
 	js/id/ui/preset/maxspeed.js \
 	js/id/ui/preset/radio.js \
+	js/id/ui/preset/range.js \
 	js/id/ui/preset/restrictions.js \
 	js/id/ui/preset/textarea.js \
 	js/id/ui/preset/wikipedia.js \

--- a/css/app.css
+++ b/css/app.css
@@ -485,6 +485,12 @@ button.save.has-count .count::before {
     border-right:  6px solid rgba(255,255,255,.5);
 }
 
+.indoormode-level-combo .combobox-input,
+.indoormode-level-combo .combobox-caret {
+    height: 40px;
+    border-radius: 4px 0 0 4px;
+}
+
 /* Icons */
 
 .icon {

--- a/css/app.css
+++ b/css/app.css
@@ -485,10 +485,22 @@ button.save.has-count .count::before {
     border-right:  6px solid rgba(255,255,255,.5);
 }
 
-.indoormode-level-combo .combobox-input,
-.indoormode-level-combo .combobox-caret {
+.indoormode-level-combo .combobox-input {
     height: 40px;
     border-radius: 4px 0 0 4px;
+}
+.indoormode-level-combo .combobox-caret {
+    display: none;
+}
+.indoormode-control .spin-control {
+    height: 40px;
+    width: 41.6666%; /* force .col5 */
+    border-right: 1px solid rgba(0,0,0,.5);
+    margin-left: 0;
+    background: white;
+}
+.indoormode-control .spin-control button {
+    border-right: 0;
 }
 
 /* Icons */

--- a/css/app.css
+++ b/css/app.css
@@ -1071,7 +1071,7 @@ button.save.has-count .count::before {
     border-radius: 0 0 4px 4px;
     overflow: hidden;
 }
-.form-field > input:last-child {
+.form-field > input:nth-child(3) {
     border-left: 0;
 }
 

--- a/css/app.css
+++ b/css/app.css
@@ -1071,6 +1071,9 @@ button.save.has-count .count::before {
     border-radius: 0 0 4px 4px;
     overflow: hidden;
 }
+.form-field > input:last-child {
+    border-left: 0;
+}
 
 .form-field textarea {
     height: 65px;

--- a/css/app.css
+++ b/css/app.css
@@ -488,6 +488,11 @@ button.save.has-count .count::before {
 .indoormode-level-combo .combobox-input {
     height: 40px;
     border-radius: 4px 0 0 4px;
+    font-weight: bold;
+    text-align: center;
+}
+.indoormode-level-combo .combobox-input::-webkit-input-placeholder  {
+    color: #000;
 }
 .indoormode-level-combo .combobox-caret {
     display: none;

--- a/css/map.css
+++ b/css/map.css
@@ -1325,7 +1325,14 @@ path.fill.tag-indoor {
 .indoor-mode path.stroke.tag-indoor {
     stroke: rgb(169, 169, 169);
 }
+.indoor-mode text {
+    display: none;
+}
 
+.indoor-mode use.icon.areaicon.tag-building,
+.indoor-mode text.arealabel.tag-building {
+    display: none;
+}
 
 
 /* Labels / Markers */

--- a/css/map.css
+++ b/css/map.css
@@ -1311,7 +1311,7 @@ path.fill.tag-amenity-shelter {
 path.fill.tag-indoor {
     display: none;
 }
-.indoor-mode path.fill.tag-building {
+.indoor-mode path.fill.tag-building.tag-max_level {
     clip-path: none !important;
     stroke-width: 30px;
 }
@@ -1330,6 +1330,9 @@ path.fill.tag-indoor {
 .indoor-mode text.arealabel-halo.tag-building,
 .indoor-mode text.arealabel-halo.tag-amenity {
     display: none;
+}
+.indoor-mode.indoor-underground .way:not(.tag-level):not(.tag-building) {
+    opacity: 0.1;
 }
 
 

--- a/css/map.css
+++ b/css/map.css
@@ -1306,6 +1306,27 @@ path.fill.tag-amenity-shelter {
     background-color: rgba(224, 110, 95, 0.3);
 }
 
+.indoor-mode path.fill.tag-building {
+    clip-path: none !important;
+    stroke-width: 120px;
+}
+
+
+/* Indoor features */
+path.fill.tag-indoor {
+    display: none;
+}
+
+.indoor-mode path.fill.tag-indoor {
+    display: block;
+    fill: rgba(169, 169, 169, 0.3);
+    stroke-width: 30px;
+}
+.indoor-mode path.stroke.tag-indoor {
+    stroke: rgb(169, 169, 169);
+}
+
+
 
 /* Labels / Markers */
 

--- a/css/map.css
+++ b/css/map.css
@@ -1306,17 +1306,15 @@ path.fill.tag-amenity-shelter {
     background-color: rgba(224, 110, 95, 0.3);
 }
 
-.indoor-mode path.fill.tag-building {
-    clip-path: none !important;
-    stroke-width: 120px;
-}
-
 
 /* Indoor features */
 path.fill.tag-indoor {
     display: none;
 }
-
+.indoor-mode path.fill.tag-building {
+    clip-path: none !important;
+    stroke-width: 30px;
+}
 .indoor-mode path.fill.tag-indoor {
     display: block;
     fill: rgba(169, 169, 169, 0.3);
@@ -1325,12 +1323,9 @@ path.fill.tag-indoor {
 .indoor-mode path.stroke.tag-indoor {
     stroke: rgb(169, 169, 169);
 }
-.indoor-mode text {
-    display: none;
-}
-
 .indoor-mode use.icon.areaicon.tag-building,
-.indoor-mode text.arealabel.tag-building {
+.indoor-mode text.arealabel.tag-building,
+.indoor-mode text.arealabel-halo.tag-building {
     display: none;
 }
 

--- a/css/map.css
+++ b/css/map.css
@@ -1324,8 +1324,11 @@ path.fill.tag-indoor {
     stroke: rgb(169, 169, 169);
 }
 .indoor-mode use.icon.areaicon.tag-building,
+.indoor-mode use.icon.areaicon.tag-amenity,
 .indoor-mode text.arealabel.tag-building,
-.indoor-mode text.arealabel-halo.tag-building {
+.indoor-mode text.arealabel.tag-amenity,
+.indoor-mode text.arealabel-halo.tag-building,
+.indoor-mode text.arealabel-halo.tag-amenity {
     display: none;
 }
 

--- a/css/map.css
+++ b/css/map.css
@@ -1315,6 +1315,9 @@ path.fill.tag-indoor {
     clip-path: none !important;
     stroke-width: 30px;
 }
+.indoor-mode path.way.area.stroke.tag-building.tag-max_level {
+    stroke-width: 6px;
+}
 .indoor-mode path.fill.tag-indoor {
     display: block;
     fill: rgba(169, 169, 169, 0.3);
@@ -1322,6 +1325,9 @@ path.fill.tag-indoor {
 }
 .indoor-mode path.stroke.tag-indoor {
     stroke: rgb(169, 169, 169);
+}
+.indoor-mode path.stroke.tag-indoor-corridor {
+    opacity: 0.1;
 }
 .indoor-mode use.icon.areaicon.tag-building,
 .indoor-mode use.icon.areaicon.tag-amenity,
@@ -1331,8 +1337,11 @@ path.fill.tag-indoor {
 .indoor-mode text.arealabel-halo.tag-amenity {
     display: none;
 }
-.indoor-mode.indoor-underground .way:not(.tag-level):not(.tag-building) {
+.indoor-mode .way:not(.tag-level):not(.tag-building) {
     opacity: 0.1;
+}
+.indoor-mode.indoor-underground .way:not(.tag-level):not(.tag-building) {
+    opacity: 0.05;
 }
 
 

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -325,9 +325,9 @@ en:
     past_future:
       description: Past/Future
       tooltip: "Proposed, Construction, Abandoned, Demolished, etc."
-    indoor_other_then_current_level:
-      description: Indoor other levels
-      tooltip: "When in indoor mode, it hides all levels except the selected one."
+    indoor_different_level:
+      description: Indoor - different levels
+      tooltip: "When in indoor mode, it hides all levels except the selected one. Also lower buildings."
     indoor:
       description: Indoor
       tooltip: "All features with filled level or repeat_on."

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -325,12 +325,12 @@ en:
     past_future:
       description: Past/Future
       tooltip: "Proposed, Construction, Abandoned, Demolished, etc."
-    indoor_different_level:
-      description: Indoor - different levels
-      tooltip: "When in indoor mode, it hides all levels except the selected one. Also lower buildings."
     indoor:
-      description: Indoor
-      tooltip: "All features with filled level or repeat_on."
+      description: Indoor Features
+      tooltip: "All features with filled level."
+    indoor_different_level:
+      description: Indoor - hidden levels
+      tooltip: "When in indoor mode, it hides all levels except the selected one."
     others:
       description: Others
       tooltip: "Everything Else"

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -373,6 +373,10 @@ en:
         Another user changed some of the same map features you changed.
         Click on each item below for more details about the conflict, and choose whether to keep
         your changes or the other user's changes.
+  indoor_mode:
+    title: Indoor
+    help: Indoor mode helps you creating indoor objects by filtering only the selected level.
+    exit: Exit indoor editing mode.
   merge_remote_changes:
     conflict:
       deleted: 'This object has been deleted by {user}.'

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -325,6 +325,12 @@ en:
     past_future:
       description: Past/Future
       tooltip: "Proposed, Construction, Abandoned, Demolished, etc."
+    indoor_other_levels:
+      description: Indoor other levels
+      tooltip: "When in indoor mode, it hides all levels except the selected one."
+    indoor:
+      description: Indoor
+      tooltip: "All features with filled level or repeat_on."
     others:
       description: Others
       tooltip: "Everything Else"

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -325,7 +325,7 @@ en:
     past_future:
       description: Past/Future
       tooltip: "Proposed, Construction, Abandoned, Demolished, etc."
-    indoor_other_levels:
+    indoor_other_then_current_level:
       description: Indoor other levels
       tooltip: "When in indoor mode, it hides all levels except the selected one."
     indoor:

--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -444,6 +444,11 @@ en:
           down: Down
           # incline=up
           up: Up
+      indoor_levels:
+        # 'min_level=*, max_level=*'
+        label: Indoor levels (min - max)
+        placeholder-0: '-1, 0, 1, 3...'
+        placeholder-1: '3, 5, 10...'
       information:
         # 'information=*'
         label: Type

--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -770,6 +770,9 @@ en:
       religion:
         # 'religion=*'
         label: Religion
+      repeat_on:
+        # 'repeat_on=*'
+        label: Repeat on
       restriction:
         # 'restriction=*'
         label: Type
@@ -2312,6 +2315,10 @@ en:
         # historic=wayside_shrine
         name: Wayside Shrine
         terms: "<translate with synonyms or related terms for 'Wayside Shrine', separated by commas>"
+      indoor:
+        # 'indoor=*'
+        name: Indoor object
+        terms: "<translate with synonyms or related terms for 'Indoor object', separated by commas>"
       junction:
         # junction=yes
         name: Junction

--- a/data/presets/fields.json
+++ b/data/presets/fields.json
@@ -1015,6 +1015,11 @@
         "type": "combo",
         "label": "Religion"
     },
+    "repeat_on": {
+        "key": "repeat_on",
+        "type": "combo",
+        "label": "Repeat on"
+    },
     "restriction": {
         "key": "restriction",
         "type": "combo",

--- a/data/presets/fields.json
+++ b/data/presets/fields.json
@@ -616,6 +616,19 @@
             }
         }
     },
+    "indoor_levels": {
+        "keys": [
+            "min_level",
+            "max_level"
+        ],
+        "type": "range",
+        "label": "Indoor levels (min - max)",
+        "universal": true,
+        "strings": {
+            "placeholder-0": "-1, 0, 1, 3...",
+            "placeholder-1": "3, 5, 10..."
+        }
+    },
     "information": {
         "key": "information",
         "type": "typeCombo",

--- a/data/presets/fields/indoor_levels.json
+++ b/data/presets/fields/indoor_levels.json
@@ -1,0 +1,13 @@
+{
+    "keys": [
+        "min_level",
+        "max_level"
+    ],
+    "type": "range",
+    "label": "Indoor levels (min - max)",
+    "universal": true,
+    "strings": {
+        "placeholder-0": "-1, 0, 1, 3...",
+        "placeholder-1": "3, 5, 10..."
+    }
+}

--- a/data/presets/fields/repeat_on.json
+++ b/data/presets/fields/repeat_on.json
@@ -1,0 +1,5 @@
+{
+    "key": "repeat_on",
+    "type": "combo",
+    "label": "Repeat on"
+}

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -5111,6 +5111,23 @@
         },
         "name": "Wayside Shrine"
     },
+    "indoor": {
+        "fields": [
+            "name",
+            "level",
+            "repeat_on"
+        ],
+        "geometry": [
+            "point",
+            "area"
+        ],
+        "tags": {
+            "indoor": "*"
+        },
+        "matchScore": 0.4,
+        "terms": [],
+        "name": "Indoor object"
+    },
     "junction": {
         "geometry": [
             "vertex",

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -2563,8 +2563,7 @@
         "icon": "building",
         "fields": [
             "address",
-            "levels",
-            "indoor_levels"
+            "levels"
         ],
         "geometry": [
             "area"
@@ -2624,7 +2623,8 @@
         "icon": "building",
         "fields": [
             "address",
-            "levels"
+            "levels",
+            "indoor_levels"
         ],
         "geometry": [
             "area"
@@ -2751,8 +2751,7 @@
         "icon": "building",
         "fields": [
             "address",
-            "levels",
-            "indoor_levels"
+            "levels"
         ],
         "geometry": [
             "area"
@@ -2767,7 +2766,8 @@
         "icon": "building",
         "fields": [
             "address",
-            "levels"
+            "levels",
+            "indoor_levels"
         ],
         "geometry": [
             "area"
@@ -2881,8 +2881,7 @@
         "icon": "building",
         "fields": [
             "address",
-            "levels",
-            "indoor_levels"
+            "levels"
         ],
         "geometry": [
             "area"
@@ -2928,7 +2927,8 @@
         "icon": "building",
         "fields": [
             "address",
-            "levels"
+            "levels",
+            "indoor_levels"
         ],
         "geometry": [
             "area"
@@ -3018,8 +3018,7 @@
         "icon": "building",
         "fields": [
             "address",
-            "levels",
-            "indoor_levels"
+            "levels"
         ],
         "geometry": [
             "area"
@@ -3061,7 +3060,8 @@
         "icon": "building",
         "fields": [
             "address",
-            "levels"
+            "levels",
+            "indoor_levels"
         ],
         "geometry": [
             "area"

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -2563,7 +2563,8 @@
         "icon": "building",
         "fields": [
             "address",
-            "levels"
+            "levels",
+            "indoor_levels"
         ],
         "geometry": [
             "area"
@@ -2642,6 +2643,7 @@
         "fields": [
             "address",
             "levels",
+            "indoor_levels",
             "smoking"
         ],
         "geometry": [
@@ -2749,7 +2751,8 @@
         "icon": "building",
         "fields": [
             "address",
-            "levels"
+            "levels",
+            "indoor_levels"
         ],
         "geometry": [
             "area"
@@ -2780,6 +2783,7 @@
         "fields": [
             "address",
             "levels",
+            "indoor_levels",
             "smoking"
         ],
         "geometry": [
@@ -2861,6 +2865,7 @@
         "fields": [
             "address",
             "levels",
+            "indoor_levels",
             "smoking"
         ],
         "geometry": [
@@ -2876,7 +2881,8 @@
         "icon": "building",
         "fields": [
             "address",
-            "levels"
+            "levels",
+            "indoor_levels"
         ],
         "geometry": [
             "area"
@@ -2892,6 +2898,7 @@
         "fields": [
             "address",
             "levels",
+            "indoor_levels",
             "smoking"
         ],
         "geometry": [
@@ -3011,7 +3018,8 @@
         "icon": "building",
         "fields": [
             "address",
-            "levels"
+            "levels",
+            "indoor_levels"
         ],
         "geometry": [
             "area"
@@ -3034,7 +3042,8 @@
         "icon": "building",
         "fields": [
             "address",
-            "levels"
+            "levels",
+            "indoor_levels"
         ],
         "geometry": [
             "point",

--- a/data/presets/presets/building/college.json
+++ b/data/presets/presets/building/college.json
@@ -2,7 +2,8 @@
     "icon": "building",
     "fields": [
         "address",
-        "levels"
+        "levels",
+        "indoor_levels"
     ],
     "geometry": [
         "area"

--- a/data/presets/presets/building/commercial.json
+++ b/data/presets/presets/building/commercial.json
@@ -3,6 +3,7 @@
     "fields": [
         "address",
         "levels",
+        "indoor_levels",
         "smoking"
     ],
     "geometry": [

--- a/data/presets/presets/building/hospital.json
+++ b/data/presets/presets/building/hospital.json
@@ -2,7 +2,8 @@
     "icon": "building",
     "fields": [
         "address",
-        "levels"
+        "levels",
+        "indoor_levels"
     ],
     "geometry": [
         "area"

--- a/data/presets/presets/building/hotel.json
+++ b/data/presets/presets/building/hotel.json
@@ -3,6 +3,7 @@
     "fields": [
         "address",
         "levels",
+        "indoor_levels",
         "smoking"
     ],
     "geometry": [

--- a/data/presets/presets/building/public.json
+++ b/data/presets/presets/building/public.json
@@ -3,6 +3,7 @@
     "fields": [
         "address",
         "levels",
+        "indoor_levels",
         "smoking"
     ],
     "geometry": [

--- a/data/presets/presets/building/retail.json
+++ b/data/presets/presets/building/retail.json
@@ -3,6 +3,7 @@
     "fields": [
         "address",
         "levels",
+        "indoor_levels",
         "smoking"
     ],
     "geometry": [

--- a/data/presets/presets/building/school.json
+++ b/data/presets/presets/building/school.json
@@ -2,7 +2,8 @@
     "icon": "building",
     "fields": [
         "address",
-        "levels"
+        "levels",
+        "indoor_levels"
     ],
     "geometry": [
         "area"

--- a/data/presets/presets/building/train_station.json
+++ b/data/presets/presets/building/train_station.json
@@ -2,7 +2,8 @@
     "icon": "building",
     "fields": [
         "address",
-        "levels"
+        "levels",
+        "indoor_levels"
     ],
     "geometry": [
         "point",

--- a/data/presets/presets/building/university.json
+++ b/data/presets/presets/building/university.json
@@ -2,7 +2,8 @@
     "icon": "building",
     "fields": [
         "address",
-        "levels"
+        "levels",
+        "indoor_levels"
     ],
     "geometry": [
         "area"

--- a/data/presets/presets/indoor.json
+++ b/data/presets/presets/indoor.json
@@ -1,0 +1,17 @@
+{
+  "fields": [
+    "name",
+    "level",
+    "repeat_on"
+  ],
+  "geometry": [
+    "point",
+    "area"
+  ],
+  "tags": {
+    "indoor": "*"
+  },
+  "matchScore": 0.4,
+  "terms": [],
+  "name": "Indoor object"
+}

--- a/data/presets/schema/field.json
+++ b/data/presets/schema/field.json
@@ -66,7 +66,8 @@
                 "localized",
                 "wikipedia",
                 "typeCombo",
-                "restrictions"
+                "restrictions",
+                "range"
             ],
             "required": true
         },

--- a/data/taginfo.json
+++ b/data/taginfo.json
@@ -1142,6 +1142,9 @@
             "value": "wayside_shrine"
         },
         {
+            "key": "indoor"
+        },
+        {
             "key": "junction",
             "value": "yes"
         },

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -1035,6 +1035,11 @@
                     "down": "Down"
                 }
             },
+            "indoor_levels": {
+                "label": "Indoor levels (min - max)",
+                "placeholder-0": "-1, 0, 1, 3...",
+                "placeholder-1": "3, 5, 10..."
+            },
             "information": {
                 "label": "Type"
             },

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -451,6 +451,11 @@
             "help": "Another user changed some of the same map features you changed.\nClick on each item below for more details about the conflict, and choose whether to keep\nyour changes or the other user's changes.\n"
         }
     },
+    "indoor_mode": {
+        "title": "Indoor",
+        "help": "Indoor mode helps you creating indoor objects by filtering only the selected level.",
+        "exit": "Exit indoor editing mode."
+    },
     "merge_remote_changes": {
         "conflict": {
             "deleted": "This object has been deleted by {user}.",

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -395,9 +395,9 @@
             "description": "Past/Future",
             "tooltip": "Proposed, Construction, Abandoned, Demolished, etc."
         },
-        "indoor_other_then_current_level": {
-            "description": "Indoor other levels",
-            "tooltip": "When in indoor mode, it hides all levels except the selected one."
+        "indoor_different_level": {
+            "description": "Indoor - different levels",
+            "tooltip": "When in indoor mode, it hides all levels except the selected one. Also lower buildings."
         },
         "indoor": {
             "description": "Indoor",

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -395,6 +395,14 @@
             "description": "Past/Future",
             "tooltip": "Proposed, Construction, Abandoned, Demolished, etc."
         },
+        "indoor_other_levels": {
+            "description": "Indoor other levels",
+            "tooltip": "When in indoor mode, it hides all levels except the selected one."
+        },
+        "indoor": {
+            "description": "Indoor",
+            "tooltip": "All features with filled level or repeat_on."
+        },
         "others": {
             "description": "Others",
             "tooltip": "Everything Else"

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -1278,6 +1278,9 @@
             "religion": {
                 "label": "Religion"
             },
+            "repeat_on": {
+                "label": "Repeat on"
+            },
             "restriction": {
                 "label": "Type"
             },
@@ -2643,6 +2646,10 @@
             },
             "historic/wayside_shrine": {
                 "name": "Wayside Shrine",
+                "terms": ""
+            },
+            "indoor": {
+                "name": "Indoor object",
                 "terms": ""
             },
             "junction": {

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -395,7 +395,7 @@
             "description": "Past/Future",
             "tooltip": "Proposed, Construction, Abandoned, Demolished, etc."
         },
-        "indoor_other_levels": {
+        "indoor_other_then_current_level": {
             "description": "Indoor other levels",
             "tooltip": "When in indoor mode, it hides all levels except the selected one."
         },

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -395,13 +395,13 @@
             "description": "Past/Future",
             "tooltip": "Proposed, Construction, Abandoned, Demolished, etc."
         },
-        "indoor_different_level": {
-            "description": "Indoor - different levels",
-            "tooltip": "When in indoor mode, it hides all levels except the selected one. Also lower buildings."
-        },
         "indoor": {
-            "description": "Indoor",
-            "tooltip": "All features with filled level or repeat_on."
+            "description": "Indoor Features",
+            "tooltip": "All features with filled level."
+        },
+        "indoor_different_level": {
+            "description": "Indoor - hidden levels",
+            "tooltip": "When in indoor mode, it hides all levels except the selected one."
         },
         "others": {
             "description": "Others",

--- a/index.html
+++ b/index.html
@@ -276,11 +276,11 @@
                             }
                         ]));
 
-                id.connection().switch({
-                    "url": "http://localhost:3000",
-                    "oauth_consumer_key": "y0SQSVjXlQRXgEefMNmJ6zSwFwI4kwXo7oUGI9eM",
-                    "oauth_secret": "kg67RISYNj9rJ7GuUdGbPwBpRzouJvLulC7DOItB"
-                });
+//                id.connection().switch({
+//                    "url": "http://localhost:3000",
+//                    "oauth_consumer_key": "y0SQSVjXlQRXgEefMNmJ6zSwFwI4kwXo7oUGI9eM",
+//                    "oauth_secret": "kg67RISYNj9rJ7GuUdGbPwBpRzouJvLulC7DOItB"
+//                });
 
             });
         </script>

--- a/index.html
+++ b/index.html
@@ -56,6 +56,7 @@
         <script src='js/id/renderer/background.js'></script>
         <script src='js/id/renderer/background_source.js'></script>
         <script src='js/id/renderer/features.js'></script>
+        <script src='js/id/renderer/indoor.js'></script>
         <script src='js/id/renderer/map.js'></script>
         <script src='js/id/renderer/tile_layer.js'></script>
 

--- a/index.html
+++ b/index.html
@@ -136,6 +136,7 @@
         <script src='js/id/ui/preset/localized.js'></script>
         <script src='js/id/ui/preset/maxspeed.js'></script>
         <script src='js/id/ui/preset/radio.js'></script>
+        <script src='js/id/ui/preset/range.js'></script>
         <script src='js/id/ui/preset/restrictions.js'></script>
         <script src='js/id/ui/preset/textarea.js'></script>
         <script src='js/id/ui/preset/wikipedia.js'></script>

--- a/index.html
+++ b/index.html
@@ -94,6 +94,7 @@
         <script src='js/id/ui/map_data.js'></script>
         <script src='js/id/ui/map_in_map.js'></script>
         <script src='js/id/ui/modes.js'></script>
+        <script src='js/id/ui/indoor_mode.js'></script>
         <script src='js/id/ui/contributors.js'></script>
         <script src='js/id/ui/help.js'></script>
         <script src='js/id/ui/geolocate.js'></script>
@@ -274,6 +275,12 @@
                                 "oauth_secret": "aMnOOCwExO2XYtRVWJ1bI9QOdqh1cay2UgpbhA6p"
                             }
                         ]));
+
+                id.connection().switch({
+                    "url": "http://localhost:3000",
+                    "oauth_consumer_key": "y0SQSVjXlQRXgEefMNmJ6zSwFwI4kwXo7oUGI9eM",
+                    "oauth_secret": "kg67RISYNj9rJ7GuUdGbPwBpRzouJvLulC7DOItB"
+                });
 
             });
         </script>

--- a/js/id/behavior/hash.js
+++ b/js/id/behavior/hash.js
@@ -36,8 +36,8 @@ iD.behavior.Hash = function(context) {
                 '/' + center[0].toFixed(precision) +
                 '/' + center[1].toFixed(precision);
 
-        if (context.indoorMode())
-            q.level = context.indoorLevel();
+        if (context.indoor().enabled())
+            q.level = context.indoor().level();
         else
             delete q.level;
 
@@ -66,8 +66,8 @@ iD.behavior.Hash = function(context) {
         context
             .on('enter.hash', throttledUpdate);
 
-        context
-            .on('indoorLevelChanged.hash', throttledUpdate);
+        context.indoor()
+            .on('levelChanged.hash', throttledUpdate);
 
         d3.select(window)
             .on('hashchange.hash', hashchange);
@@ -76,7 +76,7 @@ iD.behavior.Hash = function(context) {
             var q = iD.util.stringQs(location.hash.substring(1));
             if (q.id) context.zoomToEntity(q.id.split(',')[0], !q.map);
             if (q.comment) context.storage('comment', q.comment);
-            if (q.level) context.indoorLevel(q.level);
+            if (q.level) context.indoor().level(q.level);
             hashchange();
             if (q.map) hash.hadHash = true;
         }

--- a/js/id/behavior/hash.js
+++ b/js/id/behavior/hash.js
@@ -36,6 +36,11 @@ iD.behavior.Hash = function(context) {
                 '/' + center[0].toFixed(precision) +
                 '/' + center[1].toFixed(precision);
 
+        if (context.indoorMode())
+            q.level = context.indoorLevel();
+        else
+            delete q.level;
+
         return '#' + iD.util.qsString(_.assign(q, newParams), true);
     };
 
@@ -61,6 +66,9 @@ iD.behavior.Hash = function(context) {
         context
             .on('enter.hash', throttledUpdate);
 
+        context
+            .on('indoorLevelChanged.hash', throttledUpdate);
+
         d3.select(window)
             .on('hashchange.hash', hashchange);
 
@@ -68,6 +76,7 @@ iD.behavior.Hash = function(context) {
             var q = iD.util.stringQs(location.hash.substring(1));
             if (q.id) context.zoomToEntity(q.id.split(',')[0], !q.map);
             if (q.comment) context.storage('comment', q.comment);
+            if (q.level) context.indoorLevel(q.level);
             hashchange();
             if (q.map) hash.hadHash = true;
         }

--- a/js/id/id.js
+++ b/js/id/id.js
@@ -359,7 +359,7 @@ window.iD = function () {
             _.each(_.without(features.keys(), 'indoor', 'buildings', 'points'), features.disable);
         }
         else {
-            _.each(features.keys(), features.disable);
+            _.each(_.difference(features.keys(), enabledFeaturesBeforeIndoor), features.disable);
             _.each(enabledFeaturesBeforeIndoor, features.enable);
         }
 

--- a/js/id/id.js
+++ b/js/id/id.js
@@ -349,9 +349,9 @@ window.iD = function () {
         if (indoorMode && selected.length) {
             var entity = context.graph().entity(selected[0]);
             if (entity.tags.level)
-                indoorLevel = entity.tags.level.replace(/[-;].+/, '');
+                indoorLevel = entity.tags.level.replace(/(-?\d+(\.\d+)?).+/, '$1');
             else if (entity.tags.repeat_on)
-                indoorLevel = entity.tags.repeat_on.replace(/[-;].+/, '');
+                indoorLevel = entity.tags.repeat_on.replace(/(-?\d+(\.\d+)?).+/, '$1');
         }
 
         map.redraw(); //TODO event?

--- a/js/id/id.js
+++ b/js/id/id.js
@@ -342,11 +342,20 @@ window.iD = function () {
     context.toggleIndoorMode = function () {
         console.log("context.toggleIndoorMode called");
         indoorMode = !indoorMode;
-        dispatch.indoor(); //update combo
 
         context.surface().classed('indoor-mode', indoorMode);
 
+        var selected = context.selectedIDs();
+        if (indoorMode && selected.length) {
+            var entity = context.graph().entity(selected[0]);
+            if (entity.tags.level)
+                indoorLevel = entity.tags.level.replace(/[-;].+/, '');
+            else if (entity.tags.repeat_on)
+                indoorLevel = entity.tags.repeat_on.replace(/[-;].+/, '');
+        }
+
         map.redraw(); //TODO event?
+        dispatch.indoor(); //update combo
     };
 
     context.indoorLevels = function () {

--- a/js/id/id.js
+++ b/js/id/id.js
@@ -344,6 +344,8 @@ window.iD = function () {
         indoorMode = !indoorMode;
         dispatch.indoor(); //update combo
 
+        context.surface().classed('indoor-mode', indoorMode);
+
         map.redraw(); //TODO event?
     };
 

--- a/js/id/id.js
+++ b/js/id/id.js
@@ -356,7 +356,7 @@ window.iD = function () {
             enabledFeaturesBeforeIndoor = features.enabled();
             features.enable('indoor');
             features.enable('buildings');
-            _.each(_.without(features.keys(), 'indoor', 'buildings'), features.disable); //without indoor to prevent selection loss
+            _.each(_.without(features.keys(), 'indoor', 'buildings', 'points'), features.disable);
         }
         else {
             _.each(features.keys(), features.disable);

--- a/js/id/id.js
+++ b/js/id/id.js
@@ -2,7 +2,7 @@ window.iD = function () {
     window.locale.en = iD.data.en;
     window.locale.current('en');
 
-    var dispatch = d3.dispatch('enter', 'exit', 'indoor'),
+    var dispatch = d3.dispatch('enter', 'exit', 'indoorLevelChanged'),
         context = {};
 
     // https://github.com/openstreetmap/iD/issues/772
@@ -355,7 +355,7 @@ window.iD = function () {
         }
 
         map.redraw(); //TODO event?
-        dispatch.indoor(); //update combo
+        dispatch.indoorLevelChanged(); //update combo
     };
 
     context.indoorLevels = function () {

--- a/js/id/id.js
+++ b/js/id/id.js
@@ -2,7 +2,7 @@ window.iD = function () {
     window.locale.en = iD.data.en;
     window.locale.current('en');
 
-    var dispatch = d3.dispatch('enter', 'exit'),
+    var dispatch = d3.dispatch('enter', 'exit', 'indoorMode'),
         context = {};
 
     // https://github.com/openstreetmap/iD/issues/772
@@ -320,6 +320,23 @@ window.iD = function () {
         }
     };
 
+
+    /* Indoor mode */
+    var indoorMode = false, indoorLevel;
+
+    context.indoorMode = function () {
+        return indoorMode;
+    };
+
+    context.indoorLevel = function () {
+        return indoorLevel;
+    };
+
+    context.enterIndoorMode = function () {
+        console.log("context.enterIndoorMode called");
+        indoorMode = true;
+        indoorLevel = prompt("Enter level", "1");
+    };
 
     /* Init */
 

--- a/js/id/id.js
+++ b/js/id/id.js
@@ -2,7 +2,7 @@ window.iD = function () {
     window.locale.en = iD.data.en;
     window.locale.current('en');
 
-    var dispatch = d3.dispatch('enter', 'exit', 'indoorMode'),
+    var dispatch = d3.dispatch('enter', 'exit', 'indoor'),
         context = {};
 
     // https://github.com/openstreetmap/iD/issues/772
@@ -322,20 +322,33 @@ window.iD = function () {
 
 
     /* Indoor mode */
-    var indoorMode = false, indoorLevel;
+    var indoorMode = false, indoorLevel = '0';
+    //    return d3.rebind(indoor, dispatch, 'on');
+
 
     context.indoorMode = function () {
         return indoorMode;
     };
 
-    context.indoorLevel = function () {
+    context.indoorLevel = function (newLevel) {
+        if (newLevel && newLevel !== indoorLevel) {
+            indoorLevel = newLevel;
+            map.redraw(); //TODO event?
+
+        }
         return indoorLevel;
     };
 
-    context.enterIndoorMode = function () {
-        console.log("context.enterIndoorMode called");
-        indoorMode = true;
-        indoorLevel = prompt("Enter level", "1");
+    context.toggleIndoorMode = function () {
+        console.log("context.toggleIndoorMode called");
+        indoorMode = !indoorMode;
+        dispatch.indoor(); //update combo
+
+        map.redraw(); //TODO event?
+    };
+
+    context.indoorLevels = function () {
+        return [-1, 0, 1, 2]
     };
 
     /* Init */

--- a/js/id/modes/add_area.js
+++ b/js/id/modes/add_area.js
@@ -15,8 +15,8 @@ iD.modes.AddArea = function(context) {
 
     function defaultTags() {
         var tags = {area: 'yes'};
-        if (context.indoorMode()) {
-            tags.level = context.indoorLevel();
+        if (context.indoor().enabled()) {
+            tags.level = context.indoor().level();
         }
         return tags;
     }

--- a/js/id/modes/add_area.js
+++ b/js/id/modes/add_area.js
@@ -11,17 +11,20 @@ iD.modes.AddArea = function(context) {
             .tail(t('modes.add_area.tail'))
             .on('start', start)
             .on('startFromWay', startFromWay)
-            .on('startFromNode', startFromNode),
-        defaultTags = {area: 'yes'};
+            .on('startFromNode', startFromNode);
+
+    function defaultTags() {
+        var tags = {area: 'yes'};
+        if (context.indoorMode()) {
+            tags.level = context.indoorLevel();
+        }
+        return tags;
+    }
 
     function start(loc) {
         var graph = context.graph(),
             node = iD.Node({loc: loc}),
-            way = iD.Way({tags: defaultTags});
-
-        if (context.indoorMode()) {
-            way.tags.level = context.indoorLevel();
-        }
+            way = iD.Way({tags: defaultTags()});
 
         context.perform(
             iD.actions.AddEntity(node),
@@ -35,7 +38,7 @@ iD.modes.AddArea = function(context) {
     function startFromWay(loc, edge) {
         var graph = context.graph(),
             node = iD.Node({loc: loc}),
-            way = iD.Way({tags: defaultTags});
+            way = iD.Way({tags: defaultTags()});
 
         context.perform(
             iD.actions.AddEntity(node),
@@ -49,7 +52,7 @@ iD.modes.AddArea = function(context) {
 
     function startFromNode(node) {
         var graph = context.graph(),
-            way = iD.Way({tags: defaultTags});
+            way = iD.Way({tags: defaultTags()});
 
         context.perform(
             iD.actions.AddEntity(way),

--- a/js/id/modes/add_area.js
+++ b/js/id/modes/add_area.js
@@ -19,6 +19,10 @@ iD.modes.AddArea = function(context) {
             node = iD.Node({loc: loc}),
             way = iD.Way({tags: defaultTags});
 
+        if (context.indoorMode()) {
+            way.tags.level = context.indoorLevel();
+        }
+
         context.perform(
             iD.actions.AddEntity(node),
             iD.actions.AddEntity(way),

--- a/js/id/modes/add_line.js
+++ b/js/id/modes/add_line.js
@@ -13,10 +13,18 @@ iD.modes.AddLine = function(context) {
         .on('startFromWay', startFromWay)
         .on('startFromNode', startFromNode);
 
+    function defaultTags() {
+        var tags = {};
+        if (context.indoorMode()) {
+            tags.level = context.indoorLevel();
+        }
+        return tags;
+    }
+
     function start(loc) {
         var baseGraph = context.graph(),
             node = iD.Node({loc: loc}),
-            way = iD.Way();
+            way = iD.Way({tags: defaultTags()});
 
         if (context.indoorMode()) {
             way.tags.level = context.indoorLevel();
@@ -33,7 +41,7 @@ iD.modes.AddLine = function(context) {
     function startFromWay(loc, edge) {
         var baseGraph = context.graph(),
             node = iD.Node({loc: loc}),
-            way = iD.Way();
+            way = iD.Way({tags: defaultTags()});
 
         context.perform(
             iD.actions.AddEntity(node),
@@ -46,7 +54,7 @@ iD.modes.AddLine = function(context) {
 
     function startFromNode(node) {
         var baseGraph = context.graph(),
-            way = iD.Way();
+            way = iD.Way({tags: defaultTags()});
 
         context.perform(
             iD.actions.AddEntity(way),

--- a/js/id/modes/add_line.js
+++ b/js/id/modes/add_line.js
@@ -15,8 +15,8 @@ iD.modes.AddLine = function(context) {
 
     function defaultTags() {
         var tags = {};
-        if (context.indoorMode()) {
-            tags.level = context.indoorLevel();
+        if (context.indoor().enabled()) {
+            tags.level = context.indoor().level();
         }
         return tags;
     }
@@ -25,10 +25,6 @@ iD.modes.AddLine = function(context) {
         var baseGraph = context.graph(),
             node = iD.Node({loc: loc}),
             way = iD.Way({tags: defaultTags()});
-
-        if (context.indoorMode()) {
-            way.tags.level = context.indoorLevel();
-        }
 
         context.perform(
             iD.actions.AddEntity(node),

--- a/js/id/modes/add_line.js
+++ b/js/id/modes/add_line.js
@@ -18,6 +18,10 @@ iD.modes.AddLine = function(context) {
             node = iD.Node({loc: loc}),
             way = iD.Way();
 
+        if (context.indoorMode()) {
+            way.tags.level = context.indoorLevel();
+        }
+
         context.perform(
             iD.actions.AddEntity(node),
             iD.actions.AddEntity(way),

--- a/js/id/modes/add_point.js
+++ b/js/id/modes/add_point.js
@@ -15,12 +15,16 @@ iD.modes.AddPoint = function(context) {
         .on('cancel', cancel)
         .on('finish', cancel);
 
-    function add(loc) {
-        var node = iD.Node({loc: loc});
-
+    function defaultTags() {
+        var tags = {};
         if (context.indoorMode()) {
-            node.tags.level = context.indoorLevel();
+            tags.level = context.indoorLevel();
         }
+        return tags;
+    }
+
+    function add(loc) {
+        var node = iD.Node({loc: loc, tags: defaultTags()});
 
         context.perform(
             iD.actions.AddEntity(node),

--- a/js/id/modes/add_point.js
+++ b/js/id/modes/add_point.js
@@ -17,8 +17,8 @@ iD.modes.AddPoint = function(context) {
 
     function defaultTags() {
         var tags = {};
-        if (context.indoorMode()) {
-            tags.level = context.indoorLevel();
+        if (context.indoor().enabled()) {
+            tags.level = context.indoor().level();
         }
         return tags;
     }

--- a/js/id/modes/add_point.js
+++ b/js/id/modes/add_point.js
@@ -18,6 +18,10 @@ iD.modes.AddPoint = function(context) {
     function add(loc) {
         var node = iD.Node({loc: loc});
 
+        if (context.indoorMode()) {
+            node.tags.level = context.indoorLevel();
+        }
+
         context.perform(
             iD.actions.AddEntity(node),
             t('operations.add.annotation.point'));

--- a/js/id/renderer/features.js
+++ b/js/id/renderer/features.js
@@ -410,6 +410,11 @@ iD.Features = function(context) {
      * @returns {Array} filtered array
      */
     features.filter = function(d, resolver) {
+
+        if (context.indoorMode()) {
+            d = filterByLevel(d);
+        }
+
         if (!_hidden.length) return d;
 
         var result = [];
@@ -421,6 +426,45 @@ iD.Features = function(context) {
         }
         return result;
     };
+
+    function filterByLevel(data) {
+        var levelRange = /(-?\d+)(?:(-)(-?\d+)|(;-?\d)+)?/; // alowing untrimed string (not sure..)
+
+        return data.filter(function (entity) {
+            var current = context.indoorLevel();
+
+            return entity.tags.building
+                || inRange(current, entity.tags.level)
+                || inRange(current, entity.tags.repeat_on);
+        });
+
+        function inRange(value, rangeText) {
+            var range = rangeText && levelRange.exec(rangeText);
+
+            if (!range) {  //blank text OR not matched
+                return false;
+            }
+
+            if (range[2] === undefined && range[4] == undefined) { //exact match
+                if (range[1] === value) {
+                    return true;
+                }
+            }
+            else if (range[2] === '-') { // range from - to
+                if (range[1] <= value && range[3] >= value) {
+                    return true;
+                }
+            }
+            else { // range list
+                if (range[0].split(';').indexOf(value) !== -1) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+
 
     return d3.rebind(features, dispatch, 'on');
 };

--- a/js/id/renderer/features.js
+++ b/js/id/renderer/features.js
@@ -103,10 +103,7 @@ iD.Features = function(context) {
     defineFeature('indoor_different_level', function isHiddenByLevel(entity, resolver, geometry) { //disabled in indoor_mode -> hides unwanted levels
         var current = context.indoorLevel();
 
-        if (entity.tags.level && !inRange(current, entity.tags.level))
-            return true;
-
-        if (entity.tags.repeat_on && !inRange(current, entity.tags.repeat_on))
+        if (entity.tags.level && !inRange(current, entity.tags.level) && !inRange(current, entity.tags.repeat_on))
             return true;
 
         if (geometry === 'point' && !entity.tags.level && !entity.tags.repeat_on)

--- a/js/id/renderer/features.js
+++ b/js/id/renderer/features.js
@@ -117,10 +117,6 @@ iD.Features = function(context) {
             if (current < 0 || current >= parseFloat(entity.tags['building:levels'] || 0))  //one level <=> level=0
                 return true;
         }
-        if (current < 0) {
-            if (!entity.tags.level && !entity.tags.repeat_on)
-                return true;
-        }
     });
 
     defineFeature('indoor', function isIndoorOther(entity) {

--- a/js/id/renderer/features.js
+++ b/js/id/renderer/features.js
@@ -416,11 +416,6 @@ iD.Features = function(context) {
         return fn(entity, resolver, geometry);
     };
 
-    /**
-     * @param d array of all entities
-     * @param resolver iD.Graph
-     * @returns {Array} filtered array
-     */
     features.filter = function(d, resolver) {
         if (!_hidden.length) return d;
 
@@ -435,7 +430,7 @@ iD.Features = function(context) {
     };
 
 
-    var levelRangeRegExp = /(-?\d+)(?:(-)(-?\d+)|(;-?\d)+)?/; // alowing untrimed string (not sure..)
+    var levelRangeRegExp = /^(-?\d+)(?:(-)(-?\d+)|(;-?\d)+)?$/;
     function inRange(level, rangeText) {
         var range = rangeText && levelRangeRegExp.exec(rangeText);
 

--- a/js/id/renderer/features.js
+++ b/js/id/renderer/features.js
@@ -100,7 +100,7 @@ iD.Features = function(context) {
         );
     }, 250);
 
-    defineFeature('indoor_other_then_current_level', function isHiddenByLevel(entity, resolver, geometry) { //disabled in indoor_mode -> hides unwanted levels
+    defineFeature('indoor_different_level', function isHiddenByLevel(entity, resolver, geometry) { //disabled in indoor_mode -> hides unwanted levels
         var current = context.indoorLevel();
 
         if (entity.tags.level && !inRange(current, entity.tags.level))
@@ -118,6 +118,11 @@ iD.Features = function(context) {
         }
         else if (entity.tags['building'] || entity.tags['building:part']) {
             if (parseFloat(entity.tags['building:levels'] || 0) < current)
+                return true;
+        }
+
+        if (current < 0) {
+            if (!entity.tags.level && !entity.tags.repeat_on)
                 return true;
         }
     });

--- a/js/id/renderer/features.js
+++ b/js/id/renderer/features.js
@@ -106,14 +106,14 @@ iD.Features = function(context) {
         if (entity.tags.level && !inRange(current, entity.tags.level) && !inRange(current, entity.tags.repeat_on))
             return true;
 
-        if (geometry === 'point' && !entity.tags.level && !entity.tags.repeat_on)
+        if (geometry === 'point' && !entity.tags.level)
             return true;
 
         if (entity.tags.max_level && entity.tags.min_level) {
             if (parseFloat(entity.tags.max_level) < current || parseFloat(entity.tags.min_level) > current)
                 return true;
         }
-        else if (entity.tags['building'] || entity.tags['building:part']) {
+        else if (entity.tags.building || entity.tags['building:part']) {
             if (current < 0 || current >= parseFloat(entity.tags['building:levels'] || 0))  //one level <=> level=0
                 return true;
         }
@@ -124,7 +124,7 @@ iD.Features = function(context) {
     });
 
     defineFeature('indoor', function isIndoorOther(entity) {
-        return !!entity.tags.level || !!entity.tags.repeat_on;
+        return !!entity.tags.level;
     });
 
     defineFeature('landuse', function isLanduse(entity, resolver, geometry) {
@@ -456,7 +456,7 @@ iD.Features = function(context) {
             return false;
         }
 
-        if (range[2] === undefined && range[4] == undefined) { //exact match
+        if (range[2] === undefined && range[4] === undefined) { //exact match
             if (range[1] === level) {
                 return true;
             }

--- a/js/id/renderer/features.js
+++ b/js/id/renderer/features.js
@@ -100,6 +100,10 @@ iD.Features = function(context) {
         );
     }, 250);
 
+    defineFeature('indoor', function isIndoorOther(entity) {
+        return !!entity.tags.level;
+    });
+
     defineFeature('indoor_different_level', function isHiddenByLevel(entity, resolver, geometry) { //disabled in indoor_mode -> hides unwanted levels
         var current = context.indoor().level();
 
@@ -117,14 +121,6 @@ iD.Features = function(context) {
             if (current < 0 || current >= parseFloat(entity.tags['building:levels'] || 0))  //one level <=> level=0
                 return true;
         }
-
-        if (current > 0 && entity.tags.highway && !entity.tags.level) {
-            return true;
-        }
-    });
-
-    defineFeature('indoor', function isIndoorOther(entity) {
-        return !!entity.tags.level;
     });
 
     defineFeature('landuse', function isLanduse(entity, resolver, geometry) {

--- a/js/id/renderer/features.js
+++ b/js/id/renderer/features.js
@@ -100,11 +100,12 @@ iD.Features = function(context) {
         );
     }, 250);
 
-    defineFeature('indoor_other_levels', function isIndoorOtherLevel(entity) { //other then current level
+    defineFeature('indoor_other_levels', function isIndoorOtherLevel(entity, resolver, geometry) { //other then current level, and also non-indoor-points
         var current = context.indoorLevel();
 
         return (!!entity.tags.level && !inRange(current, entity.tags.level))
-            || (!!entity.tags.repeat_on && !inRange(current, entity.tags.repeat_on));
+            || (!!entity.tags.repeat_on && !inRange(current, entity.tags.repeat_on))
+            || (geometry === 'point' && !entity.tags.level && !entity.tags.repeat_on);
     });
 
     defineFeature('indoor', function isIndoorOther(entity) {

--- a/js/id/renderer/features.js
+++ b/js/id/renderer/features.js
@@ -394,6 +394,8 @@ iD.Features = function(context) {
         if (!_hidden.length) return false;
         if ((!context.indoorMode() && !entity.version) || geometry === 'point') return false;
 
+        if (context.indoorMode() && geometry === 'vertex' && _features.indoor_different_level.filter(entity, resolver, geometry)) return true;
+
         var parents = features.getParents(entity, resolver, geometry);
         if (!parents.length) return false;
 

--- a/js/id/renderer/features.js
+++ b/js/id/renderer/features.js
@@ -107,7 +107,7 @@ iD.Features = function(context) {
     defineFeature('indoor_different_level', function isHiddenByLevel(entity, resolver, geometry) { //disabled in indoor_mode -> hides unwanted levels
         var current = context.indoor().level();
 
-        if (entity.tags.level && !inRange(current, entity))
+        if (entity.tags.level && !context.indoor().inRange(current, entity))
             return true;
 
         if (geometry === 'point' && !entity.tags.level)
@@ -444,40 +444,6 @@ iD.Features = function(context) {
     };
 
 
-    var rangeRegExp = /^(-?\d+(?:\.\d+)?)(?:(-)(-?\d+(?:\.\d+)?)|(;-?\d(?:\.\d+)?)+)?$/;
-    function inRange(level, entity) {
-        return textInRange(level, entity.tags.level) || textInRange(level, entity.tags.repeat_on, true);
-    }
-    function textInRange(level, rangeText, discreetValuesRange) {
-        var range = rangeText && rangeRegExp.exec(rangeText);
-
-        if (!range) {  //blank text OR not matched
-            return false;
-        }
-
-        if (range[2] === undefined && range[4] === undefined) { //exact match
-            if (range[1] === level) {
-                return true;
-            }
-        }
-        else if (range[2] === '-') { // range from - to, only numeric comparison
-            var min = parseFloat(range[1]);
-            var max = parseFloat(range[3]);
-            if (min <= level && max >= level) {
-                return discreetValuesRange ? isDecimalPartEqual(level, min) : true;
-            }
-        }
-        else { // range list
-            if (range[0].split(';').indexOf(level) !== -1) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    function isDecimalPartEqual(a, b) {
-        return Math.abs(a%1 - b%1) < 0.0001; //decimal part equals
-    }
 
     return d3.rebind(features, dispatch, 'on');
 };

--- a/js/id/renderer/features.js
+++ b/js/id/renderer/features.js
@@ -100,12 +100,26 @@ iD.Features = function(context) {
         );
     }, 250);
 
-    defineFeature('indoor_other_levels', function isIndoorOtherLevel(entity, resolver, geometry) { //other then current level, and also non-indoor-points
+    defineFeature('indoor_other_then_current_level', function isHiddenByLevel(entity, resolver, geometry) { //disabled in indoor_mode -> hides unwanted levels
         var current = context.indoorLevel();
 
-        return (!!entity.tags.level && !inRange(current, entity.tags.level))
-            || (!!entity.tags.repeat_on && !inRange(current, entity.tags.repeat_on))
-            || (geometry === 'point' && !entity.tags.level && !entity.tags.repeat_on);
+        if (entity.tags.level && !inRange(current, entity.tags.level))
+            return true;
+
+        if (entity.tags.repeat_on && !inRange(current, entity.tags.repeat_on))
+            return true;
+
+        if (geometry === 'point' && !entity.tags.level && !entity.tags.repeat_on)
+            return true;
+
+        if (entity.tags.max_level && entity.tags.min_level) {
+            if (parseFloat(entity.tags.max_level) < current || parseFloat(entity.tags.min_level) > current)
+                return true;
+        }
+        else if (entity.tags['building'] || entity.tags['building:part']) {
+            if (parseFloat(entity.tags['building:levels'] || 0) < current)
+                return true;
+        }
     });
 
     defineFeature('indoor', function isIndoorOther(entity) {

--- a/js/id/renderer/features.js
+++ b/js/id/renderer/features.js
@@ -107,7 +107,7 @@ iD.Features = function(context) {
     defineFeature('indoor_different_level', function isHiddenByLevel(entity, resolver, geometry) { //disabled in indoor_mode -> hides unwanted levels
         var current = context.indoor().level();
 
-        if (entity.tags.level && !inRange(current, entity.tags.level) && !inRange(current, entity.tags.repeat_on))
+        if (entity.tags.level && !inRange(current, entity))
             return true;
 
         if (geometry === 'point' && !entity.tags.level)
@@ -445,7 +445,10 @@ iD.Features = function(context) {
 
 
     var rangeRegExp = /^(-?\d+(?:\.\d+)?)(?:(-)(-?\d+(?:\.\d+)?)|(;-?\d(?:\.\d+)?)+)?$/;
-    function inRange(level, rangeText) {
+    function inRange(level, entity) {
+        return textInRange(level, entity.tags.level) || textInRange(level, entity.tags.repeat_on, true);
+    }
+    function textInRange(level, rangeText, discreetValuesRange) {
         var range = rangeText && rangeRegExp.exec(rangeText);
 
         if (!range) {  //blank text OR not matched
@@ -458,8 +461,10 @@ iD.Features = function(context) {
             }
         }
         else if (range[2] === '-') { // range from - to, only numeric comparison
-            if (parseFloat(range[1]) <= level && parseFloat(range[3]) >= level) {
-                return true;
+            var min = parseFloat(range[1]);
+            var max = parseFloat(range[3]);
+            if (min <= level && max >= level) {
+                return discreetValuesRange ? isDecimalPartEqual(level, min) : true;
             }
         }
         else { // range list
@@ -470,6 +475,9 @@ iD.Features = function(context) {
         return false;
     }
 
+    function isDecimalPartEqual(a, b) {
+        return Math.abs(a%1 - b%1) < 0.0001; //decimal part equals
+    }
 
     return d3.rebind(features, dispatch, 'on');
 };

--- a/js/id/renderer/features.js
+++ b/js/id/renderer/features.js
@@ -444,7 +444,7 @@ iD.Features = function(context) {
     };
 
 
-    var rangeRegExp = /^(-?\d+)(?:(-)(-?\d+)|(;-?\d)+)?$/;
+    var rangeRegExp = /^(-?\d+(?:\.\d+)?)(?:(-)(-?\d+(?:\.\d+)?)|(;-?\d(?:\.\d+)?)+)?$/;
     function inRange(level, rangeText) {
         var range = rangeText && rangeRegExp.exec(rangeText);
 

--- a/js/id/renderer/features.js
+++ b/js/id/renderer/features.js
@@ -114,10 +114,9 @@ iD.Features = function(context) {
                 return true;
         }
         else if (entity.tags['building'] || entity.tags['building:part']) {
-            if (parseFloat(entity.tags['building:levels'] || 0) < current)
+            if (current < 0 || current >= parseFloat(entity.tags['building:levels'] || 0))  //one level <=> level=0
                 return true;
         }
-
         if (current < 0) {
             if (!entity.tags.level && !entity.tags.repeat_on)
                 return true;

--- a/js/id/renderer/features.js
+++ b/js/id/renderer/features.js
@@ -358,6 +358,7 @@ iD.Features = function(context) {
         return false;
     };
 
+    // entity, iD.Graph, enum(vertex,...)
     features.isHiddenChild = function(entity, resolver, geometry) {
         if (!_hidden.length) return false;
         if (!entity.version || geometry === 'point') return false;
@@ -403,6 +404,11 @@ iD.Features = function(context) {
         return fn(entity, resolver, geometry);
     };
 
+    /**
+     * @param d array of all entities
+     * @param resolver iD.Graph
+     * @returns {Array} filtered array
+     */
     features.filter = function(d, resolver) {
         if (!_hidden.length) return d;
 

--- a/js/id/renderer/indoor.js
+++ b/js/id/renderer/indoor.js
@@ -47,7 +47,7 @@ iD.Indoor = function(context) {
         if (selectedFeatures.length) {
             var entity = context.graph().entity(selectedFeatures[0]);
             if (entity.tags.level)
-                indoorLevel = entity.tags.level.replace(/(-?\d+(\.\d+)?).+/, '$1');
+                indoorLevel = entity.tags.level.replace(/(-?\d+(\.\d+)?).*/, '$1');
         }
 
         enabledFeaturesBeforeIndoor = features.enabled();

--- a/js/id/renderer/indoor.js
+++ b/js/id/renderer/indoor.js
@@ -1,0 +1,89 @@
+iD.Indoor = function (context) {
+    var dispatch = d3.dispatch('levelChanged'),
+        indoorMode = false,
+        indoorLevel = '0',
+        enabledFeaturesBeforeIndoor,
+        features = context.features();
+
+
+    function indoor() {}
+
+    indoor.enabled = function () {
+       return indoorMode;
+    };
+
+    indoor.level = function (newLevel) {
+        if (newLevel) { //setter
+            indoorLevel = newLevel;
+            if (indoorMode)
+                indoor.redraw();
+            else
+                indoor.toggle();
+        }
+        return indoorLevel;
+    };
+
+    indoor.toggle = function () {
+        if (!context.surface()) { //hash calls before surface is initialized
+            setTimeout(indoor.toggle, 200); //TODO better?
+            return false;
+        }
+
+        indoorMode = !indoorMode;
+        context.surface().classed('indoor-mode', indoorMode);
+
+        var selectedFeatures = context.selectedIDs();
+        if (indoorMode && selectedFeatures.length) {
+            var entity = context.graph().entity(selectedFeatures[0]);
+            if (entity.tags.level)
+                indoorLevel = entity.tags.level.replace(/(-?\d+(\.\d+)?).+/, '$1');
+        }
+
+        if (indoorMode) {
+            enabledFeaturesBeforeIndoor = features.enabled();
+            _.each(features.keys(), features.disable);
+            _.each(['indoor', 'buildings', 'points', 'paths', 'traffic_roads', 'service_roads'], features.enable);
+        }
+        else {
+            _.each(_.difference(features.keys(), enabledFeaturesBeforeIndoor), features.disable);
+            _.each(enabledFeaturesBeforeIndoor, features.enable);
+
+            indoorLevel = '0';
+        }
+
+        indoor.redraw();
+
+        if (selectedFeatures.length) {
+            context.enter(iD.modes.Select(context, selectedFeatures));
+        }
+    };
+
+    indoor.redraw = function () {
+        context.surface().classed('indoor-underground', indoorLevel < 0);
+        context.surface().classed('indoor-aboveground', indoorLevel > 0);
+        setBackgroundOpacity(indoorLevel < 0 ? 0.1 : 'revert');
+
+        features.reset();
+        context.map().redraw(); //TODO event?
+        dispatch.levelChanged(); //update hash & combo
+    };
+
+    indoor.levels = function () {
+        return [-1, 0, 1, 1.5];
+    };
+
+
+
+    function setBackgroundOpacity(d) {
+        var bg = context.container().selectAll('.layer-background');
+        if (d === 'revert')
+            d = bg.attr('data-opacity');
+        bg.transition().style('opacity', d);
+        if (!iD.detect().opera) {
+            iD.util.setTransform(bg, 0, 0);
+        }
+    }
+
+
+    return d3.rebind(indoor, dispatch, 'on');
+};

--- a/js/id/renderer/indoor.js
+++ b/js/id/renderer/indoor.js
@@ -25,7 +25,7 @@ iD.Indoor = function (context) {
 
     indoor.toggle = function () {
         if (!context.surface()) { //hash calls before surface is initialized
-            setTimeout(indoor.toggle, 200); //TODO better?
+            setTimeout(indoor.toggle, 200);
             return false;
         }
 

--- a/js/id/renderer/indoor.js
+++ b/js/id/renderer/indoor.js
@@ -64,8 +64,7 @@ iD.Indoor = function (context) {
         setBackgroundOpacity(indoorLevel < 0 ? 0.1 : 'revert');
 
         features.reset();
-        context.map().redraw(); //TODO event?
-        dispatch.levelChanged(); //update hash & combo
+        dispatch.levelChanged(); //update hash & combo, redraw map
     };
 
     indoor.levels = function () {

--- a/js/id/renderer/indoor.js
+++ b/js/id/renderer/indoor.js
@@ -35,11 +35,6 @@ iD.Indoor = function (context) {
             enable();
     };
 
-    indoor.levels = function () {
-        return [-1, 0, 1, 1.5];
-    };
-
-
     function enable() {
         indoorMode = true;
 
@@ -97,7 +92,8 @@ iD.Indoor = function (context) {
     var rangeRegExp = /^(-?\d+(?:\.\d+)?)(?:(-)(-?\d+(?:\.\d+)?)|(;-?\d(?:\.\d+)?)+)?$/;
     indoor.inRange = function (level, entity) {
         return textInRange(level, entity.tags.level) || textInRange(level, entity.tags.repeat_on, true);
-    }
+    };
+
     function textInRange(level, rangeText, discreetValuesRange) {
         var range = rangeText && rangeRegExp.exec(rangeText);
 

--- a/js/id/renderer/indoor.js
+++ b/js/id/renderer/indoor.js
@@ -69,13 +69,13 @@ iD.Indoor = function(context) {
 
         indoorLevel = '0';
         redraw();
+        setBackgroundOpacity('revert');
     }
 
     function redraw() {
         context.surface().classed('indoor-mode', indoorMode);
         context.surface().classed('indoor-underground', indoorLevel < 0);
-        context.surface().classed('indoor-aboveground', indoorLevel > 0);
-        setBackgroundOpacity(indoorLevel < 0 ? 0.1 : 'revert');
+        setBackgroundOpacity(indoorLevel < 0 ? 0.05 : 0.2);
 
         features.reset();
         dispatch.levelChanged(); // update hash & combo, redraw map

--- a/js/id/renderer/map.js
+++ b/js/id/renderer/map.js
@@ -173,13 +173,9 @@ iD.Map = function(context) {
             data = data.filter(function (entity) {
                 var current = context.indoorLevel();
 
-                if (inRange(current, entity.tags.level)) {
-                    return true;
-                }
-                if (inRange(current, entity.tags.repeat_on)) {
-                    return true;
-                }
-                return false;
+                return entity.tags.building
+                    || inRange(current, entity.tags.level)
+                    || inRange(current, entity.tags.repeat_on);
             });
         }
 

--- a/js/id/renderer/map.js
+++ b/js/id/renderer/map.js
@@ -32,6 +32,8 @@ iD.Map = function(context) {
             .on('change.map', redraw);
         context.features()
             .on('redraw.map', redraw);
+        context.indoor()
+            .on('levelChanged.map', redraw);
         drawLayers
             .on('change.map', function() {
                 context.background().updateImagery();
@@ -202,7 +204,6 @@ iD.Map = function(context) {
         return true;
     }
 
-    map.redraw = redraw;
     function redraw(difference, extent) {
         if (!surface || !redrawEnabled) return;
 

--- a/js/id/renderer/map.js
+++ b/js/id/renderer/map.js
@@ -140,48 +140,8 @@ iD.Map = function(context) {
             }
         }
 
-        //filtering data
-        if (context.indoorMode()) {
-            var levelRange = /(-?\d+)(?:(-)(-?\d+)|(;-?\d)+)?/; // alowing untrimed string (not sure..)
-
-            var inRange = function (value, rangeText) {
-                var range = rangeText && levelRange.exec(rangeText);
-
-                if (!range) {  //blank text OR not matched
-                    return false;
-                }
-
-                if (range[2] === undefined && range[4] == undefined) { //exact match
-                    if (range[1] === value) {
-                        return true;
-                    }
-                }
-                else if (range[2] === '-') { // range from - to
-                    if (range[1] <= value && range[3] >= value) {
-                        return true;
-                    }
-                }
-                else { // range list
-                    if (range[0].split(';').indexOf(value) !== -1) {
-                        return true;
-                    }
-                }
-
-                return false;
-            };
-
-            data = data.filter(function (entity) {
-                var current = context.indoorLevel();
-
-                return entity.tags.building
-                    || inRange(current, entity.tags.level)
-                    || inRange(current, entity.tags.repeat_on);
-            });
-        }
-
         data = features.filter(data, graph);
 
-        //surface = d3 selection of "<svg>'s surface for entities"
         surface
             .call(drawVertices, graph, data, filter, map.extent(), map.zoom())
             .call(drawLines, graph, data, filter)

--- a/js/id/svg/labels.js
+++ b/js/id/svg/labels.js
@@ -166,7 +166,7 @@ iD.svg.Labels = function(projection, context) {
 
         icons.enter()
             .append('use')
-            .attr('class', 'icon areaicon')
+            .attr('class', function(d, i) { return 'icon areaicon ' + labels[i].classes; })
             .attr('width', '18px')
             .attr('height', '18px');
 

--- a/js/id/svg/tag_classes.js
+++ b/js/id/svg/tag_classes.js
@@ -2,7 +2,7 @@ iD.svg.TagClasses = function() {
     var primaries = [
             'building', 'highway', 'railway', 'waterway', 'aeroway',
             'motorway', 'boundary', 'power', 'amenity', 'natural', 'landuse',
-            'leisure', 'place'
+            'leisure', 'place', 'indoor'
         ],
         statuses = [
             'proposed', 'construction', 'disused', 'abandoned', 'dismantled',

--- a/js/id/svg/tag_classes.js
+++ b/js/id/svg/tag_classes.js
@@ -10,7 +10,7 @@ iD.svg.TagClasses = function() {
         ],
         secondaries = [
             'oneway', 'bridge', 'tunnel', 'embankment', 'cutting', 'barrier',
-            'surface', 'tracktype', 'crossing'
+            'surface', 'tracktype', 'crossing', 'level', 'max_level'
         ],
         tagClassRe = /^tag-/,
         tags = function(entity) { return entity.tags; };

--- a/js/id/ui.js
+++ b/js/id/ui.js
@@ -58,7 +58,7 @@ iD.ui = function(context) {
             .call(iD.ui.Save(context));
 
         limiter.append('div')
-            .attr('class', 'button-wrap col1')
+            .attr('class', 'button-wrap col2')
             .call(iD.ui.IndoorMode(context));
 
         bar.append('div')

--- a/js/id/ui.js
+++ b/js/id/ui.js
@@ -54,7 +54,12 @@ iD.ui = function(context) {
 
         limiter.append('div')
             .attr('class', 'button-wrap col1')
+            .attr('style', 'margin-right: 60px')
             .call(iD.ui.Save(context));
+
+        limiter.append('div')
+            .attr('class', 'button-wrap col1 ar')
+            .call(iD.ui.IndoorMode(context));
 
         bar.append('div')
             .attr('class', 'full-screen')

--- a/js/id/ui.js
+++ b/js/id/ui.js
@@ -58,7 +58,7 @@ iD.ui = function(context) {
             .call(iD.ui.Save(context));
 
         limiter.append('div')
-            .attr('class', 'button-wrap col1 ar')
+            .attr('class', 'button-wrap col1')
             .call(iD.ui.IndoorMode(context));
 
         bar.append('div')

--- a/js/id/ui/indoor_mode.js
+++ b/js/id/ui/indoor_mode.js
@@ -71,19 +71,19 @@ iD.ui.IndoorMode = function (context) {
             var showButton = context.indoor().enabled();
 
             if (!showButton) {
-                var entities = context.selectedIDs().map(function (id) {
+                var selectedEntities = context.selectedIDs().map(function (id) {
                     return graph.entity(id);
                 });
 
-                showButton = entities.some(function isBuilding(e) {
+                showButton = selectedEntities.some(function isBuilding(e) {
                     return e.tags.building;
                 });
             }
 
             if (!showButton) {
-                var entities = context.intersects(context.map().extent());
+                var displayedEntities = context.intersects(context.map().extent());
 
-                showButton = entities.some(function hasIndoorRelatedTag(e) {
+                showButton = displayedEntities.some(function hasIndoorRelatedTag(e) {
                     return e.tags.level || e.tags.indoor;
                 });
             }
@@ -116,9 +116,9 @@ iD.ui.IndoorMode = function (context) {
     function levelChangeFunc(dif) {
         return function () {
             d3.event.preventDefault();
-            context.indoor().level(parseFloat(context.indoor().level()) + dif + "");
+            context.indoor().level(parseFloat(context.indoor().level()) + dif + '');
             indoorControl.select('input').attr('placeholder', context.indoor().level());
-        }
+        };
     }
 
     function buttonTooltip(description, cmd) {

--- a/js/id/ui/indoor_mode.js
+++ b/js/id/ui/indoor_mode.js
@@ -1,62 +1,17 @@
 iD.ui.IndoorMode = function (context) {
-    var updateControls = function (selection, enableButton) {
 
+    var enterButton, indoorControl;
 
-        var enterButton = selection.select('.indoormode-enter-button');
-        var indoorControl = selection.select('.indoormode-control');
-
-        if (context.indoorMode()) {
-            console.log("updateControls indoor=true");
-            enterButton.classed('hide', true);
-            indoorControl.classed('hide', false);
-            indoorControl.select('.combobox-input')
-                .attr('placeholder', context.indoorLevel())
-                .value('')
-                .call(d3.combobox().data(context.indoorLevels().map(comboValues)));
-
-        }
-        else {
-            enterButton.classed('hide', false).property('disabled', !enableButton);
-            indoorControl.classed('hide', true);
-        }
-    };
-
-    var toggleIndoor = function () {
-        d3.event.preventDefault();
-        context.toggleIndoorMode();
-
-    };
-
-    var buttonTooltip = function (description) {
-        return bootstrap.tooltip()
-            .placement('bottom')
-            .html(true)
-            .title(iD.ui.tooltipHtml(description, iD.ui.cmd('⌘⇧I')));
-    };
-
-    var setLevel = function () {
-        var input = d3.select(this);
-        var data = input.value(); //string!
-        if (data === '') return; //blank value
-        console.log('setLevel', data);
-
-        input
-            .attr('placeholder', data)
-            .value('');
-
-        context.indoorLevel(data);
-
-    };
-
-    var createControls = function (selection) {
-        var enterButton = selection.append('button')
+    function createControls(selection) {
+        enterButton = selection.append('button')
             .attr('class', 'indoormode-enter-button col12 ')
             .on('click', toggleIndoor)
-            .call(buttonTooltip('Enter indoor editing mode'))
+            .call(buttonTooltip('Enter indoor editing mode'));
+        enterButton
             .append('span').attr('class', 'label').text('Indoor');
 
 
-        var indoorControl = selection.append('div')
+        indoorControl = selection.append('div')
             .attr('class', 'indoormode-control joined ');
 
         indoorControl.append('div')
@@ -65,7 +20,7 @@ iD.ui.IndoorMode = function (context) {
             .attr('type', 'text')
             .call(d3.combobox().data([0, 1, 2, 3, 4, 5, 6].map(comboValues)))
             .on('blur', setLevel)
-            .on('change', setLevel)
+            .on('change', setLevel);
 
         indoorControl.append('button')
             .attr('class', 'col4')
@@ -75,16 +30,14 @@ iD.ui.IndoorMode = function (context) {
 
         enterButton.classed('hide', false).property('disabled', true);
         indoorControl.classed('hide', true);
-    };
+    }
 
 
     return function (selection) {
-
-        // draw both controls hidden
         createControls(selection);
 
         var keybinding = d3.keybinding('indoor')
-            .on(iD.ui.cmd('⌘I'), toggleIndoor)
+            .on(iD.ui.cmd('⌘I'), toggleIndoor);
 
         d3.select(document)
             .call(keybinding);
@@ -109,11 +62,53 @@ iD.ui.IndoorMode = function (context) {
             }
 
             console.log("context.on(enter) called");
-            console.log('enableIndoor', enableButton)
+            console.log('enableIndoor', enableButton);
             updateControls(selection, enableButton);
         }
     };
 
+    function updateControls(selection, enableButton) {
+        if (context.indoorMode()) {
+            console.log("updateControls indoor=true");
+            enterButton.classed('hide', true);
+            indoorControl.classed('hide', false);
+            indoorControl.select('.combobox-input')
+                .attr('placeholder', context.indoorLevel())
+                .value('')
+                .call(d3.combobox().data(context.indoorLevels().map(comboValues)));
+
+        }
+        else {
+            enterButton.classed('hide', false).property('disabled', !enableButton);
+            indoorControl.classed('hide', true);
+        }
+    }
+
+    function toggleIndoor() {
+        d3.event.preventDefault();
+        context.toggleIndoorMode();
+
+    }
+
+    function buttonTooltip(description) {
+        return bootstrap.tooltip()
+            .placement('bottom')
+            .html(true)
+            .title(iD.ui.tooltipHtml(description, iD.ui.cmd('⌘⇧I')));
+    }
+
+    function setLevel() {
+        var input = d3.select(this);
+        var data = input.value(); //string!
+        if (data === '') return; //blank value
+        console.log('setLevel', data);
+
+        input
+            .attr('placeholder', data)
+            .value('');
+
+        context.indoorLevel(data);
+    }
 
     function comboValues(d) {
         return {
@@ -122,43 +117,3 @@ iD.ui.IndoorMode = function (context) {
         };
     }
 };
-
-/*
-
- init
- - vždy : vytvořit button, nastavit .hide
- - vždy : vytvořit select+buton, .hide
-
-
- update
- - indoorMode : nastavit správný level
- -vždy unhide to správné
-
- - přidat selectbox, přepsat text na X
-
-
-
-
-
-
- */
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/js/id/ui/indoor_mode.js
+++ b/js/id/ui/indoor_mode.js
@@ -44,7 +44,7 @@ iD.ui.IndoorMode = function (context) {
 
         context
             .on('enter.indoor_mode', update)
-            .on('indoor.indoor_mode', update);
+            .on('indoorLevelChanged.indoor_mode', update);
 
         function update() {
             var enableButton = context.indoorMode();

--- a/js/id/ui/indoor_mode.js
+++ b/js/id/ui/indoor_mode.js
@@ -1,0 +1,157 @@
+iD.ui.IndoorMode = function (context) {
+    var redrawButton = function (selection, enableButton) {
+
+        //buttons.each(function(d) {
+        //    d3.select(this)
+        //        .call(iD.svg.Icon('#icon-' + d.id));
+        //});
+
+        //update selection
+        buttons.select('span.label')
+            .text('Good');
+
+        if (context.indoorMode()) {
+            commands[0].title = "Level " + context.indoorLevel();
+            //selection.selectAll('button').data(commands)
+        }
+
+        buttons
+            .property('disabled', !enableButton)
+            .classed('hide', !enableButton)
+        //.each(function() {
+        //    var selection = d3.select(this);
+        //    if (selection.property('tooltipVisible')) {
+        //        selection.call(tooltip.show);
+        //    }
+        //});
+    };
+
+    var initButtons = function (selection) {
+        var enterButtonTooltip = bootstrap.tooltip()
+            .placement('bottom')
+            .html(true)
+            .title(iD.ui.tooltipHtml('Enter indoor editing mode', iD.ui.cmd('⌘I')));
+
+        var exitButtonTooltip = bootstrap.tooltip()
+            .placement('bottom')
+            .html(true)
+            .title(iD.ui.tooltipHtml('Exit indoor editing mode', iD.ui.cmd('⌘I')));
+
+
+        var enterButton = selection.append('button')
+            .attr('class', 'col6')
+            .on('click', function () {
+                context.enterIndoorMode();
+            })
+            .call(enterButtonTooltip);
+
+
+        var buttons = selection.selectAll('button');
+
+        //enter selection
+        buttons
+            .enter().append('button')
+
+
+        //update selection
+        buttons.append('span')
+            .attr('class', 'label')
+            .text(function (mode) {
+                return mode.title;
+            });
+
+
+        buttons
+            .property('disabled', !true)
+            .classed('hide', !true);
+
+    };
+
+
+    return function (selection) {
+
+        // draw both controls hidden
+        initButtons(selection);
+
+        // enable one of them and update labels
+        redrawButton(selection, false);
+
+
+        var keybinding = d3.keybinding('indoor')
+            .on(commands[0].cmd, function () {
+                d3.event.preventDefault();
+                commands[0].action();
+            })
+        //.on(commands[1].cmd, function() { d3.event.preventDefault(); commands[1].action(); });
+
+        d3.select(document)
+            .call(keybinding);
+
+        //context.history()
+        //    .on('change.undo_redo', update);
+
+        context
+            .on('enter.indoor_mode', update)
+        //.on('indoorModeChanged.indoor_mode', update);
+
+        function update() {
+            var enableButton = context.indoorMode();
+
+            if (!enableButton) {
+                var graph = context.graph();
+                var ids = context.selectedIDs();
+                var entities = ids.map(function (id) {
+                    return graph.entity(id);
+                });
+                var hasIndoorRelatedTag = function (e) {
+                    return e.tags.level || e.tags.indoor || e.tags.building;
+                };
+                enableButton = entities.some(hasIndoorRelatedTag);
+            }
+
+            console.log("context.on(enter) called");
+            console.log('enableIndoor', enableButton)
+            redrawButton(selection, enableButton);
+        }
+    };
+};
+
+/*
+
+ init
+ - vždy : vytvořit button, nastavit .hide
+ - vždy : vytvořit select+buton, .hide
+
+
+ update
+ - indoorMode : nastavit správný level
+ -vždy unhide to správné
+
+ - přidat selectbox, přepsat text na X
+
+
+
+
+
+
+ */
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/js/id/ui/indoor_mode.js
+++ b/js/id/ui/indoor_mode.js
@@ -3,10 +3,11 @@ iD.ui.IndoorMode = function (context) {
     var enterButton, indoorControl;
 
     function createControls(selection) {
+
         enterButton = selection.append('button')
             .attr('class', 'indoormode-enter-button col12 ')
             .on('click', toggleIndoor)
-            .call(buttonTooltip('Enter indoor editing mode'));
+            .call(buttonTooltip('Indoor mode helps you creating indoor objects by filtering only the selected level. Even for currently added features.', '⌘⇧I'));
         enterButton
             .append('span').attr('class', 'label').text('Indoor');
 
@@ -14,19 +15,31 @@ iD.ui.IndoorMode = function (context) {
         indoorControl = selection.append('div')
             .attr('class', 'indoormode-control joined ');
 
-        indoorControl.append('div')
-            .attr('class', 'col8 indoormode-level-combo')
+        indoorControl.append('div') //combo
+            .attr('class', 'col4 indoormode-level-combo')
             .append('input')
             .attr('type', 'text')
             .call(d3.combobox().data([0, 1, 2, 3, 4, 5, 6].map(comboValues)))
             .on('blur', setLevel)
             .on('change', setLevel);
-
+        spinControl = indoorControl.append('div');
         indoorControl.append('button')
-            .attr('class', 'col4')
+            .attr('class', 'col3')
             .on('click', toggleIndoor)
-            .call(buttonTooltip('Exit indoor editing mode'))
+            .call(buttonTooltip('Exit indoor editing mode', '⌘⇧I'))
             .call(iD.svg.Icon('#icon-close'));
+
+        var spinControl;
+        spinControl
+            .attr('class', 'spin-control col5');
+        spinControl.append('button')
+            .attr('class', 'increment')
+            .on('click', levelChangeFunc(+1))
+            .call(buttonTooltip('Level +1'));
+        spinControl.append('button')
+            .attr('class', 'decrement')
+            .on('click', levelChangeFunc(-1))
+            .call(buttonTooltip('Level -1'));
 
         enterButton.classed('hide', true); //.property('disabled', true);
         indoorControl.classed('hide', true);
@@ -37,7 +50,7 @@ iD.ui.IndoorMode = function (context) {
         createControls(selection);
 
         var keybinding = d3.keybinding('indoor')
-            .on(iD.ui.cmd('⌘I'), toggleIndoor);
+            .on(iD.ui.cmd('⌘⇧I'), toggleIndoor);
 
         d3.select(document)
             .call(keybinding);
@@ -87,14 +100,21 @@ iD.ui.IndoorMode = function (context) {
     function toggleIndoor() {
         d3.event.preventDefault();
         context.toggleIndoorMode();
-
     }
 
-    function buttonTooltip(description) {
+    function levelChangeFunc(dif) {
+        return function () {
+            d3.event.preventDefault();
+            context.indoorLevel(parseFloat(context.indoorLevel()) + dif + "");
+            indoorControl.select('input').attr('placeholder', context.indoorLevel());
+        }
+    }
+
+    function buttonTooltip(description, cmd) {
         return bootstrap.tooltip()
             .placement('bottom')
             .html(true)
-            .title(iD.ui.tooltipHtml(description, iD.ui.cmd('⌘⇧I')));
+            .title(iD.ui.tooltipHtml(description, cmd ? iD.ui.cmd(cmd) : undefined));
     }
 
     function setLevel() {

--- a/js/id/ui/indoor_mode.js
+++ b/js/id/ui/indoor_mode.js
@@ -28,7 +28,7 @@ iD.ui.IndoorMode = function (context) {
             .call(buttonTooltip('Exit indoor editing mode'))
             .call(iD.svg.Icon('#icon-close'));
 
-        enterButton.classed('hide', false).property('disabled', true);
+        enterButton.classed('hide', true); //.property('disabled', true);
         indoorControl.classed('hide', true);
     }
 
@@ -56,7 +56,7 @@ iD.ui.IndoorMode = function (context) {
                     return graph.entity(id);
                 });
                 var hasIndoorRelatedTag = function (e) {
-                    return e.tags.level || e.tags.indoor || e.tags.building;
+                    return e.tags.level || e.tags.repeat_on || e.tags.indoor || e.tags.building;
                 };
                 enableButton = entities.some(hasIndoorRelatedTag);
             }
@@ -79,7 +79,7 @@ iD.ui.IndoorMode = function (context) {
 
         }
         else {
-            enterButton.classed('hide', false).property('disabled', !enableButton);
+            enterButton.classed('hide', !enableButton); //.property('disabled', !enableButton);
             indoorControl.classed('hide', true);
         }
     }

--- a/js/id/ui/indoor_mode.js
+++ b/js/id/ui/indoor_mode.js
@@ -7,9 +7,9 @@ iD.ui.IndoorMode = function (context) {
         enterButton = selection.append('button')
             .attr('class', 'indoormode-enter-button col12 ')
             .on('click', toggleIndoor)
-            .call(buttonTooltip('Indoor mode helps you creating indoor objects by filtering only the selected level. Even for currently added features.', '⌘⇧I'));
+            .call(buttonTooltip(t('indoor_mode.help'), '⌘⇧I'));
         enterButton
-            .append('span').attr('class', 'label').text('Indoor');
+            .append('span').attr('class', 'label').text(t('indoor_mode.title'));
 
 
         indoorControl = selection.append('div')
@@ -26,7 +26,7 @@ iD.ui.IndoorMode = function (context) {
         indoorControl.append('button')
             .attr('class', 'col3')
             .on('click', toggleIndoor)
-            .call(buttonTooltip('Exit indoor editing mode', '⌘⇧I'))
+            .call(buttonTooltip(t('indoor_mode.exit'), '⌘⇧I'))
             .call(iD.svg.Icon('#icon-close'));
 
         var spinControl;
@@ -74,15 +74,12 @@ iD.ui.IndoorMode = function (context) {
                 enableButton = entities.some(hasIndoorRelatedTag);
             }
 
-            console.log("context.on(enter) called");
-            console.log('enableIndoor', enableButton);
             updateControls(selection, enableButton);
         }
     };
 
     function updateControls(selection, enableButton) {
         if (context.indoorMode()) {
-            console.log("updateControls indoor=true");
             enterButton.classed('hide', true);
             indoorControl.classed('hide', false);
             indoorControl.select('.combobox-input')
@@ -92,7 +89,7 @@ iD.ui.IndoorMode = function (context) {
 
         }
         else {
-            enterButton.classed('hide', !enableButton); //.property('disabled', !enableButton);
+            enterButton.classed('hide', !enableButton);
             indoorControl.classed('hide', true);
         }
     }
@@ -121,7 +118,6 @@ iD.ui.IndoorMode = function (context) {
         var input = d3.select(this);
         var data = input.value(); //string!
         if (data === '') return; //blank value
-        console.log('setLevel', data);
 
         input
             .attr('placeholder', data)

--- a/js/id/ui/indoor_mode.js
+++ b/js/id/ui/indoor_mode.js
@@ -80,6 +80,14 @@ iD.ui.IndoorMode = function (context) {
                 });
             }
 
+            if (!showButton) {
+                var entities = context.intersects(context.map().extent());
+
+                showButton = entities.some(function hasIndoorRelatedTag(e) {
+                    return e.tags.level || e.tags.indoor;
+                });
+            }
+
             updateControls(selection, showButton);
         }
     };

--- a/js/id/ui/preset/range.js
+++ b/js/id/ui/preset/range.js
@@ -12,7 +12,7 @@ iD.ui.preset.range = function (field) {
             .attr('id', function (d) { return 'preset-input-' + field.id + '-' + d; })
             .style('width', '50%')
             .style('border-radius', function (d) { return d === 0 ? '0 0 0 4px' : '0 0 4px 0'; })
-            .attr('placeholder', function (d) { return field.t('placeholder-' + d); })
+            .attr('placeholder', function (d) { return field.t('placeholder-' + d); });
 
         inputs
             .on('input', change(true))

--- a/js/id/ui/preset/range.js
+++ b/js/id/ui/preset/range.js
@@ -1,0 +1,40 @@
+iD.ui.preset.range = function (field) {
+
+    var dispatch = d3.dispatch('change'),
+        inputs;
+
+    function i(selection) {
+        inputs = selection.selectAll('input')
+            .data([0, 1]);
+
+        inputs.enter().append('input')
+            .attr('type', 'number')
+            .attr('id', function (d) { return 'preset-input-' + field.id + '-' + d; })
+            .style('width', '50%')
+            .style('border-radius', function (d) { return d === 0 ? '0 0 0 4px' : '0 0 4px 0'; })
+            .attr('placeholder', function (d) { return field.t('placeholder-' + d); })
+
+        inputs
+            .on('input', change(true))
+            .on('blur', change())
+            .on('change', change());
+    }
+
+    function change(onInput) {
+        return function (d) {
+            var t = {};
+            t[field.keys[d]] = this.value || undefined;
+            dispatch.change(t, onInput);
+        };
+    }
+
+    i.tags = function (tags) {
+        inputs.value(function(d){ return tags[field.keys[d]] || ''; });
+    };
+
+    i.focus = function () {
+        inputs.node().focus();
+    };
+
+    return d3.rebind(i, dispatch, 'on');
+};

--- a/test/index.html
+++ b/test/index.html
@@ -61,6 +61,7 @@
     <script src='../js/id/renderer/background.js'></script>
     <script src='../js/id/renderer/background_source.js'></script>
     <script src='../js/id/renderer/features.js'></script>
+    <script src='../js/id/renderer/indoor.js'></script>
     <script src='../js/id/renderer/map.js'></script>
     <script src='../js/id/renderer/tile_layer.js'></script>
 
@@ -97,6 +98,7 @@
     <script src='../js/id/ui/map_data.js'></script>
     <script src='../js/id/ui/map_in_map.js'></script>
     <script src='../js/id/ui/modes.js'></script>
+    <script src='../js/id/ui/indoor_mode.js'></script>
     <script src='../js/id/ui/contributors.js'></script>
     <script src='../js/id/ui/geolocate.js'></script>
     <script src='../js/id/ui/notice.js'></script>
@@ -128,6 +130,8 @@
     <script src='../js/id/ui/preset/check.js'></script>
     <script src='../js/id/ui/preset/combo.js'></script>
     <script src='../js/id/ui/preset/localized.js'></script>
+    <!-- more presets are already missing here -->
+    <script src='../js/id/ui/preset/range.js'></script>
     <script src='../js/id/ui/preset/wikipedia.js'></script>
 
     <script src='../js/id/actions.js'></script>
@@ -289,6 +293,7 @@
     <script src="spec/renderer/tile_layer.js"></script>
     <script src="spec/renderer/background_source.js"></script>
     <script src="spec/renderer/features.js"></script>
+    <script src="spec/renderer/indoor.js"></script>
     <script src="spec/renderer/map.js"></script>
 
     <script src="spec/svg.js"></script>

--- a/test/index_packaged.html
+++ b/test/index_packaged.html
@@ -83,6 +83,7 @@
     <script src="spec/renderer/tile_layer.js"></script>
     <script src="spec/renderer/background_source.js"></script>
     <script src="spec/renderer/features.js"></script>
+    <script src="spec/renderer/indoor.js"></script>
     <script src="spec/renderer/map.js"></script>
 
     <script src="spec/svg.js"></script>

--- a/test/spec/renderer/indoor.js
+++ b/test/spec/renderer/indoor.js
@@ -1,0 +1,79 @@
+describe('iD.Indoor', function() {
+    var context,
+        features,
+        indoor;
+
+    beforeEach(function() {
+        context = iD();
+        context.map().zoom(17);
+        features = context.features();
+        indoor = context.indoor();
+
+        //mocks
+        var surface = d3.select(document.createElement('svg'));
+        context.surface = function () {
+            return surface;
+        };
+
+        var container = d3.select(document.createElement('div'));
+        context.container = function () {
+            return container;
+        };
+
+    });
+
+    describe('startup', function () {
+        it('returns correct level', function () {
+            indoor.level('134');
+            expect(indoor.level()).to.equal('134');
+        });
+
+        it('add correct classes', function () {
+            indoor.level('1');
+            expect(context.surface().classed('indoor-mode'), 'surface to have class .indoor-mode').to.be.true;
+        });
+
+        it('disables feature indoor_different_level', function () {
+            indoor.level('1');
+            expect(features.enabled('indoor_different_level'), 'indoor level ').to.be.false;
+        });
+
+
+
+    });
+
+    describe('filtering', function () {
+
+        it('hides features on different level', function () {
+
+            var node1 = iD.Node({tags: {amenity: 'bar', level: '1-2'}, version: 1});
+            var node2 = iD.Node({tags: {amenity: 'bar', level: '-2--1'}, version: 1});
+            var node3 = iD.Node({tags: {amenity: 'bar', level: '-2-4'}, version: 1});
+            var node4 = iD.Node({tags: {amenity: 'bar'}, version: 1});
+            var node5 = iD.Node({tags: {amenity: 'bar', level: 'asdf'}, version: 1});
+            var node6 = iD.Node({tags: {amenity: 'bar', level: '3;4;1'}, version: 1});
+
+            var graph = iD.Graph([node1, node2, node3, node4, node5, node6]);
+
+            // correct _hidden
+            var all = _.values(graph.base().entities),
+                dimensions = [1000, 1000];
+            features.gatherStats(all, graph, dimensions);
+
+
+            indoor.level('1');
+            expect(features.isHidden(node1, graph, node1.geometry(graph)), 'level=1-2 is shown in level 1').to.be.false;
+            expect(features.isHidden(node2, graph, node2.geometry(graph)), 'level=-2--1 is hidden in level 1').to.be.true;
+            expect(features.isHidden(node3, graph, node3.geometry(graph)), 'level=-2-4 is shown in level 1').to.be.false;
+            expect(features.isHidden(node4, graph, node4.geometry(graph)), '`no level` is hidden in level 1').to.be.true;
+            expect(features.isHidden(node5, graph, node5.geometry(graph)), 'level=asdf is hidden in level 1').to.be.true;
+            expect(features.isHidden(node6, graph, node6.geometry(graph)), 'level=3;4;1 is shown in level 1').to.be.false;
+
+
+            indoor.level('-1.5');
+            expect(features.isHidden(node2, graph, node2.geometry(graph)), 'level=-2--1 is shown in level -1.5').to.be.false;
+
+        });
+    });
+
+});

--- a/test/spec/renderer/indoor.js
+++ b/test/spec/renderer/indoor.js
@@ -1,9 +1,9 @@
-describe('iD.Indoor', function() {
+describe('iD.Indoor', function () {
     var context,
         features,
         indoor;
 
-    beforeEach(function() {
+    beforeEach(function () {
         context = iD();
         context.map().zoom(17);
         features = context.features();
@@ -39,7 +39,6 @@ describe('iD.Indoor', function() {
         });
 
 
-
     });
 
     describe('filtering', function () {
@@ -73,6 +72,19 @@ describe('iD.Indoor', function() {
             indoor.level('-1.5');
             expect(features.isHidden(node2, graph, node2.geometry(graph)), 'level=-2--1 is shown in level -1.5').to.be.false;
 
+        });
+
+        it('shows decimal level', function () {
+
+            var node1 = iD.Node({tags: {amenity: 'bar', level: '0.5'}, version: 1});
+            var all = [node1];
+            var graph = iD.Graph(all);
+
+            // update _hidden field in features
+            features.gatherStats(all, graph, [1000, 1000]);
+
+            indoor.level('0.5');
+            expect(features.isHidden(node1, graph, node1.geometry(graph)), 'level=0.5 is shown in level 0.5').to.be.false;
         });
     });
 


### PR DESCRIPTION
Hi,

I am submitting a little larger pull request. I am not sure if its possible to be merged as is, but I did my best and will be happy to cooperate further to make it so.

I’ve been engaged in OpenStreetMap since 2008 and for the time being I’ve led many [workshops](http://osmap.cz/skoleni), written some school works and worked on getting the Czech community together on [openstreetmap.cz](http://openstreetmap.cz). Last summer I had to come up with a topic for my final engineer thesis, so I decided to use the effort already invested in indoor mapping and chose to update the iD editor accordingly. Let me elaborate...

Current work-in-progress proposal is called [Simple Indoor Tagging](http://wiki.openstreetmap.org/wiki/Simple_Indoor_Tagging). I didn’t want to rely on WIP, so I realized there is already an accepted solution – the [`level=*` tag](wiki.openstreetmap.org/wiki/Key:level). 

There are two challenges for indoor:
1. making underlying background map (this is addressed by Simple Indoor’s `indoor=*` area features)
2. display ways – the accessibility of places – and this kind of was the nature of OSM from the beginning. Until we had all the `landuse=*` areas, OSM started with highways + pois. 

Drawing `highways=*` for indoor feels very natural – corridors usually repeats every floor even in multi-storey buildings, it displays clear accessibility information, can be already used for routing and also works with parking highways. The logic is also very simple - when a `level=*` feature is in viewport - show “Indoor” button, and let the user filter on these. 

**Several examples** (my build):
- [Shopping mall in Prague](https://openstreetmap.cz/edit/#id=w382843342&map=18.06/14.40284/50.07310) - underground parking, main foot passages and few shops POIs
- [University building in Aachen](https://openstreetmap.cz/edit/#map=20.02/6.07485/50.77945) - complete room plans with Simple Indoor (older proposal version with optional `level=*` xor `repeat_on=*`). Another building [here](http://openstreetmap.cz/edit/#background=Bing&map=19.00/-1.63590/42.79960).
- [Berlin main railway station](https://openstreetmap.cz/edit/#map=18.74/13.41165/52.52148) - several underground floors + indoor=\* features
- [University campus Prague](https://openstreetmap.cz/edit/#map=18.21/14.39011/50.10425) - mapping in progress ;-)
- [Another shopping mall](https://openstreetmap.cz/edit/#map=19.20/14.46135/50.07867) - only POIs

Well, i think I made my point - let’s discuss the technical background :-)

---
### Some thoughts / questions:
1. Is it ok, to call it indoor _mode_? It doesn't fit with current “modes” terminology, where modes are exclusive.
2. I think the philosophy of iD is to show disabled buttons for “availible” actions. I chose to hide the button completely, where there isn't any `level=*` features on screen. Would you agree?
3. Current `level=*` allows only separate values by semicolon, I borrowed three useful tagging from SimpleIndoor. Is it ok to use these? Should i maybe make new official proposition?
   - ranges – `level=0-12` or `-3--1` for features spaning several floors. 
   - `repeat_on` – for repeating the same (possibly multilevel) feature on other floors - ie. doors,toilets
   - `min/max_level` – when set on building, the building spans through these levels. It helps as a visual cue, and also for the renderers.
4. I had to unclip the building-outline shape, because a building completely covered with `indoor=*` areas, couldn't be clicked anyway. Kind of addresses the issue #2225.
5. I submitted my original development commits, rebased to current master. Is it appropriate to squash the commits into one or few?
6. Although I tried to abide the current code style and wrote some test, tell me if i should change something globally. Easiest would be to comment the code in the specific commits.. 
### Something to do in future
- if agreed, I would like to add level indicator as shown here https://github.com/zbycz/iD/wiki/devnotes-zbycz – but rather use another svg layer instead of filters.
- once proposition is accepted – enable switching over floating point level values (ie. `level=1.5`). But even now - any string value could be written in the level chooser, so it “works”.
- add icon for ‘highway=elevator`and`indoor=corridor+stairs=yes` as these had to be distinguished easily.
- Unfortunately I found later, I developed very similar changes as Panier’s [id-indoor fork](https://git.framasoft.org/PanierAvide/iD-indoor). Although he added many more indoor presets, which could be eventually merged here.
- Create a level switcher in osmbuildings.org 3D viewer ;-)   .. well, distant future indeed.
### Changelog until now:
- added `iD.ui.IndoorMode` control ui
- added filtering using `features.indoor_different_levels`
- added `.indoor-mode` class for svg surface
- added general preset for `indoor=*` when indoor-mode enabled
- added several map styles for enabled `.indoor-mode`
- added `indoor_levels` as general field for building, using `iD.ui.preset.range`

btw, it was a pleasure to work with iD codebase, also d3 is so very amazing :-)
