### PR TITLE
Add terms to wetland

### DIFF
--- a/data/presets/presets/natural/wetland.json
+++ b/data/presets/presets/natural/wetland.json
@@ -10,6 +10,12 @@
     "tags": {
         "natural": "wetland"
     },
-    "terms": [],
+    "terms": [
+        "bog",
+        "marsh",
+        "reedbed",
+        "swamp",
+        "tidalflat"
+    ],
     "name": "Wetland"
 }


### PR DESCRIPTION
I was retagging an old natural=marsh so searched for marsh in the presets, but didn't find anything. I've added the top five wetland=* values to help people find the wetland preset.

Maybe these could be made into proper presets in the future?