### PR TITLE
Make office=physician non-searchable

### DIFF
--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -1707,7 +1707,7 @@ en:
       amenity/doctors:
         # amenity=doctors
         name: Doctor
-        # 'terms: medic*'
+        # 'terms: medic*,physician'
         terms: '<translate with synonyms or related terms for ''Doctor'', separated by commas>'
       amenity/dojo:
         # amenity=dojo
@@ -3728,7 +3728,6 @@ en:
       office/physician:
         # office=physician
         name: Physician
-        terms: '<translate with synonyms or related terms for ''Physician'', separated by commas>'
       office/political_party:
         # office=political_party
         name: Political Party

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -1316,7 +1316,8 @@
                 "area"
             ],
             "terms": [
-                "medic*"
+                "medic*",
+                "physician"
             ],
             "tags": {
                 "amenity": "doctors"
@@ -10073,6 +10074,25 @@
             "terms": [],
             "name": "Office"
         },
+        "office/physician": {
+            "icon": "commercial",
+            "fields": [
+                "name",
+                "address",
+                "building_area",
+                "opening_hours"
+            ],
+            "geometry": [
+                "point",
+                "vertex",
+                "area"
+            ],
+            "tags": {
+                "office": "physician"
+            },
+            "searchable": false,
+            "name": "Physician"
+        },
         "office/travel_agent": {
             "icon": "suitcase",
             "fields": [
@@ -10454,25 +10474,6 @@
             },
             "terms": [],
             "name": "NGO Office"
-        },
-        "office/physician": {
-            "icon": "commercial",
-            "fields": [
-                "name",
-                "address",
-                "building_area",
-                "opening_hours"
-            ],
-            "geometry": [
-                "point",
-                "vertex",
-                "area"
-            ],
-            "tags": {
-                "office": "physician"
-            },
-            "terms": [],
-            "name": "Physician"
         },
         "office/political_party": {
             "icon": "commercial",

--- a/data/presets/presets/amenity/doctors.json
+++ b/data/presets/presets/amenity/doctors.json
@@ -11,7 +11,8 @@
         "area"
     ],
     "terms": [
-        "medic*"
+        "medic*",
+        "physician"
     ],
     "tags": {
         "amenity": "doctors"

--- a/data/presets/presets/office/_physician.json
+++ b/data/presets/presets/office/_physician.json
@@ -14,6 +14,6 @@
     "tags": {
         "office": "physician"
     },
-    "terms": [],
+    "searchable": false,
     "name": "Physician"
 }

--- a/data/taginfo.json
+++ b/data/taginfo.json
@@ -1988,6 +1988,10 @@
         },
         {
             "key": "office",
+            "value": "physician"
+        },
+        {
+            "key": "office",
             "value": "travel_agent"
         },
         {
@@ -2057,10 +2061,6 @@
         {
             "key": "office",
             "value": "ngo"
-        },
-        {
-            "key": "office",
-            "value": "physician"
         },
         {
             "key": "office",


### PR DESCRIPTION
and add term "physician" to `amenity=doctors`.

`office=physician` is only documented on the wiki at the seemingly abandoned Healthcare 2.0 proposal. It makes no sense to have its preset searchable. The supported tag for physicians is `amenity=doctors`.