### PR TITLE
Add indoor=yes/no to preset for Defibrillator

### DIFF
--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -447,6 +447,9 @@ en:
           down: Down
           # incline=up
           up: Up
+      indoor:
+        # indoor=*
+        label: Indoor
       information:
         # information=*
         label: Type

--- a/data/presets/fields.json
+++ b/data/presets/fields.json
@@ -618,6 +618,11 @@
         "type": "combo",
         "label": "Incline"
     },
+    "indoor": {
+        "key": "indoor",
+        "type": "check",
+        "label": "Indoor"
+    },
     "information": {
         "key": "information",
         "type": "typeCombo",

--- a/data/presets/fields/indoor.json
+++ b/data/presets/fields/indoor.json
@@ -1,0 +1,5 @@
+{
+    "key": "indoor",
+    "type": "check",
+    "label": "Indoor"
+}

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -4047,6 +4047,7 @@
         "fields": [
             "access",
             "opening_hours",
+            "indoor",
             "phone"
         ],
         "geometry": [

--- a/data/presets/presets/emergency/defibrillator.json
+++ b/data/presets/presets/emergency/defibrillator.json
@@ -2,6 +2,7 @@
     "fields": [
         "access",
         "opening_hours",
+        "indoor",
         "phone"
     ],
     "geometry": [

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -1028,6 +1028,9 @@
             "incline": {
                 "label": "Incline"
             },
+            "indoor": {
+                "label": "Indoor"
+            },
             "information": {
                 "label": "Type"
             },


### PR DESCRIPTION
Doing this separately from #3283 because this adds a new field and I'm not sure you're OK with it.

I add `indoor=yes` to all AEDs I map that are located inside a building.