### PR TITLE
Allow uppercase in network taginfo

### DIFF
--- a/modules/services/taginfo.js
+++ b/modules/services/taginfo.js
@@ -49,9 +49,10 @@ function filterMultikeys() {
     };
 }
 
-function filterValues() {
+function filterValues(allowUpperCase) {
     return function(d) {
-        if (d.value.match(/[A-Z*;,]/) !== null) return false;  // exclude some punctuation, uppercase letters
+        if (d.value.match(/[;,]/) !== null) return false;  // exclude some punctuation
+        if (!allowUpperCase && d.value.match(/[A-Z*]/) !== null) return false;  // exclude uppercase letters
         return parseFloat(d.fraction) > 0.0 || d.in_wiki;
     };
 }
@@ -140,7 +141,7 @@ export function init() {
                 page: 1
             }, parameters)), debounce, function(err, d) {
                 if (err) return callback(err);
-                var f = filterValues();
+                var f = filterValues(parameters.key === 'cycle_network' || parameters.key === 'network');
                 callback(null, d.data.filter(f).map(valKeyDescription));
             });
     };


### PR DESCRIPTION
When suggesting values for `network` or `cycle_network` from taginfo, include values that contain uppercase letters. This effectively enables taginfo suggestions for the`cycle_network` tag where previously they were completely disabled, and suggestions for the `network` tag are more accurate as well.

<img width="363" alt="cycle_network" src="https://cloud.githubusercontent.com/assets/1231218/17170471/0a2d12de-53a1-11e6-836f-fb216f341afb.png">

Presumably the uppercase filter was originally intended to block suggestions for freeform tags like `name`. But `network` and `cycle_network` aren’t entirely open-ended, even though their values contain uppercase letters.

/cc @bhousel