### PR TITLE
Add notary preset

### DIFF
--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -3343,6 +3343,11 @@ en:
         # office=lawyer
         name: Law Office
         terms: '<translate with synonyms or related terms for ''Law Office'', separated by commas>'
+      office/lawyer/notary:
+        # 'office=lawyer, lawyer=notary'
+        name: Notary Office
+        # 'terms: clerk,signature,wills,deeds,estate'
+        terms: '<translate with synonyms or related terms for ''Notary Office'', separated by commas>'
       office/newspaper:
         # office=newspaper
         name: Newspaper

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -8466,6 +8466,31 @@
             "terms": [],
             "name": "Law Office"
         },
+        "office/lawyer/notary": {
+            "icon": "suitcase",
+            "fields": [
+                "address",
+                "building_area",
+                "opening_hours"
+            ],
+            "geometry": [
+                "point",
+                "vertex",
+                "area"
+            ],
+            "tags": {
+                "office": "lawyer",
+                "lawyer": "notary"
+            },
+            "terms": [
+                "clerk",
+                "signature",
+                "wills",
+                "deeds",
+                "estate"
+            ],
+            "name": "Notary Office"
+        },
         "office/newspaper": {
             "icon": "commercial",
             "fields": [

--- a/data/presets/presets/office/lawyer/notary.json
+++ b/data/presets/presets/office/lawyer/notary.json
@@ -1,0 +1,25 @@
+{
+    "icon": "suitcase",
+    "fields": [
+        "address",
+        "building_area",
+        "opening_hours"
+    ],
+    "geometry": [
+        "point",
+        "vertex",
+        "area"
+    ],
+    "tags": {
+        "office": "lawyer",
+        "lawyer": "notary"
+    },
+    "terms": [
+        "clerk",
+        "signature",
+        "wills",
+        "deeds",
+        "estate"
+    ],
+    "name": "Notary Office"
+}

--- a/data/taginfo.json
+++ b/data/taginfo.json
@@ -1857,6 +1857,10 @@
             "value": "lawyer"
         },
         {
+            "key": "lawyer",
+            "value": "notary"
+        },
+        {
             "key": "office",
             "value": "newspaper"
         },

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -3696,6 +3696,10 @@
                     "name": "Law Office",
                     "terms": ""
                 },
+                "office/lawyer/notary": {
+                    "name": "Notary Office",
+                    "terms": "clerk,signature,wills,deeds,estate"
+                },
                 "office/newspaper": {
                     "name": "Newspaper",
                     "terms": ""


### PR DESCRIPTION
Adding a commonly used tag for a notary office. It has more than a thousand uses on the map.

https://wiki.openstreetmap.org/wiki/Tag:office%3Dlawyer
http://taginfo.osm.org/tags/lawyer=notary