### PR TITLE
Added more fields to clock preset

### DIFF
--- a/data/presets/fields/date.json
+++ b/data/presets/fields/date.json
@@ -1,0 +1,5 @@
+{
+    "key": "date",
+    "type": "check",
+    "label": "Date"
+}

--- a/data/presets/fields/display.json
+++ b/data/presets/fields/display.json
@@ -1,0 +1,5 @@
+{
+    "key": "display",
+    "type": "combo",
+    "label": "Display"
+}

--- a/data/presets/fields/support.json
+++ b/data/presets/fields/support.json
@@ -1,0 +1,5 @@
+{
+    "key": "support",
+    "type": "combo",
+    "label": "Support"
+}

--- a/data/presets/fields/visibility.json
+++ b/data/presets/fields/visibility.json
@@ -1,0 +1,5 @@
+{
+    "key": "visibility",
+    "type": "combo",
+    "label": "Visibility"
+}

--- a/data/presets/presets/amenity/clock.json
+++ b/data/presets/presets/amenity/clock.json
@@ -1,4 +1,10 @@
 {
+    "fields": [
+        "support",
+        "display",
+        "visibility",
+        "date"
+    ],
     "geometry": [
         "point",
         "vertex"


### PR DESCRIPTION
For later better [rendering of clocks](https://github.com/gravitystorm/openstreetmap-carto/pull/2218) i added the tags "support", "display", "visibility", "date" to clock presets.