### PR TITLE
add missing keycode for underscore

### DIFF
--- a/modules/lib/d3.keybinding.js
+++ b/modules/lib/d3.keybinding.js
@@ -169,7 +169,9 @@ d3keybinding.keyCodes = {
     '=': 187, 'equals': 187,
     // Comma, or ,
     ',': 188, comma: 188,
-    'dash': 189, //???
+    // Dash / Underscore key
+    'dash': 189,
+    '_': 189, 'underscore': 189,
     // Period, or ., or full-stop
     '.': 190, period: 190, 'full-stop': 190,
     // Slash, or /, or forward-slash

--- a/modules/lib/d3.keybinding.js
+++ b/modules/lib/d3.keybinding.js
@@ -171,7 +171,6 @@ d3keybinding.keyCodes = {
     ',': 188, comma: 188,
     // Dash / Underscore key
     'dash': 189,
-    '_': 189, 'underscore': 189,
     // Period, or ., or full-stop
     '.': 190, period: 190, 'full-stop': 190,
     // Slash, or /, or forward-slash

--- a/modules/ui/zoom.js
+++ b/modules/ui/zoom.js
@@ -75,7 +75,7 @@ export function uiZoom(context) {
             keybinding.on([key, '⇧' + key], zoomIn);
             keybinding.on([uiCmd('⌘' + key), uiCmd('⌘⇧' + key)], zoomInFurther);
         });
-        _.each(['-','ffminus','_','dash'], function(key) {
+        _.each(['-','ffminus','dash'], function(key) {
             keybinding.on([key, '⇧' + key], zoomOut);
             keybinding.on([uiCmd('⌘' + key), uiCmd('⌘⇧' + key)], zoomOutFurther);
         });


### PR DESCRIPTION
The underscore key is referenced in [zoom.js](https://github.com/openstreetmap/iD/blob/master/modules/ui/zoom.js#L78), but not defined as a keycode. This resulted in a keycode=0 definition [here](https://github.com/openstreetmap/iD/blob/master/modules/lib/d3.keybinding.js#L67-L87), which is potentially triggered by special keyboard keys (for example, on my keyboard the [Fn](https://en.wikipedia.org/wiki/Fn_key) key produces such an event). 