### PR TITLE
Embed a raw tag editor on the commit pane

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -1673,7 +1673,7 @@ div.combobox {
 
 /* Adding form fields to tag editor */
 
-.inspector-inner .add-tag {
+.raw-tag-editor .add-tag {
     width: 40%;
     height: 30px;
     border-top: 0;
@@ -1681,11 +1681,11 @@ div.combobox {
     border-radius: 0 0 4px 4px;
 }
 
-.inspector-inner .add-tag:hover {
+.raw-tag-editor .add-tag:hover {
     background: rgba(0,0,0,.8);
 }
 
-.inspector-inner .add-tag .label {
+.raw-tag-editor .add-tag .label {
     display: none;
 }
 

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -1601,6 +1601,15 @@ div.combobox {
     clear: both;
 }
 
+.tag-row.readonly,
+.tag-row.readonly input.key,
+.tag-row.readonly input.value,
+.tag-row.readonly button.remove {
+    color: #777777;
+    background-color: #eee;
+    cursor: not-allowed;
+}
+
 .tag-row input {
     height: 31px;
     border: 0;

--- a/modules/osm/changeset.js
+++ b/modules/osm/changeset.js
@@ -46,6 +46,90 @@ _.extend(osmChangeset.prototype, {
     },
 
 
+    // Generate [osmChange](http://wiki.openstreetmap.org/wiki/OsmChange)
+    // XML. Returns a string.
+    osmChangeJXON: function(changes) {
+        var changeset_id = this.id;
+
+        function nest(x, order) {
+            var groups = {};
+            for (var i = 0; i < x.length; i++) {
+                var tagName = Object.keys(x[i])[0];
+                if (!groups[tagName]) groups[tagName] = [];
+                groups[tagName].push(x[i][tagName]);
+            }
+            var ordered = {};
+            order.forEach(function(o) {
+                if (groups[o]) ordered[o] = groups[o];
+            });
+            return ordered;
+        }
+
+
+        // sort relations in a changeset by dependencies
+        function sort(changes) {
+
+            // find a referenced relation in the current changeset
+            function resolve(item) {
+                return _.find(relations, function(relation) {
+                    return item.keyAttributes.type === 'relation'
+                        && item.keyAttributes.ref === relation['@id'];
+                });
+            }
+
+            // a new item is an item that has not been already processed
+            function isNew(item) {
+                return !sorted[ item['@id'] ] && !_.find(processing, function(proc) {
+                    return proc['@id'] === item['@id'];
+                });
+            }
+
+            var processing = [],
+                sorted = {},
+                relations = changes.relation;
+
+            if (!relations) return changes;
+
+            for (var i = 0; i < relations.length; i++) {
+                var relation = relations[i];
+
+                // skip relation if already sorted
+                if (!sorted[relation['@id']]) {
+                    processing.push(relation);
+                }
+
+                while (processing.length > 0) {
+                    var next = processing[0],
+                    deps = _.filter(_.compact(next.member.map(resolve)), isNew);
+                    if (deps.length === 0) {
+                        sorted[next['@id']] = next;
+                        processing.shift();
+                    } else {
+                        processing = deps.concat(processing);
+                    }
+                }
+            }
+
+            changes.relation = _.values(sorted);
+            return changes;
+        }
+
+        function rep(entity) {
+            return entity.asJXON(changeset_id);
+        }
+
+        return {
+            osmChange: {
+                '@version': 0.6,
+                '@generator': 'iD',
+                'create': sort(nest(changes.created.map(rep), ['node', 'way', 'relation'])),
+                'modify': nest(changes.modified.map(rep), ['node', 'way', 'relation']),
+                'delete': _.extend(nest(changes.deleted.map(rep), ['relation', 'way', 'node']), { '@if-unused': true })
+            }
+        };
+    },
+
+
     asGeoJSON: function() {
         return {};
     }

--- a/modules/ui/commit.js
+++ b/modules/ui/commit.js
@@ -214,7 +214,6 @@ export function uiCommit(context) {
             })
             .on('click.save', function() {
                 dispatch.call('save', this, changeset);
-                changeset = null;
             });
 
         saveButton
@@ -383,11 +382,11 @@ export function uiCommit(context) {
             var tags = _.clone(changeset.tags);
 
             _.forEach(changed, function(v, k) {
-                k = k.trim();
+                k = k.trim().substr(0, 255);
                 if (readOnlyTags.indexOf(k) !== -1) return;
 
                 if (k !== '' && v !== undefined) {
-                    tags[k] = v.trim();
+                    tags[k] = v.trim().substr(0, 255);
                 } else {
                     delete tags[k];
                 }
@@ -401,6 +400,12 @@ export function uiCommit(context) {
         }
 
     }
+
+
+    commit.reset = function() {
+        changeset = null;
+    };
+
 
     return utilRebind(commit, dispatch, 'on');
 }

--- a/modules/ui/success.js
+++ b/modules/ui/success.js
@@ -11,9 +11,6 @@ export function uiSuccess(context) {
 
 
     function success(selection) {
-        var message = (changeset.comment || t('success.edited_osm')).substring(0, 130) +
-            ' ' + context.connection().changesetURL(changeset.id);
-
         var header = selection
             .append('div')
             .attr('class', 'header fillL');
@@ -54,6 +51,10 @@ export function uiSuccess(context) {
             .attr('target', '_blank')
             .attr('href', changesetURL)
             .text(t('success.view_on_osm'));
+
+
+        var message = (changeset.tags.comment || t('success.edited_osm')).substring(0, 130) +
+            ' ' + context.connection().changesetURL(changeset.id);
 
         var sharing = {
             facebook: 'https://facebook.com/sharer/sharer.php?u=' + encodeURIComponent(changesetURL),

--- a/test/spec/osm/changeset.js
+++ b/test/spec/osm/changeset.js
@@ -12,6 +12,7 @@ describe('iD.osmChangeset', function () {
         expect(iD.osmChangeset({tags: {foo: 'bar'}}).tags).to.eql({foo: 'bar'});
     });
 
+
     describe('#asJXON', function () {
         it('converts a node to jxon', function() {
             var node = iD.osmChangeset({tags: {'comment': 'hello'}});
@@ -26,4 +27,100 @@ describe('iD.osmChangeset', function () {
             });
         });
     });
+
+
+    describe('#osmChangeJXON', function() {
+        it('converts change data to JXON', function() {
+            var changeset = iD.osmChangeset(),
+                jxon = changeset.osmChangeJXON({ created: [], modified: [], deleted: [] });
+
+            expect(jxon).to.eql({
+                osmChange: {
+                    '@version': 0.6,
+                    '@generator': 'iD',
+                    'create': {},
+                    'modify': {},
+                    'delete': { '@if-unused': true }
+                }
+            });
+        });
+
+        it('includes creations ordered by nodes, ways, relations', function() {
+            var n = iD.osmNode({ loc: [0, 0] }),
+                w = iD.osmWay(),
+                r = iD.osmRelation(),
+                c = iD.osmChangeset({ id: '1234' }),
+                changes = { created: [r, w, n], modified: [], deleted: [] },
+                jxon = c.osmChangeJXON(changes);
+
+            expect(d3.entries(jxon.osmChange.create)).to.eql([
+                { key: 'node', value: [n.asJXON('1234').node] },
+                { key: 'way', value: [w.asJXON('1234').way] },
+                { key: 'relation', value: [r.asJXON('1234').relation] }
+            ]);
+        });
+
+        it('includes creations ordered by dependencies', function() {
+            var n = iD.osmNode({ loc: [0, 0] }),
+                w = iD.osmWay({nodes: [n.id]}),
+                r1 = iD.osmRelation({ members: [{ id: w.id, type: 'way' }] }),
+                r2 = iD.osmRelation({ members: [{ id: r1.id, type: 'relation' }] }),
+                c = iD.osmChangeset({ id: '1234' }),
+                changes = { created: [r2, r1, w, n], modified: [], deleted: [] },
+                jxon = c.osmChangeJXON(changes);
+
+            expect(d3.entries(jxon.osmChange.create)).to.eql([
+                { key: 'node', value: [n.asJXON('1234').node] },
+                { key: 'way', value: [w.asJXON('1234').way] },
+                { key: 'relation', value: [r1.asJXON('1234').relation, r2.asJXON('1234').relation] },
+            ]);
+        });
+
+        it('includes creations ignoring circular dependencies', function() {
+            var r1 = iD.osmRelation(),
+                r2 = iD.osmRelation(),
+                c = iD.osmChangeset({ id: '1234' }),
+                changes, jxon;
+            r1.addMember({ id: r2.id, type: 'relation' });
+            r2.addMember({ id: r1.id, type: 'relation' });
+            changes = { created: [r1,r2], modified: [], deleted: [] };
+            jxon = c.osmChangeJXON(changes);
+
+            expect(d3.entries(jxon.osmChange.create)).to.eql([
+                { key: 'relation', value: [r1.asJXON('1234').relation, r2.asJXON('1234').relation] },
+            ]);
+        });
+
+        it('includes modifications', function() {
+            var n = iD.osmNode({ loc: [0, 0] }),
+                w = iD.osmWay(),
+                r = iD.osmRelation(),
+                c = iD.osmChangeset({ id: '1234' }),
+                changes = { created: [], modified: [r, w, n], deleted: [] },
+                jxon = c.osmChangeJXON(changes);
+
+            expect(jxon.osmChange.modify).to.eql({
+                node: [n.asJXON('1234').node],
+                way: [w.asJXON('1234').way],
+                relation: [r.asJXON('1234').relation]
+            });
+        });
+
+        it('includes deletions ordered by relations, ways, nodes', function() {
+            var n = iD.osmNode({ loc: [0, 0] }),
+                w = iD.osmWay(),
+                r = iD.osmRelation(),
+                c = iD.osmChangeset({ id: '1234' }),
+                changes = { created: [], modified: [], deleted: [n, w, r] },
+                jxon = c.osmChangeJXON(changes);
+
+            expect(d3.entries(jxon.osmChange.delete)).to.eql([
+                { key: 'relation', value: [r.asJXON('1234').relation] },
+                { key: 'way', value: [w.asJXON('1234').way] },
+                { key: 'node', value: [n.asJXON('1234').node] },
+                { key: '@if-unused', value: true }
+            ]);
+        });
+    });
+
 });

--- a/test/spec/services/osm.js
+++ b/test/spec/services/osm.js
@@ -333,95 +333,6 @@ describe('iD.serviceOsm', function () {
     });
 
 
-    describe('#osmChangeJXON', function() {
-        it('converts change data to JXON', function() {
-            var jxon = connection.osmChangeJXON('1234', {created: [], modified: [], deleted: []});
-
-            expect(jxon).to.eql({
-                osmChange: {
-                    '@version': 0.6,
-                    '@generator': 'iD',
-                    'create': {},
-                    'modify': {},
-                    'delete': {'@if-unused': true}
-                }
-            });
-        });
-
-        it('includes creations ordered by nodes, ways, relations', function() {
-            var n = iD.Node({loc: [0, 0]}),
-                w = iD.Way(),
-                r = iD.Relation(),
-                changes = {created: [r, w, n], modified: [], deleted: []},
-                jxon = connection.osmChangeJXON('1234', changes);
-
-            expect(d3.entries(jxon.osmChange.create)).to.eql([
-                {key: 'node', value: [n.asJXON('1234').node]},
-                {key: 'way', value: [w.asJXON('1234').way]},
-                {key: 'relation', value: [r.asJXON('1234').relation]}
-            ]);
-        });
-
-        it('includes creations ordered by dependencies', function() {
-          var n = iD.Node({loc: [0, 0]}),
-              w = iD.Way({nodes: [n.id]}),
-              r1 = iD.Relation({members: [{id: w.id, type: 'way'}]}),
-              r2 = iD.Relation({members: [{id: r1.id, type: 'relation'}]}),
-              changes = {created: [r2, r1, w, n], modified: [], deleted: []},
-              jxon = connection.osmChangeJXON('1234', changes);
-
-          expect(d3.entries(jxon.osmChange.create)).to.eql([
-              {key: 'node', value: [n.asJXON('1234').node]},
-              {key: 'way', value: [w.asJXON('1234').way]},
-              {key: 'relation', value: [r1.asJXON('1234').relation, r2.asJXON('1234').relation]},
-          ]);
-        });
-
-        it('includes creations ignoring circular dependencies', function() {
-          var r1 = iD.Relation(),
-              r2 = iD.Relation(),
-              changes, jxon;
-          r1.addMember({id: r2.id, type: 'relation'});
-          r2.addMember({id: r1.id, type: 'relation'});
-          changes = {created: [r1,r2], modified: [], deleted: []};
-          jxon = connection.osmChangeJXON('1234', changes);
-
-          expect(d3.entries(jxon.osmChange.create)).to.eql([
-              {key: 'relation', value: [r1.asJXON('1234').relation, r2.asJXON('1234').relation]},
-          ]);
-        });
-
-        it('includes modifications', function() {
-            var n = iD.Node({loc: [0, 0]}),
-                w = iD.Way(),
-                r = iD.Relation(),
-                changes = {created: [], modified: [r, w, n], deleted: []},
-                jxon = connection.osmChangeJXON('1234', changes);
-
-            expect(jxon.osmChange.modify).to.eql({
-                node: [n.asJXON('1234').node],
-                way: [w.asJXON('1234').way],
-                relation: [r.asJXON('1234').relation]
-            });
-        });
-
-        it('includes deletions ordered by relations, ways, nodes', function() {
-            var n = iD.Node({loc: [0, 0]}),
-                w = iD.Way(),
-                r = iD.Relation(),
-                changes = {created: [], modified: [], deleted: [n, w, r]},
-                jxon = connection.osmChangeJXON('1234', changes);
-
-            expect(d3.entries(jxon.osmChange.delete)).to.eql([
-                {key: 'relation', value: [r.asJXON('1234').relation]},
-                {key: 'way', value: [w.asJXON('1234').way]},
-                {key: 'node', value: [n.asJXON('1234').node]},
-                {key: '@if-unused', value: true}
-            ]);
-        });
-    });
-
-
     describe('#userChangesets', function() {
         var server, userDetailsFn;
 
@@ -524,13 +435,6 @@ describe('iD.serviceOsm', function () {
             server.respond();
         });
 
-    });
-
-
-    describe('#changesetTags', function() {
-        it('omits comment when empty', function() {
-            expect(connection.changesetTags('2.0.0', '', [])).not.to.have.property('comment');
-        });
     });
 
 


### PR DESCRIPTION
This will let users add and edit changeset tags before saving. 
re: #2834, #2633 

* The raw tag editor will always start out closed in this case. 
* No taginfo support for changeset tags, so dropdowns and tag autocompletion are disabled
* TODO:  The default iD tags will be protected and not allow editing.

![changeset_tags](https://cloud.githubusercontent.com/assets/38784/23876684/0bb058f4-0815-11e7-813b-830dd9d06230.gif)
