### PR TITLE
Fix taginfo for relation presets

### DIFF
--- a/modules/presets/preset.js
+++ b/modules/presets/preset.js
@@ -61,8 +61,15 @@ export function Preset(id, preset, fields) {
             value = preset.tags[key];
 
         if (geometry === 'relation' && key === 'type') {
-            return { rtype: value };
-        } else if (value === '*') {
+            if (value in preset.tags) {
+                key = value;
+                value = preset.tags[key];
+            } else {
+                return { rtype: value };
+            }
+        }
+
+        if (value === '*') {
             return { key: key };
         } else {
             return { key: key, value: value };

--- a/modules/services/taginfo.js
+++ b/modules/services/taginfo.js
@@ -156,7 +156,7 @@ export function init() {
 
         request(endpoint + path + qsString(parameters), debounce, function(err, d) {
             if (err) return callback(err);
-            callback(null, d.data);
+            callback(null, parameters.rtype ? d : d.data);
         });
     };
 

--- a/modules/services/taginfo.js
+++ b/modules/services/taginfo.js
@@ -156,7 +156,7 @@ export function init() {
 
         request(endpoint + path + qsString(parameters), debounce, function(err, d) {
             if (err) return callback(err);
-            callback(null, parameters.rtype ? d : d.data);
+            callback(null, d.data);
         });
     };
 


### PR DESCRIPTION
taginfo’s relation/wiki_pages method no longer places results in a `data` property.

<img src="https://cloud.githubusercontent.com/assets/1231218/17274973/5860c19e-56ad-11e6-9094-49f488f66fa0.png" alt="boundary" width="360">

Also, only use relation/wiki_pages for top-level relation presets. More specific presets behave like non-relation presets. For example, the bicycle route relation has the tags `type=route` `route=bicycle`, so `route=bicycle` is what we’re interested in.

<img src="https://cloud.githubusercontent.com/assets/1231218/17274976/5fdf8a90-56ad-11e6-93e6-894455ebbd8d.png" alt="bicycle" width="340">

Fixes #3297.

/cc @bhousel