### PR TITLE
data/presets: add surveillance and camera related properties

### DIFF
--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -206,6 +206,17 @@ en:
       building_area:
         # building=*
         label: Building
+      camera/direction:
+        # 'camera:direction=*'
+        label: Camera direction
+        # camera/direction field placeholder
+        placeholder: 90 (degrees clockwise)
+      camera/mount:
+        # 'camera:mount=*'
+        label: Camera mount
+      camera/type:
+        # 'camera:type=*'
+        label: Camera type
       capacity:
         # capacity=*
         label: Capacity
@@ -261,6 +272,11 @@ en:
       construction:
         # construction=*
         label: Type
+      contact/webcam:
+        # 'contact:webcam=*'
+        label: Webcam feed URL
+        # contact/webcam field placeholder
+        placeholder: 'http://example.com/'
       content:
         # content=*
         label: Contents
@@ -1070,6 +1086,15 @@ en:
       surface:
         # surface=*
         label: Surface
+      surveillance:
+        # surveillance=*
+        label: Surveillance kind
+      surveillance/type:
+        # 'surveillance:type=*'
+        label: What is watching
+      surveillance/zone:
+        # 'surveillance:zone=*'
+        label: Zone
       tactile_paving:
         # tactile_paving=*
         label: Tactile Paving

--- a/data/presets/fields.json
+++ b/data/presets/fields.json
@@ -283,6 +283,34 @@
             "type": "combo",
             "label": "Building"
         },
+        "camera/direction": {
+            "key": "camera:direction",
+            "type": "number",
+            "label": "Camera direction",
+            "placeholder": "90 (degrees clockwise)"
+        },
+        "camera/mount": {
+            "key": "camera:mount",
+            "type": "combo",
+            "label": "Camera mount",
+            "options": [
+                "pole",
+                "wall",
+                "ceiling",
+                "roof",
+                "gantry"
+            ]
+        },
+        "camera/type": {
+            "key": "camera:type",
+            "type": "combo",
+            "label": "Camera type",
+            "options": [
+                "fixed",
+                "panning",
+                "dome"
+            ]
+        },
         "capacity": {
             "key": "capacity",
             "type": "number",
@@ -334,6 +362,13 @@
             "key": "construction",
             "type": "combo",
             "label": "Type"
+        },
+        "contact/webcam": {
+            "key": "contact:webcam",
+            "type": "url",
+            "icon": "website",
+            "label": "Webcam feed URL",
+            "placeholder": "http://example.com/"
         },
         "content": {
             "key": "content",
@@ -1456,6 +1491,39 @@
             "key": "surface",
             "type": "combo",
             "label": "Surface"
+        },
+        "surveillance": {
+            "key": "surveillance",
+            "type": "combo",
+            "label": "Surveillance kind",
+            "options": [
+                "outdoor",
+                "public",
+                "indoor"
+            ]
+        },
+        "surveillance/type": {
+            "key": "surveillance:type",
+            "type": "combo",
+            "label": "What is watching",
+            "options": [
+                "camera",
+                "guard",
+                "alpr"
+            ]
+        },
+        "surveillance/zone": {
+            "key": "surveillance:zone",
+            "type": "combo",
+            "label": "Zone",
+            "options": [
+                "traffic",
+                "building",
+                "town",
+                "parking",
+                "shop",
+                "bank"
+            ]
         },
         "tactile_paving": {
             "key": "tactile_paving",

--- a/data/presets/fields/camera/direction.json
+++ b/data/presets/fields/camera/direction.json
@@ -1,0 +1,6 @@
+{
+    "key": "camera:direction",
+    "type": "number",
+    "label": "Camera direction",
+    "placeholder": "90 (degrees clockwise)"
+}

--- a/data/presets/fields/camera/mount.json
+++ b/data/presets/fields/camera/mount.json
@@ -1,0 +1,6 @@
+{
+    "key": "camera:mount",
+    "type": "combo",
+    "label": "Camera mount",
+    "options": [ "pole", "wall", "ceiling", "roof", "gantry" ]
+}

--- a/data/presets/fields/camera/type.json
+++ b/data/presets/fields/camera/type.json
@@ -1,0 +1,6 @@
+{
+    "key": "camera:type",
+    "type": "combo",
+    "label": "Camera type",
+    "options": ["fixed", "panning", "dome"]
+}

--- a/data/presets/fields/contact/webcam.json
+++ b/data/presets/fields/contact/webcam.json
@@ -1,0 +1,7 @@
+{
+    "key": "contact:webcam",
+    "type": "url",
+    "icon": "website",
+    "label": "Webcam feed URL",
+    "placeholder": "http://example.com/"
+}

--- a/data/presets/fields/surveillance.json
+++ b/data/presets/fields/surveillance.json
@@ -1,0 +1,6 @@
+{
+    "key": "surveillance",
+    "type": "combo",
+    "label": "Surveillance kind",
+    "options": ["outdoor", "public", "indoor"]
+}

--- a/data/presets/fields/surveillance/type.json
+++ b/data/presets/fields/surveillance/type.json
@@ -1,0 +1,6 @@
+{
+    "key": "surveillance:type",
+    "type": "combo",
+    "label": "What is watching",
+    "options": ["camera", "guard", "alpr"]
+}

--- a/data/presets/fields/surveillance/zone.json
+++ b/data/presets/fields/surveillance/zone.json
@@ -1,0 +1,6 @@
+{
+    "key": "surveillance:zone",
+    "type": "combo",
+    "label": "Zone",
+    "options": ["traffic", "building", "town", "parking", "shop", "bank"]
+}

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -7004,6 +7004,15 @@
             "geometry": [
                 "point"
             ],
+            "fields": [
+                "surveillance",
+                "surveillance/type",
+                "camera/type",
+                "camera/mount",
+                "camera/direction",
+                "surveillance/zone",
+                "contact/webcam"
+            ],
             "terms": [
                 "anpr",
                 "alpr",

--- a/data/presets/presets/man_made/surveillance.json
+++ b/data/presets/presets/man_made/surveillance.json
@@ -3,6 +3,15 @@
     "geometry": [
         "point"
     ],
+    "fields": [
+        "surveillance",
+        "surveillance/type",
+        "camera/type",
+        "camera/mount",
+        "camera/direction",
+        "surveillance/zone",
+        "contact/webcam"
+     ],
     "terms": [
         "anpr",
         "alpr",

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -820,6 +820,16 @@
                 "building": {
                     "label": "Building"
                 },
+                "camera/direction": {
+                    "label": "Camera direction",
+                    "placeholder": "90 (degrees clockwise)"
+                },
+                "camera/mount": {
+                    "label": "Camera mount"
+                },
+                "camera/type": {
+                    "label": "Camera type"
+                },
                 "capacity": {
                     "label": "Capacity",
                     "placeholder": "50, 100, 200..."
@@ -857,6 +867,10 @@
                 },
                 "construction": {
                     "label": "Type"
+                },
+                "contact/webcam": {
+                    "label": "Webcam feed URL",
+                    "placeholder": "http://example.com/"
                 },
                 "content": {
                     "label": "Contents"
@@ -1535,6 +1549,15 @@
                 },
                 "surface": {
                     "label": "Surface"
+                },
+                "surveillance": {
+                    "label": "Surveillance kind"
+                },
+                "surveillance/type": {
+                    "label": "What is watching"
+                },
+                "surveillance/zone": {
+                    "label": "Zone"
                 },
                 "tactile_paving": {
                     "label": "Tactile Paving"


### PR DESCRIPTION
https://wiki.openstreetmap.org/wiki/Tag:man_made%3Dsurveillance
https://wiki.openstreetmap.org/wiki/Proposed_features/Extended_tags_for_Key:Surveillance

These are mandatory tags:
* `surveillance`
* `surveillance:type`

I do not feel that the following are important, they can be selected from
the drop down manually anyway:
* `operator`
* `name`

These tags are well established:

* `camera:type` has 15k users
* `camera:mount` has 13k users
* `surveillance:zone` has 17k users (mostly traffic is noted)
* `camera:direction` has 6k users

These tags are in the proposed status:
* `contact:webcam` usage is only starting
* `height`

People used various tags instead of `contact:webcam` in the past
because of it being a recent tag, and/or a lack of knowledge or being
mislead by the dropdown.

Thus it is difficult to quote an exact number, but by using complex
regexp queries, I could find thousands of usages for webcam links
when properly combining man_made/surveillance/camera and various
(sometimes invalid) keywords in the key or value part of a tag:

* `website`
* `image`
* `uri`, `url`, `link`, `http`, `contact`
* `stream`
* `webcam`