### PR TITLE
Performance improvement. Debounce redraw call.

### DIFF
--- a/modules/renderer/map.js
+++ b/modules/renderer/map.js
@@ -217,8 +217,6 @@ export function Map(context) {
     function redraw(difference, extent) {
         if (!surface || !redrawEnabled) return;
 
-        clearTimeout(timeoutId);
-
         // If we are in the middle of a zoom/pan, we can't do differenced redraws.
         // It would result in artifacts where differenced entities are redrawn with
         // one transform and unchanged entities with another.
@@ -254,10 +252,7 @@ export function Map(context) {
         return map;
     }
 
-    var timeoutId;
-    function queueRedraw() {
-        timeoutId = setTimeout(function() { redraw(); }, 750);
-    }
+    var queueRedraw = _.debounce(redraw, 750);
 
     function pointLocation(p) {
         var translate = projection.translate(),


### PR DESCRIPTION
This enhances panning speed especially when tiles are already loaded. 
My understanding is that the previous code will `clearTimeout()` only the last call to `queueRedraw` since the `timeoutId` variable gets overwrote upon each call

## verify

in both this branch and `origin/master`:

* go to an urban area for instance http://localhost:8080/#background=Bing&map=16.52/-71.28537/46.77116
* Pan around the buffer to make sure you get all the tiles in browser cache
* activate google chrome profiling
* pan around for a couple of seconds make sure the panning is small enough so that no new tiles are loaded (otherwise this ain't scientific)

Screenshots below show for a panning of `7000ms`. 

In `origin/master`, notice that the several redraw calls are stacked even under 750ms

![screen shot 2016-08-18 at 1 05 37 am](https://cloud.githubusercontent.com/assets/368/17762645/85c736ae-64e0-11e6-93d6-29e67c1911fb.png)


in this branch, `redraw` calls are "debounced"
![screen shot 2016-08-18 at 1 02 40 am](https://cloud.githubusercontent.com/assets/368/17762648/8a5eed38-64e0-11e6-8f68-d0e7fc275b48.png)

This also speeds up when zoomed further up like zoom 18 and such since less tiles need to be downloaded in normal interaction.