### PR TITLE
artwork_type applies to individual works of art and not to a shop

### DIFF
--- a/data/presets/presets/shop/art.json
+++ b/data/presets/presets/shop/art.json
@@ -2,7 +2,6 @@
     "icon": "shop",
     "fields": [
         "name",
-        "artwork_type",
         "operator",
         "address",
         "building_area",


### PR DESCRIPTION
Combining shop=art with artwork_type seems to give nonsensical values as it is not clear that it applies to the goods sold and not to the shop, see discussion https://forum.openstreetmap.org/viewtopic.php?id=59504 and http://wiki.openstreetmap.org/wiki/Tag:shop%3Dart

Don't have a strong opinion on this myself, but for example a mural is going to be a rather difficult good to have on premises :-).