### PR TITLE
fix persian characters on chrome and safari

### DIFF
--- a/modules/core/fix-string.js
+++ b/modules/core/fix-string.js
@@ -1,0 +1,90 @@
+const chars = {
+    1575: {initial: "ا", isolated: "ا", medial: "", final: "ﺎ" },
+    1576: {initial: "ﺑ", isolated: "ﺏ", medial: "ﺒ", final: "ﺐ" },
+    1662: {initial: "ﭘ", isolated: "ﭖ", medial: "ﭙ", final: "ﭗ" },
+    1578: {initial: "ﺗ", isolated: "ﺕ", medial: "ﺘ", final: "ﺖ" },
+    1579: {initial: "ﺛ", isolated: "ﺙ", medial: "ﺜ", final: "ﺚ" },
+    1580: {initial: "ﺟ", isolated: "ﺝ", medial: "ﺠ", final: "ﺞ" },
+    1670: {initial: "ﭼ", isolated: "ﭺ", medial: "ﭽ", final: "ﭻ" },
+    1581: {initial: "ﺣ", isolated: "ﺡ", medial: "ﺤ", final: "ﺢ" },
+    1582: {initial: "ﺧ", isolated: "ﺥ", medial: "ﺨ", final: "ﺦ" },
+    1583: {initial: "ﺩ", isolated: "ﺩ", medial: "", final: "ﺪ" },
+    1584: {initial: "ﺫ", isolated: "ﺫ", medial: "", final: "ﺬ" },
+    1585: {initial: "ﺭ", isolated: "ﺭ", medial: "", final: "ﺮ" },
+    1586: {initial: "ﺯ", isolated: "ﺯ", medial: "", final: "ﺰ" },
+    1688: {initial: "ﮊ", isolated: "ﮊ", medial: "", final: "ﮋ" },
+    1587: {initial: "ﺳ", isolated: "ﺱ", medial: "ﺴ", final: "ﺲ" },
+    1588: {initial: "ﺷ", isolated: "ﺵ", medial: "ﺸ", final: "ﺶ" },
+    1589: {initial: "ﺻ", isolated: "ﺹ", medial: "ﺼ", final: "ﺺ" },
+    1590: {initial: "ﺿ", isolated: "ﺽ", medial: "ﻀ", final: "ﺾ" },
+    1591: {initial: "ﻃ", isolated: "ﻁ", medial: "ﻄ", final: "ﻂ" },
+    1592: {initial: "ﻇ", isolated: "ﻅ", medial: "ﻈ", final: "ﻆ" },
+    1593: {initial: "ﻋ", isolated: "ﻉ", medial: "ﻌ", final: "ﻊ" },
+    1594: {initial: "ﻏ", isolated: "ﻍ", medial: "ﻐ", final: "ﻎ" },
+    1601: {initial: "ﻓ", isolated: "ﻑ", medial: "ﻔ", final: "ﻒ" },
+    1602: {initial: "ﻗ", isolated: "ﻕ", medial: "ﻘ", final: "ﻖ" },
+    1705: {initial: "ﻛ", isolated: "ﮎ", medial: "ﻜ", final: "ﮏ" },
+    1711: {initial: "ﮔ", isolated: "ﮒ", medial: "ﮕ", final: "ﮓ" },
+    1604: {initial: "ﻟ", isolated: "ﻝ", medial: "ﻠ", final: "ﻞ" },
+    1605: {initial: "ﻣ", isolated: "ﻡ", medial: "ﻤ", final: "ﻢ" },
+    1606: {initial: "ﻧ", isolated: "ﻥ", medial: "ﻨ", final: "ﻦ" },
+    1608: {initial: "ﻭ", isolated: "ﻭ", medial: "", final: "ﻮ" },
+    1607: {initial: "ﻫ", isolated: "ﻩ", medial: "ﻬ", final: "ﻪ" },
+    1740: {initial: "ﻳ", isolated: "ﻯ", medial: "ﻴ", final: "ﻰ" },
+    5000: {initial: "ﻻ", isolated: "ﻻ", medial: "", final: "ﻼ" }
+};
+
+export function fixTextForSvg(inputText){
+    return inputText.split(' ').reverse().map(function(w){
+        return fixWordForSvg(w);
+    }).join(' ');
+}
+
+export function fixWordForSvg(inputWord){    
+    let context = true;
+    let ret = [];
+    //const inputWord = inputWord.split('');
+    for(let i = 0, l = inputWord.length; i < l; i++){
+        let code = inputWord[i].charCodeAt(0);
+        let nextCode = inputWord[i + 1] ? inputWord[i + 1].charCodeAt(0) : 0;
+        if(!chars[code]){             
+            ret.push(inputWord[i]);
+            continue;
+        }                
+        if(context){            
+            if(i == l - 1){                
+                ret.push(chars[code].isolated);
+            } else {
+                // special case for لا
+                if(code == 1604 && nextCode == 1575){
+                    ret.push(chars[5000].initial);
+                    i++;
+                    context = true;
+                    continue;
+                }
+
+                ret.push(chars[code].initial);
+            }            
+        } else {
+            if(i == l - 1){                
+                ret.push(chars[code].final);
+            } else {
+                // special case for ﻼ
+                if(code == 1604 && nextCode == 1575){
+                    ret.push(chars[5000].final);
+                    i++;
+                    context = true;
+                    continue;
+                }
+                if(chars[code].medial == ''){                    
+                    ret.push(chars[code].final);
+                } else{                    
+                    ret.push(chars[code].medial);
+                }                
+            }
+        }        
+        context = (chars[code].medial == '');        
+    }   
+    
+    return ret.reverse().join('');
+}

--- a/modules/services/osm.js
+++ b/modules/services/osm.js
@@ -7,8 +7,6 @@ import { geoExtent } from '../geo/index';
 import { osmEntity, osmNode, osmRelation, osmWay } from '../osm/index';
 import { utilDetect } from '../util/detect';
 import { utilRebind } from '../util/rebind';
-import { fixArabicScriptTextForSvg } from '../util/svg_paths_arabic_fix';
-
 
 var dispatch = d3.dispatch('authLoading', 'authDone', 'change', 'loading', 'loaded'),
     useHttps = window.location.protocol === 'https:',
@@ -71,12 +69,7 @@ function getTags(obj) {
         var attrs = elems[i].attributes;
         tags[attrs.k.value] = attrs.v.value;
     }
-    var isFirefox = utilDetect().browser.toLowerCase().indexOf('firefox') > -1
-    var arabicRegex = /[\u0600-\u06FF]/g
-    if(tags.name && tags.highway && !isFirefox && arabicRegex.test(tags.name)){        
-        tags.real_name = tags.name;
-        tags.name = fixArabicScriptTextForSvg(tags.real_name);            
-    }
+    
     return tags;
 }
 

--- a/modules/services/osm.js
+++ b/modules/services/osm.js
@@ -7,7 +7,7 @@ import { geoExtent } from '../geo/index';
 import { osmEntity, osmNode, osmRelation, osmWay } from '../osm/index';
 import { utilDetect } from '../util/detect';
 import { utilRebind } from '../util/rebind';
-import { fixTextForSvg } from '../core/fix-string';
+import { fixArabicScriptTextForSvg } from '../util/svg_paths_arabic_fix';
 
 
 var dispatch = d3.dispatch('authLoading', 'authDone', 'change', 'loading', 'loaded'),
@@ -71,10 +71,11 @@ function getTags(obj) {
         var attrs = elems[i].attributes;
         tags[attrs.k.value] = attrs.v.value;
     }
-    var isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1
-    if(tags.name && tags.highway && !isFirefox){
+    var isFirefox = utilDetect().browser.toLowerCase().indexOf('firefox') > -1
+    var arabicRegex = /[\u0600-\u06FF]/g
+    if(tags.name && tags.highway && !isFirefox && arabicRegex.test(tags.name)){        
         tags.real_name = tags.name;
-        tags.name = fixTextForSvg(tags.real_name);            
+        tags.name = fixArabicScriptTextForSvg(tags.real_name);            
     }
     return tags;
 }

--- a/modules/services/osm.js
+++ b/modules/services/osm.js
@@ -349,7 +349,7 @@ export default {
     putChangeset: function(changes, version, comment, imageryUsed, callback) {
         if(changes.modified && changes.modified.length > 0){
             for(var i = 0, l = changes.modified.length; i < l; i++){
-                if(changes.modified[i].tags.highway && changes.modified[i].tags.real_name){
+                if((changes.modified[i].tags.highway || changes.modified[i].tags.railway) && changes.modified[i].tags.real_name){
                     changes.modified[i].tags.name = changes.modified[i].tags.real_name; 
                     delete changes.modified[i].tags.real_name;
                 }
@@ -357,7 +357,7 @@ export default {
         }
         if(changes.created && changes.created.length > 0){
             for(var i = 0, l = changes.created.length; i < l; i++){
-                if(changes.created[i].tags.highway && changes.created[i].tags.real_name){
+                if((changes.modified[i].tags.highway || changes.modified[i].tags.railway) && changes.created[i].tags.real_name){
                     changes.created[i].tags.name = changes.created[i].tags.real_name; 
                     delete changes.created[i].tags.real_name;
                 }
@@ -365,7 +365,7 @@ export default {
         }
         if(changes.deleted && changes.deleted.length > 0){
             for(var i = 0, l = changes.deleted.length; i < l; i++){
-                if(changes.deleted[i].tags.highway && changes.deleted[i].tags.real_name){
+                if((changes.modified[i].tags.highway || changes.modified[i].tags.railway) && changes.deleted[i].tags.real_name){
                     changes.deleted[i].tags.name = changes.deleted[i].tags.real_name; 
                     delete changes.deleted[i].tags.real_name;
                 }

--- a/modules/services/osm.js
+++ b/modules/services/osm.js
@@ -347,30 +347,6 @@ export default {
 
 
     putChangeset: function(changes, version, comment, imageryUsed, callback) {
-        if(changes.modified && changes.modified.length > 0){
-            for(var i = 0, l = changes.modified.length; i < l; i++){
-                if((changes.modified[i].tags.highway || changes.modified[i].tags.railway) && changes.modified[i].tags.real_name){
-                    changes.modified[i].tags.name = changes.modified[i].tags.real_name; 
-                    delete changes.modified[i].tags.real_name;
-                }
-            }
-        }
-        if(changes.created && changes.created.length > 0){
-            for(var i = 0, l = changes.created.length; i < l; i++){
-                if((changes.modified[i].tags.highway || changes.modified[i].tags.railway) && changes.created[i].tags.real_name){
-                    changes.created[i].tags.name = changes.created[i].tags.real_name; 
-                    delete changes.created[i].tags.real_name;
-                }
-            }
-        }
-        if(changes.deleted && changes.deleted.length > 0){
-            for(var i = 0, l = changes.deleted.length; i < l; i++){
-                if((changes.modified[i].tags.highway || changes.modified[i].tags.railway) && changes.deleted[i].tags.real_name){
-                    changes.deleted[i].tags.name = changes.deleted[i].tags.real_name; 
-                    delete changes.deleted[i].tags.real_name;
-                }
-            }
-        }
         var that = this;
         oauth.xhr({
                 method: 'PUT',

--- a/modules/ui/entity_editor.js
+++ b/modules/ui/entity_editor.js
@@ -12,8 +12,6 @@ import { uiRawTagEditor } from './raw_tag_editor';
 import { uiTagReference } from './tag_reference';
 import { uiPreset } from './preset';
 import { utilRebind } from '../util/rebind';
-import { fixArabicScriptTextForSvg } from '../util/svg_paths_arabic_fix';
-
 
 export function uiEntityEditor(context) {
     var dispatch = d3.dispatch('choose'),
@@ -225,14 +223,6 @@ export function uiEntityEditor(context) {
                 tags[k] = v;
             }
         });
-        var arabicRegex = /[\u0600-\u06FF]/g
-        if(tags.highway && tags.real_name){
-            if(arabicRegex.test(tags.real_name)){
-                tags.name = fixArabicScriptTextForSvg(tags.real_name);
-            } else{
-                tags.name = tags.real_name;
-            }
-        }
 
         if (!onInput) {
             tags = clean(tags);

--- a/modules/ui/entity_editor.js
+++ b/modules/ui/entity_editor.js
@@ -12,6 +12,7 @@ import { uiRawTagEditor } from './raw_tag_editor';
 import { uiTagReference } from './tag_reference';
 import { uiPreset } from './preset';
 import { utilRebind } from '../util/rebind';
+import { fixArabicScriptTextForSvg } from '../util/svg_paths_arabic_fix';
 
 
 export function uiEntityEditor(context) {
@@ -224,6 +225,14 @@ export function uiEntityEditor(context) {
                 tags[k] = v;
             }
         });
+        var arabicRegex = /[\u0600-\u06FF]/g
+        if(tags.highway && tags.real_name){
+            if(arabicRegex.test(tags.real_name)){
+                tags.name = fixArabicScriptTextForSvg(tags.real_name);
+            } else{
+                tags.name = tags.real_name;
+            }
+        }
 
         if (!onInput) {
             tags = clean(tags);

--- a/modules/util/svg_paths_arabic_fix.js
+++ b/modules/util/svg_paths_arabic_fix.js
@@ -51,6 +51,7 @@ const chars = {
     1662: {initial: "ﭘ", isolated: "ﭖ", medial: "ﭙ", final: "ﭗ" },
     
     1670: {initial: "ﭼ", isolated: "ﭺ", medial: "ﭽ", final: "ﭻ" },    
+    1603: {initial: "ﻛ", isolated: "ﻙ", medial: "ﻜ", final: "ﻚ" },
     1705: {initial: "ﻛ", isolated: "ﮎ", medial: "ﻜ", final: "ﮏ" },
     1711: {initial: "ﮔ", isolated: "ﮒ", medial: "ﮕ", final: "ﮓ" },
     1740: {initial: "ﻳ", isolated: "ﻯ", medial: "ﻴ", final: "ﻰ" },

--- a/modules/util/svg_paths_arabic_fix.js
+++ b/modules/util/svg_paths_arabic_fix.js
@@ -1,11 +1,21 @@
 const chars = {
+    // madda above alef
+    1570: {initial: "آ‎", isolated: "ﺁ", medial: "ﺁ", final: "ﺂ" },
+    
+    // hamza above and below alef
+    1571: { initial: "أ", isolated: "ﺃ", medial: "", final: "ﺄ" },
+    // 1572 is ؤ
+    1573: { initial: "إ", isolated: "ﺇ", medial: "", final: "ﺈ" },
+    // 1574 is ئ
     1575: {initial: "ا", isolated: "ا", medial: "", final: "ﺎ" },
     1576: {initial: "ﺑ", isolated: "ﺏ", medial: "ﺒ", final: "ﺐ" },
-    1662: {initial: "ﭘ", isolated: "ﭖ", medial: "ﭙ", final: "ﭗ" },
+
+    // 1577 ة
+    1577: {initial: "", isolated: "ة", medial: "", final: "ﺔ" },
+
     1578: {initial: "ﺗ", isolated: "ﺕ", medial: "ﺘ", final: "ﺖ" },
     1579: {initial: "ﺛ", isolated: "ﺙ", medial: "ﺜ", final: "ﺚ" },
     1580: {initial: "ﺟ", isolated: "ﺝ", medial: "ﺠ", final: "ﺞ" },
-    1670: {initial: "ﭼ", isolated: "ﭺ", medial: "ﭽ", final: "ﭻ" },
     1581: {initial: "ﺣ", isolated: "ﺡ", medial: "ﺤ", final: "ﺢ" },
     1582: {initial: "ﺧ", isolated: "ﺥ", medial: "ﺨ", final: "ﺦ" },
     1583: {initial: "ﺩ", isolated: "ﺩ", medial: "", final: "ﺪ" },
@@ -21,15 +31,28 @@ const chars = {
     1592: {initial: "ﻇ", isolated: "ﻅ", medial: "ﻈ", final: "ﻆ" },
     1593: {initial: "ﻋ", isolated: "ﻉ", medial: "ﻌ", final: "ﻊ" },
     1594: {initial: "ﻏ", isolated: "ﻍ", medial: "ﻐ", final: "ﻎ" },
+
+// 1595 ػ - may be very rare
+
     1601: {initial: "ﻓ", isolated: "ﻑ", medial: "ﻔ", final: "ﻒ" },
     1602: {initial: "ﻗ", isolated: "ﻕ", medial: "ﻘ", final: "ﻖ" },
-    1705: {initial: "ﻛ", isolated: "ﮎ", medial: "ﻜ", final: "ﮏ" },
-    1711: {initial: "ﮔ", isolated: "ﮒ", medial: "ﮕ", final: "ﮓ" },
     1604: {initial: "ﻟ", isolated: "ﻝ", medial: "ﻠ", final: "ﻞ" },
     1605: {initial: "ﻣ", isolated: "ﻡ", medial: "ﻤ", final: "ﻢ" },
     1606: {initial: "ﻧ", isolated: "ﻥ", medial: "ﻨ", final: "ﻦ" },
-    1608: {initial: "ﻭ", isolated: "ﻭ", medial: "", final: "ﻮ" },
     1607: {initial: "ﻫ", isolated: "ﻩ", medial: "ﻬ", final: "ﻪ" },
+    1608: {initial: "ﻭ", isolated: "ﻭ", medial: "", final: "ﻮ" },
+    
+    // 1609 ى
+    1609: {initial: "ﯨ", isolated: "ﻯ", medial: "ﯩ", final: "ﻰ" }, 
+    // 1610 ي
+    1610: {initial: "ﻳ", isolated: "ﻱ", medial: "ﻴ", final: "ﻲ" },
+    // short vowel sounds / tashkil markings
+
+    1662: {initial: "ﭘ", isolated: "ﭖ", medial: "ﭙ", final: "ﭗ" },
+    
+    1670: {initial: "ﭼ", isolated: "ﭺ", medial: "ﭽ", final: "ﭻ" },    
+    1705: {initial: "ﻛ", isolated: "ﮎ", medial: "ﻜ", final: "ﮏ" },
+    1711: {initial: "ﮔ", isolated: "ﮒ", medial: "ﮕ", final: "ﮓ" },
     1740: {initial: "ﻳ", isolated: "ﻯ", medial: "ﻴ", final: "ﻰ" },
     5000: {initial: "ﻻ", isolated: "ﻻ", medial: "", final: "ﻼ" }
 };

--- a/modules/util/svg_paths_arabic_fix.js
+++ b/modules/util/svg_paths_arabic_fix.js
@@ -34,13 +34,13 @@ const chars = {
     5000: {initial: "ﻻ", isolated: "ﻻ", medial: "", final: "ﻼ" }
 };
 
-export function fixTextForSvg(inputText){
+export function fixArabicScriptTextForSvg(inputText){
     return inputText.split(' ').reverse().map(function(w){
-        return fixWordForSvg(w);
+        return fixArabicScriptWordForSvg(w);
     }).join(' ');
 }
 
-export function fixWordForSvg(inputWord){    
+export function fixArabicScriptWordForSvg(inputWord){    
     let context = true;
     let ret = [];
     //const inputWord = inputWord.split('');

--- a/modules/util/svg_paths_arabic_fix.js
+++ b/modules/util/svg_paths_arabic_fix.js
@@ -59,56 +59,59 @@ const chars = {
 };
 
 export function fixArabicScriptTextForSvg(inputText){
-    return inputText.split(' ').reverse().map(function(w){
-        return fixArabicScriptWordForSvg(w);
-    }).join(' ');
-}
-
-export function fixArabicScriptWordForSvg(inputWord){    
     let context = true;
-    let ret = [];
-    //const inputWord = inputWord.split('');
-    for(let i = 0, l = inputWord.length; i < l; i++){
-        let code = inputWord[i].charCodeAt(0);
-        let nextCode = inputWord[i + 1] ? inputWord[i + 1].charCodeAt(0) : 0;
-        if(!chars[code]){             
-            ret.push(inputWord[i]);
+    let ret = '';
+    let rtlBuffer = [];
+
+    for(let i = 0, l = inputText.length; i < l; i++){
+        let code = inputText[i].charCodeAt(0);
+        let nextCode = inputText[i + 1] ? inputText[i + 1].charCodeAt(0) : 0;
+        if(!chars[code]){
+            if (code === 32 && rtlBuffer.length) {
+              // whitespace
+              rtlBuffer = [rtlBuffer.reverse().join('') + ' '];
+            } else {
+              // non-RTL character
+              ret += rtlBuffer.reverse().join('') + inputText[i];
+              rtlBuffer = [];
+            }
             continue;
         }                
         if(context){            
             if(i == l - 1){                
-                ret.push(chars[code].isolated);
+                rtlBuffer.push(chars[code].isolated);
             } else {
                 // special case for لا
                 if(code == 1604 && nextCode == 1575){
-                    ret.push(chars[5000].initial);
+                    rtlBuffer.push(chars[5000].initial);
                     i++;
                     context = true;
                     continue;
                 }
 
-                ret.push(chars[code].initial);
+                rtlBuffer.push(chars[code].initial);
             }            
         } else {
             if(i == l - 1){                
-                ret.push(chars[code].final);
+                rtlBuffer.push(chars[code].final);
             } else {
                 // special case for ﻼ
                 if(code == 1604 && nextCode == 1575){
-                    ret.push(chars[5000].final);
+                    rtlBuffer.push(chars[5000].final);
                     i++;
                     context = true;
                     continue;
                 }
                 if(chars[code].medial == ''){                    
-                    ret.push(chars[code].final);
+                    rtlBuffer.push(chars[code].final);
                 } else{                    
-                    ret.push(chars[code].medial);
+                    rtlBuffer.push(chars[code].medial);
                 }                
             }
         }        
         context = (chars[code].medial == '');        
     }   
+    ret += rtlBuffer.reverse().join('');
     
-    return ret.reverse().join('');
+    return ret;
 }

--- a/modules/util/util.js
+++ b/modules/util/util.js
@@ -2,7 +2,7 @@ import * as d3 from 'd3';
 import { t, textDirection } from './locale';
 import { utilDetect } from './detect';
 import { remove as removeDiacritics } from 'diacritics';
-
+import { fixArabicScriptTextForSvg } from '../util/svg_paths_arabic_fix';
 
 export function utilTagText(entity) {
     return d3.entries(entity.tags).map(function(e) {
@@ -66,6 +66,13 @@ export function utilDisplayName(entity) {
             name = network + ' ' + name;
         }
     }
+    
+    var isFirefox = utilDetect().browser.toLowerCase().indexOf('firefox') > -1
+    var arabicRegex = /[\u0600-\u06FF]/g
+    if(!isFirefox && name && entity.tags.highway && arabicRegex.test(name)){
+        name = fixArabicScriptTextForSvg(name);            
+    }
+    
     return name;
 }
 

--- a/modules/util/util.js
+++ b/modules/util/util.js
@@ -69,7 +69,7 @@ export function utilDisplayName(entity) {
     
     var isFirefox = utilDetect().browser.toLowerCase().indexOf('firefox') > -1
     var arabicRegex = /[\u0600-\u06FF]/g
-    if(!isFirefox && name && entity.tags.highway && arabicRegex.test(name)){
+    if(!isFirefox && name && (entity.tags.highway || entity.tags.railway) && arabicRegex.test(name)){
         name = fixArabicScriptTextForSvg(name);            
     }
     


### PR DESCRIPTION
To achieve this purpose, we created a mapping for characters in fix-string.js.

In order to display the names correctly, a temporary tag is created named real_name which is terminated while putting changesets to the server.

Closes #3491