### PR TITLE
Add outdoor_seating options

### DIFF
--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -817,11 +817,6 @@ en:
       outdoor_seating:
         # outdoor_seating=*
         label: Outdoor Seating
-        options:
-          # outdoor_seating=yes
-          yes: Outdoor seating is possible
-          # outdoor_seating=no
-          no: No outdoor seating
       par:
         # par=*
         label: Par

--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -817,6 +817,11 @@ en:
       outdoor_seating:
         # outdoor_seating=*
         label: Outdoor Seating
+        options:
+          # outdoor_seating=yes
+          yes: Outdoor seating is possible
+          # outdoor_seating=no
+          no: No outdoor seating
       par:
         # par=*
         label: Par

--- a/data/presets/fields.json
+++ b/data/presets/fields.json
@@ -1106,7 +1106,14 @@
         "outdoor_seating": {
             "key": "outdoor_seating",
             "type": "combo",
-            "label": "Outdoor Seating"
+            "label": "Outdoor Seating",
+            "placeholder": "Yes, No...",
+            "strings": {
+                "options": {
+                    "no": "No outdoor seating",
+                    "yes": "Outdoor seating is possible"
+                }
+            }
         },
         "par": {
             "key": "par",

--- a/data/presets/fields.json
+++ b/data/presets/fields.json
@@ -1105,15 +1105,8 @@
         },
         "outdoor_seating": {
             "key": "outdoor_seating",
-            "type": "combo",
-            "label": "Outdoor Seating",
-            "placeholder": "Yes, No...",
-            "strings": {
-                "options": {
-                    "no": "No outdoor seating",
-                    "yes": "Outdoor seating is possible"
-                }
-            }
+            "type": "check",
+            "label": "Outdoor Seating"
         },
         "par": {
             "key": "par",

--- a/data/presets/fields/outdoor_seating.json
+++ b/data/presets/fields/outdoor_seating.json
@@ -1,5 +1,12 @@
 {
     "key": "outdoor_seating",
     "type": "combo",
-    "label": "Outdoor Seating"
+    "label": "Outdoor Seating",
+    "placeholder": "Yes, No...",
+    "strings": {
+        "options": {
+            "no": "No outdoor seating",
+            "yes": "Outdoor seating is possible"
+        }
+    }
 }

--- a/data/presets/fields/outdoor_seating.json
+++ b/data/presets/fields/outdoor_seating.json
@@ -1,12 +1,5 @@
 {
     "key": "outdoor_seating",
-    "type": "combo",
-    "label": "Outdoor Seating",
-    "placeholder": "Yes, No...",
-    "strings": {
-        "options": {
-            "no": "No outdoor seating",
-            "yes": "Outdoor seating is possible"
-        }
-    }
+    "type": "check",
+    "label": "Outdoor Seating"
 }


### PR DESCRIPTION
This PR adds `outdoor_seating` options following [OSM wiki](http://wiki.openstreetmap.org/wiki/Key:outdoor_seating).