### PR TITLE
Lodash dependencies removed from build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.esm-cache
 /data/data.js
 /dist/*.js
 /dist/*.css

--- a/build_data.js
+++ b/build_data.js
@@ -1,11 +1,12 @@
 /* eslint-disable no-console */
+require = require('@std/esm')(module, { esm: 'js' }); // eslint-disable-line no-global-assign
 
-const _cloneDeep = require('lodash/cloneDeep');
-const _extend = require('lodash/extend');
-const _forEach = require('lodash/forEach');
-const _isEmpty = require('lodash/isEmpty');
-const _merge = require('lodash/merge');
-const _toPairs = require('lodash/toPairs');
+const _cloneDeep = require('lodash-es/cloneDeep').default;
+const _extend = require('lodash-es/extend').default;
+const _forEach = require('lodash-es/forEach').default;
+const _isEmpty = require('lodash-es/isEmpty').default;
+const _merge = require('lodash-es/merge').default;
+const _toPairs = require('lodash-es/toPairs').default;
 
 const fs = require('fs');
 const glob = require('glob');

--- a/data/update_locales.js
+++ b/data/update_locales.js
@@ -1,7 +1,9 @@
 /* Downloads the latest translations from Transifex */
 
-const _isEmpty = require('lodash/isEmpty');
-const _merge = require('lodash/merge');
+require = require('@std/esm')(module, { esm: 'js' }); // eslint-disable-line no-global-assign
+
+const _isEmpty = require('lodash-es/isEmpty').default;
+const _merge = require('lodash-es/merge').default;
 
 var request = require('request').defaults({ maxSockets: 1 });
 var yaml = require('js-yaml');

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "@mapbox/maki": "^4.0.0",
+    "@std/esm": "^0.11.3",
     "brfs": "1.4.3",
     "chai": "^4.1.0",
     "colors": "^1.1.2",

--- a/svg/spriteify.js
+++ b/svg/spriteify.js
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 'use strict';
 
-var _merge = require('lodash/merge');
+require = require('@std/esm')(module, { esm: 'js' }); // eslint-disable-line no-global-assign
+
+var _merge = require('lodash-es/merge').default;
 
 var argv = require('minimist')(process.argv.slice(2));
 if (argv.help || argv.h || !argv.svg) {


### PR DESCRIPTION
1. @std/esm added to handle ES6 imports in older node version
2. Swapped lodash dependencies for lodash-es in build scripts (#4378)