### PR TITLE
add second_hand tag in preset and second_hand field for shop=car

### DIFF
--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -825,6 +825,18 @@ en:
       seasonal:
         # seasonal=*
         label: Seasonal
+      second_hand:
+        # second_hand=*
+        label: 'Second Hand / Used / Previously Owned '
+        options:
+          # second_hand=no
+          'no': 'No'
+          # second_hand=only
+          only: Only
+          # second_hand=yes
+          'yes': 'Yes'
+        # second_hand field placeholder
+        placeholder: 'Yes, No, Only'
       service:
         # service=*
         label: Type

--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -827,7 +827,7 @@ en:
         label: Seasonal
       second_hand:
         # second_hand=*
-        label: 'Second Hand / Used / Previously Owned '
+        label: Sells Used
         options:
           # second_hand=no
           'no': 'No'

--- a/data/presets/fields.json
+++ b/data/presets/fields.json
@@ -1096,7 +1096,7 @@
     "second_hand": {
         "key": "second_hand",
         "type": "combo",
-        "label": "Second Hand / Used / Previously Owned ",
+        "label": "Sells Used",
         "placeholder": "Yes, No, Only",
         "strings": {
             "options": {

--- a/data/presets/fields.json
+++ b/data/presets/fields.json
@@ -1093,6 +1093,19 @@
         "type": "check",
         "label": "Seasonal"
     },
+    "second_hand": {
+        "key": "second_hand",
+        "type": "combo",
+        "label": "Second Hand / Used / Previously Owned ",
+        "placeholder": "Yes, No, Only",
+        "strings": {
+            "options": {
+                "yes": "Yes",
+                "no": "No",
+                "only": "Only"
+            }
+        }
+    },
     "service_rail": {
         "key": "service",
         "type": "combo",

--- a/data/presets/fields/second_hand.json
+++ b/data/presets/fields/second_hand.json
@@ -2,7 +2,7 @@
 {
     "key": "second_hand",
     "type": "combo",
-    "label": "Second Hand / Used / Previously Owned ",
+    "label": "Sells Used",
     "placeholder": "Yes, No, Only",
     "strings": {
         "options": {

--- a/data/presets/fields/second_hand.json
+++ b/data/presets/fields/second_hand.json
@@ -1,0 +1,14 @@
+
+{
+    "key": "second_hand",
+    "type": "combo",
+    "label": "Second Hand / Used / Previously Owned ",
+    "placeholder": "Yes, No, Only",
+    "strings": {
+        "options": {
+            "yes": "Yes",
+            "no": "No",
+            "only": "Only"
+        }
+    }
+}

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -8334,7 +8334,8 @@
             "operator",
             "address",
             "building_area",
-            "opening_hours"
+            "opening_hours",
+            "second_hand"
         ],
         "geometry": [
             "point",
@@ -76845,7 +76846,8 @@
             "operator",
             "address",
             "building_area",
-            "opening_hours"
+            "opening_hours",
+            "second_hand"
         ],
         "suggestion": true
     },
@@ -76864,7 +76866,8 @@
             "operator",
             "address",
             "building_area",
-            "opening_hours"
+            "opening_hours",
+            "second_hand"
         ],
         "suggestion": true
     },
@@ -76883,7 +76886,8 @@
             "operator",
             "address",
             "building_area",
-            "opening_hours"
+            "opening_hours",
+            "second_hand"
         ],
         "suggestion": true
     },
@@ -76902,7 +76906,8 @@
             "operator",
             "address",
             "building_area",
-            "opening_hours"
+            "opening_hours",
+            "second_hand"
         ],
         "suggestion": true
     },
@@ -76921,7 +76926,8 @@
             "operator",
             "address",
             "building_area",
-            "opening_hours"
+            "opening_hours",
+            "second_hand"
         ],
         "suggestion": true
     },
@@ -76940,7 +76946,8 @@
             "operator",
             "address",
             "building_area",
-            "opening_hours"
+            "opening_hours",
+            "second_hand"
         ],
         "suggestion": true
     },
@@ -76959,7 +76966,8 @@
             "operator",
             "address",
             "building_area",
-            "opening_hours"
+            "opening_hours",
+            "second_hand"
         ],
         "suggestion": true
     },
@@ -76978,7 +76986,8 @@
             "operator",
             "address",
             "building_area",
-            "opening_hours"
+            "opening_hours",
+            "second_hand"
         ],
         "suggestion": true
     },
@@ -76997,7 +77006,8 @@
             "operator",
             "address",
             "building_area",
-            "opening_hours"
+            "opening_hours",
+            "second_hand"
         ],
         "suggestion": true
     },
@@ -77016,7 +77026,8 @@
             "operator",
             "address",
             "building_area",
-            "opening_hours"
+            "opening_hours",
+            "second_hand"
         ],
         "suggestion": true
     },
@@ -77035,7 +77046,8 @@
             "operator",
             "address",
             "building_area",
-            "opening_hours"
+            "opening_hours",
+            "second_hand"
         ],
         "suggestion": true
     },
@@ -77054,7 +77066,8 @@
             "operator",
             "address",
             "building_area",
-            "opening_hours"
+            "opening_hours",
+            "second_hand"
         ],
         "suggestion": true
     },
@@ -77073,7 +77086,8 @@
             "operator",
             "address",
             "building_area",
-            "opening_hours"
+            "opening_hours",
+            "second_hand"
         ],
         "suggestion": true
     },
@@ -77092,7 +77106,8 @@
             "operator",
             "address",
             "building_area",
-            "opening_hours"
+            "opening_hours",
+            "second_hand"
         ],
         "suggestion": true
     },
@@ -77111,7 +77126,8 @@
             "operator",
             "address",
             "building_area",
-            "opening_hours"
+            "opening_hours",
+            "second_hand"
         ],
         "suggestion": true
     },
@@ -77130,7 +77146,8 @@
             "operator",
             "address",
             "building_area",
-            "opening_hours"
+            "opening_hours",
+            "second_hand"
         ],
         "suggestion": true
     },
@@ -77149,7 +77166,8 @@
             "operator",
             "address",
             "building_area",
-            "opening_hours"
+            "opening_hours",
+            "second_hand"
         ],
         "suggestion": true
     },
@@ -77168,7 +77186,8 @@
             "operator",
             "address",
             "building_area",
-            "opening_hours"
+            "opening_hours",
+            "second_hand"
         ],
         "suggestion": true
     },
@@ -77187,7 +77206,8 @@
             "operator",
             "address",
             "building_area",
-            "opening_hours"
+            "opening_hours",
+            "second_hand"
         ],
         "suggestion": true
     },
@@ -77206,7 +77226,8 @@
             "operator",
             "address",
             "building_area",
-            "opening_hours"
+            "opening_hours",
+            "second_hand"
         ],
         "suggestion": true
     },
@@ -77225,7 +77246,8 @@
             "operator",
             "address",
             "building_area",
-            "opening_hours"
+            "opening_hours",
+            "second_hand"
         ],
         "suggestion": true
     },
@@ -77244,7 +77266,8 @@
             "operator",
             "address",
             "building_area",
-            "opening_hours"
+            "opening_hours",
+            "second_hand"
         ],
         "suggestion": true
     },
@@ -77263,7 +77286,8 @@
             "operator",
             "address",
             "building_area",
-            "opening_hours"
+            "opening_hours",
+            "second_hand"
         ],
         "suggestion": true
     },
@@ -77282,7 +77306,8 @@
             "operator",
             "address",
             "building_area",
-            "opening_hours"
+            "opening_hours",
+            "second_hand"
         ],
         "suggestion": true
     },
@@ -77301,7 +77326,8 @@
             "operator",
             "address",
             "building_area",
-            "opening_hours"
+            "opening_hours",
+            "second_hand"
         ],
         "suggestion": true
     },
@@ -77320,7 +77346,8 @@
             "operator",
             "address",
             "building_area",
-            "opening_hours"
+            "opening_hours",
+            "second_hand"
         ],
         "suggestion": true
     },
@@ -77339,7 +77366,8 @@
             "operator",
             "address",
             "building_area",
-            "opening_hours"
+            "opening_hours",
+            "second_hand"
         ],
         "suggestion": true
     },
@@ -77358,7 +77386,8 @@
             "operator",
             "address",
             "building_area",
-            "opening_hours"
+            "opening_hours",
+            "second_hand"
         ],
         "suggestion": true
     },
@@ -77377,7 +77406,8 @@
             "operator",
             "address",
             "building_area",
-            "opening_hours"
+            "opening_hours",
+            "second_hand"
         ],
         "suggestion": true
     },

--- a/data/presets/presets/shop/car.json
+++ b/data/presets/presets/shop/car.json
@@ -4,7 +4,8 @@
         "operator",
         "address",
         "building_area",
-        "opening_hours"
+        "opening_hours",
+        "second_hand"
     ],
     "geometry": [
         "point",

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -1330,6 +1330,15 @@
             "seasonal": {
                 "label": "Seasonal"
             },
+            "second_hand": {
+                "label": "Second Hand / Used / Previously Owned ",
+                "placeholder": "Yes, No, Only",
+                "options": {
+                    "yes": "Yes",
+                    "no": "No",
+                    "only": "Only"
+                }
+            },
             "service_rail": {
                 "label": "Service Type",
                 "options": {

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -1331,7 +1331,7 @@
                 "label": "Seasonal"
             },
             "second_hand": {
-                "label": "Second Hand / Used / Previously Owned ",
+                "label": "Sells Used",
                 "placeholder": "Yes, No, Only",
                 "options": {
                     "yes": "Yes",


### PR DESCRIPTION

Hi, 

I added the second_hand= tag to the preset. The tag is used to denote for shops whether the merchandise is used. It's used over [4,000 times ](http://taginfo.openstreetmap.org/keys/second_hand#values) so far in the planet. 

One common use of the second_hand tag is to designate a used car lot. I've also added the second_hand tag in this pull request. 