### PR TITLE
Replace iD global with iD.Context() module

### DIFF
--- a/API.md
+++ b/API.md
@@ -144,11 +144,11 @@ iD is used to edit data outside of the OpenStreetMap environment. There are some
 
 ### Presets
 
-iD can use external presets exclusively or along with the default OpenStreetMap presets. This is configured using the `iD().presets` accessor. To use external presets alone, initialize iD in index.html with the Presets object.
+iD can use external presets exclusively or along with the default OpenStreetMap presets. This is configured using the `context.presets` accessor. To use external presets alone, initialize the iD context with a custom `Presets` object:
 
 ```js
 
-var iD = iD()
+var id = iD.Context(window)
   .presets(customPresets)
   .taginfo(iD.services.taginfo())
   .imagery(iD.data.imagery);
@@ -159,11 +159,11 @@ The format of the Preset object is [documented here](https://github.com/openstre
 
 ### Imagery
 
-Just like Presets, Imagery can be configured using the `iD().imagery` accessor.
+Just like Presets, Imagery can be configured using the `context.imagery` accessor:
 
 ```js
 
-var iD = iD()
+var id = iD.Context(window)
   .presets(customPresets)
   .taginfo(iD.services.taginfo())
   .imagery(customImagery);
@@ -175,11 +175,11 @@ The Imagery object should follow the structure defined by [editor-layer-index](h
 
 ### Taginfo
 
-[Taginfo](http://taginfo.openstreetmap.org/) is a service that provides comprehensive documentation about the tags used in OpenStreetMap. iD uses Taginfo to display description and also autocomplete keys and values. This can be completely disabled by removing the `iD().taginfo` accessor. To point iD to a different instance of Taginfo other than the default OpenStreetMap instance
+[Taginfo](http://taginfo.openstreetmap.org/) is a service that provides comprehensive documentation about the tags used in OpenStreetMap. iD uses Taginfo to display description and also autocomplete keys and values. This can be completely disabled by removing the `context.taginfo` accessor. To point iD to a different instance of Taginfo other than the default OpenStreetMap instance:
 
 ```js
 
-var iD = iD()
+var id = iD.Context(window)
   .presets(customPresets)
   .taginfo(iD.services.taginfo().endpoint('url'))
   .imagery(customImagery);
@@ -188,11 +188,11 @@ var iD = iD()
 
 ### Minimum Editable Zoom
 
-The minimum zoom at which iD enters the edit mode is configured using the `iD().minEditableZoom()` accessor. The default value is 16. To change this initialise iD as
+The minimum zoom at which iD enters the edit mode is configured using the `context.minEditableZoom()` accessor. The default value is 16. To change this initialise the iD context as:
 
 ```js
 
-var iD = iD().
+var id = iD.Context(window).
   .minEditableZoom(zoom_level)
 
 ```

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,6 @@ dist/iD.js: \
 	js/lib/d3.curtain.js \
 	js/lib/d3.value.js \
 	js/lib/lodash.js \
-	js/id/id.js \
 	$(MODULE_TARGETS) \
 	js/lib/locale.js \
 	data/introGraph.js

--- a/data/presets/README.md
+++ b/data/presets/README.md
@@ -97,7 +97,7 @@ iD supports deployments which use a custom set of presets. You can supply preset
 the `presets` accessor:
 
 ```js
-var id = iD().presets({
+var id = iD.Context(window).presets({
     presets: { ... },
     fields: { ... },
     defaults: { ... },

--- a/dist/index.html
+++ b/dist/index.html
@@ -39,10 +39,10 @@
                 document.getElementById('id-container').innerHTML = 'Sorry, your browser is not currently supported. Please use Potlatch 2 to edit the map.';
                 document.getElementById('id-container').className = 'unsupported';
             } else {
-                var id = iD()
+                var id = iD.Context(window)
                   .presets(iD.data.presets)
                   .imagery(iD.data.imagery)
-                  .taginfo(iD.services.taginfo());
+                  .taginfo(iD.services.taginfo.init());
 
                 d3.select('#id-container')
                     .call(id.ui());

--- a/index.html
+++ b/index.html
@@ -25,8 +25,6 @@
         <script src='js/lib/d3.value.js'></script>
         <script src='js/lib/d3-compat.js'></script>
         <script src='js/lib/bootstrap-tooltip.js'></script>
-
-        <script src='js/id/id.js'></script>
         <script src='js/lib/id/index.js'></script>
         <script src='js/lib/locale.js'></script>
 
@@ -37,7 +35,7 @@
         <div id='id-container'></div>
         <script>
             iD.data.load(function() {
-                id = iD()
+                id = iD.Context(window)
                     .presets(iD.data.presets)
                     .imagery(iD.data.imagery)
                     .taginfo(iD.services.taginfo.init())

--- a/modules/core/connection.js
+++ b/modules/core/connection.js
@@ -258,13 +258,13 @@ export function Connection(useHttps) {
         };
     };
 
-    connection.changesetTags = function(comment, imageryUsed) {
+    connection.changesetTags = function(version, comment, imageryUsed) {
         var detected = Detect(),
             tags = {
-                created_by: 'iD ' + iD.version,
+                created_by: ('iD ' + version).substr(0, 255),
                 imagery_used: imageryUsed.join(';').substr(0, 255),
-                host: (window.location.origin + window.location.pathname).substr(0, 255),
-                locale: detected.locale
+                host: detected.host.substr(0, 255),
+                locale: detected.locale.substr(0, 255)
             };
 
         if (comment) {
@@ -274,7 +274,7 @@ export function Connection(useHttps) {
         return tags;
     };
 
-    connection.putChangeset = function(changes, comment, imageryUsed, callback) {
+    connection.putChangeset = function(changes, version, comment, imageryUsed, callback) {
         oauth.xhr({
                 method: 'PUT',
                 path: '/api/0.6/changeset/create',

--- a/modules/core/context.js
+++ b/modules/core/context.js
@@ -1,9 +1,21 @@
-(function () {
+import { Background } from '../renderer/background';
+import { Connection } from './connection';
+import { Detect } from '../util/detect';
+import { Features } from '../renderer/features';
+import { History } from './history';
+import { Map } from '../renderer/map';
+import { RawMercator } from '../geo/raw_mercator';
+import { presets as presetsInit } from '../presets/presets';
+import { init as uiInit } from '../ui/init';
 
-/*global iD*/
-window.iD = function () {
-    window.locale.en = iD.data.en;
-    window.locale.current('en');
+export function Context(root) {
+    if (!root.locale) {
+        root.locale = {
+            current: function(_) { this._current = _; }
+        };
+    }
+    root.locale.en = iD.data.en;
+    root.locale.current('en');
 
     var dispatch = d3.dispatch('enter', 'exit', 'change'),
         context = {};
@@ -317,8 +329,8 @@ window.iD = function () {
         if (locale && locale !== 'en' && iD.data.locales.indexOf(locale) !== -1) {
             localePath = localePath || context.asset('locales/' + locale + '.json');
             d3.json(localePath, function(err, result) {
-                window.locale[locale] = result;
-                window.locale.current(locale);
+                root.locale[locale] = result;
+                root.locale.current(locale);
                 cb();
             });
         } else {
@@ -328,15 +340,16 @@ window.iD = function () {
 
 
     /* Init */
+    context.version = '2.0.0-alpha.1';
 
-    context.projection = iD.geo.RawMercator();
+    context.projection = RawMercator();
 
-    locale = iD.Detect().locale;
+    locale = Detect().locale;
     if (locale && iD.data.locales.indexOf(locale) === -1) {
         locale = locale.split('-')[0];
     }
 
-    history = iD.History(context);
+    history = History(context);
     context.graph = history.graph;
     context.changes = history.changes;
     context.intersects = history.intersects;
@@ -359,15 +372,15 @@ window.iD = function () {
     context.undo = withDebouncedSave(history.undo);
     context.redo = withDebouncedSave(history.redo);
 
-    ui = iD.ui.init(context);
+    ui = uiInit(context);
 
-    connection = iD.Connection();
+    connection = Connection();
 
-    background = iD.Background(context);
+    background = Background(context);
 
-    features = iD.Features(context);
+    features = Features(context);
 
-    map = iD.Map(context);
+    map = Map(context);
     context.mouse = map.mouse;
     context.extent = map.extent;
     context.pan = map.pan;
@@ -377,11 +390,8 @@ window.iD = function () {
     context.zoomOutFurther = map.zoomOutFurther;
     context.redrawEnable = map.redrawEnable;
 
-    presets = iD.presets.presets();
+    presets = presetsInit();
 
     return d3.rebind(context, dispatch, 'on');
-};
+}
 
-iD.version = '2.0.0-alpha.1';
-
-})();

--- a/modules/core/index.js
+++ b/modules/core/index.js
@@ -1,4 +1,5 @@
 export { Connection } from './connection';
+export { Context } from './context';
 export { Difference } from './difference';
 export { Entity } from './entity';
 export { Graph } from './graph';

--- a/modules/index.js
+++ b/modules/index.js
@@ -15,6 +15,7 @@ export { Detect } from './util/detect';
 
 // core
 export { Connection } from './core/connection';
+export { Context } from './core/context';
 export { Difference } from './core/difference';
 export { Entity } from './core/entity';
 export { Graph } from './core/graph';

--- a/modules/modes/save.js
+++ b/modules/modes/save.js
@@ -168,6 +168,7 @@ export function Save(context) {
                 if (changes.modified.length || changes.created.length || changes.deleted.length) {
                     context.connection().putChangeset(
                         changes,
+                        context.version,
                         e.comment,
                         history.imageryUsed(),
                         function(err, changeset_id) {

--- a/modules/ui/init.js
+++ b/modules/ui/init.js
@@ -148,7 +148,7 @@ export function init(context) {
             .attr('target', '_blank')
             .attr('tabindex', -1)
             .attr('href', 'https://github.com/openstreetmap/iD')
-            .text(iD.version);
+            .text(context.version);
 
         var issueLinks = aboutList.append('li');
 

--- a/modules/ui/splash.js
+++ b/modules/ui/splash.js
@@ -25,7 +25,7 @@ export function Splash(context) {
             .attr('class','modal-section')
             .append('p')
             .html(t('splash.text', {
-                version: iD.version,
+                version: context.version,
                 website: '<a href="http://ideditor.com/">ideditor.com</a>',
                 github: '<a href="https://github.com/openstreetmap/iD">github.com</a>'
             }));

--- a/modules/util/detect.js
+++ b/modules/util/detect.js
@@ -62,6 +62,8 @@ export function Detect() {
         detected.locale = loadedLocale;
     }
 
+    detected.host = window.location && (window.location.origin + window.location.pathname);
+
     detected.filedrop = (window.FileReader && 'ondrop' in window);
 
     function nav(x) {

--- a/test/index.html
+++ b/test/index.html
@@ -35,10 +35,8 @@
     <script src='../js/lib/d3-compat.js'></script>
     <script src='../js/lib/bootstrap-tooltip.js'></script>
 
-    <script src='../js/id/id.js'></script>
     <script src='../js/lib/id/index.js'></script>
     <script src='../js/lib/locale.js'></script>
-
     <script src='../data/data_dev.js'></script>
 
     <script src='spec/spec_helpers.js'></script>

--- a/test/spec/actions/split.js
+++ b/test/spec/actions/split.js
@@ -1,7 +1,8 @@
 describe('iD.actions.Split', function () {
 
     beforeEach(function () {
-        iD.areaKeys = iD().presets(iD.data.presets).presets().areaKeys();
+        iD.areaKeys = iD.Context(window)
+            .presets(iD.data.presets).presets().areaKeys();
     });
 
     describe('#disabled', function () {

--- a/test/spec/behavior/hash.js
+++ b/test/spec/behavior/hash.js
@@ -4,7 +4,8 @@ describe('iD.behavior.Hash', function () {
     var hash, context;
 
     beforeEach(function () {
-        context = iD().imagery(iD.data.imagery);
+        context = iD.Context(window)
+            .imagery(iD.data.imagery);
         context.container(d3.select(document.createElement('div')));
 
         // Neuter connection

--- a/test/spec/behavior/lasso.js
+++ b/test/spec/behavior/lasso.js
@@ -2,7 +2,7 @@ describe('iD.behavior.Lasso', function () {
     var lasso, context;
 
     beforeEach(function () {
-        context = iD().imagery(iD.data.imagery);
+        context = iD.Context(window).imagery(iD.data.imagery);
         context.container(d3.select(document.createElement('div')));
 
         // Neuter connection

--- a/test/spec/behavior/select.js
+++ b/test/spec/behavior/select.js
@@ -3,8 +3,7 @@ describe('iD.behavior.Select', function() {
 
     beforeEach(function() {
         container = d3.select('body').append('div');
-
-        context = iD().imagery(iD.data.imagery).container(container);
+        context = iD.Context(window).imagery(iD.data.imagery).container(container);
 
         a = iD.Node({loc: [0, 0]});
         b = iD.Node({loc: [0, 0]});

--- a/test/spec/core/connection.js
+++ b/test/spec/core/connection.js
@@ -254,7 +254,7 @@ describe('iD.Connection', function () {
             changesetsXML = '<?xml version="1.0" encoding="UTF-8"?><osm>' +
                 '<changeset id="36777543" user="Steve" uid="1" created_at="2016-01-24T15:02:06Z" closed_at="2016-01-24T15:02:07Z" open="false" min_lat="39.3823819" min_lon="-104.8639728" max_lat="39.3834184" max_lon="-104.8618622" comments_count="0">' +
                 '<tag k="comment" v="Caprice Court has been extended"/>' +
-                '<tag k="created_by" v="iD 1.8.5"/>' +
+                '<tag k="created_by" v="iD 2.0.0"/>' +
                 '</changeset>' +
                 '</osm>';
 
@@ -275,7 +275,7 @@ describe('iD.Connection', function () {
                 expect(changesets).to.deep.equal([{
                     tags: {
                         comment: 'Caprice Court has been extended',
-                        created_by: 'iD 1.8.5'
+                        created_by: 'iD 2.0.0'
                     }
                 }]);
                 done();
@@ -289,7 +289,7 @@ describe('iD.Connection', function () {
 
     describe('#changesetTags', function() {
         it('omits comment when empty', function() {
-            expect(c.changesetTags('', [])).not.to.have.property('comment');
+            expect(c.changesetTags('2.0.0', '', [])).not.to.have.property('comment');
         });
     });
 });

--- a/test/spec/core/history.js
+++ b/test/spec/core/history.js
@@ -3,7 +3,7 @@ describe('iD.History', function () {
         action = function() { return iD.Graph(); };
 
     beforeEach(function () {
-        context = iD();
+        context = iD.Context(window);
         history = context.history();
         spy = sinon.spy();
         // clear lock

--- a/test/spec/id.js
+++ b/test/spec/id.js
@@ -5,7 +5,7 @@ describe('iD', function() {
 
     describe('#assetPath', function() {
         it('sets and gets assetPath', function() {
-            var context = iD();
+            var context = iD.Context(window);
             expect(context.assetPath()).to.eql('');
 
             context.assetPath('iD/');
@@ -15,7 +15,7 @@ describe('iD', function() {
 
     describe('#assetMap', function() {
         it('sets and gets assetMap', function() {
-            var context = iD();
+            var context = iD.Context(window);
             expect(context.assetMap()).to.eql({});
 
             context.assetMap(assets);
@@ -25,8 +25,8 @@ describe('iD', function() {
 
     describe('#asset', function() {
         var context;
-        beforeEach(function () {
-            context = iD().assetPath('iD/').assetMap(assets);
+        beforeEach(function() {
+            context = iD.Context(window).assetPath('iD/').assetMap(assets);
         });
 
         it('looks first in assetMap', function() {
@@ -39,8 +39,8 @@ describe('iD', function() {
 
     describe('#imagePath', function() {
         var context;
-        beforeEach(function () {
-            context = iD().assetPath('iD/').assetMap(assets);
+        beforeEach(function() {
+            context = iD.Context(window).assetPath('iD/').assetMap(assets);
         });
 
         it('looks first in assetMap', function() {
@@ -58,9 +58,7 @@ describe('iD', function() {
                     'mines': {
                         geometry: ['point', 'area'],
                         name: 'Mining Concession',
-                        tags: {
-                            'concession': 'mining'
-                        }
+                        tags: { 'concession': 'mining' }
                     },
                     'area': {
                         'name': 'Area',
@@ -93,7 +91,7 @@ describe('iD', function() {
                 }
             };
 
-            var context = iD().presets(presetsCollection),
+            var context = iD.Context(window).presets(presetsCollection),
                 way = iD.Way({tags: {concession: 'mining', area: 'yes'}}),
                 graph = iD.Graph([way]);
 
@@ -103,7 +101,7 @@ describe('iD', function() {
 
     describe('#debug', function() {
         it('sets and gets debug flags', function() {
-            var context = iD(),
+            var context = iD.Context(window),
                 flags = {
                     tile: false,
                     collision: false,

--- a/test/spec/modes/add_point.js
+++ b/test/spec/modes/add_point.js
@@ -4,7 +4,7 @@ describe('iD.modes.AddPoint', function() {
     beforeEach(function() {
         var container = d3.select(document.createElement('div'));
 
-        context = iD()
+        context = iD.Context(window)
             .presets(iD.data.presets)
             .imagery([])
             .container(container);

--- a/test/spec/renderer/features.js
+++ b/test/spec/renderer/features.js
@@ -4,7 +4,7 @@ describe('iD.Features', function() {
         features;
 
     beforeEach(function() {
-        context = iD();
+        context = iD.Context(window);
         context.map().zoom(16);
         features = iD.Features(context);
     });

--- a/test/spec/renderer/map.js
+++ b/test/spec/renderer/map.js
@@ -2,7 +2,7 @@ describe('iD.Map', function() {
     var context, map;
 
     beforeEach(function() {
-        context = iD().imagery(iD.data.imagery);
+        context = iD.Context(window).imagery(iD.data.imagery);
         context.container(d3.select(document.createElement('div')));
         map = context.map();
         d3.select(document.createElement('div'))

--- a/test/spec/renderer/tile_layer.js
+++ b/test/spec/renderer/tile_layer.js
@@ -2,7 +2,7 @@ describe('iD.TileLayer', function() {
     var context, d, c;
 
     beforeEach(function() {
-        context = iD();
+        context = iD.Context(window);
         d = d3.select(document.createElement('div'));
         c = iD.TileLayer(context).projection(d3.geo.mercator());
     });

--- a/test/spec/services/mapillary.js
+++ b/test/spec/services/mapillary.js
@@ -3,7 +3,7 @@ describe('iD.services.mapillary', function() {
         context, server, mapillary;
 
     beforeEach(function() {
-        context = iD().assetPath('../dist/');
+        context = iD.Context(window).assetPath('../dist/');
         context.projection.scale(667544.214430109);  // z14
         context.projection.translate([-116508, 0]);  // 10,0
 

--- a/test/spec/svg/areas.js
+++ b/test/spec/svg/areas.js
@@ -7,7 +7,7 @@ describe('iD.svg.Areas', function () {
 
     beforeEach(function () {
         surface = d3.select(document.createElementNS('http://www.w3.org/2000/svg', 'svg'))
-            .call(iD.svg.Layers(projection, iD()));
+            .call(iD.svg.Layers(projection, iD.Context(window)));
     });
 
     it('adds way and area classes', function () {

--- a/test/spec/svg/lines.js
+++ b/test/spec/svg/lines.js
@@ -7,7 +7,7 @@ describe('iD.svg.Lines', function () {
 
     beforeEach(function () {
         surface = d3.select(document.createElementNS('http://www.w3.org/2000/svg', 'svg'))
-            .call(iD.svg.Layers(projection, iD()));
+            .call(iD.svg.Layers(projection, iD.Context(window)));
     });
 
     it('adds way and line classes', function () {

--- a/test/spec/svg/midpoints.js
+++ b/test/spec/svg/midpoints.js
@@ -5,7 +5,7 @@ describe('iD.svg.Midpoints', function () {
         context;
 
     beforeEach(function () {
-        context = iD();
+        context = iD.Context(window);
         surface = d3.select(document.createElementNS('http://www.w3.org/2000/svg', 'svg'))
             .call(iD.svg.Layers(projection, context));
     });

--- a/test/spec/svg/points.js
+++ b/test/spec/svg/points.js
@@ -4,7 +4,7 @@ describe('iD.svg.Points', function () {
         context;
 
     beforeEach(function () {
-        context = iD().presets(iD.data.presets);
+        context = iD.Context(window).presets(iD.data.presets);
         surface = d3.select(document.createElementNS('http://www.w3.org/2000/svg', 'svg'))
             .call(iD.svg.Layers(projection, context));
     });

--- a/test/spec/svg/vertices.js
+++ b/test/spec/svg/vertices.js
@@ -4,7 +4,7 @@ describe('iD.svg.Vertices', function () {
         context;
 
     beforeEach(function () {
-        context = iD();
+        context = iD.Context(window);
         surface = d3.select(document.createElementNS('http://www.w3.org/2000/svg', 'svg'))
             .call(iD.svg.Layers(projection, context));
     });

--- a/test/spec/ui/fields/access.js
+++ b/test/spec/ui/fields/access.js
@@ -2,7 +2,8 @@ describe('access', function() {
     var selection, field;
     beforeEach(function() {
         selection = d3.select(document.createElement('div'));
-        field = iD().presets(iD.data.presets).presets().field('access');
+        field = iD.Context(window)
+            .presets(iD.data.presets).presets().field('access');
     });
 
     it('creates inputs for a variety of modes of access', function() {

--- a/test/spec/ui/fields/wikipedia.js
+++ b/test/spec/ui/fields/wikipedia.js
@@ -25,7 +25,7 @@ describe('wikipedia', function() {
     beforeEach(function() {
         entity = iD.Node({id: 'n12345'});
         selectedId = entity.id;
-        context = iD();
+        context = iD.Context(window);
         context.history().merge([entity]);
         selection = d3.select(document.createElement('div'));
         field = context.presets(iD.data.presets).presets().field('wikipedia');

--- a/test/spec/ui/raw_tag_editor.js
+++ b/test/spec/ui/raw_tag_editor.js
@@ -15,7 +15,7 @@ describe('iD.ui.RawTagEditor', function() {
 
     beforeEach(function () {
         entity = iD.Node({id: 'n12345'});
-        context = iD();
+        context = iD.Context(window);
         context.history().merge([entity]);
         render({highway: 'residential'});
     });


### PR DESCRIPTION
This PR replaces the iD global window object with a Context module.

@kepta, @tmcw Does this seem right?  This might close #3179 

(though we still have to do something with `iD.data` / `data_dev.js`)