### PR TITLE
clarify extra steps necessary to add new app documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -268,13 +268,9 @@ of each new section of documentation should be of the form
 # GPS
 ```
 
-This will be used for navigation and as its title in iD. Documentation is
-shown in alphabetical order, so most documentation is prefixed with `02-` and
-so on in order to keep it in a certain order.
+This will be used for navigation and as its title in iD. To add a new piece of documentation, simply add to [/data/core.yaml](/data/core.yaml) in the same format as the rest, include your new corresponding `docKey` in [/modules/ui/help.js](/modules/ui/help.js) and call `npm run build`.
 
-To add a new piece of documentation, simply add to [core.yaml](/data/core.yaml) in the same format as the rest.
-
-
+Afte
 ## Adding or Refining Presets
 
 Presets save time for iD users by automatically showing them the tags they are


### PR DESCRIPTION
greetings!

just proposing a small tweak in the `CONTRIBUTING` regarding supplementing iD's documentation

* removed section about alphabetical order of help, as it doesn't seem to be relevant anymore
* added a breadcrumb to let folks know what is required to see changes after adding new doc:
  * add a new `docKey` in /modules/ui/help.js
  * run `npm run build`/`node build.js` to write to /dist/locales/en.json