### PR TITLE
data/presets: taxon, taxon:genus added to help identify plants

### DIFF
--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -431,6 +431,11 @@ en:
       generator/type:
         # 'generator:type=*'
         label: Type
+      genus:
+        # genus=*
+        label: Biological Genus
+        # genus field placeholder
+        placeholder: Scientific Name
       golf_hole:
         # ref=*
         label: Reference
@@ -1011,6 +1016,11 @@ en:
       source:
         # source=*
         label: Source
+      species:
+        # species=*
+        label: Biological Species
+        # species field placeholder
+        placeholder: Scientific Name
       sport:
         # sport=*
         label: Sport
@@ -1077,6 +1087,16 @@ en:
           'yes': 'Yes'
         # takeaway field placeholder
         placeholder: 'Yes, No, Takeaway Only...'
+      taxon:
+        # taxon=*
+        label: Taxonomical Name of Species
+        # taxon field placeholder
+        placeholder: Scientific & Localized Names
+      taxon/genus:
+        # 'taxon:genus=*'
+        label: Taxonomic Genus of Species
+        # taxon/genus field placeholder
+        placeholder: Scientific Name of Genus
       toilets/disposal:
         # 'toilets:disposal=*'
         label: Disposal

--- a/data/presets/fields.json
+++ b/data/presets/fields.json
@@ -603,6 +603,12 @@
             "type": "combo",
             "label": "Type"
         },
+        "genus": {
+            "key": "genus",
+            "type": "localized",
+            "label": "Biological Genus",
+            "placeholder": "Scientific Name"
+        },
         "golf_hole": {
             "key": "ref",
             "type": "text",
@@ -1352,6 +1358,12 @@
             "universal": true,
             "label": "Source"
         },
+        "species": {
+            "key": "species",
+            "type": "localized",
+            "label": "Biological Species",
+            "placeholder": "Scientific Name"
+        },
         "sport_ice": {
             "key": "sport",
             "type": "combo",
@@ -1462,6 +1474,18 @@
                     "only": "Takeaway Only"
                 }
             }
+        },
+        "taxon": {
+            "key": "taxon",
+            "type": "localized",
+            "label": "Taxonomical Name of Species",
+            "placeholder": "Scientific & Localized Names"
+        },
+        "taxon/genus": {
+            "key": "taxon:genus",
+            "type": "text",
+            "label": "Taxonomic Genus of Species",
+            "placeholder": "Scientific Name of Genus"
         },
         "toilets/disposal": {
             "key": "toilets:disposal",

--- a/data/presets/fields/genus.json
+++ b/data/presets/fields/genus.json
@@ -1,0 +1,6 @@
+{
+    "key": "genus",
+    "type": "localized",
+    "label": "Biological Genus",
+    "placeholder": "Scientific Name"
+}

--- a/data/presets/fields/species.json
+++ b/data/presets/fields/species.json
@@ -1,0 +1,6 @@
+{
+    "key": "species",
+    "type": "localized",
+    "label": "Biological Species",
+    "placeholder": "Scientific Name"
+}

--- a/data/presets/fields/taxon.json
+++ b/data/presets/fields/taxon.json
@@ -1,0 +1,6 @@
+{
+    "key": "taxon",
+    "type": "localized",
+    "label": "Taxonomical Name of Species",
+    "placeholder": "Scientific & Localized Names"
+}

--- a/data/presets/fields/taxon/genus.json
+++ b/data/presets/fields/taxon/genus.json
@@ -1,0 +1,6 @@
+{
+    "key": "taxon:genus",
+    "type": "text",
+    "label": "Taxonomic Genus of Species",
+    "placeholder": "Scientific Name of Genus"
+}

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -2728,6 +2728,10 @@
             "name": "Gate"
         },
         "barrier/hedge": {
+            "fields": [
+                "taxon/genus",
+                "taxon"
+            ],
             "geometry": [
                 "line",
                 "area"
@@ -5785,6 +5789,8 @@
         "landuse/forest": {
             "icon": "park2",
             "fields": [
+                "taxon/genus",
+                "taxon",
                 "leaf_type",
                 "leaf_cycle"
             ],
@@ -7306,6 +7312,10 @@
             "name": "Grassland"
         },
         "natural/heath": {
+            "fields": [
+                "taxon/genus",
+                "taxon"
+            ],
             "geometry": [
                 "area"
             ],
@@ -7376,6 +7386,10 @@
             "name": "Scree"
         },
         "natural/scrub": {
+            "fields": [
+                "taxon/genus",
+                "taxon"
+            ],
             "geometry": [
                 "area"
             ],
@@ -7401,6 +7415,9 @@
         },
         "natural/tree_row": {
             "fields": [
+                "taxon/genus",
+                "taxon",
+                "height",
                 "leaf_type",
                 "leaf_cycle",
                 "denotation"
@@ -7417,6 +7434,9 @@
         },
         "natural/tree": {
             "fields": [
+                "taxon/genus",
+                "taxon",
+                "height",
                 "leaf_type_singular",
                 "leaf_cycle_singular",
                 "denotation"
@@ -7526,6 +7546,8 @@
         "natural/wood": {
             "icon": "park2",
             "fields": [
+                "taxon/genus",
+                "taxon",
                 "leaf_type",
                 "leaf_cycle"
             ],

--- a/data/presets/presets/barrier/hedge.json
+++ b/data/presets/presets/barrier/hedge.json
@@ -1,4 +1,8 @@
 {
+    "fields": [
+        "taxon/genus",
+        "taxon"
+    ],
     "geometry": [
         "line",
         "area"

--- a/data/presets/presets/landuse/forest.json
+++ b/data/presets/presets/landuse/forest.json
@@ -1,6 +1,8 @@
 {
     "icon": "park2",
     "fields": [
+        "taxon/genus",
+        "taxon",
         "leaf_type",
         "leaf_cycle"
     ],

--- a/data/presets/presets/natural/heath.json
+++ b/data/presets/presets/natural/heath.json
@@ -1,4 +1,8 @@
 {
+    "fields": [
+        "taxon/genus",
+        "taxon"
+    ],
     "geometry": [
         "area"
     ],

--- a/data/presets/presets/natural/scrub.json
+++ b/data/presets/presets/natural/scrub.json
@@ -1,4 +1,8 @@
 {
+    "fields": [
+        "taxon/genus",
+        "taxon"
+    ],
     "geometry": [
         "area"
     ],

--- a/data/presets/presets/natural/tree.json
+++ b/data/presets/presets/natural/tree.json
@@ -1,5 +1,8 @@
 {
     "fields": [
+        "taxon/genus",
+        "taxon",
+        "height",
         "leaf_type_singular",
         "leaf_cycle_singular",
         "denotation"

--- a/data/presets/presets/natural/tree_row.json
+++ b/data/presets/presets/natural/tree_row.json
@@ -1,5 +1,8 @@
 {
     "fields": [
+        "taxon/genus",
+        "taxon",
+        "height",
         "leaf_type",
         "leaf_cycle",
         "denotation"

--- a/data/presets/presets/natural/wood.json
+++ b/data/presets/presets/natural/wood.json
@@ -1,6 +1,8 @@
 {
     "icon": "park2",
     "fields": [
+        "taxon/genus",
+        "taxon",
         "leaf_type",
         "leaf_cycle"
     ],

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -1018,6 +1018,10 @@
                 "generator/type": {
                     "label": "Type"
                 },
+                "genus": {
+                    "label": "Biological Genus",
+                    "placeholder": "Scientific Name"
+                },
                 "golf_hole": {
                     "label": "Reference",
                     "placeholder": "Hole number (1-18)"
@@ -1484,6 +1488,10 @@
                 "source": {
                     "label": "Source"
                 },
+                "species": {
+                    "label": "Biological Species",
+                    "placeholder": "Scientific Name"
+                },
                 "sport_ice": {
                     "label": "Sport"
                 },
@@ -1540,6 +1548,14 @@
                         "no": "No",
                         "only": "Takeaway Only"
                     }
+                },
+                "taxon": {
+                    "label": "Taxonomical Name of Species",
+                    "placeholder": "Scientific & Localized Names"
+                },
+                "taxon/genus": {
+                    "label": "Taxonomic Genus of Species",
+                    "placeholder": "Scientific Name of Genus"
                 },
                 "toilets/disposal": {
                     "label": "Disposal",


### PR DESCRIPTION
https://wiki.openstreetmap.org/wiki/Key:taxon

Add taxon to wood, tree*, hedge, forest, scrub, heath
(These were the kind of objects indicated at the definition)

Marsh was skipped because it is a deprecated tag and iD has no
preset for it.

Height is also a common tag for trees.

Display legacy fields.