### PR TITLE
Allow linter to do static analysis on modules

### DIFF
--- a/modules/.eslintrc
+++ b/modules/.eslintrc
@@ -2,5 +2,8 @@
     "parserOptions": {
         "ecmaVersion": 6,
         "sourceType": "module"
-    }
+    },
+    extends: [
+        "plugin:import/errors"
+    ]
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "d3": "3.5.5",
     "editor-layer-index": "git://github.com/osmlab/editor-layer-index.git#gh-pages",
     "eslint": "^2.12.0",
+    "eslint-plugin-import": "^1.8.1",
     "glob": "~3.1.21",
     "happen": "0.1.2",
     "http-server": "^0.9.0",
@@ -38,6 +39,7 @@
     "mocha": "~2.5.3",
     "mocha-phantomjs-core": "^2.0.1",
     "name-suggestion-index": "0.1.1",
+    "phantomjs-prebuilt": "2.1.7",
     "request": "~2.16.2",
     "rollup": "0.31.2",
     "sinon": "~1.6",
@@ -46,8 +48,7 @@
     "svg-sprite": "1.2.19",
     "uglify-js": "~2.4.16",
     "xml2js": "~0.4.13",
-    "xmlbuilder": "~4.2.0",
-    "phantomjs-prebuilt": "2.1.7"
+    "xmlbuilder": "~4.2.0"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
Currently linter doesn't support static analysis of modules( like checking if they actually exist or not).

This PR adds [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import) to dev dependency and will allow us to throw error if a module is malformed / undefined.