### PR TITLE
Custom color for farmyards.

### DIFF
--- a/css/map.css
+++ b/css/map.css
@@ -408,6 +408,18 @@ path.stroke.tag-landuse-farmland {
     background-color: rgba(140, 208, 95, 0.2);
 }
 
+path.stroke.tag-landuse-farmyard {
+    stroke: rgb(245, 220, 186);
+}
+path.fill.tag-landuse-farmyard {
+    stroke: rgba(245, 220, 186, 0.3);
+    fill: rgba(245, 220, 186, 0.3);
+}
+.preset-icon-fill-area.tag-landuse-farmyard {
+    border-color: rgb(245, 220, 186);
+    background: rgba(245, 220, 186, 0.3);
+}
+
 .pattern-color-cemetery,
 .pattern-color-orchard {
     fill: rgba(140, 208, 95, 0.2);


### PR DESCRIPTION
A change that turns everything red - well actually only farmyards - and those orange.

Right now, farmyards are not defined in iD CSS, which result in them being colored forest-green while editing. Green is not an intuitive color for a human-centric area. And farmyards are fairly common when mapping, so it seems important that they should have a distinct color.

I used a modified copy of the CSS code for residential areas, and changed the color to the same orange used for farmyards on the standard openstreetmap layer on osm.org.