### PR TITLE
Upgrade to rollup v0.50 [DO NOT MERGE]

### DIFF
--- a/development_server.js
+++ b/development_server.js
@@ -48,10 +48,10 @@ function build() {
     console.time('Rebuilt');
 
     rollup.rollup({
-        entry: './modules/id.js',
+        input: './modules/id.js',
         plugins: [
             nodeResolve({
-                jsnext: true, main: true, browser: false
+                module: true, main: true, browser: false
             }),
             commonjs(),
             json()
@@ -60,9 +60,9 @@ function build() {
     }).then(function (bundle) {
         bundle.write({
             format: 'iife',
-            dest: 'dist/iD.js',
-            sourceMap: true,
-            useStrict: false
+            file: 'dist/iD.js',
+            sourcemap: true,
+            strict: false
         });
         building = false;
         cache = bundle;

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "npm-run-all": "^4.0.0",
     "phantomjs-prebuilt": "~2.1.11",
     "request": "^2.81.0",
-    "rollup": "0.45.2",
+    "rollup": "0.50.0",
     "rollup-plugin-commonjs": "8.2.1",
     "rollup-plugin-json": "2.2.0",
     "rollup-plugin-node-resolve": "3.0.0",


### PR DESCRIPTION
This is just to upgrade to rollup v0.50

There is a rollup bug that seems to be affecting our d3 import.:  https://github.com/rollup/rollup/issues/1338 , https://github.com/rollup/rollup/issues/1411

So we can't actually take this upgrade until either the bug is fixed, or we stop using a `*` star import of d3 (this is #3948)




