### PR TITLE
Support Arabic vowel signs, include more languages in generic RTL fix

### DIFF
--- a/modules/util/util.js
+++ b/modules/util/util.js
@@ -2,7 +2,7 @@ import * as d3 from 'd3';
 import { t, textDirection } from './locale';
 import { utilDetect } from './detect';
 import { remove as removeDiacritics } from 'diacritics';
-import { fixArabicScriptTextForSvg } from './svg_paths_arabic_fix';
+import { fixRTLTextForSvg, rtlRegex } from './svg_paths_rtl_fix';
 
 
 export function utilTagText(entity) {
@@ -76,10 +76,9 @@ export function utilDisplayName(entity) {
 export function utilDisplayNameForPath(entity) {
     var name = utilDisplayName(entity);
     var isFirefox = utilDetect().browser.toLowerCase().indexOf('firefox') > -1;
-    var arabicRegex = /[\u0600-\u06FF]/g;
 
-    if (!isFirefox && name && arabicRegex.test(name)) {
-        name = fixArabicScriptTextForSvg(name);
+    if (!isFirefox && name && rtlRegex.test(name)) {
+        name = fixRTLTextForSvg(name);
     }
 
     return name;


### PR DESCRIPTION
This takes the Arabic-specific regex and fix which we implemented earlier, and extends it to two other right-to-left scripts (Hebrew, and Thaana from the Maldives)

These two languages don't need special text-shaping like we did for Arabic, just right-to-left reversal to handle the Chrome bug, and keeping vowel signs together with the letter that they modify (sort of like ```N + ̃  = Ñ``` - reversing the string should not change which letter gets the tilde)

The Arabic code also gets the fix for vowel signs