### PR TITLE
Add fire-station icon for fire-hydrant

### DIFF
--- a/data/presets/presets/emergency/fire_hydrant.json
+++ b/data/presets/presets/emergency/fire_hydrant.json
@@ -1,4 +1,5 @@
 {
+    "icon": "fire-station",
     "fields": [
         "fire_hydrant/type"
     ],


### PR DESCRIPTION
Fire hydrants are for firemen anyway, and it help distinguish them from other no-icon point on the map. 

By the way, is there any plan to upgrade maki from version 0.5.0 to latest version 2.0.x? Is that OK if I migrate iD by updating icons' name or there is a particular reason to use maki 0.5.0?