### PR TITLE
Added Anime Terms to Anime Shop

### DIFF
--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -3569,7 +3569,7 @@
             },
             "shop/anime": {
                 "name": "Anime Shop",
-                "terms": ""
+                "terms": "anime, manga, figurine, cosplay, dakimakura, japan"
             },
             "shop/antiques": {
                 "name": "Antiques Shop",


### PR DESCRIPTION
Added terms include things you might purchase at an anime shop, plus a catch all "Japan" term.