### PR TITLE
Change ordering in highway fields presets

### DIFF
--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -5349,10 +5349,10 @@
         "highway/cycleway": {
             "icon": "highway-cycleway",
             "fields": [
+                "oneway",
                 "surface",
                 "lit",
                 "width",
-                "oneway",
                 "structure",
                 "access"
             ],
@@ -5415,11 +5415,11 @@
             "fields": [
                 "oneway",
                 "maxspeed",
-                "structure",
-                "access",
                 "lanes",
                 "surface",
+                "structure",
                 "maxheight",
+                "access",
                 "cycleway"
             ],
             "geometry": [
@@ -5459,14 +5459,14 @@
         "highway/motorway_link": {
             "icon": "highway-motorway-link",
             "fields": [
+                "ref",
                 "oneway_yes",
                 "maxspeed",
-                "structure",
-                "access",
                 "lanes",
                 "surface",
                 "maxheight",
-                "ref"
+                "structure",
+                "access"
             ],
             "geometry": [
                 "line"
@@ -5492,15 +5492,15 @@
         "highway/motorway": {
             "icon": "highway-motorway",
             "fields": [
+                "ref",
                 "oneway_yes",
                 "maxspeed",
-                "structure",
-                "access",
                 "lanes",
                 "surface",
                 "maxheight",
                 "toll",
-                "ref"
+                "structure",
+                "access"
             ],
             "geometry": [
                 "line"
@@ -5575,13 +5575,13 @@
             "fields": [
                 "oneway",
                 "maxspeed",
-                "structure",
-                "access",
                 "lanes",
                 "surface",
                 "maxheight",
                 "ref",
-                "cycleway"
+                "cycleway",
+                "structure",
+                "access"
             ],
             "geometry": [
                 "line"
@@ -5601,13 +5601,13 @@
             "fields": [
                 "oneway",
                 "maxspeed",
-                "structure",
-                "access",
                 "lanes",
                 "surface",
                 "maxheight",
                 "ref",
-                "cycleway"
+                "cycleway",
+                "structure",
+                "access"
             ],
             "geometry": [
                 "line"
@@ -5624,10 +5624,10 @@
                 "oneway",
                 "surface",
                 "sport_racing_motor",
-                "structure",
                 "lit",
                 "width",
-                "lanes"
+                "lanes",
+                "structure"
             ],
             "geometry": [
                 "point",
@@ -5657,12 +5657,12 @@
             "fields": [
                 "oneway",
                 "maxspeed",
-                "structure",
-                "access",
                 "lanes",
                 "surface",
                 "maxheight",
-                "cycleway"
+                "cycleway",
+                "structure",
+                "access"
             ],
             "geometry": [
                 "line"
@@ -5693,11 +5693,11 @@
             "fields": [
                 "oneway",
                 "maxspeed",
-                "structure",
-                "access",
                 "lanes",
                 "surface",
-                "maxheight"
+                "maxheight",
+                "structure",
+                "access"
             ],
             "geometry": [
                 "line"
@@ -5713,13 +5713,13 @@
             "fields": [
                 "oneway",
                 "maxspeed",
-                "structure",
-                "access",
                 "lanes",
                 "surface",
                 "maxheight",
                 "ref",
-                "cycleway"
+                "cycleway",
+                "structure",
+                "access"
             ],
             "geometry": [
                 "line"
@@ -5739,13 +5739,13 @@
             "fields": [
                 "oneway",
                 "maxspeed",
-                "structure",
-                "access",
                 "lanes",
                 "surface",
                 "maxheight",
                 "ref",
-                "cycleway"
+                "cycleway",
+                "structure",
+                "access"
             ],
             "geometry": [
                 "line"
@@ -5762,10 +5762,10 @@
                 "service",
                 "oneway",
                 "maxspeed",
-                "structure",
-                "access",
                 "surface",
-                "maxheight"
+                "maxheight",
+                "structure",
+                "access"
             ],
             "geometry": [
                 "line"
@@ -5991,13 +5991,13 @@
             "fields": [
                 "oneway",
                 "maxspeed",
-                "structure",
-                "access",
                 "lanes",
                 "surface",
                 "maxheight",
                 "ref",
-                "cycleway"
+                "cycleway",
+                "structure",
+                "access"
             ],
             "geometry": [
                 "line"
@@ -6017,13 +6017,13 @@
             "fields": [
                 "oneway",
                 "maxspeed",
-                "structure",
-                "access",
                 "lanes",
                 "surface",
                 "maxheight",
                 "ref",
-                "cycleway"
+                "cycleway",
+                "structure",
+                "access"
             ],
             "geometry": [
                 "line"
@@ -6119,14 +6119,14 @@
         "highway/trunk_link": {
             "icon": "highway-trunk-link",
             "fields": [
+                "ref",
                 "oneway",
                 "maxspeed",
-                "structure",
-                "access",
                 "lanes",
                 "surface",
                 "maxheight",
-                "ref"
+                "structure",
+                "access"
             ],
             "geometry": [
                 "line"
@@ -6144,15 +6144,15 @@
         "highway/trunk": {
             "icon": "highway-trunk",
             "fields": [
+                "ref",
                 "oneway",
                 "maxspeed",
-                "structure",
-                "access",
                 "lanes",
                 "surface",
                 "maxheight",
                 "toll",
-                "ref"
+                "structure",
+                "access"
             ],
             "geometry": [
                 "line"
@@ -6194,12 +6194,12 @@
             "fields": [
                 "oneway",
                 "maxspeed",
-                "structure",
-                "access",
                 "lanes",
                 "surface",
                 "maxheight",
-                "cycleway"
+                "cycleway",
+                "structure",
+                "access"
             ],
             "geometry": [
                 "line"

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -5464,8 +5464,8 @@
                 "maxspeed",
                 "lanes",
                 "surface",
-                "maxheight",
                 "structure",
+                "maxheight",
                 "access"
             ],
             "geometry": [
@@ -5497,9 +5497,9 @@
                 "maxspeed",
                 "lanes",
                 "surface",
+                "structure",
                 "maxheight",
                 "toll",
-                "structure",
                 "access"
             ],
             "geometry": [
@@ -5603,10 +5603,10 @@
                 "maxspeed",
                 "lanes",
                 "surface",
+                "structure",
                 "maxheight",
                 "ref",
                 "cycleway",
-                "structure",
                 "access"
             ],
             "geometry": [
@@ -5659,9 +5659,9 @@
                 "maxspeed",
                 "lanes",
                 "surface",
+                "structure",
                 "maxheight",
                 "cycleway",
-                "structure",
                 "access"
             ],
             "geometry": [
@@ -5695,8 +5695,8 @@
                 "maxspeed",
                 "lanes",
                 "surface",
-                "maxheight",
                 "structure",
+                "maxheight",
                 "access"
             ],
             "geometry": [
@@ -5715,10 +5715,10 @@
                 "maxspeed",
                 "lanes",
                 "surface",
+                "structure",
                 "maxheight",
                 "ref",
                 "cycleway",
-                "structure",
                 "access"
             ],
             "geometry": [
@@ -5741,10 +5741,10 @@
                 "maxspeed",
                 "lanes",
                 "surface",
+                "structure",
                 "maxheight",
                 "ref",
                 "cycleway",
-                "structure",
                 "access"
             ],
             "geometry": [
@@ -5763,8 +5763,8 @@
                 "oneway",
                 "maxspeed",
                 "surface",
-                "maxheight",
                 "structure",
+                "maxheight",
                 "access"
             ],
             "geometry": [
@@ -5993,10 +5993,10 @@
                 "maxspeed",
                 "lanes",
                 "surface",
+                "structure",
                 "maxheight",
                 "ref",
                 "cycleway",
-                "structure",
                 "access"
             ],
             "geometry": [
@@ -6019,10 +6019,10 @@
                 "maxspeed",
                 "lanes",
                 "surface",
+                "structure",
                 "maxheight",
                 "ref",
                 "cycleway",
-                "structure",
                 "access"
             ],
             "geometry": [
@@ -6124,8 +6124,8 @@
                 "maxspeed",
                 "lanes",
                 "surface",
-                "maxheight",
                 "structure",
+                "maxheight",
                 "access"
             ],
             "geometry": [
@@ -6149,9 +6149,9 @@
                 "maxspeed",
                 "lanes",
                 "surface",
+                "structure",
                 "maxheight",
                 "toll",
-                "structure",
                 "access"
             ],
             "geometry": [
@@ -6196,9 +6196,9 @@
                 "maxspeed",
                 "lanes",
                 "surface",
+                "structure",
                 "maxheight",
                 "cycleway",
-                "structure",
                 "access"
             ],
             "geometry": [

--- a/data/presets/presets/highway/cycleway.json
+++ b/data/presets/presets/highway/cycleway.json
@@ -1,10 +1,10 @@
 {
     "icon": "highway-cycleway",
     "fields": [
+        "oneway",
         "surface",
         "lit",
         "width",
-        "oneway",
         "structure",
         "access"
     ],

--- a/data/presets/presets/highway/living_street.json
+++ b/data/presets/presets/highway/living_street.json
@@ -3,11 +3,11 @@
     "fields": [
         "oneway",
         "maxspeed",
-        "structure",
-        "access",
         "lanes",
         "surface",
+        "structure",
         "maxheight",
+        "access",
         "cycleway"
     ],
     "geometry": [

--- a/data/presets/presets/highway/motorway.json
+++ b/data/presets/presets/highway/motorway.json
@@ -1,15 +1,15 @@
 {
     "icon": "highway-motorway",
     "fields": [
+        "ref",
         "oneway_yes",
         "maxspeed",
-        "structure",
-        "access",
         "lanes",
         "surface",
         "maxheight",
         "toll",
-        "ref"
+        "structure",
+        "access"
     ],
     "geometry": [
         "line"

--- a/data/presets/presets/highway/motorway.json
+++ b/data/presets/presets/highway/motorway.json
@@ -6,9 +6,9 @@
         "maxspeed",
         "lanes",
         "surface",
+        "structure",
         "maxheight",
         "toll",
-        "structure",
         "access"
     ],
     "geometry": [

--- a/data/presets/presets/highway/motorway_link.json
+++ b/data/presets/presets/highway/motorway_link.json
@@ -1,14 +1,14 @@
 {
     "icon": "highway-motorway-link",
     "fields": [
+        "ref",
         "oneway_yes",
         "maxspeed",
-        "structure",
-        "access",
         "lanes",
         "surface",
         "maxheight",
-        "ref"
+        "structure",
+        "access"
     ],
     "geometry": [
         "line"

--- a/data/presets/presets/highway/motorway_link.json
+++ b/data/presets/presets/highway/motorway_link.json
@@ -6,8 +6,8 @@
         "maxspeed",
         "lanes",
         "surface",
-        "maxheight",
         "structure",
+        "maxheight",
         "access"
     ],
     "geometry": [

--- a/data/presets/presets/highway/primary.json
+++ b/data/presets/presets/highway/primary.json
@@ -5,10 +5,10 @@
         "maxspeed",
         "lanes",
         "surface",
+        "structure",
         "maxheight",
         "ref",
         "cycleway",
-        "structure",
         "access"
     ],
     "geometry": [

--- a/data/presets/presets/highway/primary.json
+++ b/data/presets/presets/highway/primary.json
@@ -3,13 +3,13 @@
     "fields": [
         "oneway",
         "maxspeed",
-        "structure",
-        "access",
         "lanes",
         "surface",
         "maxheight",
         "ref",
-        "cycleway"
+        "cycleway",
+        "structure",
+        "access"
     ],
     "geometry": [
         "line"

--- a/data/presets/presets/highway/primary_link.json
+++ b/data/presets/presets/highway/primary_link.json
@@ -3,13 +3,13 @@
     "fields": [
         "oneway",
         "maxspeed",
-        "structure",
-        "access",
         "lanes",
         "surface",
         "maxheight",
         "ref",
-        "cycleway"
+        "cycleway",
+        "structure",
+        "access"
     ],
     "geometry": [
         "line"

--- a/data/presets/presets/highway/raceway.json
+++ b/data/presets/presets/highway/raceway.json
@@ -4,10 +4,10 @@
         "oneway",
         "surface",
         "sport_racing_motor",
-        "structure",
         "lit",
         "width",
-        "lanes"
+        "lanes",
+        "structure"
     ],
     "geometry": [
         "point",

--- a/data/presets/presets/highway/residential.json
+++ b/data/presets/presets/highway/residential.json
@@ -5,9 +5,9 @@
         "maxspeed",
         "lanes",
         "surface",
+        "structure",
         "maxheight",
         "cycleway",
-        "structure",
         "access"
     ],
     "geometry": [

--- a/data/presets/presets/highway/residential.json
+++ b/data/presets/presets/highway/residential.json
@@ -3,12 +3,12 @@
     "fields": [
         "oneway",
         "maxspeed",
-        "structure",
-        "access",
         "lanes",
         "surface",
         "maxheight",
-        "cycleway"
+        "cycleway",
+        "structure",
+        "access"
     ],
     "geometry": [
         "line"

--- a/data/presets/presets/highway/road.json
+++ b/data/presets/presets/highway/road.json
@@ -5,8 +5,8 @@
         "maxspeed",
         "lanes",
         "surface",
-        "maxheight",
         "structure",
+        "maxheight",
         "access"
     ],
     "geometry": [

--- a/data/presets/presets/highway/road.json
+++ b/data/presets/presets/highway/road.json
@@ -3,11 +3,11 @@
     "fields": [
         "oneway",
         "maxspeed",
-        "structure",
-        "access",
         "lanes",
         "surface",
-        "maxheight"
+        "maxheight",
+        "structure",
+        "access"
     ],
     "geometry": [
         "line"

--- a/data/presets/presets/highway/secondary.json
+++ b/data/presets/presets/highway/secondary.json
@@ -5,10 +5,10 @@
         "maxspeed",
         "lanes",
         "surface",
+        "structure",
         "maxheight",
         "ref",
         "cycleway",
-        "structure",
         "access"
     ],
     "geometry": [

--- a/data/presets/presets/highway/secondary.json
+++ b/data/presets/presets/highway/secondary.json
@@ -3,13 +3,13 @@
     "fields": [
         "oneway",
         "maxspeed",
-        "structure",
-        "access",
         "lanes",
         "surface",
         "maxheight",
         "ref",
-        "cycleway"
+        "cycleway",
+        "structure",
+        "access"
     ],
     "geometry": [
         "line"

--- a/data/presets/presets/highway/secondary_link.json
+++ b/data/presets/presets/highway/secondary_link.json
@@ -5,10 +5,10 @@
         "maxspeed",
         "lanes",
         "surface",
+        "structure",
         "maxheight",
         "ref",
         "cycleway",
-        "structure",
         "access"
     ],
     "geometry": [

--- a/data/presets/presets/highway/secondary_link.json
+++ b/data/presets/presets/highway/secondary_link.json
@@ -3,13 +3,13 @@
     "fields": [
         "oneway",
         "maxspeed",
-        "structure",
-        "access",
         "lanes",
         "surface",
         "maxheight",
         "ref",
-        "cycleway"
+        "cycleway",
+        "structure",
+        "access"
     ],
     "geometry": [
         "line"

--- a/data/presets/presets/highway/service.json
+++ b/data/presets/presets/highway/service.json
@@ -4,10 +4,10 @@
         "service",
         "oneway",
         "maxspeed",
-        "structure",
-        "access",
         "surface",
-        "maxheight"
+        "maxheight",
+        "structure",
+        "access"
     ],
     "geometry": [
         "line"

--- a/data/presets/presets/highway/service.json
+++ b/data/presets/presets/highway/service.json
@@ -5,8 +5,8 @@
         "oneway",
         "maxspeed",
         "surface",
-        "maxheight",
         "structure",
+        "maxheight",
         "access"
     ],
     "geometry": [

--- a/data/presets/presets/highway/tertiary.json
+++ b/data/presets/presets/highway/tertiary.json
@@ -5,10 +5,10 @@
         "maxspeed",
         "lanes",
         "surface",
+        "structure",
         "maxheight",
         "ref",
         "cycleway",
-        "structure",
         "access"
     ],
     "geometry": [

--- a/data/presets/presets/highway/tertiary.json
+++ b/data/presets/presets/highway/tertiary.json
@@ -3,13 +3,13 @@
     "fields": [
         "oneway",
         "maxspeed",
-        "structure",
-        "access",
         "lanes",
         "surface",
         "maxheight",
         "ref",
-        "cycleway"
+        "cycleway",
+        "structure",
+        "access"
     ],
     "geometry": [
         "line"

--- a/data/presets/presets/highway/tertiary_link.json
+++ b/data/presets/presets/highway/tertiary_link.json
@@ -5,10 +5,10 @@
         "maxspeed",
         "lanes",
         "surface",
+        "structure",
         "maxheight",
         "ref",
         "cycleway",
-        "structure",
         "access"
     ],
     "geometry": [

--- a/data/presets/presets/highway/tertiary_link.json
+++ b/data/presets/presets/highway/tertiary_link.json
@@ -3,13 +3,13 @@
     "fields": [
         "oneway",
         "maxspeed",
-        "structure",
-        "access",
         "lanes",
         "surface",
         "maxheight",
         "ref",
-        "cycleway"
+        "cycleway",
+        "structure",
+        "access"
     ],
     "geometry": [
         "line"

--- a/data/presets/presets/highway/trunk.json
+++ b/data/presets/presets/highway/trunk.json
@@ -6,9 +6,9 @@
         "maxspeed",
         "lanes",
         "surface",
+        "structure",
         "maxheight",
         "toll",
-        "structure",
         "access"
     ],
     "geometry": [

--- a/data/presets/presets/highway/trunk.json
+++ b/data/presets/presets/highway/trunk.json
@@ -1,15 +1,15 @@
 {
     "icon": "highway-trunk",
     "fields": [
+        "ref",
         "oneway",
         "maxspeed",
-        "structure",
-        "access",
         "lanes",
         "surface",
         "maxheight",
         "toll",
-        "ref"
+        "structure",
+        "access"
     ],
     "geometry": [
         "line"

--- a/data/presets/presets/highway/trunk_link.json
+++ b/data/presets/presets/highway/trunk_link.json
@@ -6,8 +6,8 @@
         "maxspeed",
         "lanes",
         "surface",
-        "maxheight",
         "structure",
+        "maxheight",
         "access"
     ],
     "geometry": [

--- a/data/presets/presets/highway/trunk_link.json
+++ b/data/presets/presets/highway/trunk_link.json
@@ -1,14 +1,14 @@
 {
     "icon": "highway-trunk-link",
     "fields": [
+        "ref",
         "oneway",
         "maxspeed",
-        "structure",
-        "access",
         "lanes",
         "surface",
         "maxheight",
-        "ref"
+        "structure",
+        "access"
     ],
     "geometry": [
         "line"

--- a/data/presets/presets/highway/unclassified.json
+++ b/data/presets/presets/highway/unclassified.json
@@ -5,9 +5,9 @@
         "maxspeed",
         "lanes",
         "surface",
+        "structure",
         "maxheight",
         "cycleway",
-        "structure",
         "access"
     ],
     "geometry": [

--- a/data/presets/presets/highway/unclassified.json
+++ b/data/presets/presets/highway/unclassified.json
@@ -3,12 +3,12 @@
     "fields": [
         "oneway",
         "maxspeed",
-        "structure",
-        "access",
         "lanes",
         "surface",
         "maxheight",
-        "cycleway"
+        "cycleway",
+        "structure",
+        "access"
     ],
     "geometry": [
         "line"


### PR DESCRIPTION
The `structure` and `access` fields takes too much space in the screen and are less used than `surface` and `lanes`, so I change the ordering to show more fields on the screen without the need of scrolling. 

**Before:**
![image](https://cloud.githubusercontent.com/assets/666291/25806476/b1aaa36e-33d9-11e7-9494-a63c60903e90.png)

**After:**
![image](https://cloud.githubusercontent.com/assets/666291/25806494/c23edd3a-33d9-11e7-8ba6-f1d7aeff5923.png)
![image](https://cloud.githubusercontent.com/assets/666291/25806499/c5cfecc8-33d9-11e7-8e8c-5f27c99cd1c2.png)
