### PR TITLE
Use cache to speed up development

### DIFF
--- a/development_server.js
+++ b/development_server.js
@@ -10,8 +10,7 @@ var gaze = require('gaze');
 var ecstatic = require('ecstatic');
 
 var building = false;
-
-
+var cache;
 if (process.argv[2] === 'develop') {
     build();
 
@@ -56,8 +55,8 @@ function build() {
             }),
             commonjs(),
             json()
-        ]
-
+        ],
+        cache: cache
     }).then(function (bundle) {
         bundle.write({
             format: 'iife',
@@ -66,10 +65,11 @@ function build() {
             useStrict: false
         });
         building = false;
+        cache = bundle;
         console.timeEnd('Rebuilt');
-
     }, function(err) {
         building = false;
+        cache = undefined;
         console.error(err);
     });
 }


### PR DESCRIPTION
I noticed rollup provides [cache](https://github.com/rollup/rollup/wiki/JavaScript-API) to speed up subsequent builds.
I am noticing 30-40% improvement.  😎 ( from 8500ms to 5000ms)
