### PR TITLE
Inter-require iD instead of relying on the global

### DIFF
--- a/modules/core/history.js
+++ b/modules/core/history.js
@@ -1,3 +1,4 @@
+import * as Validations from '../validations/index';
 import { Difference } from './difference';
 import { Entity } from './entity';
 import { Graph } from './graph';
@@ -172,7 +173,7 @@ export function History(context) {
         },
 
         validate: function(changes) {
-            return _(iD.validations)
+            return _(Validations)
                 .map(function(fn) { return fn()(changes, stack[index].graph); })
                 .flatten()
                 .value();

--- a/modules/geo/multipolygon.js
+++ b/modules/geo/multipolygon.js
@@ -1,3 +1,5 @@
+import { Reverse } from '../actions/reverse';
+
 // For fixing up rendering of multipolygons with tags on the outer member.
 // https://github.com/openstreetmap/iD/issues/613
 export function isSimpleMultipolygonOuterMember(entity, graph) {
@@ -81,7 +83,7 @@ export function joinWays(array, graph) {
     }
 
     function reverse(member) {
-        return member.tags ? iD.actions.Reverse(member.id, {reverseOneway: true})(graph).entity(member.id) : member;
+        return member.tags ? Reverse(member.id, {reverseOneway: true})(graph).entity(member.id) : member;
     }
 
     while (array.length) {


### PR DESCRIPTION
These are the two remaining cases of relying on iD _funcitonality_ via the global iD variable. The remainder are cases where we rely on iD.data or something similar, like iD.areaTags.