### PR TITLE
Making spec/actions lint free

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
   },
   "scripts": {
     "postinstall": "rm -rf node_modules/.bin/phantomjs",
-    "test": "eslint js/id && phantomjs node_modules/mocha-phantomjs-core/mocha-phantomjs-core.js test/index.html dot && make && phantomjs node_modules/mocha-phantomjs-core/mocha-phantomjs-core.js test/index_packaged.html dot",
+    "test": "npm run lint && phantomjs node_modules/mocha-phantomjs-core/mocha-phantomjs-core.js test/index.html dot && make && phantomjs node_modules/mocha-phantomjs-core/mocha-phantomjs-core.js test/index_packaged.html dot",
     "start": "http-server .",
-    "lint": "eslint js/id"
+    "lint": "eslint js/id && npm run lint:spec:actions",
+    "lint:spec:actions": "eslint test/spec/actions"
   },
   "repository": {
     "type": "git",
@@ -27,7 +28,7 @@
     "chai": "~1.9.2",
     "d3": "3.5.5",
     "editor-layer-index": "git://github.com/osmlab/editor-layer-index.git#gh-pages",
-    "eslint": "~1.10.3",
+    "eslint": "^1.10.3",
     "glob": "~3.1.21",
     "happen": "0.1.2",
     "http-server": "^0.9.0",

--- a/test/spec/.eslintrc
+++ b/test/spec/.eslintrc
@@ -1,0 +1,13 @@
+{
+    "globals": {
+        "describe": true,
+        "it": true,
+        "expect": true,
+        "specify": true,
+        "beforeEach": true,
+        "afterEach": true
+    },
+    "rules": {
+        "no-unused-expressions": 0
+    }
+}

--- a/test/spec/actions/add_entity.js
+++ b/test/spec/actions/add_entity.js
@@ -1,5 +1,5 @@
-describe("iD.actions.AddEntity", function () {
-    it("adds an entity to the graph", function () {
+describe('iD.actions.AddEntity', function () {
+    it('adds an entity to the graph', function () {
         var entity = iD.Entity(),
             graph = iD.actions.AddEntity(entity)(iD.Graph());
         expect(graph.entity(entity.id)).to.equal(entity);

--- a/test/spec/actions/add_member.js
+++ b/test/spec/actions/add_member.js
@@ -1,16 +1,16 @@
-describe("iD.actions.AddMember", function() {
-    it("adds an member to a relation at the specified index", function() {
+describe('iD.actions.AddMember', function() {
+    it('adds an member to a relation at the specified index', function() {
         var r = iD.Relation({members: [{id: '1'}, {id: '3'}]}),
             g = iD.actions.AddMember(r.id, {id: '2'}, 1)(iD.Graph([r]));
         expect(g.entity(r.id).members).to.eql([{id: '1'}, {id: '2'}, {id: '3'}]);
     });
 
-    describe("inserts way members at a sensible index", function() {
+    describe('inserts way members at a sensible index', function() {
         function members(graph) {
             return _.map(graph.entity('r').members, 'id');
         }
 
-        specify("no members", function() {
+        specify('no members', function() {
             var graph = iD.Graph([
                 iD.Node({id: 'a', loc: [0, 0]}),
                 iD.Node({id: 'b', loc: [0, 0]}),
@@ -22,7 +22,7 @@ describe("iD.actions.AddMember", function() {
             expect(members(graph)).to.eql(['-']);
         });
 
-        specify("not connecting", function() {
+        specify('not connecting', function() {
             // a--->b    c===>d
             var graph = iD.Graph([
                 iD.Node({id: 'a', loc: [0, 0]}),
@@ -38,7 +38,7 @@ describe("iD.actions.AddMember", function() {
             expect(members(graph)).to.eql(['-', '=']);
         });
 
-        specify("connecting at end", function() {
+        specify('connecting at end', function() {
             // a--->b===>c
             var graph = iD.Graph([
                 iD.Node({id: 'a', loc: [0, 0]}),
@@ -53,7 +53,7 @@ describe("iD.actions.AddMember", function() {
             expect(members(graph)).to.eql(['-', '=']);
         });
 
-        specify("connecting at beginning", function() {
+        specify('connecting at beginning', function() {
             // a===>b--->c~~~>d
             var graph = iD.Graph([
                 iD.Node({id: 'a', loc: [0, 0]}),
@@ -70,7 +70,7 @@ describe("iD.actions.AddMember", function() {
             expect(members(graph)).to.eql(['=', '-', '~']);
         });
 
-        specify("connecting in middle", function() {
+        specify('connecting in middle', function() {
             // a--->b===>c~~~>d
             var graph = iD.Graph([
                 iD.Node({id: 'a', loc: [0, 0]}),

--- a/test/spec/actions/add_midpoint.js
+++ b/test/spec/actions/add_midpoint.js
@@ -1,5 +1,5 @@
-describe("iD.actions.AddMidpoint", function () {
-    it("adds the node at the midpoint location", function () {
+describe('iD.actions.AddMidpoint', function () {
+    it('adds the node at the midpoint location', function () {
         var node = iD.Node(),
             a = iD.Node(),
             b = iD.Node(),
@@ -9,7 +9,7 @@ describe("iD.actions.AddMidpoint", function () {
         expect(graph.entity(node.id).loc).to.eql([1, 2]);
     });
 
-    it("adds the node to a way that contains the given edge in forward order", function () {
+    it('adds the node to a way that contains the given edge in forward order', function () {
         var node = iD.Node(),
             a = iD.Node(),
             b = iD.Node(),
@@ -22,7 +22,7 @@ describe("iD.actions.AddMidpoint", function () {
         expect(graph.entity(w2.id).nodes).to.eql([a.id, node.id, b.id]);
     });
 
-    it("adds the node to a way that contains the given edge in reverse order", function () {
+    it('adds the node to a way that contains the given edge in reverse order', function () {
         var node = iD.Node(),
             a = iD.Node(),
             b = iD.Node(),
@@ -35,7 +35,7 @@ describe("iD.actions.AddMidpoint", function () {
         expect(graph.entity(w2.id).nodes).to.eql([b.id, node.id, a.id]);
     });
 
-    it("turns an invalid double-back into a self-intersection", function () {
+    it('turns an invalid double-back into a self-intersection', function () {
         // a====b (aba)
         // Expected result (converts to a valid loop):
         // a---b (acba)

--- a/test/spec/actions/change_member.js
+++ b/test/spec/actions/change_member.js
@@ -1,5 +1,5 @@
-describe("iD.actions.ChangeMember", function () {
-    it("updates the member at the specified index", function () {
+describe('iD.actions.ChangeMember', function () {
+    it('updates the member at the specified index', function () {
         var node     = iD.Node(),
             relation = iD.Relation({members: [{id: node.id}]}),
             action   = iD.actions.ChangeMember(relation.id, {id: node.id, role: 'node'}, 0),

--- a/test/spec/actions/change_preset.js
+++ b/test/spec/actions/change_preset.js
@@ -1,22 +1,22 @@
-describe("iD.actions.ChangePreset", function() {
+describe('iD.actions.ChangePreset', function() {
     var oldPreset = iD.presets.Preset('old', {tags: {old: 'true'}}),
         newPreset = iD.presets.Preset('new', {tags: {new: 'true'}});
 
-    it("changes from one preset's tags to another's", function() {
+    it('changes from one preset\'s tags to another\'s', function() {
         var entity = iD.Node({tags: {old: 'true'}}),
             graph = iD.Graph([entity]),
             action = iD.actions.ChangePreset(entity.id, oldPreset, newPreset);
         expect(action(graph).entity(entity.id).tags).to.eql({new: 'true'});
     });
 
-    it("adds the tags of a new preset to an entity without an old preset", function() {
+    it('adds the tags of a new preset to an entity without an old preset', function() {
         var entity = iD.Node(),
             graph = iD.Graph([entity]),
             action = iD.actions.ChangePreset(entity.id, null, newPreset);
         expect(action(graph).entity(entity.id).tags).to.eql({new: 'true'});
     });
 
-    it("removes the tags of an old preset from an entity without a new preset", function() {
+    it('removes the tags of an old preset from an entity without a new preset', function() {
         var entity = iD.Node({tags: {old: 'true'}}),
             graph = iD.Graph([entity]),
             action = iD.actions.ChangePreset(entity.id, oldPreset, null);

--- a/test/spec/actions/change_tags.js
+++ b/test/spec/actions/change_tags.js
@@ -1,5 +1,5 @@
-describe("iD.actions.ChangeTags", function () {
-    it("changes an entity's tags", function () {
+describe('iD.actions.ChangeTags', function () {
+    it('changes an entity\'s tags', function () {
         var entity = iD.Entity(),
             tags   = {foo: 'bar'},
             graph  = iD.actions.ChangeTags(entity.id, tags)(iD.Graph([entity]));

--- a/test/spec/actions/circularize.js
+++ b/test/spec/actions/circularize.js
@@ -1,4 +1,4 @@
-describe("iD.actions.Circularize", function () {
+describe('iD.actions.Circularize', function () {
     var projection = d3.geo.mercator();
 
     function isCircular(id, graph) {
@@ -12,7 +12,7 @@ describe("iD.actions.Circularize", function () {
         return (pctDiff < 0.025);   // within 2.5% of circular area..
     }
 
-    it("creates nodes if necessary", function () {
+    it('creates nodes if necessary', function () {
         //    d ---- c
         //    |      |
         //    a ---- b
@@ -30,7 +30,7 @@ describe("iD.actions.Circularize", function () {
         expect(graph.entity('-').nodes).to.have.length(20);
     });
 
-    it("reuses existing nodes", function () {
+    it('reuses existing nodes', function () {
         //    d,e -- c
         //    |      |
         //    a ---- b
@@ -56,7 +56,7 @@ describe("iD.actions.Circularize", function () {
         expect(nodes).to.contain('e');
     });
 
-    it("limits movement of nodes that are members of other ways", function () {
+    it('limits movement of nodes that are members of other ways', function () {
         //    b ---- a
         //    |      |
         //    c ---- d
@@ -89,7 +89,7 @@ describe("iD.actions.Circularize", function () {
         return 180 / Math.PI * Math.acos(vector1[0] * vector2[0] + vector1[1] * vector2[1]);
     }
 
-    it("creates circle respecting min-angle limit", function() {
+    it('creates circle respecting min-angle limit', function() {
         //    d ---- c
         //    |      |
         //    a ---- b
@@ -119,7 +119,7 @@ describe("iD.actions.Circularize", function () {
         return d3.geom.polygon(_.map(graph.childNodes(graph.entity(id)), 'loc')).area();
     }
 
-    it("leaves clockwise ways clockwise", function () {
+    it('leaves clockwise ways clockwise', function () {
         //    d ---- c
         //    |      |
         //    a ---- b
@@ -139,7 +139,7 @@ describe("iD.actions.Circularize", function () {
         expect(area('+', graph)).to.be.gt(0);
     });
 
-    it("leaves counter-clockwise ways counter-clockwise", function () {
+    it('leaves counter-clockwise ways counter-clockwise', function () {
         //    d ---- c
         //    |      |
         //    a ---- b
@@ -159,7 +159,7 @@ describe("iD.actions.Circularize", function () {
         expect(area('-', graph)).to.be.lt(0);
     });
 
-    it("adds new nodes on shared way wound in opposite direction", function () {
+    it('adds new nodes on shared way wound in opposite direction', function () {
         //    c ---- b ---- f
         //    |     /       |
         //    |    a        |
@@ -193,7 +193,7 @@ describe("iD.actions.Circularize", function () {
         expect(graph.entity('=').isConvex(graph)).to.be.false;
     });
 
-    it("adds new nodes on shared way wound in similar direction", function () {
+    it('adds new nodes on shared way wound in similar direction', function () {
         //    c ---- b ---- f
         //    |     /       |
         //    |    a        |
@@ -227,7 +227,7 @@ describe("iD.actions.Circularize", function () {
         expect(graph.entity('=').isConvex(graph)).to.be.false;
     });
 
-    it("circularizes extremely concave ways with a key node on the wrong side of the centroid", function () {
+    it('circularizes extremely concave ways with a key node on the wrong side of the centroid', function () {
         //    c ------------ b -- f
         //    |       ___---      |
         //    |  a ===            |
@@ -257,11 +257,11 @@ describe("iD.actions.Circularize", function () {
         expect(graph.entity('-').nodes).to.have.length(20);
     });
 
-    it("circularizes a closed single line way", function () {
+    it('circularizes a closed single line way', function () {
         var graph = iD.Graph([
                 iD.Node({id: 'a', loc: [0, 0]}),
                 iD.Node({id: 'b', loc: [0, 2]}),
-                iD.Way({id: '-', nodes: ['a', 'b', 'a']}),
+                iD.Way({id: '-', nodes: ['a', 'b', 'a']})
             ]);
 
         expect(area('-', graph)).to.eql(0);

--- a/test/spec/actions/connect.js
+++ b/test/spec/actions/connect.js
@@ -1,5 +1,5 @@
-describe("iD.actions.Connect", function() {
-    it("removes all but the final node", function() {
+describe('iD.actions.Connect', function() {
+    it('removes all but the final node', function() {
         var graph = iD.Graph([
                 iD.Node({id: 'a'}),
                 iD.Node({id: 'b'}),
@@ -13,7 +13,7 @@ describe("iD.actions.Connect", function() {
         expect(graph.entity('c')).not.to.be.undefined;
     });
 
-    it("replaces non-surviving nodes in parent ways", function() {
+    it('replaces non-surviving nodes in parent ways', function() {
         // a --- b --- c
         //
         //       e
@@ -44,7 +44,7 @@ describe("iD.actions.Connect", function() {
         expect(graph.entity('|').nodes).to.eql(['d', 'b']);
     });
 
-    it("handles circular ways", function() {
+    it('handles circular ways', function() {
         // c -- a   d === e
         // |   /
         // |  /
@@ -68,7 +68,7 @@ describe("iD.actions.Connect", function() {
         expect(graph.entity('-').nodes).to.eql(['d', 'b', 'c', 'd']);
     });
 
-    it("merges adjacent nodes", function() {
+    it('merges adjacent nodes', function() {
         // a --- b --- c
         //
         // Connect [b, c]
@@ -90,7 +90,7 @@ describe("iD.actions.Connect", function() {
         expect(graph.hasEntity('b')).to.be.undefined;
     });
 
-    it("merges adjacent nodes with connections", function() {
+    it('merges adjacent nodes with connections', function() {
         // a --- b --- c
         //       |
         //       d
@@ -119,7 +119,7 @@ describe("iD.actions.Connect", function() {
         expect(graph.hasEntity('b')).to.be.undefined;
     });
 
-    it("deletes a degenerate way", function() {
+    it('deletes a degenerate way', function() {
         // a --- b
         //
         // Connect [a, b]
@@ -136,7 +136,7 @@ describe("iD.actions.Connect", function() {
         expect(graph.hasEntity('-')).to.be.undefined;
     });
 
-    it("merges tags to the surviving node", function() {
+    it('merges tags to the surviving node', function() {
         var graph = iD.Graph([
                 iD.Node({id: 'a', tags: {a: 'a'}}),
                 iD.Node({id: 'b', tags: {b: 'b'}}),
@@ -148,7 +148,7 @@ describe("iD.actions.Connect", function() {
         expect(graph.entity('c').tags).to.eql({a: 'a', b: 'b', c: 'c'});
     });
 
-    it("merges memberships to the surviving node", function() {
+    it('merges memberships to the surviving node', function() {
         var graph = iD.Graph([
                 iD.Node({id: 'a'}),
                 iD.Node({id: 'b'}),

--- a/test/spec/actions/copy_entities.js
+++ b/test/spec/actions/copy_entities.js
@@ -1,5 +1,5 @@
-describe("iD.actions.CopyEntities", function () {
-    it("copies a node", function () {
+describe('iD.actions.CopyEntities', function () {
+    it('copies a node', function () {
         var a = iD.Node({id: 'a'}),
             base = iD.Graph([a]),
             head = iD.actions.CopyEntities(['a'], base)(base),
@@ -10,7 +10,7 @@ describe("iD.actions.CopyEntities", function () {
         expect(created).to.have.length(1);
     });
 
-    it("copies a way", function () {
+    it('copies a way', function () {
         var a = iD.Node({id: 'a'}),
             b = iD.Node({id: 'b'}),
             w = iD.Way({id: 'w', nodes: ['a', 'b']}),
@@ -24,7 +24,7 @@ describe("iD.actions.CopyEntities", function () {
         expect(created).to.have.length(3);
     });
 
-    it("copies multiple nodes", function () {
+    it('copies multiple nodes', function () {
         var base = iD.Graph([
                 iD.Node({id: 'a'}),
                 iD.Node({id: 'b'})
@@ -39,7 +39,7 @@ describe("iD.actions.CopyEntities", function () {
         expect(created).to.have.length(2);
     });
 
-    it("copies multiple ways, keeping the same connections", function () {
+    it('copies multiple ways, keeping the same connections', function () {
         var base = iD.Graph([
                 iD.Node({id: 'a'}),
                 iD.Node({id: 'b'}),
@@ -56,14 +56,14 @@ describe("iD.actions.CopyEntities", function () {
         expect(action.copies().w1.nodes[1]).to.eql(action.copies().w2.nodes[0]);
     });
 
-    it("obtains source entities from an alternate graph", function () {
+    it('obtains source entities from an alternate graph', function () {
         var a = iD.Node({id: 'a'}),
             old = iD.Graph([a]),
             base = iD.Graph(),
             action = iD.actions.CopyEntities(['a'], old),
             head = action(base),
-            diff = iD.Difference(base, head),
-            created = diff.created();
+            diff = iD.Difference(base, head);
+            diff.created();
 
         expect(head.hasEntity('a')).not.to.be.ok;
         expect(Object.keys(action.copies())).to.have.length(1);

--- a/test/spec/actions/delete_member.js
+++ b/test/spec/actions/delete_member.js
@@ -1,5 +1,5 @@
-describe("iD.actions.DeleteMember", function () {
-    it("removes the member at the specified index", function () {
+describe('iD.actions.DeleteMember', function () {
+    it('removes the member at the specified index', function () {
         var a      = iD.Node({id: 'a'}),
             b      = iD.Node({id: 'b'}),
             r      = iD.Relation({members: [{id: 'a'}, {id: 'b'}]}),
@@ -8,7 +8,7 @@ describe("iD.actions.DeleteMember", function () {
         expect(graph.entity(r.id).members).to.eql([{id: 'b'}]);
     });
 
-    it("deletes relations that become degenerate", function () {
+    it('deletes relations that become degenerate', function () {
         var a      = iD.Node({id: 'a'}),
             r      = iD.Relation({id: 'r', members: [{id: 'a'}]}),
             action = iD.actions.DeleteMember(r.id, 0),

--- a/test/spec/actions/delete_multiple.js
+++ b/test/spec/actions/delete_multiple.js
@@ -1,5 +1,5 @@
-describe("iD.actions.DeleteMultiple", function () {
-    it("deletes multiple entities of heterogeneous types", function () {
+describe('iD.actions.DeleteMultiple', function () {
+    it('deletes multiple entities of heterogeneous types', function () {
         var n      = iD.Node(),
             w      = iD.Way(),
             r      = iD.Relation(),
@@ -10,7 +10,7 @@ describe("iD.actions.DeleteMultiple", function () {
         expect(graph.hasEntity(r.id)).to.be.undefined;
     });
 
-    it("deletes a way and one of its nodes", function () {
+    it('deletes a way and one of its nodes', function () {
         var n      = iD.Node(),
             w      = iD.Way({nodes: [n.id]}),
             action = iD.actions.DeleteMultiple([w.id, n.id]),
@@ -19,8 +19,8 @@ describe("iD.actions.DeleteMultiple", function () {
         expect(graph.hasEntity(n.id)).to.be.undefined;
     });
 
-    describe("#disabled", function () {
-        it("returns the result of the first action that is disabled", function () {
+    describe('#disabled', function () {
+        it('returns the result of the first action that is disabled', function () {
             var node     = iD.Node(),
                 relation = iD.Relation({members: [{id: 'w'}]}),
                 graph    = iD.Graph([node, relation]),

--- a/test/spec/actions/delete_node.js
+++ b/test/spec/actions/delete_node.js
@@ -1,12 +1,12 @@
-describe("iD.actions.DeleteNode", function () {
-    it("removes the node from the graph", function () {
+describe('iD.actions.DeleteNode', function () {
+    it('removes the node from the graph', function () {
         var node   = iD.Node(),
             action = iD.actions.DeleteNode(node.id),
             graph  = action(iD.Graph([node]));
         expect(graph.hasEntity(node.id)).to.be.undefined;
     });
 
-    it("removes the node from parent ways", function () {
+    it('removes the node from parent ways', function () {
         var node1  = iD.Node(),
             node2  = iD.Node(),
             node3  = iD.Node(),
@@ -16,7 +16,7 @@ describe("iD.actions.DeleteNode", function () {
         expect(graph.entity(way.id).nodes).to.eql([node2.id, node3.id]);
     });
 
-    it("removes the node from parent relations", function () {
+    it('removes the node from parent relations', function () {
         var node1    = iD.Node(),
             node2    = iD.Node(),
             relation = iD.Relation({members: [{ id: node1.id }, { id: node2.id }]}),
@@ -25,7 +25,7 @@ describe("iD.actions.DeleteNode", function () {
         expect(graph.entity(relation.id).members).to.eql([{ id: node2.id }]);
     });
 
-    it("deletes parent ways that would otherwise have less than two nodes", function () {
+    it('deletes parent ways that would otherwise have less than two nodes', function () {
         var node1  = iD.Node(),
             node2  = iD.Node(),
             way    = iD.Way({nodes: [node1.id, node2.id]}),
@@ -34,7 +34,7 @@ describe("iD.actions.DeleteNode", function () {
         expect(graph.hasEntity(way.id)).to.be.undefined;
     });
 
-    it("deletes degenerate circular ways", function () {
+    it('deletes degenerate circular ways', function () {
         var node1  = iD.Node(),
             node2  = iD.Node(),
             way    = iD.Way({nodes: [node1.id, node2.id, node1.id]}),
@@ -43,7 +43,7 @@ describe("iD.actions.DeleteNode", function () {
         expect(graph.hasEntity(way.id)).to.be.undefined;
     });
 
-    it("deletes parent relations that become empty", function () {
+    it('deletes parent relations that become empty', function () {
         var node1    = iD.Node(),
             relation = iD.Relation({members: [{ id: node1.id }]}),
             action   = iD.actions.DeleteNode(node1.id),

--- a/test/spec/actions/delete_relation.js
+++ b/test/spec/actions/delete_relation.js
@@ -1,12 +1,12 @@
-describe("iD.actions.DeleteRelation", function () {
-    it("removes the relation from the graph", function () {
+describe('iD.actions.DeleteRelation', function () {
+    it('removes the relation from the graph', function () {
         var relation = iD.Relation(),
             action   = iD.actions.DeleteRelation(relation.id),
             graph    = action(iD.Graph([relation]));
         expect(graph.hasEntity(relation.id)).to.be.undefined;
     });
 
-    it("removes the relation from parent relations", function () {
+    it('removes the relation from parent relations', function () {
         var a      = iD.Relation(),
             b      = iD.Relation(),
             parent = iD.Relation({members: [{ id: a.id }, { id: b.id }]}),
@@ -15,7 +15,7 @@ describe("iD.actions.DeleteRelation", function () {
         expect(graph.entity(parent.id).members).to.eql([{ id: b.id }]);
     });
 
-    it("deletes member nodes not referenced by another parent", function() {
+    it('deletes member nodes not referenced by another parent', function() {
         var node     = iD.Node(),
             relation = iD.Relation({members: [{id: node.id}]}),
             action   = iD.actions.DeleteRelation(relation.id),
@@ -23,7 +23,7 @@ describe("iD.actions.DeleteRelation", function () {
         expect(graph.hasEntity(node.id)).to.be.undefined;
     });
 
-    it("does not delete member nodes referenced by another parent", function() {
+    it('does not delete member nodes referenced by another parent', function() {
         var node     = iD.Node(),
             way      = iD.Way({nodes: [node.id]}),
             relation = iD.Relation({members: [{id: node.id}]}),
@@ -32,7 +32,7 @@ describe("iD.actions.DeleteRelation", function () {
         expect(graph.hasEntity(node.id)).not.to.be.undefined;
     });
 
-    it("does not delete member nodes with interesting tags", function() {
+    it('does not delete member nodes with interesting tags', function() {
         var node     = iD.Node({tags: {highway: 'traffic_signals'}}),
             relation = iD.Relation({members: [{id: node.id}]}),
             action   = iD.actions.DeleteRelation(relation.id),
@@ -40,7 +40,7 @@ describe("iD.actions.DeleteRelation", function () {
         expect(graph.hasEntity(node.id)).not.to.be.undefined;
     });
 
-    it("deletes member ways not referenced by another parent", function() {
+    it('deletes member ways not referenced by another parent', function() {
         var way      = iD.Way(),
             relation = iD.Relation({members: [{id: way.id}]}),
             action   = iD.actions.DeleteRelation(relation.id),
@@ -48,7 +48,7 @@ describe("iD.actions.DeleteRelation", function () {
         expect(graph.hasEntity(way.id)).to.be.undefined;
     });
 
-    it("does not delete member ways referenced by another parent", function() {
+    it('does not delete member ways referenced by another parent', function() {
         var way       = iD.Way(),
             relation1 = iD.Relation({members: [{id: way.id}]}),
             relation2 = iD.Relation({members: [{id: way.id}]}),
@@ -57,7 +57,7 @@ describe("iD.actions.DeleteRelation", function () {
         expect(graph.hasEntity(way.id)).not.to.be.undefined;
     });
 
-    it("does not delete member ways with interesting tags", function() {
+    it('does not delete member ways with interesting tags', function() {
         var way      = iD.Node({tags: {highway: 'residential'}}),
             relation = iD.Relation({members: [{id: way.id}]}),
             action   = iD.actions.DeleteRelation(relation.id),
@@ -65,7 +65,7 @@ describe("iD.actions.DeleteRelation", function () {
         expect(graph.hasEntity(way.id)).not.to.be.undefined;
     });
 
-    it("deletes nodes of deleted member ways", function() {
+    it('deletes nodes of deleted member ways', function() {
         var node     = iD.Node(),
             way      = iD.Way({nodes: [node.id]}),
             relation = iD.Relation({members: [{id: way.id}]}),
@@ -74,7 +74,7 @@ describe("iD.actions.DeleteRelation", function () {
         expect(graph.hasEntity(node.id)).to.be.undefined;
     });
 
-    it("deletes parent relations that become empty", function () {
+    it('deletes parent relations that become empty', function () {
         var child  = iD.Relation(),
             parent = iD.Relation({members: [{ id: child.id }]}),
             action = iD.actions.DeleteRelation(child.id),
@@ -82,8 +82,8 @@ describe("iD.actions.DeleteRelation", function () {
         expect(graph.hasEntity(parent.id)).to.be.undefined;
     });
 
-    describe("#disabled", function() {
-        it("returns 'incomplete_relation' if the relation is incomplete", function() {
+    describe('#disabled', function() {
+        it('returns \'incomplete_relation\' if the relation is incomplete', function() {
             var relation = iD.Relation({members: [{id: 'w'}]}),
                 graph    = iD.Graph([relation]),
                 action   = iD.actions.DeleteRelation(relation.id);

--- a/test/spec/actions/delete_way.js
+++ b/test/spec/actions/delete_way.js
@@ -1,12 +1,12 @@
-describe("iD.actions.DeleteWay", function() {
-    it("removes the way from the graph", function() {
+describe('iD.actions.DeleteWay', function() {
+    it('removes the way from the graph', function() {
         var way    = iD.Way(),
             action = iD.actions.DeleteWay(way.id),
             graph  = iD.Graph([way]).update(action);
         expect(graph.hasEntity(way.id)).to.be.undefined;
     });
 
-    it("removes a way from parent relations", function() {
+    it('removes a way from parent relations', function() {
         var way      = iD.Way(),
             relation = iD.Relation({members: [{ id: way.id }, { id: 'w-2' }]}),
             action   = iD.actions.DeleteWay(way.id),
@@ -14,7 +14,7 @@ describe("iD.actions.DeleteWay", function() {
         expect(_.map(graph.entity(relation.id).members, 'id')).not.to.contain(way.id);
     });
 
-    it("deletes member nodes not referenced by another parent", function() {
+    it('deletes member nodes not referenced by another parent', function() {
         var node   = iD.Node(),
             way    = iD.Way({nodes: [node.id]}),
             action = iD.actions.DeleteWay(way.id),
@@ -22,7 +22,7 @@ describe("iD.actions.DeleteWay", function() {
         expect(graph.hasEntity(node.id)).to.be.undefined;
     });
 
-    it("does not delete member nodes referenced by another parent", function() {
+    it('does not delete member nodes referenced by another parent', function() {
         var node   = iD.Node(),
             way1   = iD.Way({nodes: [node.id]}),
             way2   = iD.Way({nodes: [node.id]}),
@@ -31,7 +31,7 @@ describe("iD.actions.DeleteWay", function() {
         expect(graph.hasEntity(node.id)).not.to.be.undefined;
     });
 
-    it("deletes multiple member nodes", function() {
+    it('deletes multiple member nodes', function() {
         var a      = iD.Node(),
             b      = iD.Node(),
             way    = iD.Way({nodes: [a.id, b.id]}),
@@ -41,7 +41,7 @@ describe("iD.actions.DeleteWay", function() {
         expect(graph.hasEntity(b.id)).to.be.undefined;
     });
 
-    it("deletes a circular way's start/end node", function() {
+    it('deletes a circular way\'s start/end node', function() {
         var a      = iD.Node(),
             b      = iD.Node(),
             c      = iD.Node(),
@@ -53,7 +53,7 @@ describe("iD.actions.DeleteWay", function() {
         expect(graph.hasEntity(c.id)).to.be.undefined;
     });
 
-    it("does not delete member nodes with interesting tags", function() {
+    it('does not delete member nodes with interesting tags', function() {
         var node   = iD.Node({tags: {highway: 'traffic_signals'}}),
             way    = iD.Way({nodes: [node.id]}),
             action = iD.actions.DeleteWay(way.id),
@@ -61,7 +61,7 @@ describe("iD.actions.DeleteWay", function() {
         expect(graph.hasEntity(node.id)).not.to.be.undefined;
     });
 
-    it("deletes parent relations that become empty", function () {
+    it('deletes parent relations that become empty', function () {
         var way      = iD.Way(),
             relation = iD.Relation({members: [{ id: way.id }]}),
             action   = iD.actions.DeleteWay(way.id),
@@ -69,8 +69,8 @@ describe("iD.actions.DeleteWay", function() {
         expect(graph.hasEntity(relation.id)).to.be.undefined;
     });
 
-    describe("#disabled", function () {
-        it("returns 'part_of_relation' for members of route and boundary relations", function () {
+    describe('#disabled', function () {
+        it('returns \'part_of_relation\' for members of route and boundary relations', function () {
             var a        = iD.Way({id: 'a'}),
                 b        = iD.Way({id: 'b'}),
                 route    = iD.Relation({members: [{id: 'a'}], tags: {type: 'route'}}),
@@ -80,7 +80,7 @@ describe("iD.actions.DeleteWay", function() {
             expect(iD.actions.DeleteWay('b').disabled(graph)).to.equal('part_of_relation');
         });
 
-        it("returns 'part_of_relation' for outer members of multipolygons", function () {
+        it('returns \'part_of_relation\' for outer members of multipolygons', function () {
             var way      = iD.Way({id: 'w'}),
                 relation = iD.Relation({members: [{id: 'w', role: 'outer'}], tags: {type: 'multipolygon'}}),
                 graph    = iD.Graph([way, relation]),
@@ -88,7 +88,7 @@ describe("iD.actions.DeleteWay", function() {
             expect(action.disabled(graph)).to.equal('part_of_relation');
         });
 
-        it("returns falsy for inner members of multipolygons", function () {
+        it('returns falsy for inner members of multipolygons', function () {
             var way      = iD.Way({id: 'w'}),
                 relation = iD.Relation({members: [{id: 'w', role: 'inner'}], tags: {type: 'multipolygon'}}),
                 graph    = iD.Graph([way, relation]),

--- a/test/spec/actions/discard_tags.js
+++ b/test/spec/actions/discard_tags.js
@@ -1,5 +1,5 @@
-describe("iD.actions.DiscardTags", function() {
-    it("discards obsolete tags from modified entities", function() {
+describe('iD.actions.DiscardTags', function() {
+    it('discards obsolete tags from modified entities', function() {
         var way    = iD.Way({id: 'w1', tags: {created_by: 'Potlatch'}}),
             base   = iD.Graph([way]),
             head   = base.replace(way.update({tags: {created_by: 'Potlatch', foo: 'bar'}})),
@@ -7,7 +7,7 @@ describe("iD.actions.DiscardTags", function() {
         expect(action(head).entity(way.id).tags).to.eql({foo: 'bar'});
     });
 
-    it("discards obsolete tags from created entities", function() {
+    it('discards obsolete tags from created entities', function() {
         var way    = iD.Way({tags: {created_by: 'Potlatch'}}),
             base   = iD.Graph(),
             head   = base.replace(way),
@@ -15,7 +15,7 @@ describe("iD.actions.DiscardTags", function() {
         expect(action(head).entity(way.id).tags).to.eql({});
     });
 
-    it("doesn't modify entities without obsolete tags", function() {
+    it('doesn\'t modify entities without obsolete tags', function() {
         var way    = iD.Way(),
             base   = iD.Graph(),
             head   = base.replace(way),
@@ -23,7 +23,7 @@ describe("iD.actions.DiscardTags", function() {
         expect(action(head).entity(way.id)).to.equal(way);
     });
 
-    it("discards tags with empty values", function() {
+    it('discards tags with empty values', function() {
         var way    = iD.Way({tags: {lmnop: ''}}),
             base   = iD.Graph(),
             head   = base.replace(way),

--- a/test/spec/actions/disconnect.js
+++ b/test/spec/actions/disconnect.js
@@ -1,11 +1,11 @@
-describe("iD.actions.Disconnect", function () {
-    describe("#disabled", function () {
-        it("returns 'not_connected' for a node shared by less than two ways", function () {
+describe('iD.actions.Disconnect', function () {
+    describe('#disabled', function () {
+        it('returns \'not_connected\' for a node shared by less than two ways', function () {
             var graph = iD.Graph([iD.Node({id: 'a'})]);
             expect(iD.actions.Disconnect('a').disabled(graph)).to.equal('not_connected');
         });
 
-        it("returns falsy for the closing node in a closed line", function () {
+        it('returns falsy for the closing node in a closed line', function () {
             //    a ---- b
             //    |      |
             //    d ---- c
@@ -19,7 +19,7 @@ describe("iD.actions.Disconnect", function () {
             expect(iD.actions.Disconnect('a').disabled(graph)).not.to.be.ok;
         });
 
-        it("returns not_connected for the closing node in a closed area", function () {
+        it('returns not_connected for the closing node in a closed area', function () {
             //    a ---- b
             //    |      |
             //    d ---- c
@@ -33,7 +33,7 @@ describe("iD.actions.Disconnect", function () {
             expect(iD.actions.Disconnect('a').disabled(graph)).to.equal('not_connected');
         });
 
-        it("returns falsy for a shared non-closing node in an area", function () {
+        it('returns falsy for a shared non-closing node in an area', function () {
             //    a --- b --- c
             //          |     |
             //          e --- d
@@ -49,7 +49,7 @@ describe("iD.actions.Disconnect", function () {
             expect(iD.actions.Disconnect('b').disabled(graph)).not.to.be.ok;
         });
 
-        it("returns falsy for a node shared by two or more ways", function () {
+        it('returns falsy for a node shared by two or more ways', function () {
             //    a ---- b ---- c
             //           |
             //           d
@@ -65,7 +65,7 @@ describe("iD.actions.Disconnect", function () {
             expect(iD.actions.Disconnect('b').disabled(graph)).not.to.be.ok;
         });
 
-        it("returns falsy for an intersection of two ways with parent way specified", function () {
+        it('returns falsy for an intersection of two ways with parent way specified', function () {
             //    a ---- b ---- c
             //           |
             //           d
@@ -81,7 +81,7 @@ describe("iD.actions.Disconnect", function () {
             expect(iD.actions.Disconnect('b', ['|']).disabled(graph)).not.to.be.ok;
         });
 
-        it("returns 'relation' for a node connecting any two members of the same relation", function () {
+        it('returns \'relation\' for a node connecting any two members of the same relation', function () {
             // Covers restriction relations, routes, multipolygons.
             // a ---- b ---- c
             var graph = iD.Graph([
@@ -99,7 +99,7 @@ describe("iD.actions.Disconnect", function () {
             expect(iD.actions.Disconnect('b').disabled(graph)).to.eql('relation');
         });
 
-        it("returns falsy for a node connecting two members of an unaffected relation", function () {
+        it('returns falsy for a node connecting two members of an unaffected relation', function () {
             // a ---- b ---- c
             //        |
             //        d
@@ -122,7 +122,7 @@ describe("iD.actions.Disconnect", function () {
         });
     });
 
-    it("replaces the node with a new node in all but the first way", function () {
+    it('replaces the node with a new node in all but the first way', function () {
         // Situation:
         //    a ---- b ---- c
         //           |
@@ -151,7 +151,7 @@ describe("iD.actions.Disconnect", function () {
         expect(graph.entity('|').nodes).to.eql(['d', 'e']);
     });
 
-    it("replaces the node with a new node in the specified ways", function () {
+    it('replaces the node with a new node in the specified ways', function () {
         // Situation:
         //    a ---- b ==== c
         //           |
@@ -180,7 +180,7 @@ describe("iD.actions.Disconnect", function () {
         expect(graph.entity('|').nodes).to.eql(['d', 'b']);
     });
 
-    it("replaces later occurrences in a self-intersecting way", function() {
+    it('replaces later occurrences in a self-intersecting way', function() {
         // Situtation:
         //  a --- b
         //   \   /
@@ -203,7 +203,7 @@ describe("iD.actions.Disconnect", function () {
         expect(graph.entity('w').nodes).to.eql(['a', 'b', 'c', 'd']);
     });
 
-    it("disconnects a way with multiple intersection points", function() {
+    it('disconnects a way with multiple intersection points', function() {
         // Situtation:
         //  a == b -- c
         //       |    |
@@ -234,7 +234,7 @@ describe("iD.actions.Disconnect", function () {
         expect(graph.entity('w2').nodes).to.eql(['*', 'c', 'd', 'e', '*']);
     });
 
-    it("disconnects a shared non-closing node in an area", function() {
+    it('disconnects a shared non-closing node in an area', function() {
         // Situtation:
         //  a -- b -- c
         //       |    |
@@ -261,7 +261,7 @@ describe("iD.actions.Disconnect", function () {
         expect(graph.entity('w').nodes).to.eql(['a', 'b', 'c', 'd', 'e', '*', 'a']);
     });
 
-    it("disconnects the closing node of an area without breaking the area", function() {
+    it('disconnects the closing node of an area without breaking the area', function() {
         // Situtation:
         // a --- b --- d
         //  \   / \   /
@@ -294,7 +294,7 @@ describe("iD.actions.Disconnect", function () {
         expect(graph.entity('w2').nodes).to.eql(['*', 'd', 'e', '*']);
     });
 
-    it("disconnects multiple closing nodes of multiple areas without breaking the areas", function() {
+    it('disconnects multiple closing nodes of multiple areas without breaking the areas', function() {
         // Situtation:
         // a --- b --- d
         //  \   / \   /
@@ -327,7 +327,7 @@ describe("iD.actions.Disconnect", function () {
         expect(graph.entity('w2').nodes).to.eql(['*', 'd', 'e', '*']);
     });
 
-    it("copies location and tags to the new nodes", function () {
+    it('copies location and tags to the new nodes', function () {
         var tags  = {highway: 'traffic_signals'},
             loc   = [1, 2],
             graph = iD.Graph([

--- a/test/spec/actions/join.js
+++ b/test/spec/actions/join.js
@@ -1,6 +1,6 @@
-describe("iD.actions.Join", function () {
-    describe("#disabled", function () {
-        it("returns falsy for ways that share an end/start node", function () {
+describe('iD.actions.Join', function () {
+    describe('#disabled', function () {
+        it('returns falsy for ways that share an end/start node', function () {
             // a --> b ==> c
             var graph = iD.Graph([
                     iD.Node({id: 'a'}),
@@ -13,7 +13,7 @@ describe("iD.actions.Join", function () {
             expect(iD.actions.Join(['-', '=']).disabled(graph)).not.to.be.ok;
         });
 
-        it("returns falsy for ways that share a start/end node", function () {
+        it('returns falsy for ways that share a start/end node', function () {
             // a <-- b <== c
             var graph = iD.Graph([
                     iD.Node({id: 'a'}),
@@ -26,7 +26,7 @@ describe("iD.actions.Join", function () {
             expect(iD.actions.Join(['-', '=']).disabled(graph)).not.to.be.ok;
         });
 
-        it("returns falsy for ways that share a start/start node", function () {
+        it('returns falsy for ways that share a start/start node', function () {
             // a <-- b ==> c
             var graph = iD.Graph([
                     iD.Node({id: 'a'}),
@@ -39,7 +39,7 @@ describe("iD.actions.Join", function () {
             expect(iD.actions.Join(['-', '=']).disabled(graph)).not.to.be.ok;
         });
 
-        it("returns falsy for ways that share an end/end node", function () {
+        it('returns falsy for ways that share an end/end node', function () {
             // a --> b <== c
             var graph = iD.Graph([
                     iD.Node({id: 'a'}),
@@ -52,7 +52,7 @@ describe("iD.actions.Join", function () {
             expect(iD.actions.Join(['-', '=']).disabled(graph)).not.to.be.ok;
         });
 
-        it("returns falsy for more than two ways when connected, regardless of order", function () {
+        it('returns falsy for more than two ways when connected, regardless of order', function () {
             // a --> b ==> c ~~> d
             var graph = iD.Graph([
                     iD.Node({id: 'a'}),
@@ -72,7 +72,7 @@ describe("iD.actions.Join", function () {
             expect(iD.actions.Join(['~', '-', '=']).disabled(graph)).not.to.be.ok;
         });
 
-        it("returns 'not_eligible' for non-line geometries", function () {
+        it('returns \'not_eligible\' for non-line geometries', function () {
             var graph = iD.Graph([
                     iD.Node({id: 'a'})
                 ]);
@@ -80,7 +80,7 @@ describe("iD.actions.Join", function () {
             expect(iD.actions.Join(['a']).disabled(graph)).to.equal('not_eligible');
         });
 
-        it("returns 'not_adjacent' for ways that don't share the necessary nodes", function () {
+        it('returns \'not_adjacent\' for ways that don\'t share the necessary nodes', function () {
             // a -- b -- c
             //      |
             //      d
@@ -96,7 +96,7 @@ describe("iD.actions.Join", function () {
             expect(iD.actions.Join(['-', '=']).disabled(graph)).to.equal('not_adjacent');
         });
 
-        it("returns 'restriction' in situations where a turn restriction would be damaged (a)", function () {
+        it('returns \'restriction\' in situations where a turn restriction would be damaged (a)', function () {
             // a --> b ==> c
             // from: -
             // to: =
@@ -117,7 +117,7 @@ describe("iD.actions.Join", function () {
             expect(iD.actions.Join(['-', '=']).disabled(graph)).to.equal('restriction');
         });
 
-        it("returns 'restriction' in situations where a turn restriction would be damaged (b)", function () {
+        it('returns \'restriction\' in situations where a turn restriction would be damaged (b)', function () {
             // a --> b ==> c
             //       |
             //       d
@@ -142,7 +142,7 @@ describe("iD.actions.Join", function () {
             expect(iD.actions.Join(['-', '=']).disabled(graph)).to.equal('restriction');
         });
 
-        it("returns falsy in situations where a turn restriction wouldn't be damaged (a)", function () {
+        it('returns falsy in situations where a turn restriction wouldn\'t be damaged (a)', function () {
             // a --> b ==> c
             // |
             // d
@@ -167,7 +167,7 @@ describe("iD.actions.Join", function () {
             expect(iD.actions.Join(['-', '=']).disabled(graph)).not.to.be.ok;
         });
 
-        it("returns falsy in situations where a turn restriction wouldn't be damaged (b)", function () {
+        it('returns falsy in situations where a turn restriction wouldn\'t be damaged (b)', function () {
             //       d
             //       |
             // a --> b ==> c
@@ -195,7 +195,7 @@ describe("iD.actions.Join", function () {
             expect(iD.actions.Join(['-', '=']).disabled(graph)).not.to.be.ok;
         });
 
-        it("returns 'conflicting_tags' for two entities that have conflicting tags", function () {
+        it('returns \'conflicting_tags\' for two entities that have conflicting tags', function () {
             var graph = iD.Graph([
                 iD.Node({id: 'a'}),
                 iD.Node({id: 'b'}),
@@ -207,7 +207,7 @@ describe("iD.actions.Join", function () {
             expect(iD.actions.Join(['-', '=']).disabled(graph)).to.equal('conflicting_tags');
         });
 
-        it("takes tag reversals into account when calculating conflicts", function () {
+        it('takes tag reversals into account when calculating conflicts', function () {
             var graph = iD.Graph([
                 iD.Node({id: 'a'}),
                 iD.Node({id: 'b'}),
@@ -219,7 +219,7 @@ describe("iD.actions.Join", function () {
             expect(iD.actions.Join(['-', '=']).disabled(graph)).not.to.be.ok;
         });
 
-        it("returns falsy for exceptions to tag conflicts: missing tag", function () {
+        it('returns falsy for exceptions to tag conflicts: missing tag', function () {
             var graph = iD.Graph([
                 iD.Node({id: 'a'}),
                 iD.Node({id: 'b'}),
@@ -231,7 +231,7 @@ describe("iD.actions.Join", function () {
             expect(iD.actions.Join(['-', '=']).disabled(graph)).not.to.be.ok;
         });
 
-        it("returns falsy for exceptions to tag conflicts: uninteresting tag", function () {
+        it('returns falsy for exceptions to tag conflicts: uninteresting tag', function () {
             var graph = iD.Graph([
                 iD.Node({id: 'a'}),
                 iD.Node({id: 'b'}),
@@ -244,7 +244,7 @@ describe("iD.actions.Join", function () {
         });
     });
 
-    it("joins a --> b ==> c", function () {
+    it('joins a --> b ==> c', function () {
         // Expected result:
         // a --> b --> c
         var graph = iD.Graph([
@@ -261,7 +261,7 @@ describe("iD.actions.Join", function () {
         expect(graph.hasEntity('=')).to.be.undefined;
     });
 
-    it("joins a <-- b <== c", function () {
+    it('joins a <-- b <== c', function () {
         // Expected result:
         // a <-- b <-- c
         var graph = iD.Graph([
@@ -278,7 +278,7 @@ describe("iD.actions.Join", function () {
         expect(graph.hasEntity('=')).to.be.undefined;
     });
 
-    it("joins a <-- b ==> c", function () {
+    it('joins a <-- b ==> c', function () {
         // Expected result:
         // a <-- b <-- c
         // tags on === reversed
@@ -297,7 +297,7 @@ describe("iD.actions.Join", function () {
         expect(graph.entity('-').tags).to.eql({'lanes:backward': 2});
     });
 
-    it("joins a --> b <== c", function () {
+    it('joins a --> b <== c', function () {
         // Expected result:
         // a --> b --> c
         // tags on === reversed
@@ -316,7 +316,7 @@ describe("iD.actions.Join", function () {
         expect(graph.entity('-').tags).to.eql({'lanes:backward': 2});
     });
 
-    it("joins a --> b <== c <++ d **> e", function () {
+    it('joins a --> b <== c <++ d **> e', function () {
         // Expected result:
         // a --> b --> c --> d --> e
         // tags on === reversed
@@ -341,7 +341,7 @@ describe("iD.actions.Join", function () {
         expect(graph.entity('-').tags).to.eql({'lanes:backward': 2});
     });
 
-    it("prefers to keep existing ways", function () {
+    it('prefers to keep existing ways', function () {
         // a --> b ==> c ++> d
         // --- is new, === is existing, +++ is new
         // Expected result:
@@ -363,7 +363,7 @@ describe("iD.actions.Join", function () {
         expect(graph.hasEntity('w-2')).to.be.undefined;
     });
 
-    it("merges tags", function () {
+    it('merges tags', function () {
         var graph = iD.Graph([
                 iD.Node({id: 'a'}),
                 iD.Node({id: 'b'}),
@@ -379,7 +379,7 @@ describe("iD.actions.Join", function () {
         expect(graph.entity('-').tags).to.eql({a: 'a', b: '-;=', c: 'c', d: 'd', e: 'e'});
     });
 
-    it("merges relations", function () {
+    it('merges relations', function () {
         var graph = iD.Graph([
                 iD.Node({id: 'a'}),
                 iD.Node({id: 'b'}),

--- a/test/spec/actions/merge.js
+++ b/test/spec/actions/merge.js
@@ -1,5 +1,5 @@
-describe("iD.actions.Merge", function () {
-    it("merges multiple points to a line", function () {
+describe('iD.actions.Merge', function () {
+    it('merges multiple points to a line', function () {
         var graph = iD.Graph([
                 iD.Node({id: 'a', tags: {a: 'a'}}),
                 iD.Node({id: 'b', tags: {b: 'b'}}),
@@ -18,7 +18,7 @@ describe("iD.actions.Merge", function () {
         expect(graph.entity('r').members).to.eql([{id: 'w', role: 'r', type: 'way'}]);
     });
 
-    it("merges multiple points to an area", function () {
+    it('merges multiple points to an area', function () {
         var graph = iD.Graph([
                 iD.Node({id: 'a', tags: {a: 'a'}}),
                 iD.Node({id: 'b', tags: {b: 'b'}}),

--- a/test/spec/actions/merge_polygon.js
+++ b/test/spec/actions/merge_polygon.js
@@ -1,5 +1,5 @@
-describe("iD.actions.MergePolygon", function () {
-    
+describe('iD.actions.MergePolygon', function () {
+
     function node(id, x, y) {
         e.push(iD.Node({ id: id, loc: [x, y] }));
     }
@@ -50,7 +50,7 @@ describe("iD.actions.MergePolygon", function () {
         });
     }
 
-    it("creates a multipolygon from two closed ways", function() {
+    it('creates a multipolygon from two closed ways', function() {
         graph = iD.actions.MergePolygon(['w0', 'w1'], 'r')(graph);
         var r = graph.entity('r');
         expect(!!r).to.equal(true);
@@ -63,18 +63,18 @@ describe("iD.actions.MergePolygon", function () {
         expect(find(r, 'w1').type).to.equal('way');
     });
 
-    it("creates a multipolygon from a closed way and a multipolygon relation", function() {
+    it('creates a multipolygon from a closed way and a multipolygon relation', function() {
         graph = iD.actions.MergePolygon(['w0', 'w1'], 'r')(graph);
         graph = iD.actions.MergePolygon(['r', 'w2'])(graph);
         var r = graph.entity('r');
         expect(r.members.length).to.equal(3);
     });
 
-    it("creates a multipolygon from two multipolygon relations", function() {
+    it('creates a multipolygon from two multipolygon relations', function() {
         graph = iD.actions.MergePolygon(['w0', 'w1'], 'r')(graph);
         graph = iD.actions.MergePolygon(['w2', 'w5'], 'r2')(graph);
         graph = iD.actions.MergePolygon(['r', 'r2'])(graph);
-        
+
         // Delete other relation
         expect(graph.hasEntity('r2')).to.equal(undefined);
 
@@ -85,7 +85,7 @@ describe("iD.actions.MergePolygon", function () {
         expect(find(r, 'w5').role).to.equal('outer');
     });
 
-    it("merges multipolygon tags", function() {
+    it('merges multipolygon tags', function() {
         var graph = iD.Graph([
             iD.Relation({id: 'r1', tags: {type: 'multipolygon', a: 'a'}}),
             iD.Relation({id: 'r2', tags: {type: 'multipolygon', b: 'b'}})
@@ -97,14 +97,14 @@ describe("iD.actions.MergePolygon", function () {
         expect(graph.entity('r1').tags.b).to.equal('b');
     });
 
-    it("merges tags from closed outer ways", function() {
+    it('merges tags from closed outer ways', function() {
         graph = graph.replace(graph.entity('w0').update({ tags: { 'building': 'yes' }}));
         graph = iD.actions.MergePolygon(['w0', 'w5'], 'r')(graph);
         expect(graph.entity('w0').tags.building).to.equal(undefined);
         expect(graph.entity('r').tags.building).to.equal('yes');
     });
 
-    it("merges no tags from unclosed outer ways", function() {
+    it('merges no tags from unclosed outer ways', function() {
         graph = graph.replace(graph.entity('w3').update({ tags: { 'natural': 'water' }}));
 
         var r1 = iD.Relation({id: 'r1', tags: {type: 'multipolygon'}});
@@ -120,28 +120,28 @@ describe("iD.actions.MergePolygon", function () {
         expect(graph.entity('r1').tags.natural).to.equal(undefined);
     });
 
-    it("merges no tags from inner ways", function() {
+    it('merges no tags from inner ways', function() {
         graph = graph.replace(graph.entity('w1').update({ tags: { 'natural': 'water' }}));
         graph = iD.actions.MergePolygon(['w0', 'w1'], 'r')(graph);
         expect(graph.entity('w1').tags.natural).to.equal('water');
         expect(graph.entity('r').tags.natural).to.equal(undefined);
     });
 
-    it("doesn't copy area tags from ways", function() {
+    it('doesn\'t copy area tags from ways', function() {
         graph = graph.replace(graph.entity('w0').update({ tags: { 'area': 'yes' }}));
         graph = iD.actions.MergePolygon(['w0', 'w1'], 'r')(graph);
         var r = graph.entity('r');
         expect(r.tags.area).to.equal(undefined);
     });
 
-    it("creates a multipolygon with two disjunct outer rings", function() {
+    it('creates a multipolygon with two disjunct outer rings', function() {
         graph = iD.actions.MergePolygon(['w0', 'w5'], 'r')(graph);
         var r = graph.entity('r');
         expect(find(r, 'w0').role).to.equal('outer');
         expect(find(r, 'w5').role).to.equal('outer');
     });
 
-    it("creates a multipolygon with an island in a hole", function() {
+    it('creates a multipolygon with an island in a hole', function() {
         graph = iD.actions.MergePolygon(['w0', 'w1'], 'r')(graph);
         graph = iD.actions.MergePolygon(['r', 'w2'])(graph);
         var r = graph.entity('r');
@@ -150,7 +150,7 @@ describe("iD.actions.MergePolygon", function () {
         expect(find(r, 'w2').role).to.equal('outer');
     });
 
-    it("extends a multipolygon with multi-way rings", function() {
+    it('extends a multipolygon with multi-way rings', function() {
         var r = iD.Relation({ id: 'r', tags: { type: 'multipolygon' }, members: [
             { type: 'way', role: 'outer', id: 'w0' },
             { type: 'way', role: 'inner', id: 'w3' },

--- a/test/spec/actions/merge_remote_changes.js
+++ b/test/spec/actions/merge_remote_changes.js
@@ -1,4 +1,6 @@
-describe("iD.actions.MergeRemoteChanges", function () {
+/* global locale: true */
+/* eslint no-console: 0 */
+describe('iD.actions.MergeRemoteChanges', function () {
     var base = iD.Graph([
             iD.Node({id: 'a', loc: [1, 1], version: '1', tags: {foo: 'foo'}}),
 
@@ -66,13 +68,13 @@ describe("iD.actions.MergeRemoteChanges", function () {
             _current: 'en',
             en: {
                 'merge_remote_changes': {
-                    "annotation": "Merged remote changes from server.",
-                    "conflict": {
-                        "deleted": "This object has been deleted by {user}.",
-                        "location": "This object was moved by both you and {user}.",
-                        "nodelist": "Nodes were changed by both you and {user}.",
-                        "memberlist": "Relation members were changed by both you and {user}.",
-                        "tags": "You changed the <b>{tag}</b> tag to \"{local}\" and {user} changed it to \"{remote}\"."
+                    'annotation': 'Merged remote changes from server.',
+                    'conflict': {
+                        'deleted': 'This object has been deleted by {user}.',
+                        'location': 'This object was moved by both you and {user}.',
+                        'nodelist': 'Nodes were changed by both you and {user}.',
+                        'memberlist': 'Relation members were changed by both you and {user}.',
+                        'tags': 'You changed the <b>{tag}</b> tag to \"{local}\" and {user} changed it to \"{remote}\".'
                     }
                 }
             }
@@ -90,9 +92,9 @@ describe("iD.actions.MergeRemoteChanges", function () {
         }, iD.Graph(base));
     }
 
-    describe("non-destuctive merging", function () {
-        describe("tags", function() {
-            it("doesn't merge tags if conflict (local change, remote change)", function () {
+    describe('non-destuctive merging', function () {
+        describe('tags', function() {
+            it('doesn\'t merge tags if conflict (local change, remote change)', function () {
 
                 var localTags = {foo: 'foo_local'},      // changed foo
                     remoteTags = {foo: 'foo_remote'},    // changed foo
@@ -106,7 +108,7 @@ describe("iD.actions.MergeRemoteChanges", function () {
                 expect(result).to.eql(localGraph);
             });
 
-            it("doesn't merge tags if conflict (local change, remote delete)", function () {
+            it('doesn\'t merge tags if conflict (local change, remote delete)', function () {
                 var localTags = {foo: 'foo_local'},     // changed foo
                     remoteTags = {},                    // deleted foo
                     local = base.entity('a').update({tags: localTags}),
@@ -119,7 +121,7 @@ describe("iD.actions.MergeRemoteChanges", function () {
                 expect(result).to.eql(localGraph);
             });
 
-            it("doesn't merge tags if conflict (local delete, remote change)", function () {
+            it('doesn\'t merge tags if conflict (local delete, remote change)', function () {
                 var localTags = {},                     // deleted foo
                     remoteTags = {foo: 'foo_remote'},   // changed foo
                     local = base.entity('a').update({tags: localTags}),
@@ -132,7 +134,7 @@ describe("iD.actions.MergeRemoteChanges", function () {
                 expect(result).to.eql(localGraph);
             });
 
-            it("doesn't merge tags if conflict (local add, remote add)", function () {
+            it('doesn\'t merge tags if conflict (local add, remote add)', function () {
                 var localTags = {foo: 'foo', bar: 'bar_local'},    // same foo, added bar
                     remoteTags = {foo: 'foo', bar: 'bar_remote'},  // same foo, added bar
                     local = base.entity('a').update({tags: localTags}),
@@ -145,7 +147,7 @@ describe("iD.actions.MergeRemoteChanges", function () {
                 expect(result).to.eql(localGraph);
             });
 
-            it("merges tags if no conflict (remote delete)", function () {
+            it('merges tags if no conflict (remote delete)', function () {
                 var localTags = {foo: 'foo', bar: 'bar_local'},   // same foo, added bar
                     remoteTags = {},                              // deleted foo
                     mergedTags = {bar: 'bar_local'},
@@ -160,7 +162,7 @@ describe("iD.actions.MergeRemoteChanges", function () {
                 expect(result.entity('a').tags).to.eql(mergedTags);
             });
 
-            it("merges tags if no conflict (local delete)", function () {
+            it('merges tags if no conflict (local delete)', function () {
                 var localTags = {},                                 // deleted foo
                     remoteTags = {foo: 'foo', bar: 'bar_remote'},   // same foo, added bar
                     mergedTags = {bar: 'bar_remote'},
@@ -177,8 +179,8 @@ describe("iD.actions.MergeRemoteChanges", function () {
         });
 
 
-        describe("nodes", function () {
-            it("doesn't merge nodes if location is different", function () {
+        describe('nodes', function () {
+            it('doesn\'t merge nodes if location is different', function () {
                 var localTags = {foo: 'foo_local'},                // changed foo
                     remoteTags = {foo: 'foo', bar: 'bar_remote'},  // same foo, added bar
                     localLoc = [2, 2],                             // moved node
@@ -193,7 +195,7 @@ describe("iD.actions.MergeRemoteChanges", function () {
                 expect(result).to.eql(localGraph);
             });
 
-            it("merges nodes if location is same", function () {
+            it('merges nodes if location is same', function () {
                 var localTags = {foo: 'foo_local'},                // changed foo
                     remoteTags = {foo: 'foo', bar: 'bar_remote'},  // same foo, added bar
                     mergedTags = {foo: 'foo_local', bar: 'bar_remote'},
@@ -213,8 +215,8 @@ describe("iD.actions.MergeRemoteChanges", function () {
         });
 
 
-        describe("ways", function () {
-            it("merges ways if nodelist is same", function () {
+        describe('ways', function () {
+            it('merges ways if nodelist is same', function () {
                 var localTags = {foo: 'foo_local', area: 'yes'},                // changed foo
                     remoteTags = {foo: 'foo', bar: 'bar_remote', area: 'yes'},  // same foo, added bar
                     mergedTags = {foo: 'foo_local', bar: 'bar_remote', area: 'yes'},
@@ -229,7 +231,7 @@ describe("iD.actions.MergeRemoteChanges", function () {
                 expect(result.entity('w1').tags).to.eql(mergedTags);
             });
 
-            it("merges ways if nodelist changed only remotely", function () {
+            it('merges ways if nodelist changed only remotely', function () {
                 var localTags = {foo: 'foo_local', area: 'yes'},                // changed foo
                     remoteTags = {foo: 'foo', bar: 'bar_remote', area: 'yes'},  // same foo, added bar
                     mergedTags = {foo: 'foo_local', bar: 'bar_remote', area: 'yes'},
@@ -249,7 +251,7 @@ describe("iD.actions.MergeRemoteChanges", function () {
                 expect(result.hasEntity('r3')).to.eql(r3);
             });
 
-            it("merges ways if nodelist changed only locally", function () {
+            it('merges ways if nodelist changed only locally', function () {
                 var localTags = {foo: 'foo_local', area: 'yes'},                // changed foo
                     remoteTags = {foo: 'foo', bar: 'bar_remote', area: 'yes'},  // same foo, added bar
                     mergedTags = {foo: 'foo_local', bar: 'bar_remote', area: 'yes'},
@@ -267,7 +269,7 @@ describe("iD.actions.MergeRemoteChanges", function () {
                 expect(result.entity('w1').nodes).to.eql(localNodes);
             });
 
-            it("merges ways if nodelist changes don't overlap", function () {
+            it('merges ways if nodelist changes don\'t overlap', function () {
                 var localTags   = {foo: 'foo_local', area: 'yes'},                 // changed foo
                     remoteTags  = {foo: 'foo', bar: 'bar_remote', area: 'yes'},    // same foo, added bar
                     mergedTags  = {foo: 'foo_local', bar: 'bar_remote', area: 'yes'},
@@ -288,7 +290,7 @@ describe("iD.actions.MergeRemoteChanges", function () {
                 expect(result.hasEntity('r4')).to.eql(r4);
             });
 
-            it("doesn't merge ways if nodelist changes overlap", function () {
+            it('doesn\'t merge ways if nodelist changes overlap', function () {
                 var localTags   = {foo: 'foo_local', area: 'yes'},                // changed foo
                     remoteTags  = {foo: 'foo', bar: 'bar_remote', area: 'yes'},   // same foo, added bar
                     localNodes  = ['p1', 'r1', 'r2', 'p3', 'p4', 'p1'],           // changed p2 -> r1, r2
@@ -303,7 +305,7 @@ describe("iD.actions.MergeRemoteChanges", function () {
                 expect(result).to.eql(localGraph);
             });
 
-            it("merges ways if childNode location is same", function () {
+            it('merges ways if childNode location is same', function () {
                 var localLoc = [12, 12],     // moved node
                     remoteLoc = [12, 12],    // moved node
                     local = base.entity('p1').update({loc: localLoc}),
@@ -317,7 +319,7 @@ describe("iD.actions.MergeRemoteChanges", function () {
                 expect(result.entity('p1').loc).to.eql(remoteLoc);
             });
 
-            it("doesn't merge ways if childNode location is different", function () {
+            it('doesn\'t merge ways if childNode location is different', function () {
                 var localLoc = [12, 12],     // moved node
                     remoteLoc = [13, 13],    // moved node
                     local = base.entity('p1').update({loc: localLoc}),
@@ -332,8 +334,8 @@ describe("iD.actions.MergeRemoteChanges", function () {
         });
 
 
-        describe("relations", function () {
-            it("doesn't merge relations if members have changed", function () {
+        describe('relations', function () {
+            it('doesn\'t merge relations if members have changed', function () {
                 var localTags   = {foo: 'foo_local', type: 'multipolygon'},                  // changed foo
                     remoteTags  = {foo: 'foo', bar: 'bar_remote', type: 'multipolygon'},     // same foo, added bar
                     localMembers = [{id: 'w1', role: 'outer'}, {id: 'w2', role: 'inner'}],   // same members
@@ -348,7 +350,7 @@ describe("iD.actions.MergeRemoteChanges", function () {
                 expect(result).to.eql(localGraph);
             });
 
-            it("merges relations if members are same and changed tags don't conflict", function () {
+            it('merges relations if members are same and changed tags don\'t conflict', function () {
                 var localTags   = {foo: 'foo_local', type: 'multipolygon'},                  // changed foo
                     remoteTags  = {foo: 'foo', bar: 'bar_remote', type: 'multipolygon'},     // same foo, added bar
                     mergedTags  = {foo: 'foo_local', bar: 'bar_remote', type: 'multipolygon'},
@@ -367,8 +369,8 @@ describe("iD.actions.MergeRemoteChanges", function () {
         });
 
 
-        describe("#conflicts", function () {
-            it("returns conflict details", function () {
+        describe('#conflicts', function () {
+            it('returns conflict details', function () {
                 var localTags = {foo: 'foo_local'},                // changed foo
                     remoteTags = {foo: 'foo', bar: 'bar_remote'},  // same foo, added bar
                     remoteLoc = [2, 2],                            // moved node
@@ -376,8 +378,8 @@ describe("iD.actions.MergeRemoteChanges", function () {
                     remote = base.entity('a').update({tags: remoteTags, loc: remoteLoc, version: '2'}),
                     localGraph = makeGraph([local]),
                     remoteGraph = makeGraph([remote]),
-                    action = iD.actions.MergeRemoteChanges('a', localGraph, remoteGraph),
-                    result = action(localGraph);
+                    action = iD.actions.MergeRemoteChanges('a', localGraph, remoteGraph);
+                    action(localGraph);
 
                 expect(action.conflicts()).not.to.be.empty;
             });
@@ -385,9 +387,9 @@ describe("iD.actions.MergeRemoteChanges", function () {
     });
 
 
-    describe("destuctive merging", function () {
-        describe("nodes", function () {
-            it("merges nodes with 'force_local' option", function () {
+    describe('destuctive merging', function () {
+        describe('nodes', function () {
+            it('merges nodes with \'force_local\' option', function () {
                 var localTags = {foo: 'foo_local'},       // changed foo
                     remoteTags = {foo: 'foo_remote'},     // changed foo
                     localLoc = [2, 2],                    // moved node
@@ -404,7 +406,7 @@ describe("iD.actions.MergeRemoteChanges", function () {
                 expect(result.entity('a').loc).to.eql(localLoc);
             });
 
-            it("merges nodes with 'force_remote' option", function () {
+            it('merges nodes with \'force_remote\' option', function () {
                 var localTags = {foo: 'foo_local'},       // changed foo
                     remoteTags = {foo: 'foo_remote'},     // changed foo
                     localLoc = [2, 2],                    // moved node
@@ -423,8 +425,8 @@ describe("iD.actions.MergeRemoteChanges", function () {
         });
 
 
-        describe("ways", function () {
-            it("merges ways with 'force_local' option", function () {
+        describe('ways', function () {
+            it('merges ways with \'force_local\' option', function () {
                 var localTags   = {foo: 'foo_local', area: 'yes'},        // changed foo
                     remoteTags  = {foo: 'foo_remote', area: 'yes'},       // changed foo
                     localNodes  = ['p1', 'r1', 'r2', 'p3', 'p4', 'p1'],   // changed p2 -> r1, r2
@@ -441,7 +443,7 @@ describe("iD.actions.MergeRemoteChanges", function () {
                 expect(result.entity('w1').nodes).to.eql(localNodes);
             });
 
-            it("merges ways with 'force_remote' option", function () {
+            it('merges ways with \'force_remote\' option', function () {
                 var localTags   = {foo: 'foo_local', area: 'yes'},        // changed foo
                     remoteTags  = {foo: 'foo_remote', area: 'yes'},       // changed foo
                     localNodes  = ['p1', 'r1', 'r2', 'p3', 'p4', 'p1'],   // changed p2 -> r1, r2
@@ -460,7 +462,7 @@ describe("iD.actions.MergeRemoteChanges", function () {
                 expect(result.hasEntity('r4')).to.eql(r4);
             });
 
-            it("merges way childNodes with 'force_local' option", function () {
+            it('merges way childNodes with \'force_local\' option', function () {
                 var localLoc = [12, 12],     // moved node
                     remoteLoc = [13, 13],    // moved node
                     local = base.entity('p1').update({loc: localLoc}),
@@ -474,7 +476,7 @@ describe("iD.actions.MergeRemoteChanges", function () {
                 expect(result.entity('p1').loc).to.eql(localLoc);
             });
 
-            it("merges way childNodes with 'force_remote' option", function () {
+            it('merges way childNodes with \'force_remote\' option', function () {
                 var localLoc = [12, 12],     // moved node
                     remoteLoc = [13, 13],    // moved node
                     local = base.entity('p1').update({loc: localLoc}),
@@ -488,7 +490,7 @@ describe("iD.actions.MergeRemoteChanges", function () {
                 expect(result.entity('p1').loc).to.eql(remoteLoc);
             });
 
-            it("keeps only important childNodes when merging", function () {
+            it('keeps only important childNodes when merging', function () {
                 var localNodes  = ['p1', 'r1', 'r2', 'p3', 'p4', 'p1'],    // changed p2 -> r1, r2
                     remoteNodes = ['p1', 'r3', 'r4', 'p3', 'p4', 'p1'],    // changed p2 -> r3, r4
                     localr1 = r1.update({tags: {highway: 'traffic_signals'}}),  // r1 has interesting tags
@@ -506,8 +508,8 @@ describe("iD.actions.MergeRemoteChanges", function () {
         });
 
 
-        describe("relations", function () {
-            it("merges relations with 'force_local' option", function () {
+        describe('relations', function () {
+            it('merges relations with \'force_local\' option', function () {
                 var localTags = {foo: 'foo_local', type: 'multipolygon'},      // changed foo
                     remoteTags = {foo: 'foo_remote', type: 'multipolygon'},    // changed foo
                     localMembers = [{id: 'w3', role: 'outer'}, {id: 'w2', role: 'inner'}],   // changed outer to w3
@@ -524,7 +526,7 @@ describe("iD.actions.MergeRemoteChanges", function () {
                 expect(result.entity('r').members).to.eql(localMembers);
             });
 
-            it("merges relations with 'force_remote' option", function () {
+            it('merges relations with \'force_remote\' option', function () {
                 var localTags = {foo: 'foo_local', type: 'multipolygon'},      // changed foo
                     remoteTags = {foo: 'foo_remote', type: 'multipolygon'},    // changed foo
                     localMembers = [{id: 'w3', role: 'outer'}, {id: 'w2', role: 'inner'}],   // changed outer to w3

--- a/test/spec/actions/move.js
+++ b/test/spec/actions/move.js
@@ -1,22 +1,22 @@
-describe("iD.actions.Move", function() {
+describe('iD.actions.Move', function() {
     var projection = d3.geo.mercator().scale(250 / Math.PI);
 
-    describe("#disabled", function() {
-        it("returns falsy by default", function() {
+    describe('#disabled', function() {
+        it('returns falsy by default', function() {
             var node  = iD.Node({loc: [0, 0]}),
                 action = iD.actions.Move([node.id], [0, 0], projection),
                 graph = iD.Graph([node]);
             expect(action.disabled(graph)).not.to.be.ok;
         });
 
-        it("returns 'incomplete_relation' for an incomplete relation", function() {
+        it('returns \'incomplete_relation\' for an incomplete relation', function() {
             var relation = iD.Relation({members: [{id: 1}]}),
                 action = iD.actions.Move([relation.id], [0, 0], projection),
                 graph = iD.Graph([relation]);
             expect(action.disabled(graph)).to.equal('incomplete_relation');
         });
 
-        it("returns falsy for a complete relation", function() {
+        it('returns falsy for a complete relation', function() {
             var node  = iD.Node({loc: [0, 0]}),
                 relation = iD.Relation({members: [{id: node.id}]}),
                 action = iD.actions.Move([relation.id], [0, 0], projection),
@@ -25,7 +25,7 @@ describe("iD.actions.Move", function() {
         });
     });
 
-    it("moves all nodes in a way by the given amount", function() {
+    it('moves all nodes in a way by the given amount', function() {
         var node1  = iD.Node({loc: [0, 0]}),
             node2  = iD.Node({loc: [5, 10]}),
             way    = iD.Way({nodes: [node1.id, node2.id]}),
@@ -39,7 +39,7 @@ describe("iD.actions.Move", function() {
         expect(loc2[1]).to.be.closeTo( 7.866, 0.001);
     });
 
-    it("moves repeated nodes only once", function() {
+    it('moves repeated nodes only once', function() {
         var node   = iD.Node({loc: [0, 0]}),
             way    = iD.Way({nodes: [node.id, node.id]}),
             delta  = [2, 3],
@@ -49,7 +49,7 @@ describe("iD.actions.Move", function() {
         expect(loc[1]).to.be.closeTo(-2.159, 0.001);
     });
 
-    it("moves multiple ways", function() {
+    it('moves multiple ways', function() {
         var node   = iD.Node({loc: [0, 0]}),
             way1   = iD.Way({nodes: [node.id]}),
             way2   = iD.Way({nodes: [node.id]}),
@@ -60,7 +60,7 @@ describe("iD.actions.Move", function() {
         expect(loc[1]).to.be.closeTo(-2.159, 0.001);
     });
 
-    it("moves leaf nodes of a relation", function() {
+    it('moves leaf nodes of a relation', function() {
         var node     = iD.Node({loc: [0, 0]}),
             way      = iD.Way({nodes: [node.id]}),
             relation = iD.Relation({members: [{id: way.id}]}),

--- a/test/spec/actions/move_node.js
+++ b/test/spec/actions/move_node.js
@@ -1,5 +1,5 @@
-describe("iD.actions.MoveNode", function () {
-    it("changes a node's location", function () {
+describe('iD.actions.MoveNode', function () {
+    it('changes a node\'s location', function () {
         var node   = iD.Node(),
             loc    = [2, 3],
             graph  = iD.actions.MoveNode(node.id, loc)(iD.Graph([node]));

--- a/test/spec/actions/noop.js
+++ b/test/spec/actions/noop.js
@@ -1,5 +1,5 @@
-describe("iD.actions.Noop", function () {
-    it("does nothing", function () {
+describe('iD.actions.Noop', function () {
+    it('does nothing', function () {
         var graph = iD.Graph(),
             action = iD.actions.Noop(graph);
         expect(action(graph)).to.equal(graph);

--- a/test/spec/actions/orthogonalize.js
+++ b/test/spec/actions/orthogonalize.js
@@ -1,7 +1,7 @@
-describe("iD.actions.Orthogonalize", function () {
+describe('iD.actions.Orthogonalize', function () {
     var projection = d3.geo.mercator();
 
-    it("orthogonalizes a perfect quad", function () {
+    it('orthogonalizes a perfect quad', function () {
         var graph = iD.Graph([
                 iD.Node({id: 'a', loc: [0, 0]}),
                 iD.Node({id: 'b', loc: [2, 0]}),
@@ -15,7 +15,7 @@ describe("iD.actions.Orthogonalize", function () {
         expect(graph.entity('-').nodes).to.have.length(5);
     });
 
-    it("orthogonalizes a quad", function () {
+    it('orthogonalizes a quad', function () {
         var graph = iD.Graph([
                 iD.Node({id: 'a', loc: [0, 0]}),
                 iD.Node({id: 'b', loc: [4, 0]}),
@@ -29,7 +29,7 @@ describe("iD.actions.Orthogonalize", function () {
         expect(graph.entity('-').nodes).to.have.length(5);
     });
 
-    it("orthogonalizes a triangle", function () {
+    it('orthogonalizes a triangle', function () {
         var graph = iD.Graph([
                 iD.Node({id: 'a', loc: [0, 0]}),
                 iD.Node({id: 'b', loc: [3, 0]}),
@@ -42,7 +42,7 @@ describe("iD.actions.Orthogonalize", function () {
         expect(graph.entity('-').nodes).to.have.length(4);
     });
 
-    it("deletes empty redundant nodes", function() {
+    it('deletes empty redundant nodes', function() {
         var graph = iD.Graph([
                 iD.Node({id: 'a', loc: [0, 0]}),
                 iD.Node({id: 'b', loc: [2, 0]}),
@@ -57,7 +57,7 @@ describe("iD.actions.Orthogonalize", function () {
         expect(graph.hasEntity('d')).to.eq(undefined);
     });
 
-    it("preserves non empty redundant nodes", function() {
+    it('preserves non empty redundant nodes', function() {
         var graph = iD.Graph([
                 iD.Node({id: 'a', loc: [0, 0]}),
                 iD.Node({id: 'b', loc: [2, 0]}),
@@ -68,12 +68,12 @@ describe("iD.actions.Orthogonalize", function () {
             ]);
 
         graph = iD.actions.Orthogonalize('-', projection)(graph);
-        
+
         expect(graph.entity('-').nodes).to.have.length(6);
         expect(graph.hasEntity('d')).to.not.eq(undefined);
     });
 
-    it("preserves the shape of skinny quads", function () {
+    it('preserves the shape of skinny quads', function () {
         var tests = [
             [
                 [-77.0339864831478, 38.8616391227204],
@@ -107,7 +107,7 @@ describe("iD.actions.Orthogonalize", function () {
         }
     });
 
-    it("only moves nodes which are near right or near straight", function() {
+    it('only moves nodes which are near right or near straight', function() {
         var graph = iD.Graph([
                 iD.Node({id: 'a', loc: [0, 0]}),
                 iD.Node({id: 'b', loc: [3, 0.001]}),

--- a/test/spec/actions/restrict_turn.js
+++ b/test/spec/actions/restrict_turn.js
@@ -1,4 +1,4 @@
-describe("iD.actions.RestrictTurn", function() {
+describe('iD.actions.RestrictTurn', function() {
     var projection = d3.geo.mercator().scale(250 / Math.PI);
 
     it('adds a restriction to an unrestricted turn', function() {

--- a/test/spec/actions/reverse.js
+++ b/test/spec/actions/reverse.js
@@ -1,5 +1,5 @@
-describe("iD.actions.Reverse", function () {
-    it("reverses the order of nodes in the way", function () {
+describe('iD.actions.Reverse', function () {
+    it('reverses the order of nodes in the way', function () {
         var node1 = iD.Node(),
             node2 = iD.Node(),
             way = iD.Way({nodes: [node1.id, node2.id]}),
@@ -7,7 +7,7 @@ describe("iD.actions.Reverse", function () {
         expect(graph.entity(way.id).nodes).to.eql([node2.id, node1.id]);
     });
 
-    it("preserves non-directional tags", function () {
+    it('preserves non-directional tags', function () {
         var way = iD.Way({tags: {'highway': 'residential'}}),
             graph = iD.Graph([way]);
 
@@ -15,7 +15,7 @@ describe("iD.actions.Reverse", function () {
         expect(graph.entity(way.id).tags).to.eql({'highway': 'residential'});
     });
 
-    it("preserves oneway tags", function () {
+    it('preserves oneway tags', function () {
         var way = iD.Way({tags: {'oneway': 'yes'}}),
             graph = iD.Graph([way]);
 
@@ -23,7 +23,7 @@ describe("iD.actions.Reverse", function () {
         expect(graph.entity(way.id).tags).to.eql({'oneway': 'yes'});
     });
 
-    it("reverses oneway tags if reverseOneway: true is provided", function () {
+    it('reverses oneway tags if reverseOneway: true is provided', function () {
         var graph = iD.Graph([
                 iD.Way({id: 'yes', tags: {oneway: 'yes'}}),
                 iD.Way({id: 'no', tags: {oneway: 'no'}}),
@@ -41,7 +41,7 @@ describe("iD.actions.Reverse", function () {
             .entity('-1').tags).to.eql({oneway: 'yes'});
     });
 
-    it("transforms *:right=* ⟺ *:left=*", function () {
+    it('transforms *:right=* ⟺ *:left=*', function () {
         var way = iD.Way({tags: {'cycleway:right': 'lane'}}),
             graph = iD.Graph([way]);
 
@@ -52,7 +52,7 @@ describe("iD.actions.Reverse", function () {
         expect(graph.entity(way.id).tags).to.eql({'cycleway:right': 'lane'});
     });
 
-    it("transforms *:forward=* ⟺ *:backward=*", function () {
+    it('transforms *:forward=* ⟺ *:backward=*', function () {
         var way = iD.Way({tags: {'maxspeed:forward': '25'}}),
             graph = iD.Graph([way]);
 
@@ -63,7 +63,7 @@ describe("iD.actions.Reverse", function () {
         expect(graph.entity(way.id).tags).to.eql({'maxspeed:forward': '25'});
     });
 
-    it("transforms direction=up ⟺ direction=down", function () {
+    it('transforms direction=up ⟺ direction=down', function () {
         var way = iD.Way({tags: {'incline': 'up'}}),
             graph = iD.Graph([way]);
 
@@ -74,7 +74,7 @@ describe("iD.actions.Reverse", function () {
         expect(graph.entity(way.id).tags).to.eql({'incline': 'up'});
     });
 
-    it("transforms incline=up ⟺ incline=down", function () {
+    it('transforms incline=up ⟺ incline=down', function () {
         var way = iD.Way({tags: {'incline': 'up'}}),
             graph = iD.Graph([way]);
 
@@ -85,7 +85,7 @@ describe("iD.actions.Reverse", function () {
         expect(graph.entity(way.id).tags).to.eql({'incline': 'up'});
     });
 
-    it("negates numeric-valued incline tags", function () {
+    it('negates numeric-valued incline tags', function () {
         var way = iD.Way({tags: {'incline': '5%'}}),
             graph = iD.Graph([way]);
 
@@ -102,7 +102,7 @@ describe("iD.actions.Reverse", function () {
         expect(graph.entity(way.id).tags).to.eql({'incline': '-.8°'});
     });
 
-    it("transforms *=right ⟺ *=left", function () {
+    it('transforms *=right ⟺ *=left', function () {
         var way = iD.Way({tags: {'sidewalk': 'right'}}),
             graph = iD.Graph([way]);
 
@@ -113,7 +113,7 @@ describe("iD.actions.Reverse", function () {
         expect(graph.entity(way.id).tags).to.eql({'sidewalk': 'right'});
     });
 
-    it("transforms multiple directional tags", function () {
+    it('transforms multiple directional tags', function () {
         var way = iD.Way({tags: {'maxspeed:forward': '25', 'maxspeed:backward': '30'}}),
             graph = iD.Graph([way]);
 
@@ -121,7 +121,7 @@ describe("iD.actions.Reverse", function () {
         expect(graph.entity(way.id).tags).to.eql({'maxspeed:backward': '25', 'maxspeed:forward': '30'});
     });
 
-    it("transforms role=forward ⟺ role=backward in member relations", function () {
+    it('transforms role=forward ⟺ role=backward in member relations', function () {
         var way = iD.Way({tags: {highway: 'residential'}}),
             relation = iD.Relation({members: [{type: 'way', id: way.id, role: 'forward'}]}),
             graph = iD.Graph([way, relation]);
@@ -133,7 +133,7 @@ describe("iD.actions.Reverse", function () {
         expect(graph.entity(relation.id).members[0].role).to.eql('forward');
     });
 
-    it("transforms role=north ⟺ role=south in member relations", function () {
+    it('transforms role=north ⟺ role=south in member relations', function () {
         var way = iD.Way({tags: {highway: 'residential'}}),
             relation = iD.Relation({members: [{type: 'way', id: way.id, role: 'north'}]}),
             graph = iD.Graph([way, relation]);
@@ -145,7 +145,7 @@ describe("iD.actions.Reverse", function () {
         expect(graph.entity(relation.id).members[0].role).to.eql('north');
     });
 
-    it("transforms role=east ⟺ role=west in member relations", function () {
+    it('transforms role=east ⟺ role=west in member relations', function () {
         var way = iD.Way({tags: {highway: 'residential'}}),
             relation = iD.Relation({members: [{type: 'way', id: way.id, role: 'east'}]}),
             graph = iD.Graph([way, relation]);

--- a/test/spec/actions/revert.js
+++ b/test/spec/actions/revert.js
@@ -1,5 +1,5 @@
 describe('iD.actions.Revert', function() {
-    describe("basic", function () {
+    describe('basic', function () {
         it('removes a new entity', function() {
             var n1 = iD.Node({id: 'n-1'}),
                 graph = iD.Graph().replace(n1);
@@ -26,7 +26,7 @@ describe('iD.actions.Revert', function() {
         });
     });
 
-    describe("reverting way child nodes", function () {
+    describe('reverting way child nodes', function () {
         it('removes new node, updates parent way nodelist', function() {
             // note: test with a 3 node way so w1 doesnt go degenerate..
             var n1 = iD.Node({id: 'n1'}),
@@ -65,7 +65,7 @@ describe('iD.actions.Revert', function() {
         });
     });
 
-    describe("reverting relation members", function () {
+    describe('reverting relation members', function () {
         it('removes new node, updates parent relation memberlist', function() {
             var n1 = iD.Node({id: 'n1'}),
                 n2 = iD.Node({id: 'n-2'}),
@@ -100,7 +100,7 @@ describe('iD.actions.Revert', function() {
         });
     });
 
-    describe("reverting parent ways", function () {
+    describe('reverting parent ways', function () {
         it('removes new way, preserves new and existing child nodes', function() {
             var n1 = iD.Node({id: 'n1'}),
                 n2 = iD.Node({id: 'n-2'}),
@@ -146,7 +146,7 @@ describe('iD.actions.Revert', function() {
         });
     });
 
-    describe("reverting parent relations", function () {
+    describe('reverting parent relations', function () {
         it('removes new relation, preserves new and existing members', function() {
             var n1 = iD.Node({id: 'n1'}),
                 n2 = iD.Node({id: 'n-2'}),

--- a/test/spec/actions/split.js
+++ b/test/spec/actions/split.js
@@ -1,11 +1,11 @@
-describe("iD.actions.Split", function () {
+describe('iD.actions.Split', function () {
 
     beforeEach(function () {
         iD.areaKeys = iD().presets(iD.data.presets).presets().areaKeys();
     });
 
-    describe("#disabled", function () {
-        it("returns falsy for a non-end node of a single way", function () {
+    describe('#disabled', function () {
+        it('returns falsy for a non-end node of a single way', function () {
             var graph = iD.Graph([
                     iD.Node({id: 'a'}),
                     iD.Node({id: 'b'}),
@@ -16,7 +16,7 @@ describe("iD.actions.Split", function () {
             expect(iD.actions.Split('b').disabled(graph)).not.to.be.ok;
         });
 
-        it("returns falsy for an intersection of two ways", function () {
+        it('returns falsy for an intersection of two ways', function () {
             var graph = iD.Graph([
                     iD.Node({id: 'a'}),
                     iD.Node({id: 'b'}),
@@ -30,7 +30,7 @@ describe("iD.actions.Split", function () {
             expect(iD.actions.Split('*').disabled(graph)).not.to.be.ok;
         });
 
-        it("returns falsy for an intersection of two ways with parent way specified", function () {
+        it('returns falsy for an intersection of two ways with parent way specified', function () {
             var graph = iD.Graph([
                     iD.Node({id: 'a'}),
                     iD.Node({id: 'b'}),
@@ -44,7 +44,7 @@ describe("iD.actions.Split", function () {
             expect(iD.actions.Split('*').limitWays(['-']).disabled(graph)).not.to.be.ok;
         });
 
-        it("returns falsy for a self-intersection", function () {
+        it('returns falsy for a self-intersection', function () {
             var graph = iD.Graph([
                     iD.Node({id: 'a'}),
                     iD.Node({id: 'b'}),
@@ -56,7 +56,7 @@ describe("iD.actions.Split", function () {
             expect(iD.actions.Split('a').disabled(graph)).not.to.be.ok;
         });
 
-        it("returns 'not_eligible' for the first node of a single way", function () {
+        it('returns \'not_eligible\' for the first node of a single way', function () {
             var graph = iD.Graph([
                     iD.Node({id: 'a'}),
                     iD.Node({id: 'b'}),
@@ -66,7 +66,7 @@ describe("iD.actions.Split", function () {
             expect(iD.actions.Split('a').disabled(graph)).to.equal('not_eligible');
         });
 
-        it("returns 'not_eligible' for the last node of a single way", function () {
+        it('returns \'not_eligible\' for the last node of a single way', function () {
             var graph = iD.Graph([
                     iD.Node({id: 'a'}),
                     iD.Node({id: 'b'}),
@@ -76,7 +76,7 @@ describe("iD.actions.Split", function () {
             expect(iD.actions.Split('b').disabled(graph)).to.equal('not_eligible');
         });
 
-        it("returns 'not_eligible' for an intersection of two ways with non-parent way specified", function () {
+        it('returns \'not_eligible\' for an intersection of two ways with non-parent way specified', function () {
             var graph = iD.Graph([
                     iD.Node({id: 'a'}),
                     iD.Node({id: 'b'}),
@@ -91,7 +91,7 @@ describe("iD.actions.Split", function () {
         });
     });
 
-    it("creates a new way with the appropriate nodes", function () {
+    it('creates a new way with the appropriate nodes', function () {
         // Situation:
         //    a ---- b ---- c
         //
@@ -113,7 +113,7 @@ describe("iD.actions.Split", function () {
         expect(graph.entity('=').nodes).to.eql(['b', 'c']);
     });
 
-    it("copies tags to the new way", function () {
+    it('copies tags to the new way', function () {
         var tags = {highway: 'residential'},
             graph = iD.Graph([
                 iD.Node({id: 'a'}),
@@ -129,7 +129,7 @@ describe("iD.actions.Split", function () {
         expect(graph.entity('=').tags).to.equal(tags);
     });
 
-    it("splits a way at a T-junction", function () {
+    it('splits a way at a T-junction', function () {
         // Situation:
         //    a ---- b ---- c
         //           |
@@ -158,7 +158,7 @@ describe("iD.actions.Split", function () {
         expect(graph.entity('|').nodes).to.eql(['d', 'b']);
     });
 
-    it("splits multiple ways at an intersection", function () {
+    it('splits multiple ways at an intersection', function () {
         // Situation:
         //           c
         //           |
@@ -193,7 +193,7 @@ describe("iD.actions.Split", function () {
         expect(graph.entity('¦').nodes).to.eql(['*', 'd']);
     });
 
-    it("splits the specified ways at an intersection", function () {
+    it('splits the specified ways at an intersection', function () {
         var graph = iD.Graph([
                 iD.Node({id: 'a'}),
                 iD.Node({id: 'b'}),
@@ -221,7 +221,7 @@ describe("iD.actions.Split", function () {
         expect(g3.entity('¦').nodes).to.eql(['*', 'd']);
     });
 
-    it("splits self-intersecting ways", function () {
+    it('splits self-intersecting ways', function () {
         // Situation:
         //            b
         //           / |
@@ -250,7 +250,7 @@ describe("iD.actions.Split", function () {
         expect(graph.entity('=').nodes).to.eql(['a', 'd']);
     });
 
-    it("splits a closed way at the given point and its antipode", function () {
+    it('splits a closed way at the given point and its antipode', function () {
         // Situation:
         //    a ---- b
         //    |      |
@@ -288,7 +288,7 @@ describe("iD.actions.Split", function () {
         expect(g4.entity('=').nodes).to.eql(['b', 'c', 'd']);
     });
 
-    it("splits an area by converting it to a multipolygon", function () {
+    it('splits an area by converting it to a multipolygon', function () {
         var graph = iD.Graph([
                 iD.Node({id: 'a', loc: [0,1]}),
                 iD.Node({id: 'b', loc: [1,1]}),
@@ -310,7 +310,7 @@ describe("iD.actions.Split", function () {
         ]);
     });
 
-    it("splits only the line of a node shared by a line and an area", function () {
+    it('splits only the line of a node shared by a line and an area', function () {
         var graph = iD.Graph([
                 iD.Node({id: 'a', loc: [0,1]}),
                 iD.Node({id: 'b', loc: [1,1]}),
@@ -327,7 +327,7 @@ describe("iD.actions.Split", function () {
         expect(graph.parentRelations(graph.entity('='))).to.have.length(0);
     });
 
-    it("adds the new way to parent relations (no connections)", function () {
+    it('adds the new way to parent relations (no connections)', function () {
         // Situation:
         //    a ---- b ---- c
         //    Relation: [----]
@@ -354,7 +354,7 @@ describe("iD.actions.Split", function () {
         ]);
     });
 
-    it("adds the new way to parent relations (forward order)", function () {
+    it('adds the new way to parent relations (forward order)', function () {
         // Situation:
         //    a ---- b ---- c ~~~~ d
         //    Relation: [----, ~~~~]
@@ -380,7 +380,7 @@ describe("iD.actions.Split", function () {
         expect(_.map(graph.entity('r').members, 'id')).to.eql(['-', '=', '~']);
     });
 
-    it("adds the new way to parent relations (reverse order)", function () {
+    it('adds the new way to parent relations (reverse order)', function () {
         // Situation:
         //    a ---- b ---- c ~~~~ d
         //    Relation: [~~~~, ----]
@@ -406,7 +406,7 @@ describe("iD.actions.Split", function () {
         expect(_.map(graph.entity('r').members, 'id')).to.eql(['~', '=', '-']);
     });
 
-    it("handles incomplete relations", function () {
+    it('handles incomplete relations', function () {
         var graph = iD.Graph([
                 iD.Node({id: 'a'}),
                 iD.Node({id: 'b'}),
@@ -420,7 +420,7 @@ describe("iD.actions.Split", function () {
         expect(_.map(graph.entity('r').members, 'id')).to.eql(['~', '-', '=']);
     });
 
-    it("converts simple multipolygon to a proper multipolygon", function () {
+    it('converts simple multipolygon to a proper multipolygon', function () {
         var graph = iD.Graph([
                 iD.Node({id: 'a'}),
                 iD.Node({id: 'b'}),
@@ -437,7 +437,7 @@ describe("iD.actions.Split", function () {
     });
 
     ['restriction', 'restriction:bus'].forEach(function (type) {
-        it("updates a restriction's 'from' role", function () {
+        it('updates a restriction\'s \'from\' role', function () {
             // Situation:
             //    a ----> b ----> c ~~~~ d
             // A restriction from ---- to ~~~~ via c.
@@ -469,7 +469,7 @@ describe("iD.actions.Split", function () {
                 {id: 'c', role: 'via'}]);
         });
 
-        it("updates a restriction's 'to' role", function () {
+        it('updates a restriction\'s \'to\' role', function () {
             // Situation:
             //    a ----> b ----> c ~~~~ d
             // A restriction from ~~~~ to ---- via c.
@@ -501,7 +501,7 @@ describe("iD.actions.Split", function () {
                 {id: 'c', role: 'via'}]);
         });
 
-        it("leaves unaffected restrictions unchanged", function () {
+        it('leaves unaffected restrictions unchanged', function () {
             // Situation:
             //    a <---- b <---- c ~~~~ d
             // A restriction from ---- to ~~~~ via c.

--- a/test/spec/actions/straighten.js
+++ b/test/spec/actions/straighten.js
@@ -1,8 +1,8 @@
-describe("iD.actions.Straighten", function () {
+describe('iD.actions.Straighten', function () {
     var projection = d3.geo.mercator();
 
-    describe("#disabled", function () {
-        it("returns falsy for ways with internal nodes near centerline", function () {
+    describe('#disabled', function () {
+        it('returns falsy for ways with internal nodes near centerline', function () {
             var graph = iD.Graph([
                 iD.Node({id: 'a', loc: [0, 0]}),
                 iD.Node({id: 'b', loc: [1, 0.1]}),
@@ -14,7 +14,7 @@ describe("iD.actions.Straighten", function () {
             expect(iD.actions.Straighten('-', projection).disabled(graph)).not.to.be.ok;
         });
 
-        it("returns 'too_bendy' for ways with internal nodes far off centerline", function () {
+        it('returns \'too_bendy\' for ways with internal nodes far off centerline', function () {
             var graph = iD.Graph([
                 iD.Node({id: 'a', loc: [0, 0]}),
                 iD.Node({id: 'b', loc: [1, 1]}),
@@ -26,7 +26,7 @@ describe("iD.actions.Straighten", function () {
             expect(iD.actions.Straighten('-', projection).disabled(graph)).to.equal('too_bendy');
         });
 
-        it("returns 'too_bendy' for ways with coincident start/end nodes", function () {
+        it('returns \'too_bendy\' for ways with coincident start/end nodes', function () {
             var graph = iD.Graph([
                 iD.Node({id: 'a', loc: [0, 0]}),
                 iD.Node({id: 'b', loc: [1, 0]}),
@@ -39,7 +39,7 @@ describe("iD.actions.Straighten", function () {
         });
     });
 
-    it("deletes empty nodes", function() {
+    it('deletes empty nodes', function() {
         var graph = iD.Graph([
                 iD.Node({id: 'a', loc: [0, 0]}),
                 iD.Node({id: 'b', loc: [2, 0], tags: {}}),
@@ -52,7 +52,7 @@ describe("iD.actions.Straighten", function () {
         expect(graph.hasEntity('b')).to.eq(undefined);
     });
 
-    it("does not delete tagged nodes", function() {
+    it('does not delete tagged nodes', function() {
        var graph = iD.Graph([
                 iD.Node({id: 'a', loc: [0, 0]}),
                 iD.Node({id: 'b', loc: [2, 0], tags: {foo: 'bar'}}),
@@ -65,7 +65,7 @@ describe("iD.actions.Straighten", function () {
         expect(graph.entity('-').nodes).to.eql(['a', 'b', 'c']);
     });
 
-    it("does not delete nodes connected to other ways", function() {
+    it('does not delete nodes connected to other ways', function() {
         var graph = iD.Graph([
                 iD.Node({id: 'a', loc: [0, 0]}),
                 iD.Node({id: 'b', loc: [2, 0]}),

--- a/test/spec/actions/unrestrict_turn.js
+++ b/test/spec/actions/unrestrict_turn.js
@@ -1,4 +1,4 @@
-describe("iD.actions.UnrestrictTurn", function() {
+describe('iD.actions.UnrestrictTurn', function() {
     it('removes a restriction from a restricted turn', function() {
         // u====*--->w
         var graph = iD.Graph([


### PR DESCRIPTION
To prepare for modularization of iD, I believe it would be good if we could lint all our test folder.