### PR TITLE
Add amenity=coworking_space as non-searchable preset

### DIFF
--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -1503,6 +1503,9 @@ en:
         # amenity=courthouse
         name: Courthouse
         terms: '<translate with synonyms or related terms for ''Courthouse'', separated by commas>'
+      amenity/coworking_space:
+        # office=coworking
+        name: Coworking Space
       amenity/crematorium:
         # amenity=crematorium
         name: Crematorium

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -445,6 +445,26 @@
             },
             "name": "Airport terminal"
         },
+        "amenity/coworking_space": {
+            "icon": "commercial",
+            "fields": [
+                "address",
+                "building_area",
+                "opening_hours",
+                "internet_access",
+                "internet_access/fee",
+                "internet_access/ssid"
+            ],
+            "geometry": [
+                "point",
+                "area"
+            ],
+            "tags": {
+                "office": "coworking"
+            },
+            "name": "Coworking Space",
+            "searchable": false
+        },
         "amenity/register_office": {
             "icon": "town-hall",
             "fields": [

--- a/data/presets/presets/amenity/_coworking_space.json
+++ b/data/presets/presets/amenity/_coworking_space.json
@@ -1,0 +1,20 @@
+{
+    "icon": "commercial",
+    "fields": [
+        "address",
+        "building_area",
+        "opening_hours",
+        "internet_access",
+        "internet_access/fee",
+        "internet_access/ssid"
+    ],
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "office": "coworking"
+    },
+    "name": "Coworking Space",
+    "searchable": false
+}

--- a/data/taginfo.json
+++ b/data/taginfo.json
@@ -116,6 +116,10 @@
             "value": "terminal"
         },
         {
+            "key": "office",
+            "value": "coworking"
+        },
+        {
             "key": "amenity",
             "value": "register_office"
         },

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -1909,6 +1909,10 @@
                     "name": "Airport terminal",
                     "terms": "airport,aerodrome"
                 },
+                "amenity/coworking_space": {
+                    "name": "Coworking Space",
+                    "terms": ""
+                },
                 "amenity/register_office": {
                     "name": "Register Office",
                     "terms": ""


### PR DESCRIPTION
In 23a37183762adb2b1fe044b9bee3b50d5095eff3 `amenity=coworking_space` was changed into `office=coworking`.

I'd propose to add a **non-searchable preset** for `amenity=coworking_space` so it doesn't show up as a blank Amenity in the Inspector.