### PR TITLE
Order to-be-created relations by dependencies in the changeset

### DIFF
--- a/modules/services/osm.js
+++ b/modules/services/osm.js
@@ -319,7 +319,8 @@ export default {
           // find a referenced relation in the current changeset
           function resolve(item){
             return _.find(relations, function(relation) {
-              return item.keyAttributes.ref === relation['@id'];
+              return item.keyAttributes.type === 'relation'
+                && item.keyAttributes.ref === relation['@id'];
             });
           }
           // a new item is an item that has not been already processed

--- a/modules/services/osm.js
+++ b/modules/services/osm.js
@@ -314,6 +314,52 @@ export default {
             });
             return ordered;
         }
+        // sort relations in a changeset by dependencies
+        function sort(changes) {
+          // find a referenced relation in the current changeset
+          function resolve(item){
+            return _.find(relations, function(relation) {
+              return item.keyAttributes.ref === relation['@id'];
+            });
+          }
+          // a new item is an item that has not been already processed
+          function isNew(item) {
+            return !sorted[ item['@id'] ] && !_.find(processing, function(proc){
+             return proc['@id'] === item['@id'];
+            });
+          }
+          var processing = [],
+              sorted = {},
+              relations = changes.relation;
+
+          if (!relations) return changes;
+
+          for (var i = 0; i < relations.length; i++) {
+
+            var relation = relations[i];
+
+            // skip relation if already sorted
+            if ( !sorted[relation['@id']] ) {
+              processing.push( relation );
+            }
+
+            while ( processing.length > 0 ){
+              var next = processing[0],
+                  deps = _.filter( _.compact(next.member.map(resolve)), isNew);
+
+              if ( deps.length === 0 ){
+                sorted[ next['@id'] ] = next;
+                processing.shift();
+              } else {
+                processing = deps.concat( processing );
+              }
+            }
+
+          }
+
+          changes.relation = _.values(sorted);
+          return changes;
+        }
 
         function rep(entity) {
             return entity.asJXON(changeset_id);
@@ -323,7 +369,7 @@ export default {
             osmChange: {
                 '@version': 0.6,
                 '@generator': 'iD',
-                'create': nest(changes.created.map(rep), ['node', 'way', 'relation']),
+                'create': sort(nest(changes.created.map(rep), ['node', 'way', 'relation'])),
                 'modify': nest(changes.modified.map(rep), ['node', 'way', 'relation']),
                 'delete': _.extend(nest(changes.deleted.map(rep), ['relation', 'way', 'node']), {'@if-unused': true})
             }

--- a/test/spec/services/osm.js
+++ b/test/spec/services/osm.js
@@ -365,8 +365,8 @@ describe('iD.serviceOsm', function () {
         it('includes creations ordered by dependencies', function() {
           var n = iD.Node({loc: [0, 0]}),
               w = iD.Way({nodes: [n.id]}),
-              r1 = iD.Relation({members: [{id: w.id}]}),
-              r2 = iD.Relation({members: [{id: r1.id}]}),
+              r1 = iD.Relation({members: [{id: w.id, type: 'way'}]}),
+              r2 = iD.Relation({members: [{id: r1.id, type: 'relation'}]}),
               changes = {created: [r2, r1, w, n], modified: [], deleted: []},
               jxon = connection.osmChangeJXON('1234', changes);
 
@@ -381,8 +381,8 @@ describe('iD.serviceOsm', function () {
           var r1 = iD.Relation(),
               r2 = iD.Relation(),
               changes, jxon;
-          r1.addMember({id: r2.id});
-          r2.addMember({id: r1.id});
+          r1.addMember({id: r2.id, type: 'relation'});
+          r2.addMember({id: r1.id, type: 'relation'});
           changes = {created: [r1,r2], modified: [], deleted: []};
           jxon = connection.osmChangeJXON('1234', changes);
 


### PR DESCRIPTION
This patch fixes #3208. In details:

* New relations are ordered in the changeset so that children appear in the file before their parents.
* Circular dependencies are not ordered because it is not possible. In this case, an osmChange will be generated, but the API will return an error. Ideally, the user interface should prevent users from creating circular dependencies. Hence, this case should not happen.
* The bug is specific to creations. I do not think that  we need a similar fix also for modifications and deletions.

Hope everything ok. Otherwise please let me know! :)
