### PR TITLE
Service workers are here

### DIFF
--- a/build-sw.js
+++ b/build-sw.js
@@ -1,0 +1,15 @@
+const workboxBuild = require('workbox-build');
+
+workboxBuild
+    .generateSW({
+        maximumFileSizeToCacheInBytes: 2097152 * 3,
+        clientsClaim: true,
+        skipWaiting: true,
+        swDest: 'dist/service-worker.js',
+        globDirectory: 'dist',
+        staticFileGlobs: ['**/!(*map*)'],
+        globIgnores: ['**/service-worker.js']
+    })
+    .then(() => {
+        console.log('The production service worker has been generated.');
+    });

--- a/build-sw.js
+++ b/build-sw.js
@@ -7,7 +7,7 @@ workboxBuild
         skipWaiting: true,
         swDest: 'dist/service-worker.js',
         globDirectory: 'dist',
-        staticFileGlobs: ['**/!(*map*)'],
+        staticFileGlobs: ['**/*.{js,css,png,jpg,gif,svg,eot,ttf,woff}'],
         globIgnores: ['**/service-worker.js']
     })
     .then(() => {

--- a/modules/id.js
+++ b/modules/id.js
@@ -1,2 +1,5 @@
 import * as iD from './index';
+import { registerServiceWorker } from './serviceWorker';
+
+registerServiceWorker();
 window.iD = iD;

--- a/modules/serviceWorker.js
+++ b/modules/serviceWorker.js
@@ -1,0 +1,47 @@
+
+export function registerServiceWorker() {
+  if (location.hostname !== 'localhost' && 'serviceWorker' in navigator) {
+    window.addEventListener('load', function() {
+      var swUrl = 'service-worker.js';
+      navigator.serviceWorker
+        .register(swUrl)
+        .then(function(registration) {
+          registration.onupdatefound = function() {
+            var installingWorker = registration.installing;
+            installingWorker.onstatechange = function() {
+              if (installingWorker.state === 'installed') {
+                if (navigator.serviceWorker.controller) {
+                  // At this point, the old content will have been purged and
+                  // the fresh content will have been added to the cache.
+                  // It's the perfect time to display a "New content is
+                  // available; please refresh" message in your web app.
+                  var r = window.confirm(
+                    'New version of iD editor is available. Would you like to reload?'
+                  );
+                  if (r) {
+                    window.location.reload();
+                  }
+                } else {
+                  // At this point, everything has been precached.
+                  // It's the perfect time to display a
+                  // "Content is cached for offline use." message.
+                  console.log('Content is cached for offline use.');
+                }
+              }
+            };
+          };
+        })
+        .catch(error => {
+          console.error('Error during service worker registration:', error);
+        });
+    });
+  }
+}
+
+export function unregisterServiceWorker() {
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.ready.then(function (registration) {
+      registration.unregister();
+    });
+  }
+}

--- a/modules/serviceWorker.js
+++ b/modules/serviceWorker.js
@@ -31,7 +31,7 @@ export function registerServiceWorker() {
             };
           };
         })
-        .catch(error => {
+        .catch(function(error) {
           console.error('Error during service worker registration:', error);
         });
     });

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "smash": "0.0",
     "svg-sprite": "1.3.7",
     "uglify-js": "~3.0.0",
+    "workbox-build": "^1.0.1",
     "xml2js": "~0.4.17",
     "xmlbuilder": "~9.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "all": "npm-run-all -s clean build dist",
     "build": "node build.js && node development_server.js",
+    "postall": "node build-sw.js",
     "clean": "shx rm -f dist/*.js dist/*.map dist/*.css dist/img/*.svg",
     "dist": "npm-run-all -p dist:**",
     "dist:css": "shx cat css/*.css > dist/iD.css",


### PR DESCRIPTION
This adds a simple build step to add service workers using [workbox](https://workboxjs.org).
The workbox's documentation is pretty bad and their rollup example doesn't work.

### Notes
- iD.js is pretty huge.(~4mb). Service workers get scared seeing such huge files. We need fix this sometime. ( Code splitting would help, but `rollup` doesn't [support it yet](https://github.com/rollup/rollup/issues/372) ).
- Some of API's that iD uses can have a [runtime caching]( https://workboxjs.org/reference-docs/latest/module-workbox-runtime-caching.html).
- Need some input on how to make it work with `openstreetmap.org` website.
- Figure out how to tell the user a new version is available. Currently it just does `windows.alert`. 
- Some nice [points](https://developers.google.com/web/fundamentals/instant-and-offline/offline-ux#inform_the_user_when_the_app_is_ready_for_offline_consumption) on offline first.
- Currently to test if service worker is updating assets correctly I have setup an iD instance at https://languid-alley.surge.sh . To update it with some local changes I run `surge -p dist -d languid-alley.surge.sh`. (seems to work fine and also updates the assets properly)

### What could go wrong.
Service worker doesn't actually interfere with the actual code, but it might keep sending the stale data if something goes wrong.
- Need to make sure service worker doesn't eat up children URLs like `openstreetmap.org/iD/xyz` more on this [here](https://github.com/GoogleChrome/sw-precache#navigatefallback-string)

### Bright Side
- Huge improvements in load time for users.
- Offline support.
- We can decide on a better caching strategy for APIs.
- Would make iD more aligned with [PWA](https://developers.google.com/web/progressive-web-apps/) 