### PR TITLE
Adding some more railway presets

### DIFF
--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -3760,6 +3760,11 @@ en:
         name: Railway Crossing (Path)
         # 'terms: crossing,pedestrian crossing,railroad crossing,level crossing,grade crossing,path through railroad,train crossing'
         terms: '<translate with synonyms or related terms for ''Railway Crossing (Path)'', separated by commas>'
+      railway/derail:
+        # railway=derail
+        name: Railway Derailer
+        # 'terms: derailer'
+        terms: '<translate with synonyms or related terms for ''Railway Derailer'', separated by commas>'
       railway/disused:
         # railway=disused
         name: Disused Railway
@@ -3779,6 +3784,11 @@ en:
         name: Railway Crossing (Road)
         # 'terms: crossing,railroad crossing,level crossing,grade crossing,road through railroad,train crossing'
         terms: '<translate with synonyms or related terms for ''Railway Crossing (Road)'', separated by commas>'
+      railway/milestone:
+        # railway=milestone
+        name: Railway Milestone
+        # 'terms: milestone,marker'
+        terms: '<translate with synonyms or related terms for ''Railway Milestone'', separated by commas>'
       railway/monorail:
         # railway=monorail
         name: Monorail
@@ -3796,6 +3806,11 @@ en:
         # railway=rail
         name: Rail
         terms: '<translate with synonyms or related terms for ''Rail'', separated by commas>'
+      railway/signal:
+        # railway=signal
+        name: Railway Signal
+        # 'terms: signal,lights'
+        terms: '<translate with synonyms or related terms for ''Railway Signal'', separated by commas>'
       railway/station:
         # railway=station
         name: Railway Station
@@ -3811,6 +3826,16 @@ en:
         name: Subway Entrance
         # 'terms: metro,transit'
         terms: '<translate with synonyms or related terms for ''Subway Entrance'', separated by commas>'
+      railway/switch:
+        # railway=switch
+        name: Railway Switch
+        # 'terms: switch,points'
+        terms: '<translate with synonyms or related terms for ''Railway Switch'', separated by commas>'
+      railway/train_wash:
+        # railway=wash
+        name: Train Wash
+        # 'terms: wash,clean'
+        terms: '<translate with synonyms or related terms for ''Train Wash'', separated by commas>'
       railway/tram:
         # railway=tram
         name: Tram

--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -730,6 +730,9 @@ en:
       maxweight:
         # maxweight=*
         label: Max Weight
+      milestone_position:
+        # 'railway:position=*'
+        label: Milestone Position
       mtb/scale:
         # 'mtb:scale=*'
         label: Mountain Biking Difficulty

--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -733,6 +733,8 @@ en:
       milestone_position:
         # 'railway:position=*'
         label: Milestone Position
+        # milestone_position field placeholder
+        placeholder: Distance to one decimal (123.4)
       mtb/scale:
         # 'mtb:scale=*'
         label: Mountain Biking Difficulty

--- a/data/presets/fields.json
+++ b/data/presets/fields.json
@@ -1028,6 +1028,11 @@
             "label": "Max Weight",
             "snake_case": false
         },
+        "milestone_position": {
+            "key": "railway:position",
+            "type": "text",
+            "label": "Milestone Position"
+        },
         "mtb/scale": {
             "key": "mtb:scale",
             "type": "combo",

--- a/data/presets/fields.json
+++ b/data/presets/fields.json
@@ -1031,6 +1031,7 @@
         "milestone_position": {
             "key": "railway:position",
             "type": "text",
+            "placeholder": "Distance to one decimal (123.4)",
             "label": "Milestone Position"
         },
         "mtb/scale": {

--- a/data/presets/fields/milestone_position.json
+++ b/data/presets/fields/milestone_position.json
@@ -1,5 +1,6 @@
 {
     "key": "railway:position",
     "type": "text",
+    "placeholder": "Distance to one decimal (123.4)",
     "label": "Milestone Position"
 }

--- a/data/presets/fields/milestone_position.json
+++ b/data/presets/fields/milestone_position.json
@@ -1,0 +1,5 @@
+{
+    "key": "railway:position",
+    "type": "text",
+    "label": "Milestone Position"
+}

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -10405,6 +10405,9 @@
                 "point",
                 "vertex"
             ],
+            "fields": [
+                "milestone_position"
+            ],
             "tags": {
                 "railway": "milestone"
             },
@@ -10580,6 +10583,10 @@
                 "point",
                 "vertex",
                 "area"
+            ],
+            "fields": [
+                "operator",
+                "building_area"
             ],
             "tags": {
                 "railway": "wash"

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -10313,6 +10313,19 @@
             ],
             "name": "Railway Crossing (Path)"
         },
+        "railway/derail": {
+            "icon": "roadblock",
+            "geometry": [
+                "vertex"
+            ],
+            "tags": {
+                "railway": "derail"
+            },
+            "terms": [
+                "derailer"
+            ],
+            "name": "Railway Derailer"
+        },
         "railway/disused": {
             "icon": "railway-disused",
             "geometry": [
@@ -10386,6 +10399,21 @@
             ],
             "name": "Railway Crossing (Road)"
         },
+        "railway/milestone": {
+            "icon": "triangle-stroked",
+            "geometry": [
+                "point",
+                "vertex"
+            ],
+            "tags": {
+                "railway": "milestone"
+            },
+            "terms": [
+                "milestone",
+                "marker"
+            ],
+            "name": "Railway Milestone"
+        },
         "railway/monorail": {
             "icon": "railway-monorail",
             "geometry": [
@@ -10457,6 +10485,21 @@
             "terms": [],
             "name": "Rail"
         },
+        "railway/signal": {
+            "icon": "poi-junction",
+            "geometry": [
+                "point",
+                "vertex"
+            ],
+            "tags": {
+                "railway": "signal"
+            },
+            "terms": [
+                "signal",
+                "lights"
+            ],
+            "name": "Railway Signal"
+        },
         "railway/station": {
             "icon": "rail",
             "fields": [
@@ -10516,6 +10559,36 @@
                 "transit"
             ],
             "name": "Subway"
+        },
+        "railway/switch": {
+            "icon": "poi-junction",
+            "geometry": [
+                "vertex"
+            ],
+            "tags": {
+                "railway": "switch"
+            },
+            "terms": [
+                "switch",
+                "points"
+            ],
+            "name": "Railway Switch"
+        },
+        "railway/train_wash": {
+            "icon": "rail",
+            "geometry": [
+                "point",
+                "vertex",
+                "area"
+            ],
+            "tags": {
+                "railway": "wash"
+            },
+            "terms": [
+                "wash",
+                "clean"
+            ],
+            "name": "Train Wash"
         },
         "railway/tram_stop": {
             "icon": "rail-light",

--- a/data/presets/presets/railway/derail.json
+++ b/data/presets/presets/railway/derail.json
@@ -1,0 +1,13 @@
+{
+    "icon": "roadblock",
+    "geometry": [
+        "vertex"
+    ],
+    "tags": {
+        "railway": "derail"
+    },
+    "terms": [
+        "derailer"
+    ],
+    "name": "Railway Derailer"
+}

--- a/data/presets/presets/railway/milestone.json
+++ b/data/presets/presets/railway/milestone.json
@@ -4,6 +4,9 @@
         "point",
         "vertex"
     ],
+    "fields": [
+        "milestone_position"
+    ],
     "tags": {
         "railway": "milestone"
     },

--- a/data/presets/presets/railway/milestone.json
+++ b/data/presets/presets/railway/milestone.json
@@ -1,5 +1,5 @@
 {
-    "icon": "roadblock",
+    "icon": "triangle-stroked",
     "geometry": [
         "point",
         "vertex"

--- a/data/presets/presets/railway/milestone.json
+++ b/data/presets/presets/railway/milestone.json
@@ -1,0 +1,15 @@
+{
+    "icon": "roadblock",
+    "geometry": [
+        "point",
+        "vertex"
+    ],
+    "tags": {
+        "railway": "milestone"
+    },
+    "terms": [
+        "milestone",
+        "marker"
+    ],
+    "name": "Railway Milestone"
+}

--- a/data/presets/presets/railway/signal.json
+++ b/data/presets/presets/railway/signal.json
@@ -1,0 +1,15 @@
+{
+    "icon": "poi-junction",
+    "geometry": [
+        "point",
+        "vertex"
+    ],
+    "tags": {
+        "railway": "signal"
+    },
+    "terms": [
+        "signal",
+        "lights"
+    ],
+    "name": "Railway Signal"
+}

--- a/data/presets/presets/railway/switch.json
+++ b/data/presets/presets/railway/switch.json
@@ -1,0 +1,14 @@
+{
+    "icon": "poi-junction",
+    "geometry": [
+        "vertex"
+    ],
+    "tags": {
+        "railway": "switch"
+    },
+    "terms": [
+        "switch",
+        "points"
+    ],
+    "name": "Railway Switch"
+}

--- a/data/presets/presets/railway/train_wash.json
+++ b/data/presets/presets/railway/train_wash.json
@@ -12,5 +12,5 @@
         "wash",
         "clean"
     ],
-    "name": "Railway Wash"
+    "name": "Train Wash"
 }

--- a/data/presets/presets/railway/train_wash.json
+++ b/data/presets/presets/railway/train_wash.json
@@ -5,6 +5,10 @@
         "vertex",
         "area"
     ],
+    "fields": [
+        "operator",
+        "building_area"
+    ],
     "tags": {
         "railway": "wash"
     },

--- a/data/presets/presets/railway/wash.json
+++ b/data/presets/presets/railway/wash.json
@@ -1,0 +1,16 @@
+{
+    "icon": "rail",
+    "geometry": [
+        "point",
+        "vertex",
+        "area"
+    ],
+    "tags": {
+        "railway": "wash"
+    },
+    "terms": [
+        "wash",
+        "clean"
+    ],
+    "name": "Railway Wash"
+}

--- a/data/taginfo.json
+++ b/data/taginfo.json
@@ -2139,6 +2139,10 @@
         },
         {
             "key": "railway",
+            "value": "derail"
+        },
+        {
+            "key": "railway",
             "value": "disused"
         },
         {
@@ -2152,6 +2156,10 @@
         {
             "key": "railway",
             "value": "level_crossing"
+        },
+        {
+            "key": "railway",
+            "value": "milestone"
         },
         {
             "key": "railway",
@@ -2171,6 +2179,10 @@
         },
         {
             "key": "railway",
+            "value": "signal"
+        },
+        {
+            "key": "railway",
             "value": "station"
         },
         {
@@ -2180,6 +2192,14 @@
         {
             "key": "railway",
             "value": "subway"
+        },
+        {
+            "key": "railway",
+            "value": "switch"
+        },
+        {
+            "key": "railway",
+            "value": "wash"
         },
         {
             "key": "railway",

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -4404,6 +4404,10 @@
                     "name": "Railway Crossing (Path)",
                     "terms": "crossing,pedestrian crossing,railroad crossing,level crossing,grade crossing,path through railroad,train crossing"
                 },
+                "railway/derail": {
+                    "name": "Railway Derailer",
+                    "terms": "derailer"
+                },
                 "railway/disused": {
                     "name": "Disused Railway",
                     "terms": ""
@@ -4419,6 +4423,10 @@
                 "railway/level_crossing": {
                     "name": "Railway Crossing (Road)",
                     "terms": "crossing,railroad crossing,level crossing,grade crossing,road through railroad,train crossing"
+                },
+                "railway/milestone": {
+                    "name": "Railway Milestone",
+                    "terms": "milestone,marker"
                 },
                 "railway/monorail": {
                     "name": "Monorail",
@@ -4436,6 +4444,10 @@
                     "name": "Rail",
                     "terms": ""
                 },
+                "railway/signal": {
+                    "name": "Railway Signal",
+                    "terms": "signal,lights"
+                },
                 "railway/station": {
                     "name": "Railway Station",
                     "terms": "train station,station"
@@ -4447,6 +4459,14 @@
                 "railway/subway": {
                     "name": "Subway",
                     "terms": "metro,transit"
+                },
+                "railway/switch": {
+                    "name": "Railway Switch",
+                    "terms": "switch,points"
+                },
+                "railway/train_wash": {
+                    "name": "Train Wash",
+                    "terms": "wash,clean"
                 },
                 "railway/tram_stop": {
                     "name": "Tram Stop",

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -1707,6 +1707,9 @@
                 "maxweight": {
                     "label": "Max Weight"
                 },
+                "milestone_position": {
+                    "label": "Milestone Position"
+                },
                 "mtb/scale": {
                     "label": "Mountain Biking Difficulty",
                     "placeholder": "0, 1, 2, 3...",

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -1708,7 +1708,8 @@
                     "label": "Max Weight"
                 },
                 "milestone_position": {
-                    "label": "Milestone Position"
+                    "label": "Milestone Position",
+                    "placeholder": "Distance to one decimal (123.4)"
                 },
                 "mtb/scale": {
                     "label": "Mountain Biking Difficulty",


### PR DESCRIPTION
This is to, fix #4193 
So far I have added

- Railway Derailer
- Railway Milestone
- Railway Signal
- Railway Switch
- ~~Railway Wash~~ Train wash (6da0719f3a49d4173fe4769e2522a2edccd62885)

Todo:

- [x] Find an appropriate icon for milestone (triangle-stroked)
- [x] Draw railway-signal icon, ~~maybe using something similar to this:~~ Traffic light with two lights instead of 3
- [x] Update wash icon.
- [x] ~~Remove unneeded name from derail and other tags~~ Not possible
- [x] Add a placeholder that tells the user what to input into the milestone field

This could also change the car_wash icon, as currently it is just a car, and looks like a few other presets, this is also the same for railways. So I thought we could maybe add some brushes around the side like shown:
![wash](https://d30y9cdsu7xlg0.cloudfront.net/png/12470-200.png)
All we need to do is change the car to a train, then we're done.