### PR TITLE
Highways under construction

### DIFF
--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -2421,6 +2421,124 @@ en:
         # highway=bus_stop
         name: Bus Stop
         terms: '<translate with synonyms or related terms for ''Bus Stop'', separated by commas>'
+      highway/construction:
+        # highway=construction
+        name: Highway Under Construction
+      highway/construction/bridleway:
+        # 'highway=construction, construction=bridleway'
+        name: Bridle Path Under Construction
+        # 'terms: bridleway,equestrian,horse,construction'
+        terms: '<translate with synonyms or related terms for ''Bridle Path Under Construction'', separated by commas>'
+      highway/construction/cycleway:
+        # 'highway=construction, construction=cycleway'
+        name: Cycle Path Under Construction
+        # 'terms: bike,construction'
+        terms: '<translate with synonyms or related terms for ''Cycle Path Under Construction'', separated by commas>'
+      highway/construction/footway:
+        # 'highway=construction, construction=footway'
+        name: Foot Path Under Construction
+        # 'terms: hike,hiking,trackway,trail,walk,construction'
+        terms: '<translate with synonyms or related terms for ''Foot Path Under Construction'', separated by commas>'
+      highway/construction/motorway:
+        # 'highway=construction, construction=motorway'
+        name: Motorway Under Construction
+        # 'terms: autobahn,expressway,freeway,highway,interstate,parkway,thruway,turnpike,construction'
+        terms: '<translate with synonyms or related terms for ''Motorway Under Construction'', separated by commas>'
+      highway/construction/motorway_link:
+        # 'highway=construction, construction=motorway_link'
+        name: Motorway Link Under Construction
+        # 'terms: ramp,on ramp,off ramp,construction'
+        terms: '<translate with synonyms or related terms for ''Motorway Link Under Construction'', separated by commas>'
+      highway/construction/path:
+        # 'highway=construction, construction=path'
+        name: Path Under Construction
+        # 'terms: hike,hiking,trackway,trail,walk,construction'
+        terms: '<translate with synonyms or related terms for ''Path Under Construction'', separated by commas>'
+      highway/construction/primary:
+        # 'highway=construction, construction=primary'
+        name: Primary Road Under Construction
+        # 'terms: construction'
+        terms: '<translate with synonyms or related terms for ''Primary Road Under Construction'', separated by commas>'
+      highway/construction/primary_link:
+        # 'highway=construction, construction=primary_link'
+        name: Primary Link Under Construction
+        # 'terms: ramp,on ramp,off ramp,construction'
+        terms: '<translate with synonyms or related terms for ''Primary Link Under Construction'', separated by commas>'
+      highway/construction/residential:
+        # 'highway=construction, construction=residential'
+        name: Residential Road Under Construction
+        # 'terms: construction'
+        terms: '<translate with synonyms or related terms for ''Residential Road Under Construction'', separated by commas>'
+      highway/construction/road:
+        # 'highway=construction, construction=road'
+        name: Unknown Road Under Construction
+        # 'terms: construction'
+        terms: '<translate with synonyms or related terms for ''Unknown Road Under Construction'', separated by commas>'
+      highway/construction/secondary:
+        # 'highway=construction, construction=secondary'
+        name: Secondary Road Under Construction
+        # 'terms: construction'
+        terms: '<translate with synonyms or related terms for ''Secondary Road Under Construction'', separated by commas>'
+      highway/construction/secondary_link:
+        # 'highway=construction, construction=secondary_link'
+        name: Secondary Link Under Construction
+        # 'terms: ramp,on ramp,off ramp,construction'
+        terms: '<translate with synonyms or related terms for ''Secondary Link Under Construction'', separated by commas>'
+      highway/construction/service:
+        # 'highway=construction, construction=service'
+        name: Service Road Under Construction
+        # 'terms: construction'
+        terms: '<translate with synonyms or related terms for ''Service Road Under Construction'', separated by commas>'
+      highway/construction/service/alley:
+        # 'highway=construction, construction=service, service=alley'
+        name: Alley Under Construction
+        # 'terms: construction'
+        terms: '<translate with synonyms or related terms for ''Alley Under Construction'', separated by commas>'
+      highway/construction/service/drive-through:
+        # 'highway=construction, construction=service, service=drive-through'
+        name: Drive-Through Under Construction
+        # 'terms: construction'
+        terms: '<translate with synonyms or related terms for ''Drive-Through Under Construction'', separated by commas>'
+      highway/construction/service/driveway:
+        # 'highway=construction, construction=service, service=driveway'
+        name: Driveway Under Construction
+        # 'terms: construction'
+        terms: '<translate with synonyms or related terms for ''Driveway Under Construction'', separated by commas>'
+      highway/construction/service/emergency_access:
+        # 'highway=construction, construction=service, service=emergency_access'
+        name: Emergency Access Under Construction
+        # 'terms: construction'
+        terms: '<translate with synonyms or related terms for ''Emergency Access Under Construction'', separated by commas>'
+      highway/construction/service/parking_aisle:
+        # 'highway=construction, construction=service, service=parking_aisle'
+        name: Parking Aisle Under Construction
+        # 'terms: construction'
+        terms: '<translate with synonyms or related terms for ''Parking Aisle Under Construction'', separated by commas>'
+      highway/construction/tertiary:
+        # 'highway=construction, construction=tertiary'
+        name: Tertiary Road Under Construction
+        # 'terms: construction'
+        terms: '<translate with synonyms or related terms for ''Tertiary Road Under Construction'', separated by commas>'
+      highway/construction/tertiary_link:
+        # 'highway=construction, construction=tertiary_link'
+        name: Tertiary Link Under Construction
+        # 'terms: ramp,on ramp,off ramp,construction'
+        terms: '<translate with synonyms or related terms for ''Tertiary Link Under Construction'', separated by commas>'
+      highway/construction/trunk:
+        # 'highway=construction, construction=trunk'
+        name: Trunk Road Under Construction
+        # 'terms: construction'
+        terms: '<translate with synonyms or related terms for ''Trunk Road Under Construction'', separated by commas>'
+      highway/construction/trunk_link:
+        # 'highway=construction, construction=trunk_link'
+        name: Trunk Link Under Construction
+        # 'terms: ramp,on ramp,off ramp,construction'
+        terms: '<translate with synonyms or related terms for ''Trunk Link Under Construction'', separated by commas>'
+      highway/construction/unclassified:
+        # 'highway=construction, construction=unclassified'
+        name: Minor/Unclassified Road Under Construction
+        # 'terms: construction'
+        terms: '<translate with synonyms or related terms for ''Minor/Unclassified Road Under Construction'', separated by commas>'
       highway/corridor:
         # highway=corridor
         name: Indoor Corridor

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -4789,6 +4789,22 @@
             },
             "name": "Blood Donor Center"
         },
+        "highway/construction": {
+            "fields": [
+                "construction"
+            ],
+            "geometry": [
+                "point",
+                "vertex",
+                "line",
+                "area"
+            ],
+            "tags": {
+                "highway": "construction"
+            },
+            "searchable": false,
+            "name": "Highway Under Construction"
+        },
         "highway/bridleway": {
             "fields": [
                 "surface",
@@ -4827,6 +4843,513 @@
             },
             "terms": [],
             "name": "Bus Stop"
+        },
+        "highway/construction/bridleway": {
+            "fields": [
+                "structure"
+            ],
+            "icon": "highway-bridleway",
+            "geometry": [
+                "line"
+            ],
+            "tags": {
+                "highway": "construction",
+                "construction": "bridleway"
+            },
+            "matchScore": 0.5,
+            "terms": [
+                "bridleway",
+                "equestrian",
+                "horse",
+                "construction"
+            ],
+            "name": "Bridle Path Under Construction"
+        },
+        "highway/construction/cycleway": {
+            "icon": "highway-cycleway",
+            "fields": [
+                "oneway",
+                "structure"
+            ],
+            "geometry": [
+                "line"
+            ],
+            "tags": {
+                "highway": "construction",
+                "construction": "cycleway"
+            },
+            "matchScore": 0.5,
+            "terms": [
+                "bike",
+                "construction"
+            ],
+            "name": "Cycle Path Under Construction"
+        },
+        "highway/construction/footway": {
+            "icon": "highway-footway",
+            "fields": [
+                "structure"
+            ],
+            "geometry": [
+                "line",
+                "area"
+            ],
+            "terms": [
+                "hike",
+                "hiking",
+                "trackway",
+                "trail",
+                "walk",
+                "construction"
+            ],
+            "tags": {
+                "highway": "construction",
+                "construction": "footway"
+            },
+            "matchScore": 0.5,
+            "name": "Foot Path Under Construction"
+        },
+        "highway/construction/motorway_link": {
+            "icon": "highway-motorway-link",
+            "fields": [
+                "oneway_yes",
+                "structure",
+                "ref"
+            ],
+            "geometry": [
+                "line"
+            ],
+            "tags": {
+                "highway": "construction",
+                "construction": "motorway_link"
+            },
+            "addTags": {
+                "highway": "construction",
+                "construction": "motorway_link",
+                "oneway": "yes"
+            },
+            "removeTags": {
+                "highway": "construction",
+                "construction": "motorway_link",
+                "oneway": "yes"
+            },
+            "matchScore": 0.5,
+            "terms": [
+                "ramp",
+                "on ramp",
+                "off ramp",
+                "construction"
+            ],
+            "name": "Motorway Link Under Construction"
+        },
+        "highway/construction/motorway": {
+            "icon": "highway-motorway",
+            "fields": [
+                "oneway_yes",
+                "structure",
+                "ref"
+            ],
+            "geometry": [
+                "line"
+            ],
+            "tags": {
+                "highway": "construction",
+                "construction": "motorway"
+            },
+            "matchScore": 0.5,
+            "terms": [
+                "autobahn",
+                "expressway",
+                "freeway",
+                "highway",
+                "interstate",
+                "parkway",
+                "thruway",
+                "turnpike",
+                "construction"
+            ],
+            "name": "Motorway Under Construction"
+        },
+        "highway/construction/path": {
+            "icon": "highway-path",
+            "fields": [
+                "structure",
+                "incline",
+                "ref"
+            ],
+            "geometry": [
+                "line"
+            ],
+            "matchScore": 0.5,
+            "terms": [
+                "hike",
+                "hiking",
+                "trackway",
+                "trail",
+                "walk",
+                "construction"
+            ],
+            "tags": {
+                "highway": "construction",
+                "construction": "path"
+            },
+            "name": "Path Under Construction"
+        },
+        "highway/construction/primary_link": {
+            "icon": "highway-primary-link",
+            "fields": [
+                "oneway",
+                "structure",
+                "ref",
+                "cycleway"
+            ],
+            "geometry": [
+                "line"
+            ],
+            "tags": {
+                "highway": "construction",
+                "construction": "primary_link"
+            },
+            "matchScore": 0.5,
+            "terms": [
+                "ramp",
+                "on ramp",
+                "off ramp",
+                "construction"
+            ],
+            "name": "Primary Link Under Construction"
+        },
+        "highway/construction/primary": {
+            "icon": "highway-primary",
+            "fields": [
+                "oneway",
+                "structure",
+                "ref",
+                "cycleway"
+            ],
+            "geometry": [
+                "line"
+            ],
+            "tags": {
+                "highway": "construction",
+                "construction": "primary"
+            },
+            "matchScore": 0.5,
+            "terms": [
+                "construction"
+            ],
+            "name": "Primary Road Under Construction"
+        },
+        "highway/construction/residential": {
+            "icon": "highway-residential",
+            "fields": [
+                "oneway",
+                "structure",
+                "cycleway"
+            ],
+            "geometry": [
+                "line"
+            ],
+            "tags": {
+                "highway": "construction",
+                "construction": "residential"
+            },
+            "matchScore": 0.5,
+            "terms": [
+                "construction"
+            ],
+            "name": "Residential Road Under Construction"
+        },
+        "highway/construction/road": {
+            "icon": "highway-road",
+            "fields": [
+                "oneway",
+                "structure"
+            ],
+            "geometry": [
+                "line"
+            ],
+            "tags": {
+                "highway": "construction",
+                "construction": "road"
+            },
+            "matchScore": 0.5,
+            "terms": [
+                "construction"
+            ],
+            "name": "Unknown Road Under Construction"
+        },
+        "highway/construction/secondary_link": {
+            "icon": "highway-secondary-link",
+            "fields": [
+                "oneway",
+                "structure",
+                "ref",
+                "cycleway"
+            ],
+            "geometry": [
+                "line"
+            ],
+            "tags": {
+                "highway": "construction",
+                "construction": "secondary_link"
+            },
+            "matchScore": 0.5,
+            "terms": [
+                "ramp",
+                "on ramp",
+                "off ramp",
+                "construction"
+            ],
+            "name": "Secondary Link Under Construction"
+        },
+        "highway/construction/secondary": {
+            "icon": "highway-secondary",
+            "fields": [
+                "oneway",
+                "structure",
+                "cycleway"
+            ],
+            "geometry": [
+                "line"
+            ],
+            "tags": {
+                "highway": "construction",
+                "construction": "secondary"
+            },
+            "matchScore": 0.5,
+            "terms": [
+                "construction"
+            ],
+            "name": "Secondary Road Under Construction"
+        },
+        "highway/construction/service": {
+            "icon": "highway-service",
+            "fields": [
+                "service",
+                "oneway",
+                "structure"
+            ],
+            "geometry": [
+                "line"
+            ],
+            "tags": {
+                "highway": "construction",
+                "construction": "service"
+            },
+            "matchScore": 0.5,
+            "terms": [
+                "construction"
+            ],
+            "name": "Service Road Under Construction"
+        },
+        "highway/construction/service/alley": {
+            "icon": "highway-service",
+            "fields": [
+                "oneway",
+                "structure"
+            ],
+            "geometry": [
+                "line"
+            ],
+            "tags": {
+                "highway": "construction",
+                "construction": "service",
+                "service": "alley"
+            },
+            "matchScore": 0.5,
+            "terms": [
+                "construction"
+            ],
+            "name": "Alley Under Construction"
+        },
+        "highway/construction/service/drive-through": {
+            "icon": "highway-service",
+            "fields": [
+                "oneway",
+                "structure"
+            ],
+            "geometry": [
+                "line"
+            ],
+            "tags": {
+                "highway": "construction",
+                "construction": "service",
+                "service": "drive-through"
+            },
+            "matchScore": 0.5,
+            "terms": [
+                "construction"
+            ],
+            "name": "Drive-Through Under Construction"
+        },
+        "highway/construction/service/driveway": {
+            "icon": "highway-service",
+            "fields": [
+                "oneway",
+                "structure"
+            ],
+            "geometry": [
+                "line"
+            ],
+            "tags": {
+                "highway": "construction",
+                "construction": "service",
+                "service": "driveway"
+            },
+            "matchScore": 0.5,
+            "terms": [
+                "construction"
+            ],
+            "name": "Driveway Under Construction"
+        },
+        "highway/construction/service/emergency_access": {
+            "icon": "highway-service",
+            "fields": [
+                "oneway",
+                "structure"
+            ],
+            "geometry": [
+                "line"
+            ],
+            "tags": {
+                "highway": "construction",
+                "construction": "service",
+                "service": "emergency_access"
+            },
+            "matchScore": 0.5,
+            "terms": [
+                "construction"
+            ],
+            "name": "Emergency Access Under Construction"
+        },
+        "highway/construction/service/parking_aisle": {
+            "icon": "highway-service",
+            "fields": [
+                "oneway",
+                "structure"
+            ],
+            "geometry": [
+                "line"
+            ],
+            "tags": {
+                "highway": "construction",
+                "construction": "service",
+                "service": "parking_aisle"
+            },
+            "matchScore": 0.5,
+            "terms": [
+                "construction"
+            ],
+            "name": "Parking Aisle Under Construction"
+        },
+        "highway/construction/tertiary_link": {
+            "icon": "highway-tertiary-link",
+            "fields": [
+                "oneway",
+                "structure",
+                "ref",
+                "cycleway"
+            ],
+            "geometry": [
+                "line"
+            ],
+            "tags": {
+                "highway": "construction",
+                "construction": "tertiary_link"
+            },
+            "matchScore": 0.5,
+            "terms": [
+                "ramp",
+                "on ramp",
+                "off ramp",
+                "construction"
+            ],
+            "name": "Tertiary Link Under Construction"
+        },
+        "highway/construction/tertiary": {
+            "icon": "highway-tertiary",
+            "fields": [
+                "oneway",
+                "structure",
+                "ref",
+                "cycleway"
+            ],
+            "geometry": [
+                "line"
+            ],
+            "tags": {
+                "highway": "construction",
+                "construction": "tertiary"
+            },
+            "matchScore": 0.5,
+            "terms": [
+                "construction"
+            ],
+            "name": "Tertiary Road Under Construction"
+        },
+        "highway/construction/trunk_link": {
+            "icon": "highway-trunk",
+            "fields": [
+                "oneway",
+                "structure",
+                "ref"
+            ],
+            "geometry": [
+                "line"
+            ],
+            "tags": {
+                "highway": "construction",
+                "construction": "trunk_link"
+            },
+            "terms": [
+                "ramp",
+                "on ramp",
+                "off ramp",
+                "construction"
+            ],
+            "matchScore": 0.5,
+            "name": "Trunk Link Under Construction"
+        },
+        "highway/construction/trunk": {
+            "icon": "highway-trunk",
+            "fields": [
+                "oneway",
+                "structure",
+                "ref"
+            ],
+            "geometry": [
+                "line"
+            ],
+            "tags": {
+                "highway": "construction",
+                "construction": "trunk"
+            },
+            "matchScore": 0.5,
+            "terms": [
+                "construction"
+            ],
+            "name": "Trunk Road Under Construction"
+        },
+        "highway/construction/unclassified": {
+            "icon": "highway-unclassified",
+            "fields": [
+                "oneway",
+                "structure",
+                "cycleway"
+            ],
+            "geometry": [
+                "line"
+            ],
+            "tags": {
+                "highway": "construction",
+                "construction": "unclassified"
+            },
+            "terms": [
+                "construction"
+            ],
+            "matchScore": 0.5,
+            "name": "Minor/Unclassified Road Under Construction"
         },
         "highway/corridor": {
             "icon": "highway-footway",

--- a/data/presets/presets/highway/_construction.json
+++ b/data/presets/presets/highway/_construction.json
@@ -1,0 +1,16 @@
+{
+    "fields": [
+        "construction"
+    ],
+    "geometry": [
+        "point",
+        "vertex",
+        "line",
+        "area"
+    ],
+    "tags": {
+        "highway": "construction"
+    },
+    "searchable": false,
+    "name": "Highway Under Construction"
+}

--- a/data/presets/presets/highway/construction/bridleway.json
+++ b/data/presets/presets/highway/construction/bridleway.json
@@ -1,0 +1,21 @@
+{
+    "fields": [
+        "structure"
+    ],
+    "icon": "highway-bridleway",
+    "geometry": [
+        "line"
+    ],
+    "tags": {
+        "highway": "construction",
+        "construction": "bridleway"
+    },
+    "matchScore": 0.5,
+    "terms": [
+        "bridleway",
+        "equestrian",
+        "horse",
+        "construction"
+    ],
+    "name": "Bridle Path Under Construction"
+}

--- a/data/presets/presets/highway/construction/cycleway.json
+++ b/data/presets/presets/highway/construction/cycleway.json
@@ -1,0 +1,20 @@
+{
+    "icon": "highway-cycleway",
+    "fields": [
+        "oneway",
+        "structure"
+    ],
+    "geometry": [
+        "line"
+    ],
+    "tags": {
+        "highway": "construction",
+        "construction": "cycleway"
+    },
+    "matchScore": 0.5,
+    "terms": [
+        "bike",
+        "construction"
+    ],
+    "name": "Cycle Path Under Construction"
+}

--- a/data/presets/presets/highway/construction/footway.json
+++ b/data/presets/presets/highway/construction/footway.json
@@ -1,0 +1,23 @@
+{
+    "icon": "highway-footway",
+    "fields": [
+        "structure"
+    ],
+    "geometry": [
+        "line", "area"
+    ],
+    "terms": [
+        "hike",
+        "hiking",
+        "trackway",
+        "trail",
+        "walk",
+        "construction"
+    ],
+    "tags": {
+        "highway": "construction",
+        "construction": "footway"
+    },
+    "matchScore": 0.5,
+    "name": "Foot Path Under Construction"
+}

--- a/data/presets/presets/highway/construction/motorway.json
+++ b/data/presets/presets/highway/construction/motorway.json
@@ -1,0 +1,28 @@
+{
+    "icon": "highway-motorway",
+    "fields": [
+        "oneway_yes",
+        "structure",
+        "ref"
+    ],
+    "geometry": [
+        "line"
+    ],
+    "tags": {
+        "highway": "construction",
+        "construction": "motorway"
+    },
+    "matchScore": 0.5,
+    "terms": [
+        "autobahn",
+        "expressway",
+        "freeway",
+        "highway",
+        "interstate",
+        "parkway",
+        "thruway",
+        "turnpike",
+        "construction"
+    ],
+    "name": "Motorway Under Construction"
+}

--- a/data/presets/presets/highway/construction/motorway_link.json
+++ b/data/presets/presets/highway/construction/motorway_link.json
@@ -1,0 +1,33 @@
+{
+    "icon": "highway-motorway-link",
+    "fields": [
+        "oneway_yes",
+        "structure",
+        "ref"
+    ],
+    "geometry": [
+        "line"
+    ],
+    "tags": {
+        "highway": "construction",
+        "construction": "motorway_link"
+    },
+    "addTags": {
+        "highway": "construction",
+        "construction": "motorway_link",
+        "oneway": "yes"
+    },
+    "removeTags": {
+        "highway": "construction",
+        "construction": "motorway_link",
+        "oneway": "yes"
+    },
+    "matchScore": 0.5,
+    "terms": [
+        "ramp",
+        "on ramp",
+        "off ramp",
+        "construction"
+    ],
+    "name": "Motorway Link Under Construction"
+}

--- a/data/presets/presets/highway/construction/path.json
+++ b/data/presets/presets/highway/construction/path.json
@@ -1,0 +1,25 @@
+{
+    "icon": "highway-path",
+    "fields": [
+        "structure",
+        "incline",
+        "ref"
+    ],
+    "geometry": [
+        "line"
+    ],
+    "matchScore": 0.5,
+    "terms": [
+        "hike",
+        "hiking",
+        "trackway",
+        "trail",
+        "walk",
+        "construction"
+    ],
+    "tags": {
+        "highway": "construction",
+        "construction": "path"
+    },
+    "name": "Path Under Construction"
+}

--- a/data/presets/presets/highway/construction/primary.json
+++ b/data/presets/presets/highway/construction/primary.json
@@ -1,0 +1,21 @@
+{
+    "icon": "highway-primary",
+    "fields": [
+        "oneway",
+        "structure",
+        "ref",
+        "cycleway"
+    ],
+    "geometry": [
+        "line"
+    ],
+    "tags": {
+        "highway": "construction",
+        "construction": "primary"
+    },
+    "matchScore": 0.5,
+    "terms": [
+        "construction"
+    ],
+    "name": "Primary Road Under Construction"
+}

--- a/data/presets/presets/highway/construction/primary_link.json
+++ b/data/presets/presets/highway/construction/primary_link.json
@@ -1,0 +1,24 @@
+{
+    "icon": "highway-primary-link",
+    "fields": [
+        "oneway",
+        "structure",
+        "ref",
+        "cycleway"
+    ],
+    "geometry": [
+        "line"
+    ],
+    "tags": {
+        "highway": "construction",
+        "construction": "primary_link"
+    },
+    "matchScore": 0.5,
+    "terms": [
+        "ramp",
+        "on ramp",
+        "off ramp",
+        "construction"
+    ],
+    "name": "Primary Link Under Construction"
+}

--- a/data/presets/presets/highway/construction/residential.json
+++ b/data/presets/presets/highway/construction/residential.json
@@ -1,0 +1,20 @@
+{
+    "icon": "highway-residential",
+    "fields": [
+        "oneway",
+        "structure",
+        "cycleway"
+    ],
+    "geometry": [
+        "line"
+    ],
+    "tags": {
+        "highway": "construction",
+        "construction": "residential"
+    },
+    "matchScore": 0.5,
+    "terms": [
+        "construction"
+    ],
+    "name": "Residential Road Under Construction"
+}

--- a/data/presets/presets/highway/construction/road.json
+++ b/data/presets/presets/highway/construction/road.json
@@ -1,0 +1,19 @@
+{
+    "icon": "highway-road",
+    "fields": [
+        "oneway",
+        "structure"
+    ],
+    "geometry": [
+        "line"
+    ],
+    "tags": {
+        "highway": "construction",
+        "construction": "road"
+    },
+    "matchScore": 0.5,
+    "terms": [
+        "construction"
+    ],
+    "name": "Unknown Road Under Construction"
+}

--- a/data/presets/presets/highway/construction/secondary.json
+++ b/data/presets/presets/highway/construction/secondary.json
@@ -1,0 +1,20 @@
+{
+    "icon": "highway-secondary",
+    "fields": [
+        "oneway",
+        "structure",
+        "cycleway"
+    ],
+    "geometry": [
+        "line"
+    ],
+    "tags": {
+        "highway": "construction",
+        "construction": "secondary"
+    },
+    "matchScore": 0.5,
+    "terms": [
+        "construction"
+    ],
+    "name": "Secondary Road Under Construction"
+}

--- a/data/presets/presets/highway/construction/secondary_link.json
+++ b/data/presets/presets/highway/construction/secondary_link.json
@@ -1,0 +1,24 @@
+{
+    "icon": "highway-secondary-link",
+    "fields": [
+        "oneway",
+        "structure",
+        "ref",
+        "cycleway"
+    ],
+    "geometry": [
+        "line"
+    ],
+    "tags": {
+        "highway": "construction",
+        "construction": "secondary_link"
+    },
+    "matchScore": 0.5,
+    "terms": [
+        "ramp",
+        "on ramp",
+        "off ramp",
+        "construction"
+    ],
+    "name": "Secondary Link Under Construction"
+}

--- a/data/presets/presets/highway/construction/service.json
+++ b/data/presets/presets/highway/construction/service.json
@@ -1,0 +1,20 @@
+{
+    "icon": "highway-service",
+    "fields": [
+        "service",
+        "oneway",
+        "structure"
+    ],
+    "geometry": [
+        "line"
+    ],
+    "tags": {
+        "highway": "construction",
+        "construction": "service"
+    },
+    "matchScore": 0.5,
+    "terms": [
+        "construction"
+    ],
+    "name": "Service Road Under Construction"
+}

--- a/data/presets/presets/highway/construction/service/alley.json
+++ b/data/presets/presets/highway/construction/service/alley.json
@@ -1,0 +1,20 @@
+{
+    "icon": "highway-service",
+    "fields": [
+        "oneway",
+        "structure"
+    ],
+    "geometry": [
+        "line"
+    ],
+    "tags": {
+        "highway": "construction",
+        "construction": "service",
+        "service": "alley"
+    },
+    "matchScore": 0.5,
+    "terms": [
+        "construction"
+    ],
+    "name": "Alley Under Construction"
+}

--- a/data/presets/presets/highway/construction/service/drive-through.json
+++ b/data/presets/presets/highway/construction/service/drive-through.json
@@ -1,0 +1,20 @@
+{
+    "icon": "highway-service",
+    "fields": [
+        "oneway",
+        "structure"
+    ],
+    "geometry": [
+        "line"
+    ],
+    "tags": {
+        "highway": "construction",
+        "construction": "service",
+        "service": "drive-through"
+    },
+    "matchScore": 0.5,
+    "terms": [
+        "construction"
+    ],
+    "name": "Drive-Through Under Construction"
+}

--- a/data/presets/presets/highway/construction/service/driveway.json
+++ b/data/presets/presets/highway/construction/service/driveway.json
@@ -1,0 +1,20 @@
+{
+    "icon": "highway-service",
+    "fields": [
+        "oneway",
+        "structure"
+    ],
+    "geometry": [
+        "line"
+    ],
+    "tags": {
+        "highway": "construction",
+        "construction": "service",
+        "service": "driveway"
+    },
+    "matchScore": 0.5,
+    "terms": [
+        "construction"
+    ],
+    "name": "Driveway Under Construction"
+}

--- a/data/presets/presets/highway/construction/service/emergency_access.json
+++ b/data/presets/presets/highway/construction/service/emergency_access.json
@@ -1,0 +1,20 @@
+{
+    "icon": "highway-service",
+    "fields": [
+        "oneway",
+        "structure"
+    ],
+    "geometry": [
+        "line"
+    ],
+    "tags": {
+        "highway": "construction",
+        "construction": "service",
+        "service": "emergency_access"
+    },
+    "matchScore": 0.5,
+    "terms": [
+        "construction"
+    ],
+    "name": "Emergency Access Under Construction"
+}

--- a/data/presets/presets/highway/construction/service/parking_aisle.json
+++ b/data/presets/presets/highway/construction/service/parking_aisle.json
@@ -1,0 +1,20 @@
+{
+    "icon": "highway-service",
+    "fields": [
+        "oneway",
+        "structure"
+    ],
+    "geometry": [
+        "line"
+    ],
+    "tags": {
+        "highway": "construction",
+        "construction": "service",
+        "service": "parking_aisle"
+    },
+    "matchScore": 0.5,
+    "terms": [
+        "construction"
+    ],
+    "name": "Parking Aisle Under Construction"
+}

--- a/data/presets/presets/highway/construction/tertiary.json
+++ b/data/presets/presets/highway/construction/tertiary.json
@@ -1,0 +1,21 @@
+{
+    "icon": "highway-tertiary",
+    "fields": [
+        "oneway",
+        "structure",
+        "ref",
+        "cycleway"
+    ],
+    "geometry": [
+        "line"
+    ],
+    "tags": {
+        "highway": "construction",
+        "construction": "tertiary"
+    },
+    "matchScore": 0.5,
+    "terms": [
+        "construction"
+    ],
+    "name": "Tertiary Road Under Construction"
+}

--- a/data/presets/presets/highway/construction/tertiary_link.json
+++ b/data/presets/presets/highway/construction/tertiary_link.json
@@ -1,0 +1,24 @@
+{
+    "icon": "highway-tertiary-link",
+    "fields": [
+        "oneway",
+        "structure",
+        "ref",
+        "cycleway"
+    ],
+    "geometry": [
+        "line"
+    ],
+    "tags": {
+        "highway": "construction",
+        "construction": "tertiary_link"
+    },
+    "matchScore": 0.5,
+    "terms": [
+        "ramp",
+        "on ramp",
+        "off ramp",
+        "construction"
+    ],
+    "name": "Tertiary Link Under Construction"
+}

--- a/data/presets/presets/highway/construction/trunk.json
+++ b/data/presets/presets/highway/construction/trunk.json
@@ -1,0 +1,20 @@
+{
+    "icon": "highway-trunk",
+    "fields": [
+        "oneway",
+        "structure",
+        "ref"
+    ],
+    "geometry": [
+        "line"
+    ],
+    "tags": {
+        "highway": "construction",
+        "construction": "trunk"
+    },
+    "matchScore": 0.5,
+    "terms": [
+        "construction"
+    ],
+    "name": "Trunk Road Under Construction"
+}

--- a/data/presets/presets/highway/construction/trunk_link.json
+++ b/data/presets/presets/highway/construction/trunk_link.json
@@ -1,0 +1,23 @@
+{
+    "icon": "highway-trunk",
+    "fields": [
+        "oneway",
+        "structure",
+        "ref"
+    ],
+    "geometry": [
+        "line"
+    ],
+    "tags": {
+        "highway": "construction",
+        "construction": "trunk_link"
+    },
+    "terms": [
+        "ramp",
+        "on ramp",
+        "off ramp",
+        "construction"
+    ],
+    "matchScore": 0.5,
+    "name": "Trunk Link Under Construction"
+}

--- a/data/presets/presets/highway/construction/unclassified.json
+++ b/data/presets/presets/highway/construction/unclassified.json
@@ -1,0 +1,20 @@
+{
+    "icon": "highway-unclassified",
+    "fields": [
+        "oneway",
+        "structure",
+        "cycleway"
+    ],
+    "geometry": [
+        "line"
+    ],
+    "tags": {
+        "highway": "construction",
+        "construction": "unclassified"
+    },
+    "terms": [
+        "construction"
+    ],
+    "matchScore": 0.5,
+    "name": "Minor/Unclassified Road Under Construction"
+}

--- a/data/taginfo.json
+++ b/data/taginfo.json
@@ -1052,11 +1052,107 @@
         },
         {
             "key": "highway",
+            "value": "construction"
+        },
+        {
+            "key": "highway",
             "value": "bridleway"
         },
         {
             "key": "highway",
             "value": "bus_stop"
+        },
+        {
+            "key": "construction",
+            "value": "bridleway"
+        },
+        {
+            "key": "construction",
+            "value": "cycleway"
+        },
+        {
+            "key": "construction",
+            "value": "footway"
+        },
+        {
+            "key": "construction",
+            "value": "motorway_link"
+        },
+        {
+            "key": "construction",
+            "value": "motorway"
+        },
+        {
+            "key": "construction",
+            "value": "path"
+        },
+        {
+            "key": "construction",
+            "value": "primary_link"
+        },
+        {
+            "key": "construction",
+            "value": "primary"
+        },
+        {
+            "key": "construction",
+            "value": "residential"
+        },
+        {
+            "key": "construction",
+            "value": "road"
+        },
+        {
+            "key": "construction",
+            "value": "secondary_link"
+        },
+        {
+            "key": "construction",
+            "value": "secondary"
+        },
+        {
+            "key": "construction",
+            "value": "service"
+        },
+        {
+            "key": "service",
+            "value": "alley"
+        },
+        {
+            "key": "service",
+            "value": "drive-through"
+        },
+        {
+            "key": "service",
+            "value": "driveway"
+        },
+        {
+            "key": "service",
+            "value": "emergency_access"
+        },
+        {
+            "key": "service",
+            "value": "parking_aisle"
+        },
+        {
+            "key": "construction",
+            "value": "tertiary_link"
+        },
+        {
+            "key": "construction",
+            "value": "tertiary"
+        },
+        {
+            "key": "construction",
+            "value": "trunk_link"
+        },
+        {
+            "key": "construction",
+            "value": "trunk"
+        },
+        {
+            "key": "construction",
+            "value": "unclassified"
         },
         {
             "key": "highway",

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -2849,6 +2849,10 @@
                     "name": "Blood Donor Center",
                     "terms": "blood bank,blood donation,blood transfusion,apheresis,plasmapheresis,plateletpheresis,stem cell donation"
                 },
+                "highway/construction": {
+                    "name": "Highway Under Construction",
+                    "terms": ""
+                },
                 "highway/bridleway": {
                     "name": "Bridle Path",
                     "terms": "bridleway,equestrian,horse"
@@ -2856,6 +2860,98 @@
                 "highway/bus_stop": {
                     "name": "Bus Stop",
                     "terms": ""
+                },
+                "highway/construction/bridleway": {
+                    "name": "Bridle Path Under Construction",
+                    "terms": "bridleway,equestrian,horse,construction"
+                },
+                "highway/construction/cycleway": {
+                    "name": "Cycle Path Under Construction",
+                    "terms": "bike,construction"
+                },
+                "highway/construction/footway": {
+                    "name": "Foot Path Under Construction",
+                    "terms": "hike,hiking,trackway,trail,walk,construction"
+                },
+                "highway/construction/motorway_link": {
+                    "name": "Motorway Link Under Construction",
+                    "terms": "ramp,on ramp,off ramp,construction"
+                },
+                "highway/construction/motorway": {
+                    "name": "Motorway Under Construction",
+                    "terms": "autobahn,expressway,freeway,highway,interstate,parkway,thruway,turnpike,construction"
+                },
+                "highway/construction/path": {
+                    "name": "Path Under Construction",
+                    "terms": "hike,hiking,trackway,trail,walk,construction"
+                },
+                "highway/construction/primary_link": {
+                    "name": "Primary Link Under Construction",
+                    "terms": "ramp,on ramp,off ramp,construction"
+                },
+                "highway/construction/primary": {
+                    "name": "Primary Road Under Construction",
+                    "terms": "construction"
+                },
+                "highway/construction/residential": {
+                    "name": "Residential Road Under Construction",
+                    "terms": "construction"
+                },
+                "highway/construction/road": {
+                    "name": "Unknown Road Under Construction",
+                    "terms": "construction"
+                },
+                "highway/construction/secondary_link": {
+                    "name": "Secondary Link Under Construction",
+                    "terms": "ramp,on ramp,off ramp,construction"
+                },
+                "highway/construction/secondary": {
+                    "name": "Secondary Road Under Construction",
+                    "terms": "construction"
+                },
+                "highway/construction/service": {
+                    "name": "Service Road Under Construction",
+                    "terms": "construction"
+                },
+                "highway/construction/service/alley": {
+                    "name": "Alley Under Construction",
+                    "terms": "construction"
+                },
+                "highway/construction/service/drive-through": {
+                    "name": "Drive-Through Under Construction",
+                    "terms": "construction"
+                },
+                "highway/construction/service/driveway": {
+                    "name": "Driveway Under Construction",
+                    "terms": "construction"
+                },
+                "highway/construction/service/emergency_access": {
+                    "name": "Emergency Access Under Construction",
+                    "terms": "construction"
+                },
+                "highway/construction/service/parking_aisle": {
+                    "name": "Parking Aisle Under Construction",
+                    "terms": "construction"
+                },
+                "highway/construction/tertiary_link": {
+                    "name": "Tertiary Link Under Construction",
+                    "terms": "ramp,on ramp,off ramp,construction"
+                },
+                "highway/construction/tertiary": {
+                    "name": "Tertiary Road Under Construction",
+                    "terms": "construction"
+                },
+                "highway/construction/trunk_link": {
+                    "name": "Trunk Link Under Construction",
+                    "terms": "ramp,on ramp,off ramp,construction"
+                },
+                "highway/construction/trunk": {
+                    "name": "Trunk Road Under Construction",
+                    "terms": "construction"
+                },
+                "highway/construction/unclassified": {
+                    "name": "Minor/Unclassified Road Under Construction",
+                    "terms": "construction"
                 },
                 "highway/corridor": {
                     "name": "Indoor Corridor",


### PR DESCRIPTION
💡 **Motivation**: Someone changed a cycleway under construction to a finished cycleway, presumably because iD showed `Highway` where it should have shown `Cycle Path Under Construction`.

👎 **Cons**: This will generate redundant work for the translators, but there may not be a cleaner way to handle all language's quirks. If you can think of a better way, feel free to improve.

➕➖ Because the diff is a bit unwieldy, here's a **change summary**:
* Add a preset file for each road type under construction, in a new subdir `.../highway/construction`. Service road types are under `.../highway/construction/service`.
* Create `.../highway/_construction.json`, for `highway=construction` without a recognized `construction=*`.