### PR TITLE
Draw selected objects after not-selected objects

### DIFF
--- a/css/50_misc.css
+++ b/css/50_misc.css
@@ -55,13 +55,13 @@ path.casing.tag-bridge {
 }
 
 path.shadow.tag-bridge {
-    stroke-width: 22;
+    stroke-width: 24;
 }
 path.casing.tag-bridge {
     stroke-width: 16;
 }
 .low-zoom path.shadow.tag-bridge {
-    stroke-width: 14;
+    stroke-width: 16;
 }
 .low-zoom path.casing.tag-bridge {
     stroke-width: 10;
@@ -78,7 +78,7 @@ path.shadow.tag-highway-steps.tag-bridge,
 path.shadow.tag-highway-footway.tag-bridge,
 path.shadow.tag-highway-cycleway.tag-bridge,
 path.shadow.tag-highway-bridleway.tag-bridge {
-    stroke-width: 17;
+    stroke-width: 18;
 }
 path.casing.line.tag-railway.tag-bridge,
 path.casing.tag-highway-living_street.tag-bridge,

--- a/modules/behavior/hash.js
+++ b/modules/behavior/hash.js
@@ -28,20 +28,17 @@ export function behaviorHash(context) {
             q = _.omit(utilStringQs(window.location.hash.substring(1)), 'comment'),
             newParams = {};
 
-        if (mode && mode.id === 'browse') {
-            delete q.id;
-        } else {
-            var selected = context.selectedIDs().filter(function(id) {
-                return !context.entity(id).isNew();
-            });
-            if (selected.length) {
-                newParams.id = selected.join(',');
-            }
+        delete q.id;
+        var selected = context.selectedIDs().filter(function(id) {
+            return !context.entity(id).isNew();
+        });
+        if (selected.length) {
+            newParams.id = selected.join(',');
         }
 
         newParams.map = zoom.toFixed(2) +
-                '/' + center[1].toFixed(precision) +
-                '/' + center[0].toFixed(precision);
+            '/' + center[1].toFixed(precision) +
+            '/' + center[0].toFixed(precision);
 
         return '#' + utilQsString(_.assign(q, newParams), true);
     };

--- a/modules/modes/select.js
+++ b/modules/modes/select.js
@@ -477,8 +477,8 @@ export function modeSelect(context, selectedIDs) {
 
             var loc = extent.center();
             context.map().centerEase(loc);
-        } else {
-            context.map().pan([0,0]);
+        } else if (singular() && singular().type === 'way') {
+            context.map().pan([0,0]);  // full redraw, to adjust z-sorting #2914
         }
 
         timeout = window.setTimeout(function() {

--- a/modules/modes/select.js
+++ b/modules/modes/select.js
@@ -477,6 +477,8 @@ export function modeSelect(context, selectedIDs) {
 
             var loc = extent.center();
             context.map().centerEase(loc);
+        } else {
+            context.map().pan([0,0]);
         }
 
         timeout = window.setTimeout(function() {

--- a/modules/renderer/map.js
+++ b/modules/renderer/map.js
@@ -42,7 +42,7 @@ export function rendererMap(context) {
         drawLayers = svgLayers(projection, context),
         drawPoints = svgPoints(projection, context),
         drawVertices = svgVertices(projection, context),
-        drawLines = svgLines(projection),
+        drawLines = svgLines(projection, context),
         drawAreas = svgAreas(projection, context),
         drawMidpoints = svgMidpoints(projection, context),
         drawLabels = svgLabels(projection, context),

--- a/modules/svg/lines.js
+++ b/modules/svg/lines.js
@@ -57,7 +57,9 @@ export function svgLines(projection, context) {
             // works because osmEntity.key is defined to include the entity v attribute.
             lines.enter()
                 .append('path')
-                .attr('class', function(d) { return 'way line ' + klass + ' ' + d.id; })
+                .attr('class', function(d) {
+                    return 'way line ' + klass + ' ' + d.id + (isSelected ? ' selected' : '');
+                })
                 .call(svgTagClasses())
                 .merge(lines)
                 .sort(waystack)

--- a/test/spec/svg/lines.js
+++ b/test/spec/svg/lines.js
@@ -22,7 +22,7 @@ describe('iD.svgLines', function () {
             line = iD.Way({nodes: [a.id, b.id]}),
             graph = iD.Graph([a, b, line]);
 
-        surface.call(iD.svgLines(projection), graph, [line], all);
+        surface.call(iD.svgLines(projection, context), graph, [line], all);
 
         expect(surface.select('path.way')).to.be.classed('way');
         expect(surface.select('path.line')).to.be.classed('line');
@@ -34,7 +34,7 @@ describe('iD.svgLines', function () {
             line = iD.Way({nodes: [a.id, b.id], tags: {highway: 'residential'}}),
             graph = iD.Graph([a, b, line]);
 
-        surface.call(iD.svgLines(projection), graph, [line], all);
+        surface.call(iD.svgLines(projection, context), graph, [line], all);
 
         expect(surface.select('.line')).to.be.classed('tag-highway');
         expect(surface.select('.line')).to.be.classed('tag-highway-residential');
@@ -47,7 +47,7 @@ describe('iD.svgLines', function () {
             relation = iD.Relation({members: [{id: line.id}], tags: {type: 'multipolygon', natural: 'wood'}}),
             graph = iD.Graph([a, b, line, relation]);
 
-        surface.call(iD.svgLines(projection), graph, [line], all);
+        surface.call(iD.svgLines(projection, context), graph, [line], all);
 
         expect(surface.select('.stroke')).to.be.classed('tag-natural-wood');
     });
@@ -60,7 +60,7 @@ describe('iD.svgLines', function () {
             r = iD.Relation({members: [{id: w.id}], tags: {type: 'multipolygon'}}),
             graph = iD.Graph([a, b, c, w, r]);
 
-        surface.call(iD.svgLines(projection), graph, [w], all);
+        surface.call(iD.svgLines(projection, context), graph, [w], all);
 
         expect(surface.select('.stroke')).to.be.classed('tag-natural-wood');
     });
@@ -74,7 +74,7 @@ describe('iD.svgLines', function () {
             r = iD.Relation({members: [{id: o.id, role: 'outer'}, {id: i.id, role: 'inner'}], tags: {type: 'multipolygon'}}),
             graph = iD.Graph([a, b, c, o, i, r]);
 
-        surface.call(iD.svgLines(projection), graph, [i], all);
+        surface.call(iD.svgLines(projection, context), graph, [i], all);
 
         expect(surface.select('.stroke')).to.be.classed('tag-natural-wood');
     });
@@ -90,7 +90,7 @@ describe('iD.svgLines', function () {
             ]);
 
         it('stacks higher lines above lower ones in a single render', function () {
-            surface.call(iD.svgLines(projection), graph, [graph.entity('lo'), graph.entity('hi')], none);
+            surface.call(iD.svgLines(projection, context), graph, [graph.entity('lo'), graph.entity('hi')], none);
 
             var selection = surface.selectAll('g.line-stroke > path.line');
             expect(selection.nodes()[0].__data__.id).to.eql('lo');
@@ -98,7 +98,7 @@ describe('iD.svgLines', function () {
         });
 
         it('stacks higher lines above lower ones in a single render (reverse)', function () {
-            surface.call(iD.svgLines(projection), graph, [graph.entity('hi'), graph.entity('lo')], none);
+            surface.call(iD.svgLines(projection, context), graph, [graph.entity('hi'), graph.entity('lo')], none);
 
             var selection = surface.selectAll('g.line-stroke > path.line');
             expect(selection.nodes()[0].__data__.id).to.eql('lo');
@@ -106,8 +106,8 @@ describe('iD.svgLines', function () {
         });
 
         it('stacks higher lines above lower ones in separate renders', function () {
-            surface.call(iD.svgLines(projection), graph, [graph.entity('lo')], none);
-            surface.call(iD.svgLines(projection), graph, [graph.entity('hi')], none);
+            surface.call(iD.svgLines(projection, context), graph, [graph.entity('lo')], none);
+            surface.call(iD.svgLines(projection, context), graph, [graph.entity('hi')], none);
 
             var selection = surface.selectAll('g.line-stroke > path.line');
             expect(selection.nodes()[0].__data__.id).to.eql('lo');
@@ -115,8 +115,8 @@ describe('iD.svgLines', function () {
         });
 
         it('stacks higher lines above lower in separate renders (reverse)', function () {
-            surface.call(iD.svgLines(projection), graph, [graph.entity('hi')], none);
-            surface.call(iD.svgLines(projection), graph, [graph.entity('lo')], none);
+            surface.call(iD.svgLines(projection, context), graph, [graph.entity('hi')], none);
+            surface.call(iD.svgLines(projection, context), graph, [graph.entity('lo')], none);
 
             var selection = surface.selectAll('g.line-stroke > path.line');
             expect(selection.nodes()[0].__data__.id).to.eql('lo');


### PR DESCRIPTION
This is a fix for #2914 to draw any selected ways in a separate group after the unselected ways.
Code still needs some cleanup

![halo order](https://cloud.githubusercontent.com/assets/38784/24134889/83a173f2-0ddd-11e7-937c-2e591773e7c4.gif)
