### PR TITLE
reorder path preset category

### DIFF
--- a/data/presets/categories.json
+++ b/data/presets/categories.json
@@ -99,13 +99,13 @@
             "geometry": "line",
             "name": "Path Features",
             "members": [
-                "highway/pedestrian",
-                "footway/crosswalk",
-                "footway/sidewalk",
-                "highway/steps",
-                "highway/path",
-                "highway/footway",
                 "highway/cycleway",
+                "highway/footway",
+                "highway/pedestrian",
+                "highway/path",
+                "highway/steps",
+                "footway/sidewalk",
+                "footway/crosswalk",
                 "highway/bridleway"
             ]
         },

--- a/data/presets/categories/path.json
+++ b/data/presets/categories/path.json
@@ -3,13 +3,13 @@
     "geometry": "line",
     "name": "Path Features",
     "members": [
-        "highway/pedestrian",
-        "footway/crosswalk",
-        "footway/sidewalk",
-        "highway/steps",
-        "highway/path",
-        "highway/footway",
         "highway/cycleway",
+        "highway/footway",
+        "highway/pedestrian",
+        "highway/path",
+        "highway/steps",
+        "footway/sidewalk",
+        "footway/crosswalk",
         "highway/bridleway"
     ]
 }


### PR DESCRIPTION
I ordered better the `path` presets category, based on type and most used.

![captura de tela de 2017-03-07 14-40-53](https://cloud.githubusercontent.com/assets/666291/23670183/ab5cc614-0345-11e7-9a95-6a5d0997786f.png)
