### PR TITLE
Adding playground presets

### DIFF
--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -1041,6 +1041,9 @@ en:
         label: Power Output
         # plant/output/electricity field placeholder
         placeholder: '500 MW, 1000 MW, 2000 MW...'
+      playground/baby:
+        # baby=*
+        label: Baby Seat
       population:
         # population=*
         label: Population
@@ -3962,6 +3965,64 @@ en:
         # place=village
         name: Village
         terms: '<translate with synonyms or related terms for ''Village'', separated by commas>'
+      playground/balance_beam:
+        # playground=balancebeam
+        name: Balance Beam
+        terms: '<translate with synonyms or related terms for ''Balance Beam'', separated by commas>'
+      playground/basket_spinner:
+        # playground=basketrotator
+        name: Basket Spinner
+        # 'terms: basket rotator'
+        terms: '<translate with synonyms or related terms for ''Basket Spinner'', separated by commas>'
+      playground/basket_swing:
+        # playground=basketswing
+        name: Basket Swing
+        terms: '<translate with synonyms or related terms for ''Basket Swing'', separated by commas>'
+      playground/climbing_frame:
+        # playground=climbingframe
+        name: Climbing Frame
+        terms: '<translate with synonyms or related terms for ''Climbing Frame'', separated by commas>'
+      playground/cushion:
+        # playground=cushion
+        name: Bouncy Cushion
+        terms: '<translate with synonyms or related terms for ''Bouncy Cushion'', separated by commas>'
+      playground/horizontal_bar:
+        # playground=horizontal_bar
+        name: Horizontal Bar
+        # 'terms: high bar'
+        terms: '<translate with synonyms or related terms for ''Horizontal Bar'', separated by commas>'
+      playground/rocker:
+        # playground=springy
+        name: Springy Rocker
+        terms: '<translate with synonyms or related terms for ''Springy Rocker'', separated by commas>'
+      playground/roundabout:
+        # playground=roundabout
+        name: Play Roundabout
+        terms: '<translate with synonyms or related terms for ''Play Roundabout'', separated by commas>'
+      playground/sandpit:
+        # playground=sandpit
+        name: Sandpit
+        terms: '<translate with synonyms or related terms for ''Sandpit'', separated by commas>'
+      playground/seesaw:
+        # playground=seesaw
+        name: Seesaw
+        terms: '<translate with synonyms or related terms for ''Seesaw'', separated by commas>'
+      playground/slide:
+        # playground=slide
+        name: Slide
+        terms: '<translate with synonyms or related terms for ''Slide'', separated by commas>'
+      playground/structure:
+        # playground=structure
+        name: Play Structure
+        terms: '<translate with synonyms or related terms for ''Play Structure'', separated by commas>'
+      playground/swing:
+        # playground=swing
+        name: Swing
+        terms: '<translate with synonyms or related terms for ''Swing'', separated by commas>'
+      playground/zipwire:
+        # playground=zipwire
+        name: Zip Wire
+        terms: '<translate with synonyms or related terms for ''Zip Wire'', separated by commas>'
       point:
         name: Point
         terms: '<translate with synonyms or related terms for ''Point'', separated by commas>'

--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -1047,6 +1047,9 @@ en:
       playground/max_age:
         # max_age=*
         label: Maximum Age
+      playground/min_age:
+        # max_age=*
+        label: Minimum Age
       population:
         # population=*
         label: Population

--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -1044,6 +1044,9 @@ en:
       playground/baby:
         # baby=*
         label: Baby Seat
+      playground/max_age:
+        # max_age=*
+        label: Maximum Age
       population:
         # population=*
         label: Population

--- a/data/presets/fields.json
+++ b/data/presets/fields.json
@@ -1390,8 +1390,13 @@
         },
         "playground/max_age": {
             "key": "max_age",
-            "type": "text",
+            "type": "number",
             "label": "Maximum Age"
+        },
+        "playground/min_age": {
+            "key": "max_age",
+            "type": "number",
+            "label": "Minimum Age"
         },
         "population": {
             "key": "population",

--- a/data/presets/fields.json
+++ b/data/presets/fields.json
@@ -1383,6 +1383,11 @@
             "label": "Power Output",
             "placeholder": "500 MW, 1000 MW, 2000 MW..."
         },
+        "playground/baby": {
+            "key": "baby",
+            "type": "check",
+            "label": "Baby Seat"
+        },
         "population": {
             "key": "population",
             "type": "text",

--- a/data/presets/fields.json
+++ b/data/presets/fields.json
@@ -1388,6 +1388,11 @@
             "type": "check",
             "label": "Baby Seat"
         },
+        "playground/max_age": {
+            "key": "max_age",
+            "type": "text",
+            "label": "Maximum Age"
+        },
         "population": {
             "key": "population",
             "type": "text",

--- a/data/presets/fields/playground/baby.json
+++ b/data/presets/fields/playground/baby.json
@@ -1,0 +1,5 @@
+{
+    "key": "baby",
+    "type": "check",
+    "label": "Baby Seat"
+}

--- a/data/presets/fields/playground/max_age.json
+++ b/data/presets/fields/playground/max_age.json
@@ -1,0 +1,5 @@
+{
+    "key": "max_age",
+    "type": "text",
+    "label": "Maximum Age"
+}

--- a/data/presets/fields/playground/min_age.json
+++ b/data/presets/fields/playground/min_age.json
@@ -1,5 +1,5 @@
 {
     "key": "max_age",
     "type": "number",
-    "label": "Maximum Age"
+    "label": "Minimum Age"
 }

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -9497,6 +9497,7 @@
                 "operator",
                 "surface",
                 "playground/max_age",
+                "playground/min_age",
                 "access_simple"
             ],
             "geometry": [
@@ -11601,7 +11602,7 @@
             "name": "Seesaw"
         },
         "playground/slide": {
-            "icon": "entrance",
+            "icon": "playground",
             "geometry": [
                 "point",
                 "line"
@@ -56344,6 +56345,7 @@
                 "operator",
                 "surface",
                 "playground/max_age",
+                "playground/min_age",
                 "access_simple"
             ],
             "suggestion": true
@@ -56364,6 +56366,7 @@
                 "operator",
                 "surface",
                 "playground/max_age",
+                "playground/min_age",
                 "access_simple"
             ],
             "suggestion": true

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -11476,6 +11476,170 @@
             },
             "name": "Village"
         },
+        "playground/balance_beam": {
+            "icon": "playground",
+            "geometry": [
+                "point",
+                "line"
+            ],
+            "tags": {
+                "playground": "balancebeam"
+            },
+            "name": "Balance Beam"
+        },
+        "playground/basket_spinner": {
+            "icon": "playground",
+            "geometry": [
+                "point"
+            ],
+            "terms": [
+                "basket rotator"
+            ],
+            "tags": {
+                "playground": "basketrotator"
+            },
+            "name": "Basket Spinner"
+        },
+        "playground/basket_swing": {
+            "icon": "playground",
+            "geometry": [
+                "point"
+            ],
+            "tags": {
+                "playground": "basketswing"
+            },
+            "name": "Basket Swing"
+        },
+        "playground/climbing_frame": {
+            "icon": "playground",
+            "geometry": [
+                "point",
+                "area"
+            ],
+            "tags": {
+                "playground": "climbingframe"
+            },
+            "name": "Climbing Frame"
+        },
+        "playground/cushion": {
+            "icon": "playground",
+            "geometry": [
+                "point",
+                "area"
+            ],
+            "tags": {
+                "playground": "cushion"
+            },
+            "name": "Bouncy Cushion"
+        },
+        "playground/horizontal_bar": {
+            "icon": "pitch",
+            "fields": [
+                "height"
+            ],
+            "geometry": [
+                "point"
+            ],
+            "terms": [
+                "high bar"
+            ],
+            "tags": {
+                "playground": "horizontal_bar"
+            },
+            "name": "Horizontal Bar"
+        },
+        "playground/rocker": {
+            "icon": "playground",
+            "geometry": [
+                "point"
+            ],
+            "tags": {
+                "playground": "springy"
+            },
+            "name": "Springy Rocker"
+        },
+        "playground/roundabout": {
+            "icon": "stadium",
+            "fields": [
+                "bench"
+            ],
+            "geometry": [
+                "point",
+                "area"
+            ],
+            "tags": {
+                "playground": "roundabout"
+            },
+            "name": "Play Roundabout"
+        },
+        "playground/sandpit": {
+            "icon": "playground",
+            "geometry": [
+                "point",
+                "area"
+            ],
+            "tags": {
+                "playground": "sandpit"
+            },
+            "name": "Sandpit"
+        },
+        "playground/seesaw": {
+            "icon": "playground",
+            "geometry": [
+                "point"
+            ],
+            "tags": {
+                "playground": "seesaw"
+            },
+            "name": "Seesaw"
+        },
+        "playground/slide": {
+            "icon": "entrance",
+            "geometry": [
+                "point",
+                "line"
+            ],
+            "tags": {
+                "playground": "slide"
+            },
+            "name": "Slide"
+        },
+        "playground/structure": {
+            "icon": "pitch",
+            "geometry": [
+                "point",
+                "area"
+            ],
+            "tags": {
+                "playground": "structure"
+            },
+            "name": "Play Structure"
+        },
+        "playground/swing": {
+            "icon": "playground",
+            "fields": [
+                "playground/baby",
+                "wheelchair"
+            ],
+            "geometry": [
+                "point"
+            ],
+            "tags": {
+                "playground": "swing"
+            },
+            "name": "Swing"
+        },
+        "playground/zipwire": {
+            "icon": "playground",
+            "geometry": [
+                "point",
+                "line"
+            ],
+            "tags": {
+                "playground": "zipwire"
+            },
+            "name": "Zip Wire"
+        },
         "point": {
             "fields": [
                 "name"

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -9492,6 +9492,13 @@
         },
         "leisure/playground": {
             "icon": "playground",
+            "fields": [
+                "name",
+                "operator",
+                "surface",
+                "playground/max_age",
+                "access_simple"
+            ],
             "geometry": [
                 "point",
                 "area"
@@ -56332,6 +56339,13 @@
                 "point",
                 "area"
             ],
+            "fields": [
+                "name",
+                "operator",
+                "surface",
+                "playground/max_age",
+                "access_simple"
+            ],
             "suggestion": true
         },
         "leisure/playground/놀이터": {
@@ -56344,6 +56358,13 @@
             "geometry": [
                 "point",
                 "area"
+            ],
+            "fields": [
+                "name",
+                "operator",
+                "surface",
+                "playground/max_age",
+                "access_simple"
             ],
             "suggestion": true
         },

--- a/data/presets/presets/leisure/playground.json
+++ b/data/presets/presets/leisure/playground.json
@@ -1,5 +1,12 @@
 {
     "icon": "playground",
+    "fields": [
+        "name",
+        "operator",
+        "surface",
+        "playground/max_age",
+        "access_simple"
+    ],
     "geometry": [
         "point",
         "area"

--- a/data/presets/presets/leisure/playground.json
+++ b/data/presets/presets/leisure/playground.json
@@ -5,6 +5,7 @@
         "operator",
         "surface",
         "playground/max_age",
+        "playground/min_age",
         "access_simple"
     ],
     "geometry": [

--- a/data/presets/presets/playground/balance_beam.json
+++ b/data/presets/presets/playground/balance_beam.json
@@ -1,0 +1,11 @@
+{
+    "icon": "playground",
+    "geometry": [
+        "point",
+        "line"
+    ],
+    "tags": {
+        "playground": "balancebeam"
+    },
+    "name": "Balance Beam"
+}

--- a/data/presets/presets/playground/basket_spinner.json
+++ b/data/presets/presets/playground/basket_spinner.json
@@ -1,0 +1,13 @@
+{
+    "icon": "playground",
+    "geometry": [
+        "point"
+    ],
+    "terms": [
+        "basket rotator"
+    ],
+    "tags": {
+        "playground": "basketrotator"
+    },
+    "name": "Basket Spinner"
+}

--- a/data/presets/presets/playground/basket_swing.json
+++ b/data/presets/presets/playground/basket_swing.json
@@ -1,0 +1,10 @@
+{
+    "icon": "playground",
+    "geometry": [
+        "point"
+    ],
+    "tags": {
+        "playground": "basketswing"
+    },
+    "name": "Basket Swing"
+}

--- a/data/presets/presets/playground/climbing_frame.json
+++ b/data/presets/presets/playground/climbing_frame.json
@@ -1,0 +1,11 @@
+{
+    "icon": "playground",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "playground": "climbingframe"
+    },
+    "name": "Climbing Frame"
+}

--- a/data/presets/presets/playground/cushion.json
+++ b/data/presets/presets/playground/cushion.json
@@ -1,0 +1,11 @@
+{
+    "icon": "playground",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "playground": "cushion"
+    },
+    "name": "Bouncy Cushion"
+}

--- a/data/presets/presets/playground/horizontal_bar.json
+++ b/data/presets/presets/playground/horizontal_bar.json
@@ -1,0 +1,16 @@
+{
+    "icon": "pitch",
+    "fields": [
+        "height"
+    ],
+    "geometry": [
+        "point"
+    ],
+    "terms": [
+        "high bar"
+    ],
+    "tags": {
+        "playground": "horizontal_bar"
+    },
+    "name": "Horizontal Bar"
+}

--- a/data/presets/presets/playground/rocker.json
+++ b/data/presets/presets/playground/rocker.json
@@ -1,0 +1,10 @@
+{
+    "icon": "playground",
+    "geometry": [
+        "point"
+    ],
+    "tags": {
+        "playground": "springy"
+    },
+    "name": "Springy Rocker"
+}

--- a/data/presets/presets/playground/roundabout.json
+++ b/data/presets/presets/playground/roundabout.json
@@ -1,0 +1,14 @@
+{
+    "icon": "stadium",
+    "fields": [
+        "bench"
+    ],
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "playground": "roundabout"
+    },
+    "name": "Play Roundabout"
+}

--- a/data/presets/presets/playground/sandpit.json
+++ b/data/presets/presets/playground/sandpit.json
@@ -1,0 +1,11 @@
+{
+    "icon": "playground",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "playground": "sandpit"
+    },
+    "name": "Sandpit"
+}

--- a/data/presets/presets/playground/seesaw.json
+++ b/data/presets/presets/playground/seesaw.json
@@ -1,0 +1,10 @@
+{
+    "icon": "playground",
+    "geometry": [
+        "point"
+    ],
+    "tags": {
+        "playground": "seesaw"
+    },
+    "name": "Seesaw"
+}

--- a/data/presets/presets/playground/slide.json
+++ b/data/presets/presets/playground/slide.json
@@ -1,5 +1,5 @@
 {
-    "icon": "entrance",
+    "icon": "playground",
     "geometry": [
         "point",
         "line"

--- a/data/presets/presets/playground/slide.json
+++ b/data/presets/presets/playground/slide.json
@@ -1,0 +1,11 @@
+{
+    "icon": "entrance",
+    "geometry": [
+        "point",
+        "line"
+    ],
+    "tags": {
+        "playground": "slide"
+    },
+    "name": "Slide"
+}

--- a/data/presets/presets/playground/structure.json
+++ b/data/presets/presets/playground/structure.json
@@ -1,0 +1,11 @@
+{
+    "icon": "pitch",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "playground": "structure"
+    },
+    "name": "Play Structure"
+}

--- a/data/presets/presets/playground/swing.json
+++ b/data/presets/presets/playground/swing.json
@@ -1,0 +1,14 @@
+{
+    "icon": "playground",
+    "fields": [
+        "playground/baby",
+        "wheelchair"
+    ],
+    "geometry": [
+        "point"
+    ],
+    "tags": {
+        "playground": "swing"
+    },
+    "name": "Swing"
+}

--- a/data/presets/presets/playground/zipwire.json
+++ b/data/presets/presets/playground/zipwire.json
@@ -1,0 +1,11 @@
+{
+    "icon": "playground",
+    "geometry": [
+        "point",
+        "line"
+    ],
+    "tags": {
+        "playground": "zipwire"
+    },
+    "name": "Zip Wire"
+}

--- a/data/taginfo.json
+++ b/data/taginfo.json
@@ -2221,6 +2221,62 @@
             "value": "village"
         },
         {
+            "key": "playground",
+            "value": "balancebeam"
+        },
+        {
+            "key": "playground",
+            "value": "basketrotator"
+        },
+        {
+            "key": "playground",
+            "value": "basketswing"
+        },
+        {
+            "key": "playground",
+            "value": "climbingframe"
+        },
+        {
+            "key": "playground",
+            "value": "cushion"
+        },
+        {
+            "key": "playground",
+            "value": "horizontal_bar"
+        },
+        {
+            "key": "playground",
+            "value": "springy"
+        },
+        {
+            "key": "playground",
+            "value": "roundabout"
+        },
+        {
+            "key": "playground",
+            "value": "sandpit"
+        },
+        {
+            "key": "playground",
+            "value": "seesaw"
+        },
+        {
+            "key": "playground",
+            "value": "slide"
+        },
+        {
+            "key": "playground",
+            "value": "structure"
+        },
+        {
+            "key": "playground",
+            "value": "swing"
+        },
+        {
+            "key": "playground",
+            "value": "zipwire"
+        },
+        {
             "key": "power",
             "value": "sub_station"
         },

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -1958,6 +1958,9 @@
                 "playground/baby": {
                     "label": "Baby Seat"
                 },
+                "playground/max_age": {
+                    "label": "Maximum Age"
+                },
                 "population": {
                     "label": "Population"
                 },

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -1961,6 +1961,9 @@
                 "playground/max_age": {
                     "label": "Maximum Age"
                 },
+                "playground/min_age": {
+                    "label": "Minimum Age"
+                },
                 "population": {
                     "label": "Population"
                 },

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -1955,6 +1955,9 @@
                     "label": "Power Output",
                     "placeholder": "500 MW, 1000 MW, 2000 MW..."
                 },
+                "playground/baby": {
+                    "label": "Baby Seat"
+                },
                 "population": {
                     "label": "Population"
                 },
@@ -4570,6 +4573,62 @@
                 },
                 "place/village": {
                     "name": "Village",
+                    "terms": ""
+                },
+                "playground/balance_beam": {
+                    "name": "Balance Beam",
+                    "terms": ""
+                },
+                "playground/basket_spinner": {
+                    "name": "Basket Spinner",
+                    "terms": "basket rotator"
+                },
+                "playground/basket_swing": {
+                    "name": "Basket Swing",
+                    "terms": ""
+                },
+                "playground/climbing_frame": {
+                    "name": "Climbing Frame",
+                    "terms": ""
+                },
+                "playground/cushion": {
+                    "name": "Bouncy Cushion",
+                    "terms": ""
+                },
+                "playground/horizontal_bar": {
+                    "name": "Horizontal Bar",
+                    "terms": "high bar"
+                },
+                "playground/rocker": {
+                    "name": "Springy Rocker",
+                    "terms": ""
+                },
+                "playground/roundabout": {
+                    "name": "Play Roundabout",
+                    "terms": ""
+                },
+                "playground/sandpit": {
+                    "name": "Sandpit",
+                    "terms": ""
+                },
+                "playground/seesaw": {
+                    "name": "Seesaw",
+                    "terms": ""
+                },
+                "playground/slide": {
+                    "name": "Slide",
+                    "terms": ""
+                },
+                "playground/structure": {
+                    "name": "Play Structure",
+                    "terms": ""
+                },
+                "playground/swing": {
+                    "name": "Swing",
+                    "terms": ""
+                },
+                "playground/zipwire": {
+                    "name": "Zip Wire",
                     "terms": ""
                 },
                 "point": {


### PR DESCRIPTION
Closes #4252 

### Presets Added

- Balance Beam
- Basket Spinner
- Basket Swing
- Climbing Frame
- Bouncy Cushion
- Horizontal Bar
- Springy Rocker
- Play Roundabout
- Sandpit
- Seesaw
- Slide
- Playground Structure
- Swing
- Zipwire

### Things to do

- ~~Add a new field for the `swing` preset that says whether it has a special wheelchair seat~~
- [x] Change text for the `baby` field on the `swing` preset 
I changed it from `Designed for babies` to `Baby seat`, but I'm still unsure if I like this or not
- [x] Add some more fields to the `playground` preset, such as operator and age restrictions