### PR TITLE
Fix reflect-typo

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -159,10 +159,10 @@ en:
         short: Y
       annotation:
         long:
-          area: Reflected an area across its long axis.
+          single: Reflected an object across its long axis.
           multiple: Reflected multiple objects across their long axis.
         short:
-          area: Reflected an area across its short axis.
+          single: Reflected an object across its short axis.
           multiple: Reflected multiple objects across their short axis.
       incomplete_relation:
         single: This object can't be reflected because it hasn't been fully downloaded.

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -205,11 +205,11 @@
                 },
                 "annotation": {
                     "long": {
-                        "area": "Reflected an area across its long axis.",
+                        "single": "Reflected an object across its long axis.",
                         "multiple": "Reflected multiple objects across their long axis."
                     },
                     "short": {
-                        "area": "Reflected an area across its short axis.",
+                        "single": "Reflected an object across its short axis.",
                         "multiple": "Reflected multiple objects across their short axis."
                     }
                 },


### PR DESCRIPTION
Fix errors in console after reflect-operation on single object.

> Missing en translation: operations.reflect.annotation.short.single
> Missing en translation: operations.reflect.annotation.long.single