### PR TITLE
.travis.yml: validate consistency of generated files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,13 @@ node_js:
   - "4"
   - "6"
 sudo: false
+
+script:
+  - npm test
+  - if ! git diff --patch --stat --color=never --exit-code; then
+        echo "";
+        echo "#### You can apply this patch via:";
+        echo "git apply -";
+        echo "git commit --all --message 'fix up generated files via `npm run build`'";
+        false;
+    fi >&2


### PR DESCRIPTION
If one forgets to commit changes to generated files, the build should fail
and the requested diff will be posted in the log.

Hence one could also simply apply the displayed patch in order to fix it.