### PR TITLE
add preset for nail salon

### DIFF
--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -3345,8 +3345,13 @@ en:
       shop/beauty:
         # shop=beauty
         name: Beauty Shop
-        # 'terms: nail spa,spa,salon,tanning'
+        # 'terms: spa,salon,tanning'
         terms: '<translate with synonyms or related terms for ''Beauty Shop'', separated by commas>'
+      shop/beauty/nails:
+        # 'shop=beauty, beauty=nails'
+        name: Nail Salon
+        # 'terms: Nail Salon,nails'
+        terms: '<translate with synonyms or related terms for ''Nail Salon'', separated by commas>'
       shop/bed:
         # shop=bed
         name: Bedding/Mattress Store

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -8495,7 +8495,6 @@
             "area"
         ],
         "terms": [
-            "nail spa",
             "spa",
             "salon",
             "tanning"
@@ -8504,6 +8503,28 @@
             "shop": "beauty"
         },
         "name": "Beauty Shop"
+    },
+    "shop/beauty/nails": {
+        "icon": "shop",
+        "fields": [
+            "shop",
+            "building_area",
+            "address",
+            "opening_hours"
+        ],
+        "geometry": [
+            "point",
+            "area"
+        ],
+        "terms": [
+            "Nail Salon",
+            "nails"
+        ],
+        "tags": {
+            "shop": "beauty",
+            "beauty": "nails"
+        },
+        "name": "Nail Salon"
     },
     "shop/bed": {
         "icon": "lodging",

--- a/data/presets/presets/shop/beauty/nails.json
+++ b/data/presets/presets/shop/beauty/nails.json
@@ -1,9 +1,10 @@
+
 {
     "icon": "shop",
     "fields": [
-        "operator",
-        "address",
+    	"shop",
         "building_area",
+        "address",
         "opening_hours"
     ],
     "geometry": [
@@ -11,12 +12,12 @@
         "area"
     ],
     "terms": [
-        "spa",
-        "salon",
-        "tanning"
+        "Nail Salon",
+        "nails"
     ],
     "tags": {
-        "shop": "beauty"
+        "shop": "beauty",
+        "beauty": "nails"
     },
-    "name": "Beauty Shop"
+    "name": "Nail Salon"
 }

--- a/data/taginfo.json
+++ b/data/taginfo.json
@@ -1979,6 +1979,10 @@
             "value": "beauty"
         },
         {
+            "key": "beauty",
+            "value": "nails"
+        },
+        {
             "key": "shop",
             "value": "bed"
         },

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -3605,7 +3605,11 @@
             },
             "shop/beauty": {
                 "name": "Beauty Shop",
-                "terms": "nail spa,spa,salon,tanning"
+                "terms": "spa,salon,tanning"
+            },
+            "shop/beauty/nails": {
+                "name": "Nail Salon",
+                "terms": "Nail Salon,nails"
             },
             "shop/bed": {
                 "name": "Bedding/Mattress Store",


### PR DESCRIPTION
Here's a pull request that adds nail salons (where people have their fingernails lacquered and/or manicured) to the generic preset. 

The common tags for tagging these are shop=beauty and beauty=nails. [taginfo](http://taginfo.openstreetmap.org/search?q=nails#values) and [wiki](https://wiki.openstreetmap.org/wiki/Tag:shop%3Dbeauty)

I wasn't sure on the correct file location for this preset but I created a new folder within the shop folder, and 
named it after its parent tag, beauty. 

This structure is based the practice of presets whose meaning are not defined so much by their first tag but rather by their second tag. This occurs with a mosque which has amenity=place_of_worship and religion=muslim)[https://github.com/openstreetmap/iD/tree/master/data/presets/presets/amenity/place_of_worship]. 

Bryan, would you like iD continue with this precendence? 

![selection_081](https://cloud.githubusercontent.com/assets/955351/19627172/0e83f54c-990f-11e6-9173-d8b008a1b0a2.png)
My other question regarding this PR is that after adding this preset, rebuilding the presets, and testing it locally, there's an additional box of 'beauty' as indicated in the image below. Is there a way to hide this? 
