### PR TITLE
Add a parent ways section to the inspector for vertexes, and improve vertex navigation

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -1756,14 +1756,36 @@ img.wiki-image {
 }
 
 .raw-parent-way-editor .parent-way-vertex-index {
-    border-radius: 15px 15px 15px 15px;
-    border: 3px solid #cfcfcf;
     width: 15%;
+    padding: 0px;
 }
 
-.raw-parent-way-editor .rp-active {
-    background: rgba(0,0,0,.5);
+.raw-parent-way-editor .button-parent-way-vertex-border {
+    border-radius: 15px 15px 15px 15px;
+    border: 3px solid #cfcfcf;
+    padding: 4px;
+    width: 100%;
+    min-width: 34px;
 }
+
+.raw-parent-way-editor .rp-active .button-parent-way-vertex-border {
+    background: rgba(0,0,0,.5);
+    color:  white;
+}
+
+.raw-parent-way-editor .rp-active .button-parent-way-vertex:hover .button-parent-way-vertex-border {
+    background: rgba(0,0,0,.8);
+}
+
+.raw-parent-way-editor .button-parent-way-vertex .tooltip {
+    display: none;
+}
+
+.raw-parent-way-editor .rp-active .button-parent-way-vertex:hover .tooltip {
+    display: block;
+    transition: display 0s 2s;
+}
+
 
 .member-incomplete .member-delete {
     display: none;

--- a/css/app.css
+++ b/css/app.css
@@ -1717,22 +1717,52 @@ img.wiki-image {
     margin-bottom: 20px;
 }
 
-/* Raw relation membership editor */
+/* Raw relation membership editor and parent way editor*/
 
 .raw-member-editor .member-list li:first-child,
-.raw-membership-editor .member-list li:first-child {
+.raw-membership-editor .member-list li:first-child,
+.raw-parent-way-editor .parent-way-list li:first-child {
     padding-top: 10px;
 }
 
 .raw-member-editor .member-row,
-.raw-membership-editor .member-row {
+.raw-membership-editor .member-row,
+.raw-parent-way-editor .parent-way-row {
     position: relative;
 }
 
 .raw-member-editor .member-row .member-entity-name,
-.raw-membership-editor .member-row .member-entity-name {
+.raw-membership-editor .member-row .member-entity-name,
+.raw-parent-way-editor .parent-way-row .parent-way-entity-name {
     font-weight: normal;
     padding-left: 10px;
+}
+
+.raw-parent-way-editor .entity-geom-icon-hidden,
+.raw-parent-way-editor .parent-way-repeated .form-label {
+    display: none;
+}
+
+.raw-parent-way-editor .button-parent-way-vertex {
+    position: relative;
+    right: 1px;
+    width: 10%;
+    border: 1px solid #CCC;
+    border-top-width: 0;
+    border-right-width: 0;
+    border-radius: 0 0 0 0;
+    height: 30px;
+    vertical-align: top;
+}
+
+.raw-parent-way-editor .parent-way-vertex-index {
+    border-radius: 15px 15px 15px 15px;
+    border: 3px solid #cfcfcf;
+    width: 15%;
+}
+
+.raw-parent-way-editor .rp-active {
+    background: rgba(0,0,0,.5);
 }
 
 .member-incomplete .member-delete {

--- a/modules/behavior/hash.js
+++ b/modules/behavior/hash.js
@@ -31,8 +31,10 @@ export function behaviorHash(context) {
         if (mode && mode.id === 'browse') {
             delete q.id;
         } else {
-            var selected = context.selectedIDs().filter(function(id) {
-                return !context.entity(id).isNew();
+            var selected = context.selectedIDs().filter(function(id) { 
+                var entity = context.hasEntity(id);
+                if (entity) return !entity.isNew();
+                return false;
             });
             if (selected.length) {
                 newParams.id = selected.join(',');

--- a/modules/modes/select.js
+++ b/modules/modes/select.js
@@ -72,6 +72,32 @@ export function modeSelect(context, selectedIDs) {
         }
     }
 
+    function loadSelectedIDs() {
+        function callback() {
+            loadCount -= 1;
+            if  (!loadCount) mode.enter2();
+        }
+        var ids = [];
+        var loadCount=0;
+        if (Array.isArray(selectedIDs)) {
+            ids = selectedIDs.filter(function(id) {
+                return !context.hasEntity(id);
+            });
+        }
+
+        loadCount = ids.length;
+        if (loadCount) {
+            ids.forEach(
+                function (id) {
+                    context.loadEntity(id, callback);
+                }
+            );
+        } else {
+            mode.enter2();
+        }
+    }
+
+
     function checkSelectedIDs() {
         var ids = [];
         if (Array.isArray(selectedIDs)) {
@@ -315,6 +341,11 @@ export function modeSelect(context, selectedIDs) {
 
 
     mode.enter = function() {
+        loadSelectedIDs();
+    };     
+        
+        
+    mode.enter2 = function() {
 
         function update() {
             closeMenu();

--- a/modules/ui/entity_editor.js
+++ b/modules/ui/entity_editor.js
@@ -8,6 +8,7 @@ import { svgIcon } from '../svg/index';
 import { uiPresetIcon } from './preset_icon';
 import { uiRawMemberEditor } from './raw_member_editor';
 import { uiRawMembershipEditor } from './raw_membership_editor';
+import { uiRawParentWayEditor } from './raw_parent_way_editor';
 import { uiRawTagEditor } from './raw_tag_editor';
 import { uiTagReference } from './tag_reference';
 import { uiPreset } from './preset';
@@ -94,6 +95,10 @@ export function uiEntityEditor(context) {
         enter
             .append('div')
             .attr('class', 'inspector-border raw-tag-editor inspector-inner');
+ 
+        enter
+            .append('div')
+            .attr('class', 'raw-parent-way-editor inspector-inner');
 
         enter
             .append('div')
@@ -137,6 +142,16 @@ export function uiEntityEditor(context) {
                 .entityID(id)
                 .tags(tags)
                 .state(state));
+
+        if (entity.type === 'node') {
+        body.select('.raw-parent-way-editor')
+                .style('display', 'block')
+                .call(uiRawParentWayEditor(context)
+                .entityID(id));
+        } else {
+            body.select('.raw-parent-way-editor')
+            .style('display', 'none');
+        }
 
         if (entity.type === 'relation') {
             body.select('.raw-member-editor')

--- a/modules/ui/index.js
+++ b/modules/ui/index.js
@@ -32,6 +32,7 @@ export { uiPresetList } from './preset_list';
 export { uiRadialMenu } from './radial_menu';
 export { uiRawMemberEditor } from './raw_member_editor';
 export { uiRawMembershipEditor } from './raw_membership_editor';
+export { uiRawParentWayEditor } from './raw_parent_way_editor';
 export { uiRawTagEditor } from './raw_tag_editor';
 export { uiRestore } from './restore';
 export { uiSave } from './save';

--- a/modules/ui/raw_parent_way_editor.js
+++ b/modules/ui/raw_parent_way_editor.js
@@ -13,12 +13,10 @@ import { tooltip } from '../util/tooltip';
 import { uiTooltipHtml } from './tooltipHtml';
 import { uiDisclosure } from './disclosure';
 import { utilDisplayName } from '../util/index';
-//import { relatedParent} from '../modes/select';
-
+import { utilEntityOrMemberSelector, utilEntitySelector } from '../util/index';
 
 export function uiRawParentWayEditor(context) {
     var id;
-
 
     function selectWay(d) {
         d3.event.preventDefault();
@@ -26,6 +24,7 @@ export function uiRawParentWayEditor(context) {
     }
 
 
+    
 
     function jumpVertex(way, index) { 
         if (index >= 0 && index < way.nodes.length) {
@@ -39,7 +38,35 @@ export function uiRawParentWayEditor(context) {
     function jumpPreviousVertex(d) { if (d.index>0) jumpVertex(d.way, d.index - 1); }
     function jumpNextVertex(d) { if (d.index + 1 < d.len) jumpVertex(d.way, d.index + 1); }
     function jumpLastVertex(d) { if (d.len>0) jumpVertex(d.way, d.len-1); }
+
+    function mouseout() {
+        d3.event.preventDefault();
+        var surface = context.surface();
+        surface.selectAll('.hover')
+        .classed('hover', false);
+    }    
+        
+    function mouseover(d) {
+        d3.event.preventDefault();
+        var surface = context.surface();
+        surface.selectAll(utilEntitySelector([d.way.id]))
+        .classed('hover', true);      
+    }
     
+    function mouseoverVertex(way, index) { 
+        if (index >= 0 && index < way.nodes.length) {
+            d3.event.preventDefault();
+        var surface = context.surface();
+        surface.selectAll(utilEntitySelector([way.nodes[index]]))
+        .classed('hover', true);      
+        }
+    }
+    
+    function mouseoverFirstVertex(d) { mouseoverVertex(d.way, 0); }
+    function mouseoverPreviousVertex(d) { if (d.index>0) mouseoverVertex(d.way, d.index - 1); }
+    function mouseoverNextVertex(d) { if (d.index + 1 < d.len) mouseoverVertex(d.way, d.index + 1); }
+    function mouseoverLastVertex(d) { if (d.len>0) mouseoverVertex(d.way, d.len-1); }
+
 
     function rawParentWayEditor(selection) {
         var entity = context.entity(id);
@@ -125,7 +152,9 @@ export function uiRawParentWayEditor(context) {
                 .attr('class', 'form-label')
                 .append('a')
                 .attr('href', '#')
-                .on('click', selectWay);
+                .on('click', selectWay)
+                .on('mouseover', mouseover)
+                .on('mouseout', mouseout);
 
             label
                 .append('span')
@@ -157,6 +186,8 @@ export function uiRawParentWayEditor(context) {
                 .text(function(d) {return (d.index>0)? '1' : '';})
             
                 .on('click', jumpFirstVertex)
+                .on('mouseover', mouseoverFirstVertex)
+                .on('mouseout', mouseout)
                 .call(tooltip()
                     .placement('bottom')
                     .html(true)
@@ -172,6 +203,8 @@ export function uiRawParentWayEditor(context) {
                 .text(function(d) {return (d.index>0)? '◄' : '';})
         
                 .on('click', jumpPreviousVertex)
+                .on('mouseover', mouseoverPreviousVertex)
+                .on('mouseout', mouseout)
                 .call(tooltip()
                     .placement('bottom')
                     .html(true)
@@ -187,6 +220,8 @@ export function uiRawParentWayEditor(context) {
                       + ' rp-'+d.way.id+'-'+d.index+( d.related ? ' rp-active' : '')); } )
                 .text(function(d) { return (d.index+1);})              
                 .on('click', jumpThisVertex)
+                .on('mouseover', mouseover) // hover style the potential next related way
+                .on('mouseout', mouseout)
                 .call(tooltip()
                     .placement('bottom')
                     .html(true)
@@ -200,13 +235,15 @@ export function uiRawParentWayEditor(context) {
                 .attr('class', 'button-parent-way-vertex parent-way-next-vertex minor')
                 .text(function(d) {return (d.index + 1 < d.len)? '►' : '';})
                 .on('click', jumpNextVertex)
-            .call(tooltip()
-                .placement('bottom')
-                .html(true)
-                .title(function() {
-                    return uiTooltipHtml('Jump to next vertex', 'PgDn');
-                    })
-                );
+                .on('mouseover', mouseoverNextVertex)
+                .on('mouseout', mouseout)
+                .call(tooltip()
+                    .placement('bottom')
+                    .html(true)
+                    .title(function() {
+                        return uiTooltipHtml('Jump to next vertex', 'PgDn');
+                        })
+                    );
             
             enter
                 .append('button')
@@ -214,6 +251,8 @@ export function uiRawParentWayEditor(context) {
                 .attr('class', 'button-parent-way-vertex parent-way-last-vertex minor')
                 .text(function(d) {return (d.index + 1 < d.len)? d.len : '';})
                 .on('click', jumpLastVertex)
+                .on('mouseover', mouseoverLastVertex)
+                .on('mouseout', mouseout)
                 .call(tooltip()
                     .placement('bottom')
                     .html(true)

--- a/modules/ui/raw_parent_way_editor.js
+++ b/modules/ui/raw_parent_way_editor.js
@@ -145,8 +145,8 @@ export function uiRawParentWayEditor(context) {
             var enter = items.enter()
                 .append('li')
                 .attr('class', function(d) { 
-                    return  ( d.repeated ? 'parent-way-repeated ' : '') + 'parent-way-row form-field'; } );
-
+                    return  ( d.repeated ? 'parent-way-repeated ' : '') + 'parent-way-row form-field'
+                        + ' rp-'+d.way.id+'-'+d.index+( d.related ? ' rp-active' : ''); } );
             var label = enter
                 .append('label')
                 .attr('class', 'form-label')
@@ -213,12 +213,10 @@ export function uiRawParentWayEditor(context) {
                     })
                 );    
             
-            enter
+            var button = enter
                 .append('button')
                 .attr('tabindex', -1)
-                .attr('class', function(d) { return ('button-parent-way-vertex parent-way-vertex-index minor' 
-                      + ' rp-'+d.way.id+'-'+d.index+( d.related ? ' rp-active' : '')); } )
-                .text(function(d) { return (d.index+1);})              
+                .attr('class', function(d) { return ('button-parent-way-vertex parent-way-vertex-index minor'); } ) 
                 .on('click', jumpThisVertex)
                 .on('mouseover', mouseover) // hover style the potential next related way
                 .on('mouseout', mouseout)
@@ -228,7 +226,13 @@ export function uiRawParentWayEditor(context) {
                     .title(function() {
                         return uiTooltipHtml('Make this the way to stay on', 'End');
                     })
-                );    
+                );
+            
+            button
+                .append('span')
+                .attr('class', 'button-parent-way-vertex-border' )
+                .text(function(d) { return (d.index+1);});
+            
             enter
                 .append('button')
                 .attr('tabindex', -1)

--- a/modules/ui/raw_parent_way_editor.js
+++ b/modules/ui/raw_parent_way_editor.js
@@ -1,0 +1,241 @@
+import * as d3 from 'd3';
+//import _ from 'lodash';
+//import { t } from '../util/locale';
+
+
+
+import { modeSelect } from '../modes/index';
+import { osmEntity } from '../osm/index';
+//import { osmWay } from '../osm/index';
+//import { services } from '../services/index';
+import { svgIcon } from '../svg/index';
+import { tooltip } from '../util/tooltip';
+import { uiTooltipHtml } from './tooltipHtml';
+import { uiDisclosure } from './disclosure';
+import { utilDisplayName } from '../util/index';
+//import { relatedParent} from '../modes/select';
+
+
+export function uiRawParentWayEditor(context) {
+    var id;
+
+
+    function selectWay(d) {
+        d3.event.preventDefault();
+        context.enter(modeSelect(context, [d.way.id]));
+    }
+
+
+
+    function jumpVertex(way, index) { 
+        if (index >= 0 && index < way.nodes.length) {
+            d3.event.preventDefault();
+            context.enter(modeSelect(context, [way.nodes[index]]).relatedParent({id:way.id,index:index}).follow(true));
+        }
+    }
+    
+    function jumpThisVertex(d) { jumpVertex(d.way, d.index); }
+    function jumpFirstVertex(d) { jumpVertex(d.way, 0); }
+    function jumpPreviousVertex(d) { if (d.index>0) jumpVertex(d.way, d.index - 1); }
+    function jumpNextVertex(d) { if (d.index + 1 < d.len) jumpVertex(d.way, d.index + 1); }
+    function jumpLastVertex(d) { if (d.len>0) jumpVertex(d.way, d.len-1); }
+    
+
+    function rawParentWayEditor(selection) {
+        var entity = context.entity(id);
+        var parentWays = [];
+        var lineCount = 0;
+        var areaCount = 0;
+
+        var mode = context.mode();
+        var relatedParent = null;
+        if (mode.id==='select'){
+            relatedParent = mode.relatedParent();
+        }
+        
+        var xx = context.graph().parentWays(entity);
+        xx.forEach(function(way) {
+            var closed = way.isClosed(),
+                area   = way.isArea(),
+                repeated = false,
+                related = false;
+            
+            if ( relatedParent && ( way.id === relatedParent.id )) {
+                related=true; 
+            }
+
+            if ( !repeated ) {
+                if (area ) {
+                    areaCount += 1;       				
+                    } else {
+                    lineCount += 1;
+                    }
+            }
+            way.nodes.forEach(function(node, index) {
+                if (node === entity.id) {
+                    parentWays.push({ way: way, node: node, index: index, len: way.nodes.length, 
+                        repeated: repeated, closed: closed, area: area, related: related&&index===relatedParent.index });
+                    repeated = true;
+                    }
+                });
+            });
+
+        
+        selection.call(uiDisclosure()
+            .title('Connected Lines (' + lineCount + ') and Areas (' + areaCount + ')')
+            .expanded(true)
+            .on('toggled', toggled)
+            .content(content)
+        );
+
+
+        function toggled(expanded) {
+            if (expanded) {
+                selection.node().parentNode.scrollTop += 200;
+            }
+        }
+
+
+        function content(wrap) {
+            var list = wrap.selectAll('.parent-way-list')
+                .data([0]);
+
+            list = list.enter()
+                .append('ul')
+                .attr('class', 'parent-way-list')
+                .merge(list);
+
+
+            var items = list.selectAll('li.parent-way-row')
+                .data(parentWays, function(d) {
+                    return osmEntity.key(d.way) + ',' + d.index;
+                });
+
+            items.exit()
+                .each(unbind)
+                .remove();
+
+            var enter = items.enter()
+                .append('li')
+                .attr('class', function(d) { 
+                    return  ( d.repeated ? 'parent-way-repeated ' : '') + 'parent-way-row form-field'; } );
+
+            var label = enter
+                .append('label')
+                .attr('class', 'form-label')
+                .append('a')
+                .attr('href', '#')
+                .on('click', selectWay);
+
+            label
+                .append('span')
+                .attr('class', function(d) { return ('entity-geom-icon' + ( d.area ? '-hidden' : '')); } )
+                .call(svgIcon( '#icon-line', 'pre-text'));
+            
+           label
+                .append('span')
+                .attr('class', function(d) { return ('entity-geom-icon' + ( d.area ? '' : '-hidden')); } )
+                .call(svgIcon( '#icon-area', 'pre-text'));
+
+            
+            label
+                .append('span')
+                .attr('class', 'parent-way-entity-type')
+                .text(function(d) {
+                    return context.presets().match(d.way, context.graph()).name();
+                });
+
+            label
+                .append('span')
+                .attr('class', 'parent-way-entity-name')
+                .text(function(d) { return utilDisplayName(d.way); });
+
+            enter
+                .append('button')
+                .attr('tabindex', -1)
+                .attr('class', 'button-parent-way-vertex parent-way-first-vertex minor')
+                .text(function(d) {return (d.index>0)? '1' : '';})
+            
+                .on('click', jumpFirstVertex)
+                .call(tooltip()
+                    .placement('bottom')
+                    .html(true)
+                    .title(function() {
+                        return uiTooltipHtml('Jump to first vertex', 'Home');
+                    })
+                );    
+
+            enter
+                .append('button')
+                .attr('tabindex', -1)
+                .attr('class', 'button-parent-way-vertex parent-way-previous-vertex minor')
+                .text(function(d) {return (d.index>0)? '◄' : '';})
+        
+                .on('click', jumpPreviousVertex)
+                .call(tooltip()
+                    .placement('bottom')
+                    .html(true)
+                    .title(function() {
+                        return uiTooltipHtml('Jump to previous vertex', 'PgUp');
+                    })
+                );    
+            
+            enter
+                .append('button')
+                .attr('tabindex', -1)
+                .attr('class', function(d) { return ('button-parent-way-vertex parent-way-vertex-index minor' 
+                      + ' rp-'+d.way.id+'-'+d.index+( d.related ? ' rp-active' : '')); } )
+                .text(function(d) { return (d.index+1);})              
+                .on('click', jumpThisVertex)
+                .call(tooltip()
+                    .placement('bottom')
+                    .html(true)
+                    .title(function() {
+                        return uiTooltipHtml('Make this the way to stay on', 'End');
+                    })
+                );    
+            enter
+                .append('button')
+                .attr('tabindex', -1)
+                .attr('class', 'button-parent-way-vertex parent-way-next-vertex minor')
+                .text(function(d) {return (d.index + 1 < d.len)? '►' : '';})
+                .on('click', jumpNextVertex)
+            .call(tooltip()
+                .placement('bottom')
+                .html(true)
+                .title(function() {
+                    return uiTooltipHtml('Jump to next vertex', 'PgDn');
+                    })
+                );
+            
+            enter
+                .append('button')
+                .attr('tabindex', -1)
+                .attr('class', 'button-parent-way-vertex parent-way-last-vertex minor')
+                .text(function(d) {return (d.index + 1 < d.len)? d.len : '';})
+                .on('click', jumpLastVertex)
+                .call(tooltip()
+                    .placement('bottom')
+                    .html(true)
+                    .title(function() {
+                        return uiTooltipHtml('Jump to last vertex', 'End');
+                    })
+                );
+  
+
+            
+            function unbind() {
+            }
+        }
+    }
+
+
+    rawParentWayEditor.entityID = function(_) {
+        if (!arguments.length) return id;
+        id = _;
+        return rawParentWayEditor;
+    };
+
+
+    return rawParentWayEditor;
+}


### PR DESCRIPTION
This adds a section to the inspector which shows the connected ways of a vertex #3603 .
It enables the user to select a specific way in case of coincidence, which makes it a partial solution for #1239. 
It provides an visual equivalent of the keyboard vertex navigation, which can also make the respective shortcuts discoverable.

In addition the vertex keyboard navigation has been improved.

This pull request is currently a first preview version for discussion.

Known issues:
- npm test does still fail on a few tests, but I have the same issue with the current master (on Windows 10).
- The visual indications of the current related parent in the parent ways section of the inspector does not update as long as the selected element is not changed. Update of the sidebar seems to be prohibited when mode select is reentered without changing the selectedIDs. @bhousel How to address this? Update the sidebar more often, or implement some callbacks for updating the related parent? 
- some CSS styling to be done
- preparations for translation to be done