### PR TITLE
Restore original Vietnam addressing

### DIFF
--- a/data/address-formats.json
+++ b/data/address-formats.json
@@ -53,7 +53,7 @@
         {
             "countryCodes": ["vn"],
             "format": [
-                ["housenumber", "street","unit"],
+                ["housenumber", "street"],
                 ["subdistrict"],
                 ["district"],
                 ["city"],


### PR DESCRIPTION
Unit is only used once. 
Comment #4235 