### PR TITLE
Do not suggest duplicate commit messages

### DIFF
--- a/modules/ui/commit.js
+++ b/modules/ui/commit.js
@@ -59,13 +59,18 @@ export function uiCommit(context) {
             if (err) return;
 
             var comments = [];
+            var addedComments = [];
 
             for (var i = 0; i < changesets.length; i++) {
                 if (changesets[i].tags.comment) {
-                    comments.push({
-                        title: changesets[i].tags.comment,
-                        value: changesets[i].tags.comment
-                    });
+                    if (addedComments.indexOf(changesets[i].tags.comment) === -1) {
+                        comments.push({
+                            title: changesets[i].tags.comment,
+                            value: changesets[i].tags.comment
+                        });
+
+                        addedComments.push(changesets[i].tags.comment);
+                    }
                 }
             }
 


### PR DESCRIPTION
This makes sure no duplicate commit messages are suggested.

The issue illustrated:
![screen shot](https://cloud.githubusercontent.com/assets/2631719/21944641/89f963ac-d9d7-11e6-9dc0-95ea4412d2f5.png)

I had to add a container variable to be able to use `indexOf`, the alternative would have been a loop as far as I know...