### PR TITLE
Add AED as term for Defibrillator

### DIFF
--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -2082,6 +2082,7 @@ en:
       emergency/defibrillator:
         # emergency=defibrillator
         name: Defibrillator
+        # 'terms: AED'
         terms: '<translate with synonyms or related terms for ''Defibrillator'', separated by commas>'
       emergency/fire_hydrant:
         # emergency=fire_hydrant

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -4052,6 +4052,9 @@
         "geometry": [
             "point"
         ],
+        "terms": [
+            "AED"
+        ],
         "tags": {
             "emergency": "defibrillator"
         },

--- a/data/presets/presets/emergency/defibrillator.json
+++ b/data/presets/presets/emergency/defibrillator.json
@@ -6,7 +6,9 @@
     ],
     "geometry": [
         "point"
-    
+    ],
+    "terms": [
+        "AED"
     ],
    "tags": {
         "emergency": "defibrillator"

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -2433,7 +2433,7 @@
             },
             "emergency/defibrillator": {
                 "name": "Defibrillator",
-                "terms": ""
+                "terms": "AED"
             },
             "emergency/fire_hydrant": {
                 "name": "Fire Hydrant",


### PR DESCRIPTION
AED, short for Automated External Defibrillator, is a term known by many people and often marked on defibrillators. Was also originally requested in #3202:

> Would be ideal if this came up when either "defibrillator" or "AED" was searched for.