### PR TITLE
add support for displaying esri metadata

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -279,6 +279,9 @@ en:
       zoom: Zoom
       vintage: Vintage
       source: Source
+      description: Description
+      resolution: Resolution
+      accuracy: Accuracy
       unknown: Unknown
       show_tiles: Show Tiles
       hide_tiles: Hide Tiles

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -278,6 +278,7 @@ en:
       title: Background
       zoom: Zoom
       vintage: Vintage
+      source: Source
       unknown: Unknown
       show_tiles: Show Tiles
       hide_tiles: Hide Tiles

--- a/modules/renderer/background_source.js
+++ b/modules/renderer/background_source.js
@@ -232,6 +232,7 @@ rendererBackgroundSource.Bing = function(data, dispatch) {
 rendererBackgroundSource.Esri = function(data) {
 
     // don't request blank tiles, instead overzoom real tiles - #4327
+    // deprecated technique, but it works (for now)
     if (data.template.match(/blankTile/) === null) {
         data.template = data.template + '?blankTile=false';
     }
@@ -240,12 +241,25 @@ rendererBackgroundSource.Esri = function(data) {
         cache = {};
 
     esri.getVintage = function(center, tileCoord, callback) {
-        var tileId = tileCoord.slice(0, 3).join('/');
-            // FIXME: construct service URL
-            // zoom = Math.min(tileCoord[2], esri.scaleExtent[1]),
-            // centerPoint = center[1] + ',' + center[0],  // lat,lng
-            // url = 'https://dev.virtualearth.net/REST/v1/Imagery/Metadata/Aerial/' + centerPoint +
-            //     '?zl=' + zoom + '&key=' + key + '&jsonp={callback}';
+        var tileId = tileCoord.slice(0, 3).join('/'),
+            zoom = Math.min(tileCoord[2], esri.scaleExtent[1]),
+            centerPoint = center[0] + ',' + center[1],  // long, lat (as it should be)
+            metadataLayer;
+            switch (true) {
+                case zoom >= 19:
+                    metadataLayer = 3;
+                    break;
+                case zoom >= 17:
+                    metadataLayer = 2;
+                    break;
+                case zoom >= 13:
+                    metadataLayer = 0;
+                    break;
+                default:
+                    metadataLayer = 99;
+            }
+            // build up query using the layer appropriate to the current zoom
+            var url = 'https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/' + metadataLayer + '/query?returnGeometry=false&geometry=' + centerPoint + '&inSR=4326&geometryType=esriGeometryPoint&outFields=*&f=json&callback={callback}';
 
         if (!cache[tileId]) {
             cache[tileId] = {};
@@ -254,24 +268,26 @@ rendererBackgroundSource.Esri = function(data) {
             return callback(null, cache[tileId].vintage);
         }
 
-        // FIXME: remove dummy result:
-        callback(null, { start: null, end: null, range: '? - ?'});
-
-        // FIXME: call service instead:
-        // jsonpRequest(url, function(result) {
-        //     var err = (!result && 'Unknown Error') || result.errorDetails;
-        //     if (err) {
-        //         return callback(err);
-        //     } else {
-        //         var vintage = {
-        //             start: localeDateString(result.resourceSets[0].resources[0].vintageStart),
-        //             end: localeDateString(result.resourceSets[0].resources[0].vintageEnd)
-        //         };
-        //         vintage.range = vintageRange(vintage);
-        //         cache[tileId].vintage = vintage;
-        //         return callback(null, vintage);
-        //     }
-        // });
+        // accurate metadata is only available at zoom 13 and closer
+        if (metadataLayer === 99) {
+            callback(null, { range: '', source: ' '});
+        } else {
+            jsonpRequest(url, function(result) {
+                var err = !result || result.features.length < 1;
+                if (err) {
+                    return callback(err);
+                } else {
+                    var vintage = {
+                        // pass through the discrete capture date from metadata
+                        range: localeDateString(result.features[0].attributes.SRC_DATE2),
+                        source: result.features[0].attributes.NICE_DESC
+                    };
+    
+                    cache[tileId].vintage = vintage;
+                    return callback(null, vintage);
+                }
+            });
+        }
     };
 
     return esri;

--- a/modules/renderer/tile_layer.js
+++ b/modules/renderer/tile_layer.js
@@ -255,7 +255,7 @@ export function rendererTileLayer(context) {
                 .each(function(d) {
                     var span = d3.select(this);
                     var center = context.projection.invert(tileCenter(d));
-                    source.getVintage(center, d, function(err, result) {
+                    source.getMetadata(center, d, function(err, result) {
                         span.text((result && result.range) ||
                             t('info_panels.background.vintage') + ': ' + t('info_panels.background.unknown')
                         );

--- a/modules/ui/panels/background.js
+++ b/modules/ui/panels/background.js
@@ -8,7 +8,7 @@ export function uiPanelBackground(context) {
     var currSource = null;
     var currZoom = '';
     var currVintage = '';
-
+    var currEsriSource = '';
 
     function redraw(selection) {
         if (currSource !== background.baseLayerSource().name()) {
@@ -45,6 +45,14 @@ export function uiPanelBackground(context) {
             debouncedGetVintage(selection);
         }
 
+        if (currSource === 'Esri World Imagery') {
+            list
+                .append('li')
+                .text(t('info_panels.background.source') + ': ')
+                .append('span')
+                .attr('class', 'source')
+                .text(currEsriSource);
+        }
         var toggle = context.getDebug('tile') ? 'hide_tiles' : 'show_tiles';
 
         selection
@@ -78,6 +86,12 @@ export function uiPanelBackground(context) {
             currVintage = (result && result.range) || t('info_panels.background.unknown');
             selection.selectAll('.vintage')
                 .text(currVintage);
+            // metadata from Esri can tell us the specific provider
+            if (result.source) {
+                currEsriSource = result.source;
+                selection.selectAll('.source')
+                    .text(currEsriSource);
+            }
         });
     }
 

--- a/modules/ui/status.js
+++ b/modules/ui/status.js
@@ -29,6 +29,7 @@ export function uiStatus(context) {
                                 osm.authenticate();
                             });
                     } else {
+                        // eslint-disable-next-line no-warning-comments
                         // TODO: nice messages for different error types
                         selection.text(t('status.error'));
                     }

--- a/test/spec/spec_helpers.js
+++ b/test/spec/spec_helpers.js
@@ -20,4 +20,5 @@ mocha.setup({
 });
 
 expect = chai.expect;
+// eslint-disable-next-line no-unused-vars
 var d3 = iD.d3;


### PR DESCRIPTION
resolves #4280

* restricts fetching metadata when zoomed to 13 or tighter
* adds a new line to the metadata panel when Esri imagery is active to display the individual provider (NAIP, DigitalGlobe, Municipality etc.)

![screenshot 2017-09-09 22 00 42](https://user-images.githubusercontent.com/3011734/30246289-aec5b5c0-95aa-11e7-8cd7-0db1992d70a7.png)
