### PR TITLE
taginfo tooltips for combo values

### DIFF
--- a/modules/ui/fields/combo.js
+++ b/modules/ui/fields/combo.js
@@ -143,13 +143,14 @@ export function combo(field, context) {
             query: (isMulti ? field.key : '') + q
         }, function(err, data) {
             if (err) return;
-            comboData = _.map(data, 'value').map(function(k) {
+            comboData = _.map(data, function(d) {
+                var k = d.value;
                 if (isMulti) k = k.replace(field.key, '');
                 var v = snake_case ? unsnake(k) : k;
                 return {
                     key: k,
                     value: v,
-                    title: v
+                    title: isMulti ? v : d.title
                 };
             });
             comboData = objectDifference(comboData, multiData);


### PR DESCRIPTION
Each combo value obtained from taginfo now has a tooltip describing the value, if available.

<img width="529" alt="culvert" src="https://cloud.githubusercontent.com/assets/1231218/17275243/c005875a-56b5-11e6-8011-f4b9cf2cd01b.png">

(taginfo suggestions in the “All tags” section already have descriptive tooltips.)