### PR TITLE
Fixed overlapping in feature editor

### DIFF
--- a/modules/ui/preset_list.js
+++ b/modules/ui/preset_list.js
@@ -223,7 +223,7 @@ export function uiPresetList(context) {
                 box.transition()
                     .duration(200)
                     .style('opacity', '1')
-                    .style('max-height', 200 + preset.members.collection.length * 80 + 'px')
+                    .style('max-height', 200 + preset.members.collection.length * 190 + 'px')
                     .style('padding-bottom', '20px');
             }
         };


### PR DESCRIPTION
Fixes possible overlapping when multiple tag references are expanded.
New max-height 190 px = button 80 px + content 110 px

Closes #4023