### PR TITLE
Combo Network Type field for bike/hike routes

### DIFF
--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -269,6 +269,9 @@ en:
       currency_multi:
         # 'currency:=*'
         label: Currency Types
+      cycle_network:
+        # cycle_network=*
+        label: Network
       cycleway:
         # 'cycleway:left=*, cycleway:right=*'
         label: Bike Lanes
@@ -628,6 +631,34 @@ en:
       network:
         # network=*
         label: Network
+      network_bicycle:
+        # network=*
+        label: Network Type
+        options:
+          # network=icn
+          icn: International
+          # network=lcn
+          lcn: Local
+          # network=ncn
+          ncn: National
+          # network=rcn
+          rcn: Regional
+        # network_bicycle field placeholder
+        placeholder: 'Local, Regional, National, International'
+      network_foot:
+        # network=*
+        label: Network Type
+        options:
+          # network=iwn
+          iwn: International
+          # network=lwn
+          lwn: Local
+          # network=nwn
+          nwn: National
+          # network=rwn
+          rwn: Regional
+        # network_foot field placeholder
+        placeholder: 'Local, Regional, National, International'
       note:
         # note=*
         label: Note

--- a/data/presets/fields.json
+++ b/data/presets/fields.json
@@ -352,6 +352,11 @@
         "type": "multiCombo",
         "label": "Currency Types"
     },
+    "cycle_network": {
+        "key": "cycle_network",
+        "type": "combo",
+        "label": "Network"
+    },
     "cycleway": {
         "keys": [
             "cycleway:left",
@@ -840,6 +845,34 @@
         "key": "natural",
         "type": "typeCombo",
         "label": "Natural"
+    },
+    "network_bicycle": {
+        "key": "network",
+        "type": "combo",
+        "label": "Network Type",
+        "placeholder": "Local, Regional, National, International",
+        "strings": {
+            "options": {
+                "lcn": "Local",
+                "rcn": "Regional",
+                "ncn": "National",
+                "icn": "International"
+            }
+        }
+    },
+    "network_foot": {
+        "key": "network",
+        "type": "combo",
+        "label": "Network Type",
+        "placeholder": "Local, Regional, National, International",
+        "strings": {
+            "options": {
+                "lwn": "Local",
+                "rwn": "Regional",
+                "nwn": "National",
+                "iwn": "International"
+            }
+        }
     },
     "network": {
         "key": "network",

--- a/data/presets/fields/cycle_network.json
+++ b/data/presets/fields/cycle_network.json
@@ -1,0 +1,5 @@
+{
+    "key": "cycle_network",
+    "type": "combo",
+    "label": "Network"
+}

--- a/data/presets/fields/network_bicycle.json
+++ b/data/presets/fields/network_bicycle.json
@@ -1,0 +1,14 @@
+{
+    "key": "network",
+    "type": "combo",
+    "label": "Network Type",
+    "placeholder": "Local, Regional, National, International",
+    "strings": {
+        "options": {
+            "lcn": "Local",
+            "rcn": "Regional",
+            "ncn": "National",
+            "icn": "International"
+        }
+    }
+}

--- a/data/presets/fields/network_foot.json
+++ b/data/presets/fields/network_foot.json
@@ -1,0 +1,14 @@
+{
+    "key": "network",
+    "type": "combo",
+    "label": "Network Type",
+    "placeholder": "Local, Regional, National, International",
+    "strings": {
+        "options": {
+            "lwn": "Local",
+            "rwn": "Regional",
+            "nwn": "National",
+            "iwn": "International"
+        }
+    }
+}

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -10650,7 +10650,8 @@
         "icon": "route-bicycle",
         "fields": [
             "ref",
-            "network"
+            "network_bicycle",
+            "cycle_network"
         ]
     },
     "type/route/bus": {
@@ -10712,7 +10713,7 @@
         "fields": [
             "ref",
             "operator",
-            "network"
+            "network_foot"
         ]
     },
     "type/route/hiking": {
@@ -10728,7 +10729,7 @@
         "fields": [
             "ref",
             "operator",
-            "network"
+            "network_foot"
         ]
     },
     "type/route/horse": {

--- a/data/presets/presets/type/route/bicycle.json
+++ b/data/presets/presets/type/route/bicycle.json
@@ -10,6 +10,7 @@
     "icon": "route-bicycle",
     "fields": [
         "ref",
-        "network"
+        "network_bicycle",
+        "cycle_network"
     ]
 }

--- a/data/presets/presets/type/route/foot.json
+++ b/data/presets/presets/type/route/foot.json
@@ -11,6 +11,6 @@
     "fields": [
         "ref",
         "operator",
-        "network"
+        "network_foot"
     ]
 }

--- a/data/presets/presets/type/route/hiking.json
+++ b/data/presets/presets/type/route/hiking.json
@@ -11,6 +11,6 @@
     "fields": [
         "ref",
         "operator",
-        "network"
+        "network_foot"
     ]
 }

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -864,6 +864,9 @@
             "currency_multi": {
                 "label": "Currency Types"
             },
+            "cycle_network": {
+                "label": "Network"
+            },
             "cycleway": {
                 "label": "Bike Lanes",
                 "placeholder": "none",
@@ -1167,6 +1170,26 @@
             },
             "natural": {
                 "label": "Natural"
+            },
+            "network_bicycle": {
+                "label": "Network Type",
+                "placeholder": "Local, Regional, National, International",
+                "options": {
+                    "lcn": "Local",
+                    "rcn": "Regional",
+                    "ncn": "National",
+                    "icn": "International"
+                }
+            },
+            "network_foot": {
+                "label": "Network Type",
+                "placeholder": "Local, Regional, National, International",
+                "options": {
+                    "lwn": "Local",
+                    "rwn": "Regional",
+                    "nwn": "National",
+                    "iwn": "International"
+                }
             },
             "network": {
                 "label": "Network"

--- a/modules/services/taginfo.js
+++ b/modules/services/taginfo.js
@@ -49,9 +49,10 @@ function filterMultikeys() {
     };
 }
 
-function filterValues() {
+function filterValues(allowUpperCase) {
     return function(d) {
-        if (d.value.match(/[A-Z*;,]/) !== null) return false;  // exclude some punctuation, uppercase letters
+        if (d.value.match(/[;,]/) !== null) return false;  // exclude some punctuation
+        if (!allowUpperCase && d.value.match(/[A-Z*]/) !== null) return false;  // exclude uppercase letters
         return parseFloat(d.fraction) > 0.0 || d.in_wiki;
     };
 }
@@ -140,7 +141,7 @@ export function init() {
                 page: 1
             }, parameters)), debounce, function(err, d) {
                 if (err) return callback(err);
-                var f = filterValues();
+                var f = filterValues(parameters.key === 'cycle_network' || parameters.key === 'network');
                 callback(null, d.data.filter(f).map(valKeyDescription));
             });
     };


### PR DESCRIPTION
Replaced the generic Network field (`network`) with a specialized Network Type field (`network`) in the bicycle, foot, and hiking route relation presets. Added a Network (`cycle_network`) field to the cycling route relation preset.

<img width="382" alt="bicycle" src="https://cloud.githubusercontent.com/assets/1231218/17171329/12861c10-53a5-11e6-83c7-0e8e642af6d7.png">
_Cycling route relation fields_

<img width="383" alt="bicycle-open" src="https://cloud.githubusercontent.com/assets/1231218/17171337/1a57252e-53a5-11e6-9699-3f1020256cfb.png">
_Cycling route network types_

The combo values for the cycling route relation preset conform to [wiki guidelines](http://wiki.openstreetmap.org/wiki/Tag:route%3Dbicycle) and common usage:

* Local (`network=lcn`)
* Regional (`network=rcn`)
* National (`network=ncn`)
* International (`network=icn`)

The combo values for the walking and hiking route relation presets also conform to [wiki guidelines](http://wiki.openstreetmap.org/wiki/Tag:route%3Dhiking):

* Local (`network=lwn`)
* Regional (`network=rwn`)
* National (`network=nwn`)
* International (`network=iwn`)

Depends on #3280.

/cc @bhousel