### PR TITLE
improve autozooming on non-gpx background data layers

### DIFF
--- a/modules/svg/gpx.js
+++ b/modules/svg/gpx.js
@@ -203,11 +203,25 @@ export function svgGpx(projection, context, dispatch) {
             viewport = map.trimmedExtent().polygon(),
             coords = _.reduce(geojson.features, function(coords, feature) {
                 var c = feature.geometry.coordinates;
-                return _.union(coords, feature.geometry.type === 'Point' ? [c] : c);
+                switch (feature.geometry.type) {
+                    case 'Point':
+                        c = [c];
+                    case 'MultiPoint':
+                    case 'LineString':
+                        break;
+
+                    case 'MultiPolygon':
+                        c = _.flatten(c);
+                    case 'Polygon':
+                    case 'MultiLineString':
+                        c = _.flatten(c);
+                        break;
+                }
+                return _.union(coords, c);
             }, []);
 
         if (!geoPolygonIntersectsPolygon(viewport, coords, true)) {
-            var extent = geoExtent(d3.geoBounds(geojson));
+            var extent = geoExtent(d3.geoBounds({ type: 'LineString', coordinates: coords }));
             map.centerZoom(extent.center(), map.trimmedExtentZoom(extent));
         }
 

--- a/modules/svg/gpx.js
+++ b/modules/svg/gpx.js
@@ -203,6 +203,8 @@ export function svgGpx(projection, context, dispatch) {
             viewport = map.trimmedExtent().polygon(),
             coords = _.reduce(geojson.features, function(coords, feature) {
                 var c = feature.geometry.coordinates;
+
+                /* eslint-disable no-fallthrough */
                 switch (feature.geometry.type) {
                     case 'Point':
                         c = [c];
@@ -217,6 +219,8 @@ export function svgGpx(projection, context, dispatch) {
                         c = _.flatten(c);
                         break;
                 }
+                /* eslint-enable no-fallthrough */
+
                 return _.union(coords, c);
             }, []);
 


### PR DESCRIPTION
The original implementation only worked for Points and LineStrings, but GeoJSON and KML can contain any geometry.

Aso, d3 is a bit [special](https://github.com/d3/d3-geo#d3-geo) when working with GeoJSON Polygons: it does require clockwise winding, but typical GeoJSON uses either counterclockwise winding ([RFC7946](https://tools.ietf.org/html/rfc7946#section-3.1.6)) or "winding doesn't matter" mode (old geojson.org spec). When inputing such GeoJSON (or KML) input, iD would zoom out all the way, which is not the intended behavior.
