### PR TITLE
Highlight related members

### DIFF
--- a/js/id/ui/raw_membership_editor.js
+++ b/js/id/ui/raw_membership_editor.js
@@ -4,6 +4,19 @@ iD.ui.RawMembershipEditor = function(context) {
     function selectRelation(d) {
         d3.event.preventDefault();
         context.enter(iD.modes.Select(context, [d.relation.id]));
+
+        d.relation.members.forEach(function(member, index) {
+            if (member.type === 'way') {
+                var element = document.getElementsByClassName(member.id + ' ' + member.type + ' shadow');
+            }
+            else if (member.type === 'node') {
+                var element = document.getElementsByClassName(member.id + ' ' + member.type);
+            }
+            else {
+                return;
+            }
+            element[0].classList.add("selected");
+        });
     }
 
     function changeRole(d) {


### PR DESCRIPTION
I notice the issue:  indicate route membership with shadow #659 and related issues #2980 . I add 13 lines in raw_membership_editor.js. 

This make when selecting a relation, all members (including points, ways) are highlighted on the map.

![highlight related members](https://cloud.githubusercontent.com/assets/1564154/15675631/67d0b916-2775-11e6-8cb5-55aa8faa0f85.jpg)


 