### PR TITLE
update docu - use {zoom} instead of {z} for TMS URLs

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -280,7 +280,7 @@ en:
     switch: Switch back to this background
     custom: Custom
     custom_button: Edit custom background
-    custom_prompt: "Enter a tile URL template. Valid tokens are {z}, {x}, {y} for Z/X/Y scheme and {u} for quadtile scheme."
+    custom_prompt: "Enter a tile URL template. Valid tokens are {zoom}, {x}, {y} for Z/X/Y scheme and {u} for quadtile scheme."
     fix_misalignment: Adjust imagery offset
     imagery_source_faq: Where does this imagery come from?
     reset: reset


### PR DESCRIPTION
 {zoom} is the default and should be used. See also osmlab/editor-layer-index/issues/226