### PR TITLE
Tests and fixes of potential duplicate consecutive node issues in way.js

### DIFF
--- a/modules/osm/way.js
+++ b/modules/osm/way.js
@@ -188,17 +188,16 @@ _.extend(osmWay.prototype, {
     },
 
     // Adds a node (id) in front of the node which is currently at position index.
-    // If index is negative, it will be counted from the end of the way.
-    // If index is 0 or < -length, the node (id) will be added at the start of the way.
-    // If index is undefined or >= length, the node (id) will be added at the end of the way.
+    // If index equals length, the node (id) will be added at the end of the way.
+    // If index is negative or > length, it will throw an error.
     // Generating consecutive duplicates is silently prevented
     
     addNode: function(id, index) {
         var nodes = this.nodes.slice(),
             spliceIndex = index === undefined ? nodes.length : index;
-        if (spliceIndex > nodes.length) spliceIndex = nodes.length;
-        if (spliceIndex < 0) spliceIndex = nodes.length + index;
-        if (spliceIndex < 0) spliceIndex = 0;
+        if (spliceIndex > nodes.length || spliceIndex < 0) {
+            throw new Error('addNode: index ' + spliceIndex + ' is invalid');
+        }
         if (nodes[spliceIndex] !== id&& nodes[spliceIndex-1] !== id) {
             nodes.splice(spliceIndex, 0, id);
         }
@@ -206,14 +205,15 @@ _.extend(osmWay.prototype, {
     },
 
     // Replaces the node which is currently at position index with the given node (id). 
-    // If index is negative, it will be counted from the end of the way.
-    
+    // If index is negative or >= length, it will throw an error.   
     // Consecutive duplicates are eliminated including existing ones.
 
     updateNode: function(id, index) {
         var nodes = [];
         
-        if (index < 0) index = this.nodes.length + index;
+        if (index === undefined || index >= this.nodes.length || index < 0) {
+            throw new Error('updateNode: index ' + index + ' is invalid');
+        }
 
         for (var i = 0; i < this.nodes.length; i++) {
             var node = this.nodes[i];

--- a/modules/osm/way.js
+++ b/modules/osm/way.js
@@ -187,34 +187,70 @@ _.extend(osmWay.prototype, {
         });
     },
 
-
+    // Adds a node (id) in front of the node which is currently at position index.
+    // If index is negative, it will be counted from the end of the way.
+    // If index is 0 or < -length, the node (id) will be added at the start of the way.
+    // If index is undefined or >= length, the node (id) will be added at the end of the way.
+    // Generating consecutive duplicates is silently prevented
+    
     addNode: function(id, index) {
-        var nodes = this.nodes.slice();
-        nodes.splice(index === undefined ? nodes.length : index, 0, id);
-        return this.update({nodes: nodes});
-    },
-
-
-    updateNode: function(id, index) {
-        var nodes = this.nodes.slice();
-        nodes.splice(index, 1, id);
-        return this.update({nodes: nodes});
-    },
-
-
-    replaceNode: function(needle, replacement) {
-        if (this.nodes.indexOf(needle) < 0)
-            return this;
-
-        var nodes = this.nodes.slice();
-        for (var i = 0; i < nodes.length; i++) {
-            if (nodes[i] === needle) {
-                nodes[i] = replacement;
-            }
+        var nodes = this.nodes.slice(),
+            spliceIndex = index === undefined ? nodes.length : index;
+        if (spliceIndex > nodes.length) spliceIndex = nodes.length;
+        if (spliceIndex < 0) spliceIndex = nodes.length + index;
+        if (spliceIndex < 0) spliceIndex = 0;
+        if (nodes[spliceIndex] !== id&& nodes[spliceIndex-1] !== id) {
+            nodes.splice(spliceIndex, 0, id);
         }
         return this.update({nodes: nodes});
     },
 
+    // Replaces the node which is currently at position index with the given node (id). 
+    // If index is negative, it will be counted from the end of the way.
+    
+    // Consecutive duplicates are eliminated including existing ones.
+
+    updateNode: function(id, index) {
+        var nodes = [];
+        
+        if (index < 0) index = this.nodes.length + index;
+
+        for (var i = 0; i < this.nodes.length; i++) {
+            var node = this.nodes[i];
+            if (i === index) {
+                if (nodes[nodes.length - 1] !== id)
+                    nodes.push(id);
+            } else {
+                if (nodes[nodes.length - 1] !== node)
+                    nodes.push(node);
+            }    
+        }
+
+        return this.update({nodes: nodes});
+    },
+
+    // Replaces each occurrence of node id needle with replacement. 
+    // Consecutive duplicates are eliminated including existing ones.
+
+    replaceNode: function(needle, replacement) {
+        var nodes = [];
+
+        for (var i = 0; i < this.nodes.length; i++) {
+            var node = this.nodes[i];
+            if (node === needle) {
+                if (nodes[nodes.length - 1] !== replacement)
+                    nodes.push(replacement);
+            } else {
+                if (nodes[nodes.length - 1] !== node)
+                    nodes.push(node);
+            }    
+        }
+
+        return this.update({nodes: nodes});
+    },
+
+    // Removes each occurrence of node id needle with replacement. 
+    // Consecutive duplicates are eliminated. Circularity is preserved.
 
     removeNode: function(id) {
         var nodes = [];

--- a/test/spec/osm/way.js
+++ b/test/spec/osm/way.js
@@ -420,9 +420,9 @@ describe('iD.osmWay', function() {
             expect(w.addNode('a').nodes).to.eql(['a']);
         });
 
-        it('adds a node to the end of a way at a index greater than length', function () {
+        it('throws when using a index greater than length', function () {
             var w = iD.Way({nodes: ['a', 'b']});
-            expect(w.addNode('c',3).nodes).to.eql(['a', 'b', 'c']);
+            expect(function() { w.addNode('c',3); }).to.throw;
         });
 
         it('adds a node to a way at index 0', function () {
@@ -435,9 +435,9 @@ describe('iD.osmWay', function() {
             expect(w.addNode('c', 1).nodes).to.eql(['a', 'c', 'b']);
         });
 
-        it('adds a node to a way at a negative index', function () {
+        it('throws when using a negative index', function () {
             var w = iD.Way({nodes: ['a', 'b']});
-            expect(w.addNode('c', -1).nodes).to.eql(['a', 'c', 'b']);
+            expect(function() { w.addNode('c', -1); }).to.throw;
         });
         
         it('prevents duplicate consecutive nodes when adding in front of', function () {
@@ -455,11 +455,6 @@ describe('iD.osmWay', function() {
             expect(w.addNode('a', 0).nodes).to.eql(['a', 'b']);
         });
         
-        it('prevents duplicate consecutive nodes at a negative index', function () {
-            var w = iD.Way({nodes: ['a', 'b']});
-            expect(w.addNode('a', -1).nodes).to.eql(['a', 'b']);
-        });
-        
         it('prevents duplicate consecutive nodes at a index equal to length', function () {
             var w = iD.Way({nodes: ['a', 'b']});
             expect(w.addNode('b', 2).nodes).to.eql(['a', 'b']);
@@ -475,6 +470,13 @@ describe('iD.osmWay', function() {
         it('updates the node id at the specified index', function () {
             var w = iD.Way({nodes: ['a', 'b', 'c']});
             expect(w.updateNode('d', 1).nodes).to.eql(['a', 'd', 'c']);
+        });
+        it('throws at an invalid index', function () {
+            var w = iD.Way({nodes: ['a', 'b', 'c']});
+            expect(function() { w.updateNode('d', -1); }).to.throw;
+            expect(function() { w.updateNode('d'); }).to.throw;
+            expect(function() { w.updateNode('d', 5); }).to.throw;
+            expect(function() { w.updateNode('d', 3); }).to.throw;
         });
         
         it('prevents duplicate consecutive nodes', function () {


### PR DESCRIPTION
I have added some tests for replaceNode, updateNode, addNode, and removeNode. These are partially failing with the original code, due to some potential issues in view of duplicate nodes.

Reworked code passing these tests is in the second commit.

In addition I have added some code comments.

Related issues are #1296 and #3211.