### PR TITLE
Include network in relation display name

### DIFF
--- a/modules/util/util.js
+++ b/modules/util/util.js
@@ -29,12 +29,13 @@ export function entityOrMemberSelector(ids, graph) {
 }
 
 export function displayName(entity) {
-    var localizedNameKey = 'name:' + Detect().locale.toLowerCase().split('-')[0];
-    var name = entity.tags[localizedNameKey] || entity.tags.name;
+    var localizedNameKey = 'name:' + Detect().locale.toLowerCase().split('-')[0]
+        name = entity.tags[localizedNameKey] || entity.tags.name || '',
+        network = entity.tags.cycle_network || entity.tags.network;
     if (!name && entity.tags.ref) {
         name = entity.tags.ref;
-        if (entity.tags.network) {
-            name = entity.tags.network + ' ' + name;
+        if (network) {
+            name = network + ' ' + name;
         }
     }
     return name;

--- a/modules/util/util.js
+++ b/modules/util/util.js
@@ -29,8 +29,15 @@ export function entityOrMemberSelector(ids, graph) {
 }
 
 export function displayName(entity) {
-    var localeName = 'name:' + Detect().locale.toLowerCase().split('-')[0];
-    return entity.tags[localeName] || entity.tags.name || entity.tags.ref;
+    var localizedNameKey = 'name:' + Detect().locale.toLowerCase().split('-')[0];
+    var name = entity.tags[localizedNameKey] || entity.tags.name;
+    if (!name && entity.tags.ref) {
+        name = entity.tags.ref;
+        if (entity.tags.network) {
+            name = entity.tags.network + ' ' + name;
+        }
+    }
+    return name;
 }
 
 export function displayType(id) {

--- a/modules/util/util.js
+++ b/modules/util/util.js
@@ -29,7 +29,7 @@ export function entityOrMemberSelector(ids, graph) {
 }
 
 export function displayName(entity) {
-    var localizedNameKey = 'name:' + Detect().locale.toLowerCase().split('-')[0]
+    var localizedNameKey = 'name:' + Detect().locale.toLowerCase().split('-')[0],
         name = entity.tags[localizedNameKey] || entity.tags.name || '',
         network = entity.tags.cycle_network || entity.tags.network;
     if (!name && entity.tags.ref) {


### PR DESCRIPTION
If a relation is tagged with a `network`, the `network` is needed alongside the `ref` to identify the relation.

For example, this Ohio State Route relation is tagged `type=route` `route=road` `network=US:OH` `ref=28`, while its members are tagged `ref=SR 28`:

<img src="https://cloud.githubusercontent.com/assets/1231218/17275990/966a371e-56cf-11e6-94e8-fb143015fe17.png" alt="membership" width="360">

<img src="https://cloud.githubusercontent.com/assets/1231218/17275992/a42bee2e-56cf-11e6-95e8-9020f72fc057.png" alt="changes" width="400">

Displaying the network will make mappers less inclined to redundantly tag the network-ref combination in `name`.