### PR TITLE
Add vertex keyboard navigation

### DIFF
--- a/css/map.css
+++ b/css/map.css
@@ -37,6 +37,7 @@ g.point .shadow {
     stroke-opacity: 0;
 }
 
+g.point.related:not(.selected) .shadow,
 g.point.hover:not(.selected) .shadow {
     stroke-opacity: 0.5;
 }
@@ -104,7 +105,9 @@ g.vertex.vertex-hover {
     display: block;
 }
 
+g.vertex.related:not(.selected) .shadow,
 g.vertex.hover:not(.selected) .shadow,
+g.midpoint.related:not(.selected) .shadow,
 g.midpoint.hover:not(.selected) .shadow {
     fill-opacity: 0.5;
 }
@@ -144,6 +147,7 @@ path.shadow {
     stroke-opacity: 0;
 }
 
+path.shadow.related:not(.selected),
 path.shadow.hover:not(.selected) {
     stroke-opacity: 0.4;
 }
@@ -1600,6 +1604,7 @@ text.gpx {
     stroke-width: 8;
 }
 
+.fill-wireframe path.shadow.related:not(.selected),
 .fill-wireframe path.shadow.hover:not(.selected) {
     stroke-opacity: 0.4;
 }

--- a/modules/lib/d3.keybinding.js
+++ b/modules/lib/d3.keybinding.js
@@ -58,39 +58,44 @@ export function d3keybinding(namespace) {
         return keybinding;
     };
 
-    keybinding.on = function(code, callback, capture) {
-        var binding = {
-            event: {
-                keyCode: 0,
-                shiftKey: false,
-                ctrlKey: false,
-                altKey: false,
-                metaKey: false
-            },
-            capture: capture,
-            callback: callback
-        };
+    keybinding.on = function(codes, callback, capture) {
+        var arr = [].concat(codes);
+        for (var i = 0; i < arr.length; i++) {
+            var code = arr[i];
+            var binding = {
+                event: {
+                    keyCode: 0,
+                    shiftKey: false,
+                    ctrlKey: false,
+                    altKey: false,
+                    metaKey: false
+                },
+                capture: capture,
+                callback: callback
+            };
 
-        code = code.toLowerCase().match(/(?:(?:[^+⇧⌃⌥⌘])+|[⇧⌃⌥⌘]|\+\+|^\+$)/g);
+            code = code.toLowerCase().match(/(?:(?:[^+⇧⌃⌥⌘])+|[⇧⌃⌥⌘]|\+\+|^\+$)/g);
 
-        for (var i = 0; i < code.length; i++) {
-            // Normalise matching errors
-            if (code[i] === '++') code[i] = '+';
+            for (var j = 0; j < code.length; j++) {
+                // Normalise matching errors
+                if (code[j] === '++') code[i] = '+';
 
-            if (code[i] in d3keybinding.modifierCodes) {
-                binding.event[d3keybinding.modifierProperties[d3keybinding.modifierCodes[code[i]]]] = true;
-            } else if (code[i] in d3keybinding.keyCodes) {
-                binding.event.keyCode = d3keybinding.keyCodes[code[i]];
+                if (code[j] in d3keybinding.modifierCodes) {
+                    binding.event[d3keybinding.modifierProperties[d3keybinding.modifierCodes[code[j]]]] = true;
+                } else if (code[j] in d3keybinding.keyCodes) {
+                    binding.event.keyCode = d3keybinding.keyCodes[code[j]];
+                }
             }
-        }
 
-        bindings.push(binding);
+            bindings.push(binding);
+        }
 
         return keybinding;
     };
 
     return keybinding;
 }
+
 
 d3keybinding.modifierCodes = {
     // Shift key, ⇧

--- a/modules/modes/select.js
+++ b/modules/modes/select.js
@@ -29,6 +29,7 @@ import { modeBrowse } from './browse';
 import { modeDragNode } from './drag_node';
 import * as Operations from '../operations/index';
 import { uiRadialMenu, uiSelectionList } from '../ui/index';
+import { uiCmd } from '../ui/cmd';
 import { utilEntityOrMemberSelector } from '../util/index';
 
 
@@ -344,8 +345,8 @@ export function modeSelect(context, selectedIDs) {
         keybinding
             .on(['[','pgup'], previousNode)
             .on([']', 'pgdown'], nextNode)
-            .on(['⌘[', 'home'], firstNode)
-            .on(['⌘]', 'end'], lastNode)
+            .on([uiCmd('⌘['), 'home'], firstNode)
+            .on([uiCmd('⌘]'), 'end'], lastNode)
             .on('⎋', esc, true)
             .on('space', toggleMenu);
 

--- a/modules/modes/select.js
+++ b/modules/modes/select.js
@@ -243,7 +243,10 @@ export function modeSelect(context, selectedIDs) {
                     .selectAll(utilEntityOrMemberSelector(selectedIDs, context.graph()));
 
             if (selection.empty()) {
-                if (drawn) {  // Exit mode if selected DOM elements have disappeared..
+                // Return to browse mode if selected DOM elements have
+                // disappeared because the user moved them out of view..
+                var source = d3.event && d3.event.type === 'zoom' && d3.event.sourceEvent;
+                if (drawn && source && (source.type === 'mousemove' || source.type === 'touchmove')) {
                     context.enter(modeBrowse(context));
                 }
             } else {

--- a/modules/modes/select.js
+++ b/modules/modes/select.js
@@ -342,10 +342,10 @@ export function modeSelect(context, selectedIDs) {
         operations.unshift(Operations.operationDelete(selectedIDs, context));
 
         keybinding
-            .on('[', previousNode)
-            .on(']', nextNode)
-            .on('⌘[', firstNode)
-            .on('⌘]', lastNode)
+            .on(['[','pgup'], previousNode)
+            .on([']', 'pgdown'], nextNode)
+            .on(['⌘[', 'home'], firstNode)
+            .on(['⌘]', 'end'], lastNode)
             .on('⎋', esc, true)
             .on('space', toggleMenu);
 

--- a/modules/ui/init.js
+++ b/modules/ui/init.js
@@ -256,14 +256,10 @@ export function uiInit(context) {
             .on('↑', pan([0, pa]))
             .on('→', pan([-pa, 0]))
             .on('↓', pan([0, -pa]))
-            .on('⇧←', pan([mapDimensions[0], 0]))
-            .on('⇧↑', pan([0, mapDimensions[1]]))
-            .on('⇧→', pan([-mapDimensions[0], 0]))
-            .on('⇧↓', pan([0, -mapDimensions[1]]))
-            .on(uiCmd('⌘←'), pan([mapDimensions[0], 0]))
-            .on(uiCmd('⌘↑'), pan([0, mapDimensions[1]]))
-            .on(uiCmd('⌘→'), pan([-mapDimensions[0], 0]))
-            .on(uiCmd('⌘↓'), pan([0, -mapDimensions[1]]));
+            .on(['⇧←', uiCmd('⌘←')], pan([mapDimensions[0], 0]))
+            .on(['⇧↑', uiCmd('⌘↑')], pan([0, mapDimensions[1]]))
+            .on(['⇧→', uiCmd('⌘→')], pan([-mapDimensions[0], 0]))
+            .on(['⇧↓', uiCmd('⌘↓')], pan([0, -mapDimensions[1]]));
 
         d3.select(document)
             .call(keybinding);

--- a/modules/ui/zoom.js
+++ b/modules/ui/zoom.js
@@ -72,16 +72,12 @@ export function uiZoom(context) {
         var keybinding = d3keybinding('zoom');
 
         _.each(['=','ffequals','plus','ffplus'], function(key) {
-            keybinding.on(key, zoomIn);
-            keybinding.on('⇧' + key, zoomIn);
-            keybinding.on(uiCmd('⌘' + key), zoomInFurther);
-            keybinding.on(uiCmd('⌘⇧' + key), zoomInFurther);
+            keybinding.on([key, '⇧' + key], zoomIn);
+            keybinding.on([uiCmd('⌘' + key), uiCmd('⌘⇧' + key)], zoomInFurther);
         });
         _.each(['-','ffminus','_','dash'], function(key) {
-            keybinding.on(key, zoomOut);
-            keybinding.on('⇧' + key, zoomOut);
-            keybinding.on(uiCmd('⌘' + key), zoomOutFurther);
-            keybinding.on(uiCmd('⌘⇧' + key), zoomOutFurther);
+            keybinding.on([key, '⇧' + key], zoomOut);
+            keybinding.on([uiCmd('⌘' + key), uiCmd('⌘⇧' + key)], zoomOutFurther);
         });
 
         d3.select(document)

--- a/test/spec/lib/d3.keybinding.js
+++ b/test/spec/lib/d3.keybinding.js
@@ -38,6 +38,16 @@ describe('d3.keybinding', function() {
             expect(spy).to.have.been.calledOnce;
         });
 
+        it('adds multiple bindings given an array of keys', function () {
+            d3.select(document).call(keybinding.on(['A','B'], spy));
+
+            happen.keydown(document, {keyCode: 65});
+            expect(spy).to.have.been.calledOnce;
+
+            happen.keydown(document, {keyCode: 66});
+            expect(spy).to.have.been.calledTwice;
+        });
+
         it('does not dispatch when focus is in input elements by default', function () {
             d3.select(document).call(keybinding.on('A', spy));
 


### PR DESCRIPTION
Today I played around with keyboard navigation for vertexes.  

This closes #1917 and adds some useful keyboard shortcuts:

`[` - jump to previous vertex
`]` - jump to next vertex
`⌘[` - jump to first vertex
`⌘]` - jump to last vertex

Also it: 
* handles circular ways (can jump next/previous across the connecting node)
* adds interpolated viewport following  (see #3250 - which is this but in the draw modes)
* when navigating across a vertex with multiple parents, remembers which line to stay on

![keyboard node navigation](https://cloud.githubusercontent.com/assets/38784/19913876/b56c20ea-a07c-11e6-8b41-1dd537c633a3.gif)

There are still a few weird things to clean up - e.g. it's possible for the vertex to go unselected when jumping to one that's offscreen.

Also I'd like to try to support a shift modifier, which woud let you add or remove nodes from the selection.
