### PR TITLE
Add e-cigarette shop preset

### DIFF
--- a/data/presets/presets/shop/e-cigarette.json
+++ b/data/presets/presets/shop/e-cigarette.json
@@ -1,0 +1,21 @@
+{
+    "icon": "shop",
+    "fields": [
+        "operator",
+        "address",
+        "building_area",
+        "opening_hours"
+    ],
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "shop": "e-cigarette"
+    },
+    "terms": [
+        "electronic",
+        "vapor"
+    ],
+    "name": "E-Cigarette Shop"
+}


### PR DESCRIPTION
https://wiki.openstreetmap.org/wiki/Tag:shop%3De-cigarette

Only 500+ uses but more popular than some of the preset tags in iD, and helps with consistent tagging.