### PR TITLE
Added fields for address in Ukraine

### DIFF
--- a/data/address-formats.json
+++ b/data/address-formats.json
@@ -110,6 +110,13 @@
                 ["street", "housenumber"],
                 ["postcode", "district", "city"]
             ]
+        },
+        {
+            "countryCodes": ["ua"],
+            "format": [
+                ["housenumber", "postcode"],
+                ["street"]
+            ]
         }
     ]
 }


### PR DESCRIPTION
As Ukrainian OSM Community don't fill in `addr:city` for each building, It is better to decrease amount of fields for adding addresses.
>Теґ addr:city=* в Україні зазвичай не використовується.

☝️ https://wiki.openstreetmap.org/wiki/Uk:Addresses