### PR TITLE
Change instructions to use node's http-server instead of going into python land

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ To run the current development version of iD on your own computer:
 2. (Windows Only)  Run `fixWinSymlinks.bat`.  This script will prompt for Administrator rights.  see also: http://stackoverflow.com/questions/5917249/git-symlinks-in-windows
 3. Run `npm install`
 4. Run `make`
-5. Start a local web server, e.g. `python -m SimpleHTTPServer`
-6. Open `http://localhost:8000/` in a web browser
+5. Start the local web server `npm run-script web`
+6. Open `http://localhost:8080/` in a web browser
 
 For guidance on building a packaged version, running tests, and contributing to
 development, see [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "test": "npm run lint && make && phantomjs node_modules/mocha-phantomjs-core/mocha-phantomjs-core.js test/index.html dot",
     "start": "rollup --config=./rollup.config.js -w --input ./modules/id.js --output dist/iD.js",
+    "web": "node_modules/http-server/bin/http-server",
     "build": "rollup --config=./rollup.config.js -f iife --input ./modules/id.js --output dist/iD.js && uglifyjs dist/iD.js -c -m -o dist/iD.min.js",
     "lint": "eslint js/id test/spec modules"
   },
@@ -40,6 +41,7 @@
     "eslint": "~3.3.1",
     "glob": "~7.0.5",
     "happen": "~0.3.1",
+    "http-server": "0.9.0",
     "js-yaml": "~3.6.1",
     "jsonschema": "~1.1.0",
     "maki": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "test": "npm run lint && make && phantomjs node_modules/mocha-phantomjs-core/mocha-phantomjs-core.js test/index.html dot",
     "start": "rollup --config=./rollup.config.js -w --input ./modules/id.js --output dist/iD.js",
-    "web": "node_modules/http-server/bin/http-server",
+    "web": "http-server",
     "build": "rollup --config=./rollup.config.js -f iife --input ./modules/id.js --output dist/iD.js && uglifyjs dist/iD.js -c -m -o dist/iD.min.js",
     "lint": "eslint js/id test/spec modules"
   },


### PR DESCRIPTION
http-server for node.js is very convenient, and is a lot faster than Python's SimpleHTTPServer. This is primarily because it uses asynchronous IO for concurrent handling of requests, instead of serialising requests.

> 🎶  it's a node world after all 🎶 

Enjoy the ride! https://www.youtube.com/watch?v=iJFGAX77zw4
