### PR TITLE
Add geojson data layer

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -3588,7 +3588,8 @@ img.tile-removing {
   border-radius: 0 0 4px 0;
 }
 
-[dir='rtl'] .list-item-gpx-browse svg {
+[dir='rtl'] .list-item-gpx-browse svg,
+[dir='rtl'] .list-item-geojson-browse svg {
   transform: rotateY(180deg);
 }
 

--- a/css/map.css
+++ b/css/map.css
@@ -1529,6 +1529,21 @@ text.gpx {
     fill: #FF26D4;
 }
 
+/* GEOJSON Paths */
+.layer-geojson {
+    pointer-events: none;
+}
+
+path.geojson {
+    stroke: #2ECCFA;
+    stroke-width: 2;
+    fill: none;
+}
+
+text.geojson {
+    fill: #2ECCFA;
+}
+
 /* Mapillary Image Layer */
 
 .layer-mapillary-images {

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -480,6 +480,11 @@ en:
     drag_drop: "Drag and drop a .gpx file on the page, or click the button to the right to browse"
     zoom: "Zoom to GPX track"
     browse: "Browse for a .gpx file"
+  geojson:
+    local_layer: "Local GEOJSON file"
+    drag_drop: "Drag and drop a .geojson file on the page, or click the button to the right to browse"
+    zoom: "Zoom to GEOJSON"
+    browse: "Browse for a .geojson file"
   mapillary_images:
     tooltip: "Street-level photos from Mapillary"
     title: "Photo Overlay (Mapillary)"

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -590,6 +590,12 @@
             "zoom": "Zoom to GPX track",
             "browse": "Browse for a .gpx file"
         },
+        "geojson": {
+            "local_layer": "Local GEOJSON file",
+            "drag_drop": "Drag and drop a .geojson file on the page, or click the button to the right to browse",
+            "zoom": "Zoom to GEOJSON",
+            "browse": "Browse for a .geojson file"
+        },
         "mapillary_images": {
             "tooltip": "Street-level photos from Mapillary",
             "title": "Photo Overlay (Mapillary)"

--- a/modules/renderer/background.js
+++ b/modules/renderer/background.js
@@ -94,6 +94,11 @@ export function rendererBackground(context) {
             imageryUsed.push('Local GPX');
         }
 
+        var geojson = context.layers().layer('geojson');
+        if (geojson && geojson.enabled() && geojson.hasGeojson()) {
+            imageryUsed.push('Local GEOJSON');
+        }
+
         var mapillary_images = context.layers().layer('mapillary-images');
         if (mapillary_images && mapillary_images.enabled()) {
             imageryUsed.push('Mapillary Images');

--- a/modules/svg/geojson.js
+++ b/modules/svg/geojson.js
@@ -1,0 +1,168 @@
+import * as d3 from 'd3';
+import _ from 'lodash';
+import { geoExtent, geoPolygonIntersectsPolygon } from '../geo/index';
+import { utilDetect } from '../util/detect';
+
+export function svgGeoJson(projection, context, dispatch) {
+    var showLabels = true,
+        detected = utilDetect(),
+        layer;
+
+
+    function init() {
+        if (svgGeoJson.initialized) return;  // run once
+
+        svgGeoJson.geojson = {};
+        svgGeoJson.enabled = true;
+
+        function over() {
+            d3.event.stopPropagation();
+            d3.event.preventDefault();
+            d3.event.dataTransfer.dropEffect = 'copy';
+        }
+
+        d3.select('body')
+            .attr('dropzone', 'copy')
+            .on('drop.localggeojson', function() {
+                d3.event.stopPropagation();
+                d3.event.preventDefault();
+                if (!detected.filedrop) return;
+                drawGeojson.files(d3.event.dataTransfer.files);
+            })
+            .on('dragenter.localgeojson', over)
+            .on('dragexit.localgeojson', over)
+            .on('dragover.localgeojson', over);
+
+        svgGeoJson.initialized = true;
+    }
+
+
+    function drawGeojson(selection) {
+        var geojson = svgGeoJson.geojson,
+            enabled = svgGeoJson.enabled;
+
+        layer = selection.selectAll('.layer-geojson')
+            .data(enabled ? [0] : []);
+
+        layer.exit()
+            .remove();
+
+        layer = layer.enter()
+            .append('g')
+            .attr('class', 'layer-geojson')
+            .merge(layer);
+
+
+        var paths = layer
+            .selectAll('path')
+            .data([geojson]);
+
+        paths.exit()
+            .remove();
+
+        paths = paths.enter()
+            .append('path')
+            .attr('class', 'geojson')
+            .merge(paths);
+
+
+        var path = d3.geoPath(projection);
+
+        paths
+            .attr('d', path);
+
+
+        var labels = layer.selectAll('text')
+            .data(showLabels && geojson.features ? geojson.features : []);
+
+        labels.exit()
+            .remove();
+
+        labels = labels.enter()
+            .append('text')
+            .attr('class', 'geojson')
+            .merge(labels);
+
+        labels
+            .text(function(d) {
+                return d.properties.desc || d.properties.name;
+            })
+            .attr('x', function(d) {
+                var centroid = path.centroid(d);
+                return centroid[0] + 7;
+            })
+            .attr('y', function(d) {
+                var centroid = path.centroid(d);
+                return centroid[1];
+            });
+
+    }
+
+
+    drawGeojson.showLabels = function(_) {
+        if (!arguments.length) return showLabels;
+        showLabels = _;
+        return this;
+    };
+
+
+    drawGeojson.enabled = function(_) {
+        if (!arguments.length) return svgGeoJson.enabled;
+        svgGeoJson.enabled = _;
+        dispatch.call('change');
+        return this;
+    };
+
+
+    drawGeojson.hasGeojson = function() {
+        var geojson = svgGeoJson.geojson;
+        return (!(_.isEmpty(geojson) || _.isEmpty(geojson.features)));
+    };
+
+
+    drawGeojson.geojson = function(gj) {
+        if (!arguments.length) return svgGeoJson.geojson;
+        if (_.isEmpty(gj) || _.isEmpty(gj.features)) return this;
+        svgGeoJson.geojson = gj;
+        dispatch.call('change');
+        return this;
+    };
+
+
+    drawGeojson.files = function(fileList) {
+        if (!fileList.length) return this;
+        var f = fileList[0],
+            reader = new FileReader();
+
+        reader.onload = function(e) {
+            drawGeojson.geojson(JSON.parse(e.target.result)).fitZoom();
+        };
+
+        reader.readAsText(f);
+        return this;
+    };
+
+
+    drawGeojson.fitZoom = function() {
+        if (!this.hasGeojson()) return this;
+        var geojson = svgGeoJson.geojson;
+
+        var map = context.map(),
+            viewport = map.trimmedExtent().polygon(),
+            coords = _.reduce(geojson.features, function(coords, feature) {
+                var c = feature.geometry.coordinates;
+                return _.union(coords, feature.geometry.type === 'Point' ? [c] : c);
+            }, []);
+
+        if (!geoPolygonIntersectsPolygon(viewport, coords, true)) {
+            var extent = geoExtent(d3.geoBounds(geojson));
+            map.centerZoom(extent.center(), map.trimmedExtentZoom(extent));
+        }
+
+        return this;
+    };
+
+
+    init();
+    return drawGeojson;
+}

--- a/modules/svg/index.js
+++ b/modules/svg/index.js
@@ -2,6 +2,7 @@ export { svgAreas } from './areas.js';
 export { svgDebug } from './debug.js';
 export { svgDefs } from './defs.js';
 export { svgGpx } from './gpx.js';
+export { svgGeoJson } from './geojson.js';
 export { svgIcon } from './icon.js';
 export { svgLabels } from './labels.js';
 export { svgLayers } from './layers.js';

--- a/modules/svg/layers.js
+++ b/modules/svg/layers.js
@@ -4,6 +4,7 @@ import { utilRebind } from '../util/rebind';
 import { utilGetDimensions, utilSetDimensions } from '../util/dimensions';
 import { svgDebug } from './debug';
 import { svgGpx } from './gpx';
+import { svgGeoJson } from './geojson';
 import { svgMapillaryImages } from './mapillary_images';
 import { svgMapillarySigns } from './mapillary_signs';
 import { svgOsm } from './osm';
@@ -15,6 +16,7 @@ export function svgLayers(projection, context) {
         layers = [
             { id: 'osm', layer: svgOsm(projection, context, dispatch) },
             { id: 'gpx', layer: svgGpx(projection, context, dispatch) },
+            { id: 'geojson', layer: svgGeoJson(projection, context, dispatch) },
             { id: 'mapillary-images', layer: svgMapillaryImages(projection, context, dispatch) },
             { id: 'mapillary-signs',  layer: svgMapillarySigns(projection, context, dispatch) },
             { id: 'debug', layer: svgDebug(projection, context, dispatch) }

--- a/modules/ui/map_data.js
+++ b/modules/ui/map_data.js
@@ -81,6 +81,11 @@ export function uiMapData(context) {
         }
 
 
+        function clickGeoJson() {
+            toggleLayer('geojson');
+        }
+
+
         function clickMapillaryImages() {
             toggleLayer('mapillary-images');
             if (!showsLayer('mapillary-images')) {
@@ -270,6 +275,86 @@ export function uiMapData(context) {
         }
 
 
+
+        function drawGeoJsonItem(selection) {
+            var geojson = layers.layer('geojson'),
+                hasGeojson = geojson && geojson.hasGeojson(),
+                showsGeojson = hasGeojson && geojson.enabled();
+
+            var geojsonLayerItem = selection
+                .selectAll('.layer-list-geojson')
+                .data(geojson ? [0] : []);
+
+            // Exit
+            geojsonLayerItem.exit()
+                .remove();
+
+            // Enter
+            var enter = geojsonLayerItem.enter()
+                .append('ul')
+                .attr('class', 'layer-list layer-list-geojson')
+                .append('li')
+                .classed('list-item-geojson', true);
+
+            enter
+                .append('button')
+                .attr('class', 'list-item-geojson-extent')
+                .call(tooltip()
+                    .title(t('geojson.zoom'))
+                    .placement((textDirection === 'rtl') ? 'right' : 'left'))
+                .on('click', function() {
+                    d3.event.preventDefault();
+                    d3.event.stopPropagation();
+                    geojson.fitZoom();
+                })
+                .call(svgIcon('#icon-search'));
+
+            enter
+                .append('button')
+                .attr('class', 'list-item-geojson-browse')
+                .call(tooltip()
+                    .title(t('geojson.browse'))
+                    .placement((textDirection === 'rtl') ? 'right' : 'left'))
+                .on('click', function() {
+                    d3.select(document.createElement('input'))
+                        .attr('type', 'file')
+                        .on('change', function() {
+                            geojson.files(d3.event.target.files);
+                        })
+                        .node().click();
+                })
+                .call(svgIcon('#icon-geolocate'));
+
+            var labelGeojson = enter
+                .append('label')
+                .call(tooltip().title(t('geojson.drag_drop')).placement('top'));
+
+            labelGeojson
+                .append('input')
+                .attr('type', 'checkbox')
+                .on('change', clickGeoJson);
+
+            labelGeojson
+                .append('span')
+                .text(t('geojson.local_layer'));
+
+
+            // Update
+            geojsonLayerItem = geojsonLayerItem
+                .merge(enter);
+
+            geojsonLayerItem
+                .classed('active', showsGeojson)
+                .selectAll('input')
+                .property('disabled', !hasGeojson)
+                .property('checked', showsGeojson);
+
+            geojsonLayerItem
+                .selectAll('label')
+                .classed('deemphasize', !hasGeojson);
+        }
+
+
         function drawList(selection, data, type, name, change, active) {
             var items = selection.selectAll('li')
                 .data(data);
@@ -326,6 +411,7 @@ export function uiMapData(context) {
         function update() {
             dataLayerContainer.call(drawMapillaryItems);
             dataLayerContainer.call(drawGpxItem);
+            dataLayerContainer.call(drawGeoJsonItem);
 
             fillList.call(drawList, fills, 'radio', 'area_fill', setFill, showsFill);
             featureList.call(drawList, features, 'checkbox', 'feature', clickFeature, showsFeature);

--- a/modules/ui/map_in_map.js
+++ b/modules/ui/map_in_map.js
@@ -1,6 +1,6 @@
 import * as d3 from 'd3';
 import { d3keybinding } from '../lib/d3.keybinding.js';
-import { svgDebug, svgGpx } from '../svg/index';
+import { svgDebug, svgGpx, svgGeoJson } from '../svg/index';
 import { geoRawMercator } from '../geo/index';
 import { rendererTileLayer } from '../renderer/index';
 import { utilSetTransform } from '../util/index';
@@ -23,6 +23,7 @@ export function uiMapInMap(context) {
             overlayLayers = {},
             projection = geoRawMercator(),
             gpxLayer = svgGpx(projection, context).showLabels(false),
+            geojsonLayer = svgGeoJson(projection, context).showLabels(false),
             debugLayer = svgDebug(projection, context),
             zoom = d3.zoom()
                 .scaleExtent([ztok(0.5), ztok(24)])
@@ -232,6 +233,7 @@ export function uiMapInMap(context) {
                 .attr('class', 'map-in-map-data')
                 .merge(dataLayers)
                 .call(gpxLayer)
+                .call(geojsonLayer)
                 .call(debugLayer);
 
 

--- a/test/spec/svg/layers.js
+++ b/test/spec/svg/layers.js
@@ -26,12 +26,13 @@ describe('iD.svgLayers', function () {
     it('creates default data layers', function () {
         container.call(iD.svgLayers(projection, context));
         var nodes = container.selectAll('svg .data-layer').nodes();
-        expect(nodes.length).to.eql(5);
+        expect(nodes.length).to.eql(6);
         expect(d3.select(nodes[0])).to.be.classed('data-layer-osm');
         expect(d3.select(nodes[1])).to.be.classed('data-layer-gpx');
-        expect(d3.select(nodes[2])).to.be.classed('data-layer-mapillary-images');
-        expect(d3.select(nodes[3])).to.be.classed('data-layer-mapillary-signs');
-        expect(d3.select(nodes[4])).to.be.classed('data-layer-debug');
+        expect(d3.select(nodes[2])).to.be.classed('data-layer-geojson');
+        expect(d3.select(nodes[3])).to.be.classed('data-layer-mapillary-images');
+        expect(d3.select(nodes[4])).to.be.classed('data-layer-mapillary-signs');
+        expect(d3.select(nodes[5])).to.be.classed('data-layer-debug');
     });
 
 });


### PR DESCRIPTION
I had some geojson data from local sources that I wanted to use to create new objects and edit/improve existing ones. Rather than doing this programmatically (bulk imports or other ways of import etc) I wanted to have a way to display data on the map and work on it.

Even though iD had a data layer concept, I couldn't find a way to get some geojson data displayed on the map. I saw the `gpx` one though and used that as an example to create geojson data layer. Unlike `gpx`, geojson would have more information than some location points, but I think for now this is a good start.

I am not sure if using geojson as a base to edit is a common scenario or not. But I wanted to share this with the community anyway. I am using this feature locally and it has been helpful so far.

Looks like this is related to https://github.com/openstreetmap/iD/issues/2586