### PR TITLE
Fixed validate function

### DIFF
--- a/build.js
+++ b/build.js
@@ -25,10 +25,10 @@ function rp(f) {
 }
 
 function validate(file, instance, schema) {
-    var result = jsonschema.validate(instance, schema);
-    if (result.length) {
+    var validationErrors = jsonschema.validate(instance, schema).errors;
+    if (validationErrors.length) {
         console.error(file + ": ");
-        result.forEach(function(error) {
+        validationErrors.forEach(function(error) {
             if (error.property) {
                 console.error(error.property + ' ' + error.message);
             } else {


### PR DESCRIPTION
Preset validation failed to identify schema errors because `jsonschema.validate(instance, schema).length` is always `undefined`.

This PR checks `jsonschema.validate(instance, schema).errors` instead.