### PR TITLE
Combo field with taginfo for road networks

### DIFF
--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -688,6 +688,9 @@ en:
           rhn: Regional
         # network_horse field placeholder
         placeholder: 'Local, Regional, National, International'
+      network_road:
+        # network=*
+        label: Network
       note:
         # note=*
         label: Note

--- a/data/presets/fields.json
+++ b/data/presets/fields.json
@@ -906,6 +906,11 @@
             }
         }
     },
+    "network_road": {
+        "key": "network",
+        "type": "networkCombo",
+        "label": "Network"
+    },
     "network": {
         "key": "network",
         "type": "text",

--- a/data/presets/fields.json
+++ b/data/presets/fields.json
@@ -367,7 +367,7 @@
     },
     "cycle_network": {
         "key": "cycle_network",
-        "type": "combo",
+        "type": "networkCombo",
         "label": "Network"
     },
     "cycleway": {

--- a/data/presets/fields/cycle_network.json
+++ b/data/presets/fields/cycle_network.json
@@ -1,5 +1,5 @@
 {
     "key": "cycle_network",
-    "type": "combo",
+    "type": "networkCombo",
     "label": "Network"
 }

--- a/data/presets/fields/network_road.json
+++ b/data/presets/fields/network_road.json
@@ -1,0 +1,5 @@
+{
+    "key": "network",
+    "type": "networkCombo",
+    "label": "Network"
+}

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -10868,7 +10868,7 @@
         "icon": "route-road",
         "fields": [
             "ref",
-            "network"
+            "network_road"
         ]
     },
     "type/route/train": {

--- a/data/presets/presets/type/route/road.json
+++ b/data/presets/presets/type/route/road.json
@@ -10,6 +10,6 @@
     "icon": "route-road",
     "fields": [
         "ref",
-        "network"
+        "network_road"
     ]
 }

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -1213,6 +1213,9 @@
                     "ihn": "International"
                 }
             },
+            "network_road": {
+                "label": "Network"
+            },
             "network": {
                 "label": "Network"
             },

--- a/modules/ui/fields/combo.js
+++ b/modules/ui/fields/combo.js
@@ -140,7 +140,7 @@ export function combo(field, context) {
     function setTaginfoValues(q, callback) {
         var fn = isMulti ? 'multikeys' : 'values';
         var query = (isMulti ? field.key : '') + q;
-        if (isNetwork && countryCode && countryCode.indexOf(q) === 0) {
+        if (isNetwork && countryCode && countryCode.indexOf(q.toLowerCase()) === 0) {
             query = countryCode + ':';
         }
         context.taginfo()[fn]({

--- a/modules/ui/fields/combo.js
+++ b/modules/ui/fields/combo.js
@@ -140,7 +140,8 @@ export function combo(field, context) {
     function setTaginfoValues(q, callback) {
         var fn = isMulti ? 'multikeys' : 'values';
         var query = (isMulti ? field.key : '') + q;
-        if (isNetwork && countryCode && countryCode.indexOf(q.toLowerCase()) === 0) {
+        var hasCountryPrefix = isNetwork && countryCode && countryCode.indexOf(q.toLowerCase()) === 0;
+        if (hasCountryPrefix) {
             query = countryCode + ':';
         }
         context.taginfo()[fn]({
@@ -150,6 +151,11 @@ export function combo(field, context) {
             query: query
         }, function(err, data) {
             if (err) return;
+            if (hasCountryPrefix) {
+                data = _.filter(data, function(d) {
+                    return d.value.toLowerCase().indexOf(countryCode + ':') === 0;
+                });
+            }
             comboData = _.map(data, function(d) {
                 var k = d.value;
                 if (isMulti) k = k.replace(field.key, '');

--- a/modules/ui/fields/combo.js
+++ b/modules/ui/fields/combo.js
@@ -3,11 +3,13 @@ import _ from 'lodash';
 
 export {
     combo as typeCombo,
-    combo as multiCombo
+    combo as multiCombo,
+    combo as networkCombo
 };
 export function combo(field, context) {
     var dispatch = d3.dispatch('change'),
         isMulti = (field.type === 'multiCombo'),
+        isNetwork = (field.type === 'networkCombo'),
         optstrings = field.strings && field.strings.options,
         optarray = field.options,
         snake_case = (field.snake_case || (field.snake_case === undefined)),
@@ -16,7 +18,8 @@ export function combo(field, context) {
         multiData = [],
         container,
         input,
-        entity;
+        entity,
+        countryCode;
 
     // ensure multiCombo field.key ends with a ':'
     if (isMulti && field.key.match(/:$/) === null) {
@@ -136,11 +139,15 @@ export function combo(field, context) {
 
     function setTaginfoValues(q, callback) {
         var fn = isMulti ? 'multikeys' : 'values';
+        var query = (isMulti ? field.key : '') + q;
+        if (isNetwork && countryCode && countryCode.indexOf(q) === 0) {
+            query = countryCode + ':';
+        }
         context.taginfo()[fn]({
             debounce: true,
             key: field.key,
             geometry: context.geometry(entity.id),
-            query: (isMulti ? field.key : '') + q
+            query: query
         }, function(err, data) {
             if (err) return;
             comboData = _.map(data, function(d) {
@@ -224,6 +231,14 @@ export function combo(field, context) {
             .attr('type', 'text')
             .attr('id', 'preset-input-' + field.id)
             .call(initCombo, selection);
+
+        if (isNetwork) {
+            var center = entity.extent(context.graph()).center();
+            iD.services.nominatim.init();
+            iD.services.nominatim.countryCode(center, function (err, code) {
+                countryCode = code;
+            });
+        }
 
         input
             .on('change', change)

--- a/modules/ui/fields/index.js
+++ b/modules/ui/fields/index.js
@@ -1,5 +1,5 @@
 import { check, defaultcheck} from './check';
-import { combo, multiCombo, typeCombo } from './combo';
+import { combo, multiCombo, networkCombo, typeCombo } from './combo';
 import { email, number, tel, text, url } from './input';
 
 import { access } from './access';
@@ -21,6 +21,7 @@ export var fields = {
     combo: combo,
     typeCombo: typeCombo,
     multiCombo: multiCombo,
+    networkCombo: networkCombo,
     cycleway: cycleway,
     text: text,
     url: url,


### PR DESCRIPTION
Added a variation of the combo field for road networks. If the field’s value is blank or shares a prefix with the current country code, search taginfo for values beginning with the country code and a colon.

<img width="381" alt="combo" src="https://cloud.githubusercontent.com/assets/1231218/17276230/7df6adae-56d7-11e6-8272-d46671c1cab1.png">

`network` values for road routes generally begin with the country code (either uppercase or lowercase) followed by a colon. The one big exception is Ontario: 2,023 are relations tagged [`network=ca_on_county`](http://taginfo.openstreetmap.org/tags/network=ca_on_county), so overall there are 1,500 elements tagged `network=CA:*` versus 2,429 tagged `network=ca_*`. On the other hand, 2,478 bus stops are tagged [`network=co:dc:sitp`](http://overpass-turbo.eu/s/hBi), which does begin with the country code and a colon. Also, a few popular values in Europe are unqualified letters. Despite these exceptions, I think it’s reasonable to suggest values beginning with the country code and a colon; if local standards differ, the user is free to enter any other value.

/cc @bhousel