### PR TITLE
make sure inspector footer stays on top

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -657,6 +657,7 @@ button.save.has-count .count::before {
     border-top: 1px solid #ccc;
     background-color: #fafafa;
     width: 100%;
+    z-index: 1;
 }
 
 .sidebar-component .body {


### PR DESCRIPTION
After uploading changes, the "view on osm.org" link is currently unclickable (until one reloads the whole page). This is because the order of the divs in the `.inspector_wrap` gets inverted for some reason (I don't see why, though[?](https://github.com/openstreetmap/iD/blob/master/modules/ui/inspector.js)). Adding this z-index helps keeping it on top of the rest of the inspector pane and the link clickable.