### PR TITLE
Refine playground preset terminology

### DIFF
--- a/data/presets/presets/playground/rocker.json
+++ b/data/presets/presets/playground/rocker.json
@@ -6,5 +6,9 @@
     "tags": {
         "playground": "springy"
     },
-    "name": "Springy Rocker"
+    "name": "Spring Rider",
+    "terms": [
+        "spring rocker",
+        "springy rocker"
+    ]
 }

--- a/data/presets/presets/playground/roundabout.json
+++ b/data/presets/presets/playground/roundabout.json
@@ -10,5 +10,8 @@
     "tags": {
         "playground": "roundabout"
     },
-    "name": "Play Roundabout"
+    "name": "Play Roundabout",
+    "terms": [
+        "merry-go-round"
+    ]
 }

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -4620,7 +4620,7 @@
                 },
                 "playground/rocker": {
                     "name": "Spring Rider",
-                    "terms": "spring rocker, springy rocker"
+                    "terms": "spring rocker,springy rocker"
                 },
                 "playground/roundabout": {
                     "name": "Play Roundabout",

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -4619,8 +4619,8 @@
                     "terms": "high bar"
                 },
                 "playground/rocker": {
-                    "name": "Springy Rocker",
-                    "terms": ""
+                    "name": "Spring Rider",
+                    "terms": "spring rocker, springy rocker"
                 },
                 "playground/roundabout": {
                     "name": "Play Roundabout",

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -4624,7 +4624,7 @@
                 },
                 "playground/roundabout": {
                     "name": "Play Roundabout",
-                    "terms": ""
+                    "terms": "merry-go-round"
                 },
                 "playground/sandpit": {
                     "name": "Sandpit",


### PR DESCRIPTION
A couple improvements to playground presets:

* Renamed the “Springy Rocker” preset to “Spring Rider” and added “spring rocker” as a synonym. Both “[spring rider](https://en.wikipedia.org/wiki/Spring_rider)” and “spring rocker” appear to be more common than “springy rocker” in usage online.
* Added “merry-go-round” as a synonym for “Play Roundabout”.