### PR TITLE
Treat punctuation as hashtag delimiters

### DIFF
--- a/modules/ui/commit.js
+++ b/modules/ui/commit.js
@@ -26,6 +26,10 @@ var readOnlyTags = [
     /^locale$/
 ];
 
+// treat all punctuation as hashtag delimiters
+// from https://stackoverflow.com/a/25575009
+var hashtagRegex = /(#[^\u2000-\u206F\u2E00-\u2E7F\s\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^_`{|}~]*)/g;
+
 
 export function uiCommit(context) {
     var dispatch = d3_dispatch('cancel', 'save'),
@@ -309,7 +313,7 @@ export function uiCommit(context) {
         function commentTags() {
             return tags.comment
                 .replace(/http\S*/g, '')  // drop anything that looks like a URL - #4289
-                .match(/#[\w-]+/g);
+                .match(hashtagRegex);
         }
 
         // Extract and clean hashtags from `hashtags`
@@ -319,7 +323,7 @@ export function uiCommit(context) {
                 .split(/[,;\s]+/)
                 .map(function (s) {
                     if (s[0] !== '#') { s = '#' + s; }    // prepend '#'
-                    var matched = s.match(/#[\w-]+/g);    // match valid hashtags
+                    var matched = s.match(hashtagRegex);
                     return matched && matched[0];
                 }).filter(Boolean);                       // exclude falsey
         }


### PR DESCRIPTION
Unicode ranges for punctuation are simpler than creating a Unicode-aware word class, so delimit on non-words.

Fixes #4398