### PR TITLE
Allow -,_,+,& as hashtag characters

### DIFF
--- a/modules/ui/commit.js
+++ b/modules/ui/commit.js
@@ -26,9 +26,9 @@ var readOnlyTags = [
     /^locale$/
 ];
 
-// treat all punctuation as hashtag delimiters - #4398
+// treat most punctuation (except -, _, +, &) as hashtag delimiters - #4398
 // from https://stackoverflow.com/a/25575009
-var hashtagRegex = /(#[^\u2000-\u206F\u2E00-\u2E7F\s\\'!"#$%&()*+,\-.\/:;<=>?@\[\]^`{|}~]+)/g;
+var hashtagRegex = /(#[^\u2000-\u206F\u2E00-\u2E7F\s\\'!"#$%()*,.\/:;<=>?@\[\]^`{|}~]+)/g;
 
 
 export function uiCommit(context) {


### PR DESCRIPTION
@bhousel your comment in #4419 made me realize that these characters also valid: `-`, `+`, `&` (and in use)