### PR TITLE
show "You have unsaved changes" message also in save mode

### DIFF
--- a/modules/core/context.js
+++ b/modules/core/context.js
@@ -131,8 +131,9 @@ export function coreContext() {
     };
 
     context.save = function() {
-        if (inIntro || (mode && mode.id === 'save') || d3.select('.modal').size()) return;
-        history.save();
+        if (inIntro || d3.select('.modal').size()) return;
+        if (!(mode && mode.id === 'save'))
+            history.save();
         if (history.hasChanges()) return t('save.unsaved_changes');
     };
 


### PR DESCRIPTION
While it makes sense to not save the state of the history in save mode (see 15bc08795d5a0daaeaddd804cdc6729e1dfff848) we should still display the *"You have unsaved changes"* browser message. This should remind people that changes are not actually saved unless the second save button is also pressed (see #3777).