### PR TITLE
Add custom references for runway and taxiway, improve searchability

### DIFF
--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -1467,6 +1467,7 @@ en:
       aerialway/t-bar:
         # aerialway=t-bar
         name: T-bar Lift
+        # 'terms: tbar'
         terms: '<translate with synonyms or related terms for ''T-bar Lift'', separated by commas>'
       aeroway:
         # aeroway=*

--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -1051,6 +1051,11 @@ en:
       ref_stop_position:
         # ref=*
         label: Stop Number
+      ref_taxiway:
+        # ref=*
+        label: Taxiway Name
+        # ref_taxiway field placeholder
+        placeholder: e.g A5
       relation:
         # type=*
         label: Type

--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -1043,6 +1043,11 @@ en:
       ref_route:
         # ref=*
         label: Route Number
+      ref_runway:
+        # ref=*
+        label: Runway Number
+        # ref_runway field placeholder
+        placeholder: e.g 01L/23R
       ref_stop_position:
         # ref=*
         label: Stop Number

--- a/data/presets/fields.json
+++ b/data/presets/fields.json
@@ -1393,6 +1393,12 @@
             "type": "text",
             "label": "Route Number"
         },
+        "ref_runway": {
+            "key": "ref",
+            "type": "text",
+            "label": "Runway Number",
+            "placeholder": "e.g 01L/23R"
+        },
         "ref_stop_position": {
             "key": "ref",
             "type": "text",

--- a/data/presets/fields.json
+++ b/data/presets/fields.json
@@ -1404,6 +1404,12 @@
             "type": "text",
             "label": "Stop Number"
         },
+        "ref_taxiway": {
+            "key": "ref",
+            "type": "text",
+            "label": "Taxiway Name",
+            "placeholder": "e.g A5"
+        },
         "ref": {
             "key": "ref",
             "type": "text",

--- a/data/presets/fields/ref_runway.json
+++ b/data/presets/fields/ref_runway.json
@@ -1,0 +1,6 @@
+{
+    "key": "ref",
+    "type": "text",
+    "label": "Runway Number",
+    "placeholder": "e.g 01L/23R"
+}

--- a/data/presets/fields/ref_taxiway.json
+++ b/data/presets/fields/ref_taxiway.json
@@ -1,0 +1,6 @@
+{
+    "key": "ref",
+    "type": "text",
+    "label": "Taxiway Name",
+    "placeholder": "e.g A5"
+}

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -467,7 +467,7 @@
                 "landing strip"
             ],
             "fields": [
-                "ref",
+                "ref_runway",
                 "surface",
                 "length",
                 "width"

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -482,7 +482,7 @@
                 "line"
             ],
             "fields": [
-                "ref",
+                "ref_taxiway",
                 "surface"
             ],
             "tags": {

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -366,6 +366,9 @@
                 "aerialway/capacity",
                 "aerialway/duration"
             ],
+            "terms": [
+                "tbar"
+            ],
             "tags": {
                 "aerialway": "t-bar"
             },

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -345,12 +345,14 @@
             "icon": "aerialway",
             "geometry": [
                 "point",
-                "vertex"
+                "vertex",
+                "area"
             ],
             "fields": [
                 "aerialway/access",
                 "aerialway/summer/access",
-                "elevation"
+                "elevation",
+                "building_area"
             ],
             "tags": {
                 "aerialway": "station"

--- a/data/presets/presets/aerialway/station.json
+++ b/data/presets/presets/aerialway/station.json
@@ -2,12 +2,14 @@
     "icon": "aerialway",
     "geometry": [
         "point",
-        "vertex"
+        "vertex",
+        "area"
     ],
     "fields": [
         "aerialway/access",
         "aerialway/summer/access",
-        "elevation"
+        "elevation",
+        "building_area"
     ],
     "tags": {
         "aerialway": "station"

--- a/data/presets/presets/aerialway/t-bar.json
+++ b/data/presets/presets/aerialway/t-bar.json
@@ -7,6 +7,9 @@
         "aerialway/capacity",
         "aerialway/duration"
     ],
+    "terms": [
+        "tbar"
+    ],
     "tags": {
         "aerialway": "t-bar"
     },

--- a/data/presets/presets/aeroway/runway.json
+++ b/data/presets/presets/aeroway/runway.json
@@ -7,7 +7,7 @@
         "landing strip"
     ],
     "fields": [
-        "ref",
+        "ref_runway",
         "surface",
         "length",
         "width"

--- a/data/presets/presets/aeroway/taxiway.json
+++ b/data/presets/presets/aeroway/taxiway.json
@@ -3,7 +3,7 @@
         "line"
     ],
     "fields": [
-        "ref",
+        "ref_taxiway",
         "surface"
     ],
     "tags": {

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -2350,7 +2350,7 @@
                 },
                 "aerialway/t-bar": {
                     "name": "T-bar Lift",
-                    "terms": ""
+                    "terms": "tbar"
                 },
                 "aeroway/aerodrome": {
                     "name": "Airport",

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -1949,6 +1949,10 @@
                 "ref_route": {
                     "label": "Route Number"
                 },
+                "ref_runway": {
+                    "label": "Runway Number",
+                    "placeholder": "e.g 01L/23R"
+                },
                 "ref_stop_position": {
                     "label": "Stop Number"
                 },

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -1956,6 +1956,10 @@
                 "ref_stop_position": {
                     "label": "Stop Number"
                 },
+                "ref_taxiway": {
+                    "label": "Taxiway Name",
+                    "placeholder": "e.g A5"
+                },
                 "ref": {
                     "label": "Reference Code"
                 },


### PR DESCRIPTION
This PR does the following:

- Runway now has "Runway number"
- Taxiway now has "Taxiway Name"
- T-Bar lift would not appear if "tbar" was entered, this has been changed
- Aerialway station can now be drawn as an area and as a building