### PR TITLE
Add kml and geojson support to gpx layer

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -476,10 +476,10 @@ en:
   cannot_zoom: "Cannot zoom out further in current mode."
   full_screen: Toggle Full Screen
   gpx:
-    local_layer: "Local GPX file"
-    drag_drop: "Drag and drop a .gpx file on the page, or click the button to the right to browse"
-    zoom: "Zoom to GPX track"
-    browse: "Browse for a .gpx file"
+    local_layer: "Local file"
+    drag_drop: "Drag and drop a .gpx, .geojson or .kml file on the page, or click the button to the right to browse"
+    zoom: "Zoom to layer"
+    browse: "Browse for a file"
   mapillary_images:
     tooltip: "Street-level photos from Mapillary"
     title: "Photo Overlay (Mapillary)"

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -585,10 +585,10 @@
         "cannot_zoom": "Cannot zoom out further in current mode.",
         "full_screen": "Toggle Full Screen",
         "gpx": {
-            "local_layer": "Local GPX file",
-            "drag_drop": "Drag and drop a .gpx file on the page, or click the button to the right to browse",
-            "zoom": "Zoom to GPX track",
-            "browse": "Browse for a .gpx file"
+            "local_layer": "Local file",
+            "drag_drop": "Drag and drop a .gpx, .geojson or .kml file on the page, or click the button to the right to browse",
+            "zoom": "Zoom to layer",
+            "browse": "Browse for a file"
         },
         "mapillary_images": {
             "tooltip": "Street-level photos from Mapillary",


### PR DESCRIPTION
After @bhousel's comment on https://github.com/openstreetmap/iD/pull/3808 I updated existing gpx layer, added ability to read in .kml and .geojson files based on file extension.