### PR TITLE
Fix way disappearing due to invalid "layer" tag

### DIFF
--- a/modules/core/way.js
+++ b/modules/core/way.js
@@ -68,7 +68,7 @@ _.extend(Way.prototype, {
 
     layer: function() {
         // explicit layer tag, clamp between -10, 10..
-        if (this.tags.layer !== undefined) {
+        if (isFinite(this.tags.layer)) {
             return Math.max(-10, Math.min(+(this.tags.layer), 10));
         }
 


### PR DESCRIPTION
Hello.

Now layer() returns only a finite number, not NaN.

/* Chrome 53 */