### PR TITLE
Update Chinese address format

### DIFF
--- a/data/address-formats.json
+++ b/data/address-formats.json
@@ -122,8 +122,7 @@
             "countryCodes": ["cn"],
             "format": [
                 ["postcode", "province"],
-                ["city", "unit"],
-                ["district"],
+                ["city", "district"],
                 ["street", "housenumber"]
             ]
         }


### PR DESCRIPTION
We have `addr:district` that works similar as `addr:unit` (in western style).
In Chinese language, the word 'unit' is translated to "单元"(a numbered entrance of a building), which is more specific than `addr:housenumber`, so there's no need to keep it.

See [https://en.wikipedia.org/wiki/Address_(geography)#China](https://en.wikipedia.org/wiki/Address_(geography)#China)

#3980 
#4235 