### PR TITLE
Add Turkish address scheme

### DIFF
--- a/data/address-formats.json
+++ b/data/address-formats.json
@@ -42,6 +42,10 @@
         {
             "countryCodes": ["jp"],
             "format": [["postcode", "province", "county"], ["city", "suburb", "quarter"], ["neighbourhood", "block_number", "housenumber"]]
+        },
+        {
+            "countryCodes": ["tr"],
+            "format": [["neighbourhood"], ["street", "housenumber"], ["postcode", "district", "city"]]
         }
     ]
 }


### PR DESCRIPTION
This PR adds Turkish address scheme defined [here](http://postakodu.ptt.gov.tr/Dosyalar/adres.pdf). That is an official documentation, but only available in Turkish.

The scheme is defined as (in Turkish):
* Mahalle / Köy
* Bulvar/ Cadde / Sokak / Mevki / Site / Blok / Bina ismi / Dış Kapı No / Kat / İç Kapı No
* Posta kodu / Bucak (Semt) / İlçe / İl / Ülke 

That maps to English as:
* Neighborhood
* Street, House number
* Postal code, District, City