### PR TITLE
When setting a form’s background colour, also set the text colour

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -159,6 +159,7 @@ input[type=url],
 input[type=tel],
 input[type=email] {
     background-color: white;
+    color: #333;
     border:1px solid #ccc;
     padding:5px 10px;
     height:30px;


### PR DESCRIPTION
This should fix #3100, where the background colour of form inputs had been set to white, and firefox was then using the dark theme’s light text colour which had poor contrast.

A solution is to also define a sane `color` property.