### PR TITLE
Authenticate OSM API calls

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,12 +30,12 @@
             .call(iD.uiSourceSwitch(id)
                 .keys([
                     {
-                        'url': 'http://www.openstreetmap.org',
+                        'urlroot': 'http://www.openstreetmap.org',
                         'oauth_consumer_key': '5A043yRSEugj4DJ5TljuapfnrflWDte8jTOcWLlT',
                         'oauth_secret': 'aB3jKq1TRsCOUrfOIZ6oQMEDmv2ptV76PA54NGLL'
                     },
                     {
-                        'url': 'http://api06.dev.openstreetmap.org',
+                        'urlroot': 'http://api06.dev.openstreetmap.org',
                         'oauth_consumer_key': 'zwQZFivccHkLs3a8Rq5CoS412fE5aPCXDw9DZj7R',
                         'oauth_secret': 'aMnOOCwExO2XYtRVWJ1bI9QOdqh1cay2UgpbhA6p'
                     }

--- a/modules/services/osm.js
+++ b/modules/services/osm.js
@@ -464,20 +464,20 @@ export default {
                 dispatch.call('loading');
             }
 
-            function bboxPath(tile) {
-                return '/api/0.6/map?bbox=' + tile.extent.toParam();
-            }
+            inflight[id] = that.loadFromAPI(
+                '/api/0.6/map?bbox=' + tile.extent.toParam(),
+                function(err, parsed) {
+                    loadedTiles[id] = true;
+                    delete inflight[id];
 
-            inflight[id] = that.loadFromAPI(bboxPath(tile), function(err, parsed) {
-                loadedTiles[id] = true;
-                delete inflight[id];
+                    if (callback) {
+                        callback(err, _.extend({ data: parsed }, tile));
+                    }
 
-                if (callback) callback(err, _.extend({ data: parsed }, tile));
-
-                if (_.isEmpty(inflight)) {
-                    dispatch.call('loaded');
-                }
-            });
+                    if (_.isEmpty(inflight)) {
+                        dispatch.call('loaded');
+                    }
+                });
         });
     },
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "diacritics": "1.2.3",
     "lodash": "4.16.4",
     "marked": "0.3.6",
-    "osm-auth": "0.2.9",
+    "osm-auth": "1.0.0",
     "rbush": "2.0.1",
     "sexagesimal": "0.5.0",
     "togeojson": "0.16.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "diacritics": "1.2.3",
     "lodash": "4.16.4",
     "marked": "0.3.6",
-    "osm-auth": "1.0.0",
+    "osm-auth": "1.0.1",
     "rbush": "2.0.1",
     "sexagesimal": "0.5.0",
     "togeojson": "0.16.0",


### PR DESCRIPTION
This attempts to make authenticated calls to the OSM API if the user is logged in.
(see https://github.com/openstreetmap/iD/issues/2262#issuecomment-253215027)

I'm still having some trouble with the map call.  The server is not too happy with my attempt to send OAuth headers.  Any ideas @zerebubuth ?

Full headers for a typical map call look like this:

##### General
```
Request URL:http://www.openstreetmap.org/api/0.6/map?bbox=-74.53674316406232,40.66397287638667,-74.53124999999982,40.66813955408022
Request Method:GET
Status Code:401 Internal Server Error
Remote Address:193.63.75.103:80
```

##### Response Headers
```
HTTP/1.1 401 Internal Server Error
Date: Mon, 24 Oct 2016 05:20:02 GMT
Server: Apache/2.4.18 (Ubuntu)
Access-Control-Allow-Credentials: true
Access-Control-Allow-Methods: GET
Access-Control-Allow-Origin: http://localhost:8080
Access-Control-Max-Age: 1728000
Error: Unauthorized OAuth request.
Cache-Control: no-cache
Content-Length: 0
Content-Type: text/html; charset=utf-8
Keep-Alive: timeout=5, max=100
Connection: Keep-Alive
```
##### Request Headers
```
GET /api/0.6/map?bbox=-74.53674316406232,40.66397287638667,-74.53124999999982,40.66813955408022 HTTP/1.1
Host: www.openstreetmap.org
Connection: keep-alive
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.71 Safari/537.36
Origin: http://localhost:8080
Authorization: OAuth oauth_consumer_key="xxxxxxxxxxx", oauth_nonce="SL9Dpd", oauth_signature="xxxxxxxxxxx", oauth_signature_method="HMAC-SHA1", oauth_timestamp="1477286402", oauth_token="xxxxxxxxxxx"
Content-Type: application/x-www-form-urlencoded
Accept: */*
DNT: 1
Referer: http://localhost:8080/
Accept-Encoding: gzip, deflate, sdch
Accept-Language: en,en-US;q=0.8
```

##### Query String Parameters
```
bbox=-74.53674316406232,40.66397287638667,-74.53124999999982,40.66813955408022
```