### PR TITLE
Add sidewalk preset to Path presets category

### DIFF
--- a/data/presets/categories/path.json
+++ b/data/presets/categories/path.json
@@ -5,6 +5,7 @@
     "members": [
         "highway/pedestrian",
         "highway/footway",
+        "footway/sidewalk",
         "highway/cycleway",
         "highway/bridleway",
         "highway/path",


### PR DESCRIPTION
![sidewalk](https://cloud.githubusercontent.com/assets/666291/16164924/47fa4d24-34b7-11e6-921f-2ac811bacea5.png)

I think it's important to have this preset in the Path Category. More information about this tag: 

* https://www.mapbox.com/blog/mapping-sidewalks/
* https://wiki.openstreetmap.org/wiki/Sidewalks
