### PR TITLE
Preset/field additions: ssid lunch mirror outdoor_seating terms

### DIFF
--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -498,6 +498,9 @@ en:
       internet_access/fee:
         # 'internet_access:fee=*'
         label: Internet Access Fee
+      internet_access/ssid:
+        # 'internet_access:ssid=*'
+        label: SSID (Network Name)
       kerb:
         # kerb=*
         label: Curb Ramp
@@ -583,6 +586,21 @@ en:
       location:
         # location=*
         label: Location
+      lunch:
+        # lunch=*
+        label: Daily Lunch (Unknown Kind)
+        # lunch field placeholder
+        placeholder: 'Yes, No, <Lunch Hours>'
+      lunch/buffet:
+        # 'lunch:buffet=*'
+        label: Daily Buffet Lunch (All You Can Eat)
+        # lunch/buffet field placeholder
+        placeholder: 'Yes, No, <Lunch Hours>'
+      lunch/menu:
+        # 'lunch:menu=*'
+        label: 'Daily Menu Lunch (Mass Prepared, Inexpensive)'
+        # lunch/menu field placeholder
+        placeholder: 'Yes, No, <Lunch Hours>'
       man_made:
         # man_made=*
         label: Type
@@ -742,6 +760,9 @@ en:
       operator:
         # operator=*
         label: Operator
+      outdoor_seating:
+        # outdoor_seating=*
+        label: Outdoor Seating
       par:
         # par=*
         label: Par
@@ -1467,6 +1488,7 @@ en:
       amenity/hunting_stand:
         # amenity=hunting_stand
         name: Hunting Stand
+        # 'terms: game,lookout,shoot,wild,watch'
         terms: '<translate with synonyms or related terms for ''Hunting Stand'', separated by commas>'
       amenity/ice_cream:
         # amenity=ice_cream
@@ -1571,7 +1593,7 @@ en:
       amenity/pub:
         # amenity=pub
         name: Pub
-        # 'terms: dive,beer,bier,booze'
+        # 'terms: alcohol,drink,dive,beer,bier,booze'
         terms: '<translate with synonyms or related terms for ''Pub'', separated by commas>'
       amenity/public_bookcase:
         # amenity=public_bookcase
@@ -2451,6 +2473,11 @@ en:
         name: Unmaintained Track Road
         # 'terms: woods road,forest road,logging road,fire road,farm road,agricultural road,ranch road,carriage road,primitive,unmaintained,rut,offroad,4wd,4x4,four wheel drive,atv,quad,jeep,double track,two track'
         terms: '<translate with synonyms or related terms for ''Unmaintained Track Road'', separated by commas>'
+      highway/traffic_mirror:
+        # highway=traffic_mirror
+        name: Traffic Mirror
+        # 'terms: blind spot,convex,corner,curved,roadside,round,safety,sphere,visibility'
+        terms: '<translate with synonyms or related terms for ''Traffic Mirror'', separated by commas>'
       highway/traffic_signals:
         # highway=traffic_signals
         name: Traffic Signals
@@ -2880,7 +2907,7 @@ en:
       man_made/surveillance:
         # man_made=surveillance
         name: Surveillance
-        # 'terms: cctv'
+        # 'terms: anpr,alpr,camera,car plate recognition,cctv,guard,license plate recognition,monitoring,number plate recognition,security,video,webcam'
         terms: '<translate with synonyms or related terms for ''Surveillance'', separated by commas>'
       man_made/survey_point:
         # man_made=survey_point

--- a/data/presets/fields.json
+++ b/data/presets/fields.json
@@ -696,6 +696,11 @@
             "type": "check",
             "label": "Internet Access Fee"
         },
+        "internet_access/ssid": {
+            "key": "internet_access:ssid",
+            "type": "text",
+            "label": "SSID (Network Name)"
+        },
         "kerb": {
             "key": "kerb",
             "type": "combo",
@@ -805,6 +810,25 @@
             "key": "location",
             "type": "combo",
             "label": "Location"
+        },
+        "lunch": {
+            "key": "lunch",
+            "type": "combo",
+            "label": "Daily Lunch (Unknown Kind)",
+            "default": "no",
+            "placeholder": "Yes, No, <Lunch Hours>"
+        },
+        "lunch/buffet": {
+            "key": "lunch:buffet",
+            "type": "combo",
+            "label": "Daily Buffet Lunch (All You Can Eat)",
+            "placeholder": "Yes, No, <Lunch Hours>"
+        },
+        "lunch/menu": {
+            "key": "lunch:menu",
+            "type": "combo",
+            "label": "Daily Menu Lunch (Mass Prepared, Inexpensive)",
+            "placeholder": "Yes, No, <Lunch Hours>"
         },
         "man_made": {
             "key": "man_made",
@@ -1002,6 +1026,11 @@
             "key": "operator",
             "type": "text",
             "label": "Operator"
+        },
+        "outdoor_seating": {
+            "key": "outdoor_seating",
+            "type": "combo",
+            "label": "Outdoor Seating"
         },
         "par": {
             "key": "par",

--- a/data/presets/fields/internet_access/ssid.json
+++ b/data/presets/fields/internet_access/ssid.json
@@ -1,0 +1,5 @@
+{
+    "key": "internet_access:ssid",
+    "type": "text",
+    "label": "SSID (Network Name)"
+}

--- a/data/presets/fields/lunch.json
+++ b/data/presets/fields/lunch.json
@@ -1,0 +1,7 @@
+{
+    "key": "lunch",
+    "type": "combo",
+    "label": "Daily Lunch (Unknown Kind)",
+    "default": "no",
+    "placeholder": "Yes, No, <Lunch Hours>"
+}

--- a/data/presets/fields/lunch/buffet.json
+++ b/data/presets/fields/lunch/buffet.json
@@ -1,0 +1,6 @@
+{
+    "key": "lunch:buffet",
+    "type": "combo",
+    "label": "Daily Buffet Lunch (All You Can Eat)",
+    "placeholder": "Yes, No, <Lunch Hours>"
+}

--- a/data/presets/fields/lunch/menu.json
+++ b/data/presets/fields/lunch/menu.json
@@ -1,0 +1,6 @@
+{
+    "key": "lunch:menu",
+    "type": "combo",
+    "label": "Daily Menu Lunch (Mass Prepared, Inexpensive)",
+    "placeholder": "Yes, No, <Lunch Hours>"
+}

--- a/data/presets/fields/outdoor_seating.json
+++ b/data/presets/fields/outdoor_seating.json
@@ -1,0 +1,5 @@
+{
+    "key": "outdoor_seating",
+    "type": "combo",
+    "label": "Outdoor Seating"
+}

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -1280,7 +1280,13 @@
                 "vertex",
                 "area"
             ],
-            "terms": [],
+            "terms": [
+                "game",
+                "lookout",
+                "shoot",
+                "wild",
+                "watch"
+            ],
             "tags": {
                 "amenity": "hunting_stand"
             },
@@ -1786,6 +1792,8 @@
                 "amenity": "pub"
             },
             "terms": [
+                "alcohol",
+                "drink",
                 "dive",
                 "beer",
                 "bier",
@@ -5371,6 +5379,26 @@
             ],
             "name": "Unmaintained Track Road"
         },
+        "highway/traffic_mirror": {
+            "geometry": [
+                "point"
+            ],
+            "tags": {
+                "highway": "traffic_mirror"
+            },
+            "terms": [
+                "blind spot",
+                "convex",
+                "corner",
+                "curved",
+                "roadside",
+                "round",
+                "safety",
+                "sphere",
+                "visibility"
+            ],
+            "name": "Traffic Mirror"
+        },
         "highway/traffic_signals": {
             "geometry": [
                 "vertex"
@@ -6853,7 +6881,18 @@
                 "point"
             ],
             "terms": [
-                "cctv"
+                "anpr",
+                "alpr",
+                "camera",
+                "car plate recognition",
+                "cctv",
+                "guard",
+                "license plate recognition",
+                "monitoring",
+                "number plate recognition",
+                "security",
+                "video",
+                "webcam"
             ],
             "tags": {
                 "man_made": "surveillance"

--- a/data/presets/presets/amenity/hunting_stand.json
+++ b/data/presets/presets/amenity/hunting_stand.json
@@ -4,7 +4,13 @@
         "vertex",
         "area"
     ],
-    "terms": [],
+    "terms": [
+        "game",
+        "lookout",
+        "shoot",
+        "wild",
+        "watch"
+    ],
     "tags": {
         "amenity": "hunting_stand"
     },

--- a/data/presets/presets/amenity/pub.json
+++ b/data/presets/presets/amenity/pub.json
@@ -14,6 +14,8 @@
         "amenity": "pub"
     },
     "terms": [
+        "alcohol",
+        "drink",
         "dive",
         "beer",
         "bier",

--- a/data/presets/presets/highway/traffic_mirror.json
+++ b/data/presets/presets/highway/traffic_mirror.json
@@ -1,0 +1,20 @@
+{
+    "geometry": [
+        "point"
+    ],
+    "tags": {
+        "highway": "traffic_mirror"
+    },
+    "terms": [
+        "blind spot",
+        "convex",
+        "corner",
+        "curved",
+        "roadside",
+        "round",
+        "safety",
+        "sphere",
+        "visibility"
+    ],
+    "name": "Traffic Mirror"
+}

--- a/data/presets/presets/man_made/surveillance.json
+++ b/data/presets/presets/man_made/surveillance.json
@@ -4,7 +4,18 @@
         "point"
     ],
     "terms": [
-        "cctv"
+        "anpr",
+        "alpr",
+        "camera",
+        "car plate recognition",
+        "cctv",
+        "guard",
+        "license plate recognition",
+        "monitoring",
+        "number plate recognition",
+        "security",
+        "video",
+        "webcam"
     ],
     "tags": {
         "man_made": "surveillance"

--- a/data/taginfo.json
+++ b/data/taginfo.json
@@ -1180,6 +1180,10 @@
         },
         {
             "key": "highway",
+            "value": "traffic_mirror"
+        },
+        {
+            "key": "highway",
             "value": "traffic_signals"
         },
         {

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -1077,6 +1077,9 @@
                 "internet_access/fee": {
                     "label": "Internet Access Fee"
                 },
+                "internet_access/ssid": {
+                    "label": "SSID (Network Name)"
+                },
                 "kerb": {
                     "label": "Curb Ramp"
                 },
@@ -1147,6 +1150,18 @@
                 },
                 "location": {
                     "label": "Location"
+                },
+                "lunch": {
+                    "label": "Daily Lunch (Unknown Kind)",
+                    "placeholder": "Yes, No, <Lunch Hours>"
+                },
+                "lunch/buffet": {
+                    "label": "Daily Buffet Lunch (All You Can Eat)",
+                    "placeholder": "Yes, No, <Lunch Hours>"
+                },
+                "lunch/menu": {
+                    "label": "Daily Menu Lunch (Mass Prepared, Inexpensive)",
+                    "placeholder": "Yes, No, <Lunch Hours>"
                 },
                 "man_made": {
                     "label": "Type"
@@ -1270,6 +1285,9 @@
                 },
                 "operator": {
                     "label": "Operator"
+                },
+                "outdoor_seating": {
+                    "label": "Outdoor Seating"
                 },
                 "par": {
                     "label": "Par",
@@ -1913,7 +1931,7 @@
                 },
                 "amenity/hunting_stand": {
                     "name": "Hunting Stand",
-                    "terms": ""
+                    "terms": "game,lookout,shoot,wild,watch"
                 },
                 "amenity/ice_cream": {
                     "name": "Ice Cream Shop",
@@ -2001,7 +2019,7 @@
                 },
                 "amenity/pub": {
                     "name": "Pub",
-                    "terms": "dive,beer,bier,booze"
+                    "terms": "alcohol,drink,dive,beer,bier,booze"
                 },
                 "amenity/public_bookcase": {
                     "name": "Public Bookcase",
@@ -2807,6 +2825,10 @@
                     "name": "Unmaintained Track Road",
                     "terms": "woods road,forest road,logging road,fire road,farm road,agricultural road,ranch road,carriage road,primitive,unmaintained,rut,offroad,4wd,4x4,four wheel drive,atv,quad,jeep,double track,two track"
                 },
+                "highway/traffic_mirror": {
+                    "name": "Traffic Mirror",
+                    "terms": "blind spot,convex,corner,curved,roadside,round,safety,sphere,visibility"
+                },
                 "highway/traffic_signals": {
                     "name": "Traffic Signals",
                     "terms": "light,stoplight,traffic light"
@@ -3201,7 +3223,7 @@
                 },
                 "man_made/surveillance": {
                     "name": "Surveillance",
-                    "terms": "cctv"
+                    "terms": "anpr,alpr,camera,car plate recognition,cctv,guard,license plate recognition,monitoring,number plate recognition,security,video,webcam"
                 },
                 "man_made/survey_point": {
                     "name": "Survey Point",


### PR DESCRIPTION
_I could split it even further if you think it is still too big._

Support handling of some common fields:
* `internet_access:ssid`
* `lunch`
* `outdoor_seating`

New preset:
* `highway=traffic_mirror`

Extend search terms:
* `amenity=pub`
* `amenity=hunting_stand`
* `man_made=surveillance`