### PR TITLE
Add jetty term to pier

### DIFF
--- a/data/presets/presets/man_made/pier.json
+++ b/data/presets/presets/man_made/pier.json
@@ -4,7 +4,8 @@
         "area"
     ],
     "terms": [
-        "dock"
+        "dock",
+        "jetty"
     ],
     "tags": {
         "man_made": "pier"


### PR DESCRIPTION
Looking through man_made=jetty, quite a number of them should be piers.

Think I messed up resetting github but hope this PR is ok for you (save me having to fully refork)