### PR TITLE
First shot: control plugins

### DIFF
--- a/modules/ui/init.js
+++ b/modules/ui/init.js
@@ -36,6 +36,8 @@ import { uiCmd } from './cmd';
 
 export function uiInit(context) {
 
+    var controls;
+
     function render(container) {
         var map = context.map();
 
@@ -119,7 +121,7 @@ export function uiInit(context) {
             .attr('class', 'spinner')
             .call(uiSpinner(context));
 
-        var controls = bar
+        controls = bar
             .append('div')
             .attr('class', 'map-controls');
 
@@ -302,6 +304,13 @@ export function uiInit(context) {
     }
 
     ui.sidebar = uiSidebar(context);
+
+    ui.pluginRegisterControl = function (plugin) {
+        controls
+            .append('div')
+            .attr('class', 'map-control ' + plugin.buttonClass)
+            .call(plugin.handler(context));
+    };
 
     return ui;
 }


### PR DESCRIPTION
Okay, here goes: first shot at #1392

See [id-upwards](https://github.com/osmlab/id-upwards) for an example plugin.

This establishes the 'hook' which JavaScript plugins can call by invoking a function, but it does not yet propose how you'd include other JavaScript on the page. This could be loading from npm, local sources, an iD-specific source, etc. Open to options.

Tweet-gif of [example in action](https://twitter.com/tmcw/status/786937538271248384).

Observations:
- Control styling will need to adapt to a variable number of controls
- Need to decide whether to control the panel size & placement or let plugins do that.
