### PR TITLE
Do not attach dragNode behavior in browse mode

### DIFF
--- a/modules/modes/browse.js
+++ b/modules/modes/browse.js
@@ -1,6 +1,5 @@
 import { t } from '../util/locale';
 import { Hover, Lasso, Paste, Select } from '../behavior/index';
-import { DragNode } from './index';
 
 export function Browse(context) {
     var mode = {
@@ -15,8 +14,7 @@ export function Browse(context) {
         Hover(context)
             .on('hover', context.ui().sidebar.hover),
         Select(context),
-        Lasso(context),
-        DragNode(context).behavior];
+        Lasso(context)];
 
     mode.enter = function() {
         behaviors.forEach(function(behavior) {


### PR DESCRIPTION
Currently when in 'browse' mode (i.e. when nothing is selected) it is very easy for a user to accidentally drag a point when they are trying to move the map. This is not currently the case for lines or areas: they must be selected before it is possible to move anything.

This PR changes the browse mode so that it does not attach the DragNode behavior to points. The new behavior is that you need to select a point first before dragging to move it.

This is to reduce the possibility of users accidentally moving points without realizing when they are just trying to move the map. This is a particular issue in areas of the map where there is a high density of points, which makes it almost impossible to drag the map without accidentally moving a point. This fixes that.
