### PR TITLE
remove addr:unit from Brazil addresses field

### DIFF
--- a/data/address-formats.json
+++ b/data/address-formats.json
@@ -45,7 +45,7 @@
         {
             "countryCodes": ["br"],
             "format": [
-                ["street","unit"],
+                ["street"],
                 ["housenumber", "suburb"],
                 ["city", "postcode"]
             ]


### PR DESCRIPTION
addr:unit is not common in Brazil addresses