### PR TITLE
Fix misleading connectivity error

### DIFF
--- a/dist/locales/en-GB.json
+++ b/dist/locales/en-GB.json
@@ -138,7 +138,7 @@
                 "key": "C",
                 "annotation": "Merged {n} features.",
                 "not_eligible": "These features can't be merged.",
-                "not_adjacent": "These features can't be merged because they aren't connected.",
+                "not_adjacent": "These features can't be merged because their endpoints aren't connected.",
                 "restriction": "These features can't be merged because at least one is a member of a \"{relation}\" relation.",
                 "incomplete_relation": "These features can't be merged because at least one hasn't been fully downloaded.",
                 "conflicting_tags": "These features can't be merged because some of their tags have conflicting values."

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -159,7 +159,7 @@
                 "key": "C",
                 "annotation": "Merged {n} features.",
                 "not_eligible": "These features can't be merged.",
-                "not_adjacent": "These features can't be merged because they aren't connected.",
+                "not_adjacent": "These features can't be merged because their endpoints aren't connected.",
                 "restriction": "These features can't be merged because at least one is a member of a \"{relation}\" relation.",
                 "incomplete_relation": "These features can't be merged because at least one hasn't been fully downloaded.",
                 "conflicting_tags": "These features can't be merged because some of their tags have conflicting values."


### PR DESCRIPTION
fixes #3952.

I think it's appropriate to fix this in /en.json and /en-GB.json, and it will update Transifex to request new translations for the other languages? I read the contributing.md but didn't see how that was supposed to be handled, let me know if this is wrong.