### PR TITLE
Keyboard shortcuts pt2

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -3156,6 +3156,21 @@ img.tile-removing {
     box-shadow: inset 0 -1px 0 #bbb;
 }
 
+.modal-shortcuts .shortcut-keys svg.mouseclick use.left {
+    fill: rgba(112, 146, 255, 1);
+    color: rgba(112, 146, 255, 0);
+}
+.modal-shortcuts .shortcut-keys svg.mouseclick use.right {
+    fill: rgba(112, 146, 255, 0);
+    color: rgba(112, 146, 255, 1);
+}
+
+.modal-shortcuts .shortcut-keys .gesture {
+    color: #333;
+    padding: 3px;
+}
+
+
 
 /* Save Mode
 ------------------------------------------------------- */

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1018,6 +1018,8 @@ en:
       start: "Start mapping!"
   shortcuts:
     title: "Keyboard shortcuts"
+    or: "-or-"
+    drag: drag
     browsing:
       title: "Browsing"
       navigation:

--- a/data/shortcuts.json
+++ b/data/shortcuts.json
@@ -10,18 +10,22 @@
                         "text": "shortcuts.browsing.navigation.title"
                     }, {
                         "shortcuts": ["↓", "↑", "←", "→"],
-                        "text": "shortcuts.browsing.navigation.pan"
+                        "text": "shortcuts.browsing.navigation.pan",
+                        "separator": ","
                     }, {
                         "modifiers": ["⇧"],
                         "shortcuts": ["↓", "↑", "←", "→"],
-                        "text": "shortcuts.browsing.navigation.pan_more"
+                        "text": "shortcuts.browsing.navigation.pan_more",
+                        "separator": ","
                     }, {
                         "shortcuts": ["+", "-"],
-                        "text": "shortcuts.browsing.navigation.zoom"
+                        "text": "shortcuts.browsing.navigation.zoom",
+                        "separator": ","
                     }, {
                         "modifiers": ["⇧"],
                         "shortcuts": ["+", "-"],
-                        "text": "shortcuts.browsing.navigation.zoom_more"
+                        "text": "shortcuts.browsing.navigation.zoom_more",
+                        "separator": ","
                     },
 
                     {
@@ -70,7 +74,8 @@
                         "text": "shortcuts.browsing.selecting.select_multi"
                     }, {
                         "modifiers": ["⇧"],
-                        "shortcuts": ["Left-click + drag"],
+                        "shortcuts": ["Left-click"],
+                        "gesture": "shortcuts.drag",
                         "text": "shortcuts.browsing.selecting.lasso"
                     }, {
                         "shortcuts": [],

--- a/data/shortcuts.json
+++ b/data/shortcuts.json
@@ -86,12 +86,12 @@
                         "section": "with_selected",
                         "text": "shortcuts.browsing.with_selected.title"
                     }, {
+                        "shortcuts": ["Right-click", "Space"],
+                        "text": "shortcuts.browsing.with_selected.edit_menu"
+                    }, {
                         "modifiers": ["⌘"],
                         "shortcuts": ["I"],
                         "text": "shortcuts.browsing.with_selected.infobox"
-                    }, {
-                        "shortcuts": ["Right-click", "Space"],
-                        "text": "shortcuts.browsing.with_selected.edit_menu"
                     },
 
                     {

--- a/data/shortcuts.json
+++ b/data/shortcuts.json
@@ -9,16 +9,18 @@
                         "section": "navigation",
                         "text": "shortcuts.browsing.navigation.title"
                     }, {
-                        "shortcut": ["↓", "↑", "←", "→"],
+                        "shortcuts": ["↓", "↑", "←", "→"],
                         "text": "shortcuts.browsing.navigation.pan"
                     }, {
-                        "shortcut": ["⇧↓", "⇧↑", "⇧←", "⇧→"],
+                        "modifiers": ["⇧"],
+                        "shortcuts": ["↓", "↑", "←", "→"],
                         "text": "shortcuts.browsing.navigation.pan_more"
                     }, {
-                        "shortcut": ["+", "-"],
+                        "shortcuts": ["+", "-"],
                         "text": "shortcuts.browsing.navigation.zoom"
                     }, {
-                        "shortcut": ["⌘+", "⌘-"],
+                        "modifiers": ["⇧"],
+                        "shortcuts": ["+", "-"],
                         "text": "shortcuts.browsing.navigation.zoom_more"
                     },
 
@@ -26,10 +28,10 @@
                         "section": "help",
                         "text": "shortcuts.browsing.help.title"
                     }, {
-                        "shortcut": ["H"],
+                        "shortcuts": ["H"],
                         "text": "shortcuts.browsing.help.help"
                     }, {
-                        "shortcut": ["?"],
+                        "shortcuts": ["?"],
                         "text": "shortcuts.browsing.help.keyboard"
                     },
 
@@ -37,19 +39,20 @@
                         "section": "display_options",
                         "text": "shortcuts.browsing.display_options.title"
                     }, {
-                        "shortcut": ["B"],
+                        "shortcuts": ["B"],
                         "text": "shortcuts.browsing.display_options.background"
                     }, {
-                        "shortcut": ["⌘B"],
+                        "modifiers": ["⌘"],
+                        "shortcuts": ["B"],
                         "text": "shortcuts.browsing.display_options.background_switch"
                     }, {
-                        "shortcut": ["F"],
+                        "shortcuts": ["F"],
                         "text": "shortcuts.browsing.display_options.map_data"
                     }, {
-                        "shortcut": ["W"],
+                        "shortcuts": ["W"],
                         "text": "shortcuts.browsing.display_options.wireframe"
                     }, {
-                        "shortcut": ["/"],
+                        "shortcuts": ["/"],
                         "text": "shortcuts.browsing.display_options.minimap"
                     }
                 ]
@@ -59,16 +62,18 @@
                         "section": "selecting",
                         "text": "shortcuts.browsing.selecting.title"
                     }, {
-                        "shortcut": ["Left-click"],
+                        "shortcuts": ["Left-click"],
                         "text": "shortcuts.browsing.selecting.select_one"
                     }, {
-                        "shortcut": ["⇧ Left-click"],
+                        "modifiers": ["⇧"],
+                        "shortcuts": ["Left-click"],
                         "text": "shortcuts.browsing.selecting.select_multi"
                     }, {
-                        "shortcut": ["⇧ Left-click + drag"],
+                        "modifiers": ["⇧"],
+                        "shortcuts": ["Left-click + drag"],
                         "text": "shortcuts.browsing.selecting.lasso"
                     }, {
-                        "shortcut": [],
+                        "shortcuts": [],
                         "text": ""
                     },
 
@@ -76,10 +81,11 @@
                         "section": "with_selected",
                         "text": "shortcuts.browsing.with_selected.title"
                     }, {
-                        "shortcut": ["⌘I"],
+                        "modifiers": ["⌘"],
+                        "shortcuts": ["I"],
                         "text": "shortcuts.browsing.with_selected.infobox"
                     }, {
-                        "shortcut": ["Right-click", "Space"],
+                        "shortcuts": ["Right-click", "Space"],
                         "text": "shortcuts.browsing.with_selected.edit_menu"
                     },
 
@@ -87,19 +93,19 @@
                         "section": "vertex_selected",
                         "text": "shortcuts.browsing.vertex_selected.title"
                     }, {
-                        "shortcut": ["[", "↖ PgUp"],
+                        "shortcuts": ["[", "↖"],
                         "text": "shortcuts.browsing.vertex_selected.previous"
                     }, {
-                        "shortcut": ["]", "↘ PgDn"],
+                        "shortcuts": ["]", "↘"],
                         "text": "shortcuts.browsing.vertex_selected.next"
                     }, {
-                        "shortcut": ["{", "⇞ Home"],
+                        "shortcuts": ["{", "⇞"],
                         "text": "shortcuts.browsing.vertex_selected.first"
                     }, {
-                        "shortcut": ["}", "⇟ End"],
+                        "shortcuts": ["}", "⇟"],
                         "text": "shortcuts.browsing.vertex_selected.last"
                     }, {
-                        "shortcut": ["\\", "Pause"],
+                        "shortcuts": ["\\", "Pause"],
                         "text": "shortcuts.browsing.vertex_selected.change_parent"
                     }
 
@@ -116,22 +122,22 @@
                         "section": "drawing",
                         "text": "shortcuts.editing.drawing.title"
                     }, {
-                        "shortcut": ["1"],
+                        "shortcuts": ["1"],
                         "text": "shortcuts.editing.drawing.add_point"
                     }, {
-                        "shortcut": ["2"],
+                        "shortcuts": ["2"],
                         "text": "shortcuts.editing.drawing.add_line"
                     }, {
-                        "shortcut": ["3"],
+                        "shortcuts": ["3"],
                         "text": "shortcuts.editing.drawing.add_area"
                     }, {
-                        "shortcut": ["Space"],
+                        "shortcuts": ["Space"],
                         "text": "shortcuts.editing.drawing.place_point"
                     }, {
-                        "shortcut": ["⌥ Alt"],
+                        "shortcuts": ["⌥"],
                         "text": "shortcuts.editing.drawing.disable_snap"
                     }, {
-                        "shortcut": ["↵ Enter", "⎋ Esc"],
+                        "shortcuts": ["↵", "⎋"],
                         "text": "shortcuts.editing.drawing.stop_line"
                     },
 
@@ -139,19 +145,24 @@
                         "section": "commands",
                         "text": "shortcuts.editing.commands.title"
                     }, {
-                        "shortcut": ["⌘C"],
+                        "modifiers": ["⌘"],
+                        "shortcuts": ["C"],
                         "text": "shortcuts.editing.commands.copy"
                     }, {
-                        "shortcut": ["⌘V"],
+                        "modifiers": ["⌘"],
+                        "shortcuts": ["V"],
                         "text": "shortcuts.editing.commands.paste"
                     }, {
-                        "shortcut": ["⌘Z"],
+                        "modifiers": ["⌘"],
+                        "shortcuts": ["Z"],
                         "text": "shortcuts.editing.commands.undo"
                     }, {
-                        "shortcut": ["⌘⇧Z"],
+                        "modifiers": ["⌘","⇧"],
+                        "shortcuts": ["Z"],
                         "text": "shortcuts.editing.commands.redo"
                     }, {
-                        "shortcut": ["⌘S"],
+                        "modifiers": ["⌘"],
+                        "shortcuts": ["S"],
                         "text": "shortcuts.editing.commands.save"
                     }
                 ]
@@ -161,40 +172,41 @@
                         "section": "operations",
                         "text": "shortcuts.editing.operations.title"
                     }, {
-                        "shortcut": ["operations.continue.key"],
+                        "shortcuts": ["operations.continue.key"],
                         "text": "shortcuts.editing.operations.continue_line"
                     }, {
-                        "shortcut": ["operations.merge.key"],
+                        "shortcuts": ["operations.merge.key"],
                         "text": "shortcuts.editing.operations.merge"
                     }, {
-                        "shortcut": ["operations.disconnect.key"],
+                        "shortcuts": ["operations.disconnect.key"],
                         "text": "shortcuts.editing.operations.disconnect"
                     }, {
-                        "shortcut": ["operations.split.key"],
+                        "shortcuts": ["operations.split.key"],
                         "text": "shortcuts.editing.operations.split"
                     }, {
-                        "shortcut": ["operations.reverse.key"],
+                        "shortcuts": ["operations.reverse.key"],
                         "text": "shortcuts.editing.operations.reverse"
                     }, {
-                        "shortcut": ["operations.move.key"],
+                        "shortcuts": ["operations.move.key"],
                         "text": "shortcuts.editing.operations.move"
                     }, {
-                        "shortcut": ["operations.rotate.key"],
+                        "shortcuts": ["operations.rotate.key"],
                         "text": "shortcuts.editing.operations.rotate"
                     }, {
-                        "shortcut": ["operations.orthogonalize.key"],
+                        "shortcuts": ["operations.orthogonalize.key"],
                         "text": "shortcuts.editing.operations.orthogonalize"
                     }, {
-                        "shortcut": ["operations.circularize.key"],
+                        "shortcuts": ["operations.circularize.key"],
                         "text": "shortcuts.editing.operations.circularize"
                     }, {
-                        "shortcut": ["operations.reflect.key.long"],
+                        "shortcuts": ["operations.reflect.key.long"],
                         "text": "shortcuts.editing.operations.reflect_long"
                     }, {
-                        "shortcut": ["operations.reflect.key.short"],
+                        "shortcuts": ["operations.reflect.key.short"],
                         "text": "shortcuts.editing.operations.reflect_short"
                     }, {
-                        "shortcut": ["⌘⌫", "⌦"],
+                        "modifiers": ["⌘"],
+                        "shortcuts": ["⌫"],
                         "text": "shortcuts.editing.operations.delete"
                     }
                 ]

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -885,6 +885,8 @@
         },
         "shortcuts": {
             "title": "Keyboard shortcuts",
+            "or": "-or-",
+            "drag": "drag",
             "browsing": {
                 "title": "Browsing",
                 "navigation": {

--- a/modules/ui/cmd.js
+++ b/modules/ui/cmd.js
@@ -1,9 +1,8 @@
 import { utilDetect } from '../util/detect';
 
-
 // Translate a MacOS key command into the appropriate Windows/Linux equivalent.
 // For example, ⌘Z -> Ctrl+Z
-export function uiCmd(code) {
+export var uiCmd = function (code) {
     var detected = utilDetect();
 
     if (detected.os === 'mac') {
@@ -32,4 +31,28 @@ export function uiCmd(code) {
     }
 
     return result;
-}
+};
+
+
+// return a display-focused string for a given keyboard code
+uiCmd.display = function(code) {
+    if (code.length !== 1) return code;
+
+    var detected = utilDetect();
+    var mac = (detected.os === 'mac');
+    var replacements = {
+        '⌘': mac ? '⌘ Cmd'       : 'Ctrl',
+        '⇧': mac ? '⇧ Shift'     : 'Shift',
+        '⌥': mac ? '⌥ Option'    : 'Alt',
+        '⌫': mac ? '⌫ Delete'    : 'Backspace',
+        '⌦': mac ? '⌦ Del'       : 'Del',
+        '↖': mac ? '↖ PgUp'      : 'PgUp',
+        '↘': mac ? '↘ PgDn'      : 'PgDn',
+        '⇞': mac ? '⇞ Home'      : 'Home',
+        '⇟': mac ? '⇟ End'       : 'End',
+        '↵': mac ? '↵ Return'    : 'Enter',
+        '⎋': mac ? '⎋ Esc'       : 'Esc',
+    };
+
+    return replacements[code] || code;
+};

--- a/modules/ui/shortcuts.js
+++ b/modules/ui/shortcuts.js
@@ -1,9 +1,11 @@
 import * as d3 from 'd3';
+
+import { t } from '../util/locale';
+import { d3keybinding } from '../lib/d3.keybinding.js';
+import { dataShortcuts } from '../../data';
+import { svgIcon } from '../svg';
 import { uiCmd } from './cmd';
 import { uiModal } from './modal';
-import { d3keybinding } from '../lib/d3.keybinding.js';
-import { t } from '../util/locale';
-import { dataShortcuts } from '../../data';
 
 
 export function uiShortcuts() {
@@ -113,6 +115,7 @@ export function uiShortcuts() {
             .append('tr')
             .attr('class', 'shortcut-row');
 
+
         var sectionRows = rowsEnter
             .filter(function (d) { return !d.shortcuts; });
 
@@ -124,6 +127,7 @@ export function uiShortcuts() {
             .attr('class', 'shortcut-section')
             .append('h3')
             .text(function (d) { return t(d.text); });
+
 
         var shortcutRows = rowsEnter
             .filter(function (d) { return d.shortcuts; });
@@ -141,6 +145,7 @@ export function uiShortcuts() {
             .enter()
             .each(function () {
                 var selection = d3.select(this);
+
                 selection
                     .append('kbd')
                     .attr('class', 'modifier')
@@ -154,22 +159,53 @@ export function uiShortcuts() {
 
         shortcutKeys
             .selectAll('kbd.shortcut')
-            .data(function (d) { return d.shortcuts; })
+            .data(function (d) {
+                return d.shortcuts.map(function(s) {
+                    return {
+                        shortcut: s,
+                        separator: d.separator
+                    };
+                });
+            })
             .enter()
             .each(function (d, i, nodes) {
                 var selection = d3.select(this);
-                selection
-                    .append('kbd')
-                    .attr('class', 'shortcut')
-                    .text(function (d) {
-                        return d.indexOf('.') !== -1 ? uiCmd.display(t(d)) : uiCmd.display(d);
-                    });
+                var click = d.shortcut.toLowerCase().match(/(.*).click/);
+
+                if (click && click[1]) {
+                    selection
+                        .call(svgIcon('#walkthrough-mouse', 'mouseclick', click[1]));
+                } else {
+                    selection
+                        .append('kbd')
+                        .attr('class', 'shortcut')
+                        .text(function (d) {
+                            var key = d.shortcut;
+                            return key.indexOf('.') !== -1 ? uiCmd.display(t(key)) : uiCmd.display(key);
+                        });
+                }
 
                 if (i < nodes.length - 1) {
                     selection
                         .append('span')
-                        .text(',');
+                        .text(d.separator || '\u00a0' + t('shortcuts.or') + '\u00a0');
                 }
+            });
+
+
+        shortcutKeys
+            .filter(function(d) { return d.gesture; })
+            .each(function () {
+                var selection = d3.select(this);
+
+                selection
+                    .append('span')
+                    .text('+');
+
+                selection
+                    .append('span')
+                    .attr('class', 'gesture')
+                    .text(function (d) { return t(d.gesture); });
             });
 
 

--- a/modules/ui/shortcuts.js
+++ b/modules/ui/shortcuts.js
@@ -114,7 +114,7 @@ export function uiShortcuts() {
             .attr('class', 'shortcut-row');
 
         var sectionRows = rowsEnter
-            .filter(function (d) { return !d.shortcut; });
+            .filter(function (d) { return !d.shortcuts; });
 
         sectionRows
             .append('td');
@@ -126,18 +126,52 @@ export function uiShortcuts() {
             .text(function (d) { return t(d.text); });
 
         var shortcutRows = rowsEnter
-            .filter(function (d) { return d.shortcut; });
+            .filter(function (d) { return d.shortcuts; });
 
-        shortcutRows
+        var shortcutKeys = shortcutRows
             .append('td')
-            .attr('class', 'shortcut-keys')
-            .selectAll('kbd')
-            .data(function (d) { return d.shortcut; })
+            .attr('class', 'shortcut-keys');
+
+        var modifierKeys = shortcutKeys
+            .filter(function (d) { return d.modifiers; });
+
+        modifierKeys
+            .selectAll('kbd.modifier')
+            .data(function (d) { return d.modifiers; })
             .enter()
-            .append('kbd')
-            .text(function (d) {
-                return d.indexOf('.') !== -1 ? uiCmd(t(d)) : uiCmd(d);
+            .each(function () {
+                var selection = d3.select(this);
+                selection
+                    .append('kbd')
+                    .attr('class', 'modifier')
+                    .text(function (d) { return uiCmd.display(d); });
+
+                selection
+                    .append('span')
+                    .text('+');
             });
+
+
+        shortcutKeys
+            .selectAll('kbd.shortcut')
+            .data(function (d) { return d.shortcuts; })
+            .enter()
+            .each(function (d, i, nodes) {
+                var selection = d3.select(this);
+                selection
+                    .append('kbd')
+                    .attr('class', 'shortcut')
+                    .text(function (d) {
+                        return d.indexOf('.') !== -1 ? uiCmd.display(t(d)) : uiCmd.display(d);
+                    });
+
+                if (i < nodes.length - 1) {
+                    selection
+                        .append('span')
+                        .text(',');
+                }
+            });
+
 
         shortcutRows
             .append('td')

--- a/modules/ui/shortcuts.js
+++ b/modules/ui/shortcuts.js
@@ -6,12 +6,15 @@ import { dataShortcuts } from '../../data';
 import { svgIcon } from '../svg';
 import { uiCmd } from './cmd';
 import { uiModal } from './modal';
+import { utilDetect } from '../util/detect';
 
 
 export function uiShortcuts() {
+    var detected = utilDetect();
     var activeTab = 0;
     var modalSelection;
     var savedSelection;
+
 
     var keybinding = d3keybinding('shortcuts')
         .on(['?', '⇧/'], function () {
@@ -141,7 +144,13 @@ export function uiShortcuts() {
 
         modifierKeys
             .selectAll('kbd.modifier')
-            .data(function (d) { return d.modifiers; })
+            .data(function (d) {
+                if (detected.os === 'win' && d.text === 'shortcuts.editing.commands.redo') {
+                    return ['⌘'];
+                } else {
+                    return d.modifiers;
+                }
+            })
             .enter()
             .each(function () {
                 var selection = d3.select(this);
@@ -160,6 +169,14 @@ export function uiShortcuts() {
         shortcutKeys
             .selectAll('kbd.shortcut')
             .data(function (d) {
+                var arr;
+                if (detected.os === 'win' && d.text === 'shortcuts.editing.commands.redo') {
+                    return [{
+                        shortcut: 'Y',
+                        separator: d.separator
+                    }];
+                }
+
                 return d.shortcuts.map(function(s) {
                     return {
                         shortcut: s,

--- a/modules/ui/shortcuts.js
+++ b/modules/ui/shortcuts.js
@@ -18,22 +18,25 @@ export function uiShortcuts() {
 
     var keybinding = d3keybinding('shortcuts')
         .on(['?', '⇧/'], function () {
-            if (modalSelection) {
-                modalSelection.close();
-                modalSelection = null;
-                return;
+            if (d3.selectAll('.modal-shortcuts').size()) {  // already showing
+                if (modalSelection) {
+                    modalSelection.close();
+                    modalSelection = null;
+                }
+            } else {
+                modalSelection = uiModal(savedSelection);
+                shortcutsModal(modalSelection);
             }
-            modalSelection = uiModal(savedSelection);
-            shortcutsModal(modalSelection);
         });
 
     d3.select(document)
         .call(keybinding);
 
 
+
     function shortcutsModal(modalSelection) {
         modalSelection.select('.modal')
-        .attr('class', 'modal modal-shortcuts fillL col6');
+            .classed('modal-shortcuts', true);
 
         var shortcutsModal = modalSelection.select('.content');
 
@@ -169,7 +172,6 @@ export function uiShortcuts() {
         shortcutKeys
             .selectAll('kbd.shortcut')
             .data(function (d) {
-                var arr;
                 if (detected.os === 'win' && d.text === 'shortcuts.editing.commands.redo') {
                     return [{
                         shortcut: 'Y',


### PR DESCRIPTION
Some improvements for the items in #4073 

- [x] fix display of redo command on windows

* replace "left-click"/"right-click" with mouse icons to save space
* split modifiers from key array
* add separator for key array (can be char like `,` or a string like "-or-")
* change display of certain keys for Mac/Windows (see below):

```js
    var detected = utilDetect();
    var mac = (detected.os === 'mac');
    var replacements = {
        '⌘': mac ? '⌘ Cmd'       : 'Ctrl',
        '⇧': mac ? '⇧ Shift'     : 'Shift',
        '⌥': mac ? '⌥ Option'    : 'Alt',
        '⌫': mac ? '⌫ Delete'    : 'Backspace',
        '⌦': mac ? '⌦ Del'       : 'Del',
        '↖': mac ? '↖ PgUp'      : 'PgUp',
        '↘': mac ? '↘ PgDn'      : 'PgDn',
        '⇞': mac ? '⇞ Home'      : 'Home',
        '⇟': mac ? '⇟ End'       : 'End',
        '↵': mac ? '↵ Return'    : 'Enter',
        '⎋': mac ? '⎋ Esc'       : 'Esc',
    };
```