### PR TITLE
taginfo for relation roles

### DIFF
--- a/modules/ui/raw_member_editor.js
+++ b/modules/ui/raw_member_editor.js
@@ -113,8 +113,51 @@ export function RawMemberEditor(context) {
                 .on('click', deleteMember)
                 .call(Icon('#operation-delete'));
 
+            if (context.taginfo()) {
+                $enter.each(bindTypeahead);
+            }
+
             $items.exit()
+                .each(unbind)
                 .remove();
+
+            function bindTypeahead(d) {
+                var row = d3.select(this),
+                    role = row.selectAll('input.member-role');
+    
+                function sort(value, data) {
+                    var sameletter = [],
+                        other = [];
+                    for (var i = 0; i < data.length; i++) {
+                        if (data[i].value.substring(0, value.length) === value) {
+                            sameletter.push(data[i]);
+                        } else {
+                            other.push(data[i]);
+                        }
+                    }
+                    return sameletter.concat(other);
+                }
+    
+                role.call(d3.combobox()
+                    .fetcher(function(role, callback) {
+                        var rtype = entity.tags.type;
+                        context.taginfo().roles({
+                            debounce: true,
+                            rtype: rtype || '',
+                            geometry: context.geometry(d.member.id),
+                            query: role
+                        }, function(err, data) {
+                            if (!err) callback(sort(role, data));
+                        });
+                    }));
+            }
+    
+            function unbind() {
+                var row = d3.select(this);
+    
+                row.selectAll('input.member-role')
+                    .call(d3.combobox.off);
+            }
         }
     }
 

--- a/modules/ui/raw_membership_editor.js
+++ b/modules/ui/raw_membership_editor.js
@@ -159,7 +159,12 @@ export function RawMembershipEditor(context) {
                 .on('click', deleteMembership)
                 .call(Icon('#operation-delete'));
 
+            if (context.taginfo()) {
+                $enter.each(bindTypeahead);
+            }
+
             $items.exit()
+                .each(unbind)
                 .remove();
 
             if (showBlank) {
@@ -213,6 +218,44 @@ export function RawMembershipEditor(context) {
                     content($wrap);
                     $list.selectAll('.member-entity-input').node().focus();
                 });
+
+            function bindTypeahead(d) {
+                var row = d3.select(this),
+                    role = row.selectAll('input.member-role');
+    
+                function sort(value, data) {
+                    var sameletter = [],
+                        other = [];
+                    for (var i = 0; i < data.length; i++) {
+                        if (data[i].value.substring(0, value.length) === value) {
+                            sameletter.push(data[i]);
+                        } else {
+                            other.push(data[i]);
+                        }
+                    }
+                    return sameletter.concat(other);
+                }
+    
+                role.call(d3.combobox()
+                    .fetcher(function(role, callback) {
+                        var rtype = d.relation.tags.type;
+                        context.taginfo().roles({
+                            debounce: true,
+                            rtype: rtype || '',
+                            geometry: context.geometry(id),
+                            query: role
+                        }, function(err, data) {
+                            if (!err) callback(sort(role, data));
+                        });
+                    }));
+            }
+    
+            function unbind() {
+                var row = d3.select(this);
+    
+                row.selectAll('input.member-role')
+                    .call(d3.combobox.off);
+            }
         }
     }
 

--- a/test/spec/services/taginfo.js
+++ b/test/spec/services/taginfo.js
@@ -197,6 +197,26 @@ describe('iD.services.taginfo', function() {
         });
     });
 
+    describe('#roles', function() {
+        it('calls the given callback with the results of the roles query', function() {
+            var callback = sinon.spy();
+            taginfo.roles({rtype: 'route', query: 's', geometry: 'relation'}, callback);
+
+            server.respondWith('GET', new RegExp('https://taginfo.openstreetmap.org/api/4/relation/roles'),
+                [200, { 'Content-Type': 'application/json' },
+                    '{"data":[{"role":"stop","count_relation_members_fraction":0.1757},' +
+                             '{"role":"south","count_relation_members_fraction":0.0035}]}']);
+            server.respond();
+
+            expect(query(server.requests[0].url)).to.eql(
+                {rtype: 'route', query: 's', page: '1', rp: '25', sortname: 'count_relation_members', sortorder: 'desc'});
+            expect(callback).to.have.been.calledWith(null, [
+                {'value': 'stop', 'title': 'stop'},
+                {'value': 'south', 'title': 'south'}
+            ]);
+        });
+    });
+
     describe('#docs', function() {
         it('calls the given callback with the results of the docs query', function() {
             var callback = sinon.spy();


### PR DESCRIPTION
Enabled taginfo suggestions for roles on relation members and memberships.

<img width="400" alt="roles" src="https://cloud.githubusercontent.com/assets/1231218/17275851/944044d2-56cb-11e6-8d43-74bc5ab145cc.png">