### PR TITLE
4489 add missing office presets

### DIFF
--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -4006,6 +4006,10 @@ en:
         # office=administrative
         name: Administrative Office
         terms: '<translate with synonyms or related terms for ''Administrative Office'', separated by commas>'
+      office/adoption_agency:
+        # office=adoption_agency
+        name: Adoption Agency
+        terms: '<translate with synonyms or related terms for ''Adoption Agency'', separated by commas>'
       office/advertising_agency:
         # office=advertising_agency
         name: Advertising Agency
@@ -4017,9 +4021,14 @@ en:
         terms: '<translate with synonyms or related terms for ''Architect'', separated by commas>'
       office/association:
         # office=association
-        name: Association
-        # 'terms: non-profit,organization,society'
-        terms: '<translate with synonyms or related terms for ''Association'', separated by commas>'
+        name: Nonprofit Organization Office
+        # 'terms: association,non-profit,nonprofit,organization,society'
+        terms: '<translate with synonyms or related terms for ''Nonprofit Organization Office'', separated by commas>'
+      office/charity:
+        # office=charity
+        name: Charity Office
+        # 'terms: charitable organization'
+        terms: '<translate with synonyms or related terms for ''Charity Office'', separated by commas>'
       office/company:
         # office=company
         name: Company Office
@@ -4038,6 +4047,11 @@ en:
         name: Employment Agency
         # 'terms: job'
         terms: '<translate with synonyms or related terms for ''Employment Agency'', separated by commas>'
+      office/energy_supplier:
+        # office=energy_supplier
+        name: Energy Supplier Office
+        # 'terms: electricity,energy company,energy utility,gas utility'
+        terms: '<translate with synonyms or related terms for ''Energy Supplier Office'', separated by commas>'
       office/estate_agent:
         # office=estate_agent
         name: Real Estate Office
@@ -4046,6 +4060,15 @@ en:
         # office=financial
         name: Financial Office
         terms: '<translate with synonyms or related terms for ''Financial Office'', separated by commas>'
+      office/forestry:
+        # office=forestry
+        name: Forestry Office
+        # 'terms: forest'
+        terms: '<translate with synonyms or related terms for ''Forestry Office'', separated by commas>'
+      office/foundation:
+        # office=foundation
+        name: Foundation Office
+        terms: '<translate with synonyms or related terms for ''Foundation Office'', separated by commas>'
       office/government:
         # office=government
         name: Government Office
@@ -4055,6 +4078,16 @@ en:
         name: Register Office
         # 'terms: clerk,marriage,death,birth,certificate'
         terms: '<translate with synonyms or related terms for ''Register Office'', separated by commas>'
+      office/government/tax:
+        # 'office=government, government=tax'
+        name: Tax and Revenue Office
+        # 'terms: fiscal authorities,revenue office,tax office'
+        terms: '<translate with synonyms or related terms for ''Tax and Revenue Office'', separated by commas>'
+      office/guide:
+        # office=guide
+        name: Guide Office
+        # 'terms: dive guide,mountain guide,tour guide'
+        terms: '<translate with synonyms or related terms for ''Guide Office'', separated by commas>'
       office/insurance:
         # office=insurance
         name: Insurance Office
@@ -4072,6 +4105,11 @@ en:
         name: Notary Office
         # 'terms: clerk,signature,wills,deeds,estate'
         terms: '<translate with synonyms or related terms for ''Notary Office'', separated by commas>'
+      office/moving_company:
+        # office=moving_company
+        name: Moving Company Office
+        # 'terms: relocation'
+        terms: '<translate with synonyms or related terms for ''Moving Company Office'', separated by commas>'
       office/newspaper:
         # office=newspaper
         name: Newspaper
@@ -4080,6 +4118,10 @@ en:
         # office=ngo
         name: NGO Office
         terms: '<translate with synonyms or related terms for ''NGO Office'', separated by commas>'
+      office/notary:
+        # office=notary
+        name: Notary Office
+        terms: '<translate with synonyms or related terms for ''Notary Office'', separated by commas>'
       office/physician:
         # office=physician
         name: Physician
@@ -4087,14 +4129,29 @@ en:
         # office=political_party
         name: Political Party
         terms: '<translate with synonyms or related terms for ''Political Party'', separated by commas>'
+      office/private_investigator:
+        # office=private_investigator
+        name: Private Investigator Office
+        # 'terms: PI,private eye,private detective'
+        terms: '<translate with synonyms or related terms for ''Private Investigator Office'', separated by commas>'
+      office/quango:
+        # office=quango
+        name: Quango Office
+        # 'terms: Quasi-Autonomous Non-Government Organisation,Quasi-Autonomous Non-Government Organization,Quasi-Autonomous NGO'
+        terms: '<translate with synonyms or related terms for ''Quango Office'', separated by commas>'
       office/research:
         # office=research
         name: Research Office
         terms: '<translate with synonyms or related terms for ''Research Office'', separated by commas>'
       office/surveyor:
         # office=surveyor
-        name: Surveyor
-        terms: '<translate with synonyms or related terms for ''Surveyor'', separated by commas>'
+        name: Surveyor Office
+        terms: '<translate with synonyms or related terms for ''Surveyor Office'', separated by commas>'
+      office/tax_advisor:
+        # office=tax_advisor
+        name: Tax Advisor Office
+        # 'terms: tax,tax consultant'
+        terms: '<translate with synonyms or related terms for ''Tax Advisor Office'', separated by commas>'
       office/telecommunication:
         # office=telecommunication
         name: Telecom Office
@@ -4106,6 +4163,11 @@ en:
       office/travel_agent:
         # office=travel_agent
         name: Travel Agency
+      office/water_utility:
+        # office=water_utility
+        name: Water Utility Office
+        # 'terms: water board,utility'
+        terms: '<translate with synonyms or related terms for ''Water Utility Office'', separated by commas>'
       piste:
         # 'piste:type=*'
         name: Piste/Ski Trail

--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -4008,9 +4008,9 @@ en:
         terms: '<translate with synonyms or related terms for ''Administrative Office'', separated by commas>'
       office/advertising_agency:
         # office=advertising_agency
-        name: Association
+        name: Advertising Agency
         # 'terms: ad,ad agency,advert agency,advertising,marketing'
-        terms: '<translate with synonyms or related terms for ''Association'', separated by commas>'
+        terms: '<translate with synonyms or related terms for ''Advertising Agency'', separated by commas>'
       office/architect:
         # office=architect
         name: Architect
@@ -4018,7 +4018,7 @@ en:
       office/association:
         # office=association
         name: Association
-        # 'terms: organization,non-profit,society'
+        # 'terms: non-profit,organization,society'
         terms: '<translate with synonyms or related terms for ''Association'', separated by commas>'
       office/company:
         # office=company
@@ -4091,6 +4091,10 @@ en:
         # office=research
         name: Research Office
         terms: '<translate with synonyms or related terms for ''Research Office'', separated by commas>'
+      office/surveyor:
+        # office=surveyor
+        name: Surveyor
+        terms: '<translate with synonyms or related terms for ''Surveyor'', separated by commas>'
       office/telecommunication:
         # office=telecommunication
         name: Telecom Office

--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -4010,6 +4010,11 @@ en:
         # office=architect
         name: Architect
         terms: '<translate with synonyms or related terms for ''Architect'', separated by commas>'
+      office/association:
+        # office=association
+        name: Association
+        # 'terms: organization,non-profit,society'
+        terms: '<translate with synonyms or related terms for ''Association'', separated by commas>'
       office/company:
         # office=company
         name: Company Office

--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -4006,6 +4006,11 @@ en:
         # office=administrative
         name: Administrative Office
         terms: '<translate with synonyms or related terms for ''Administrative Office'', separated by commas>'
+      office/advertising_agency:
+        # office=advertising_agency
+        name: Association
+        # 'terms: ad,ad agency,advert agency,advertising,marketing'
+        terms: '<translate with synonyms or related terms for ''Association'', separated by commas>'
       office/architect:
         # office=architect
         name: Architect

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -11502,7 +11502,7 @@
                 "advertising",
                 "marketing"
             ],
-            "name": "Association"
+            "name": "Advertising Agency"
         },
         "office/architect": {
             "icon": "commercial",
@@ -11540,8 +11540,8 @@
                 "office": "association"
             },
             "terms": [
-                "organization",
                 "non-profit",
+                "organization",
                 "society"
             ],
             "name": "Association"
@@ -11884,6 +11884,25 @@
             },
             "terms": [],
             "name": "Research Office"
+        },
+        "office/surveyor": {
+            "icon": "commercial",
+            "fields": [
+                "name",
+                "address",
+                "building_area",
+                "opening_hours"
+            ],
+            "geometry": [
+                "point",
+                "vertex",
+                "area"
+            ],
+            "tags": {
+                "office": "surveyor"
+            },
+            "terms": [],
+            "name": "Surveyor"
         },
         "office/telecommunication": {
             "icon": "commercial",

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -11479,6 +11479,25 @@
             "terms": [],
             "name": "Administrative Office"
         },
+        "office/adoption_agency": {
+            "icon": "commercial",
+            "fields": [
+                "name",
+                "address",
+                "building_area",
+                "opening_hours"
+            ],
+            "geometry": [
+                "point",
+                "vertex",
+                "area"
+            ],
+            "tags": {
+                "office": "adoption_agency"
+            },
+            "terms": [],
+            "name": "Adoption Agency"
+        },
         "office/advertising_agency": {
             "icon": "commercial",
             "fields": [
@@ -11540,11 +11559,34 @@
                 "office": "association"
             },
             "terms": [
+                "association",
                 "non-profit",
+                "nonprofit",
                 "organization",
                 "society"
             ],
-            "name": "Association"
+            "name": "Nonprofit Organization Office"
+        },
+        "office/charity": {
+            "icon": "commercial",
+            "fields": [
+                "name",
+                "address",
+                "building_area",
+                "opening_hours"
+            ],
+            "geometry": [
+                "point",
+                "vertex",
+                "area"
+            ],
+            "tags": {
+                "office": "charity"
+            },
+            "terms": [
+                "charitable organization"
+            ],
+            "name": "Charity Office"
         },
         "office/company": {
             "icon": "commercial",
@@ -11634,6 +11676,30 @@
             ],
             "name": "Employment Agency"
         },
+        "office/energy_supplier": {
+            "icon": "commercial",
+            "fields": [
+                "name",
+                "address",
+                "building_area",
+                "opening_hours"
+            ],
+            "geometry": [
+                "point",
+                "vertex",
+                "area"
+            ],
+            "tags": {
+                "office": "energy_supplier"
+            },
+            "terms": [
+                "electricity",
+                "energy company",
+                "energy utility",
+                "gas utility"
+            ],
+            "name": "Energy Supplier Office"
+        },
         "office/estate_agent": {
             "icon": "commercial",
             "fields": [
@@ -11671,6 +11737,46 @@
             },
             "terms": [],
             "name": "Financial Office"
+        },
+        "office/forestry": {
+            "icon": "commercial",
+            "fields": [
+                "name",
+                "address",
+                "building_area",
+                "opening_hours"
+            ],
+            "geometry": [
+                "point",
+                "vertex",
+                "area"
+            ],
+            "tags": {
+                "office": "forestry"
+            },
+            "terms": [
+                "forest"
+            ],
+            "name": "Forestry Office"
+        },
+        "office/foundation": {
+            "icon": "commercial",
+            "fields": [
+                "name",
+                "address",
+                "building_area",
+                "opening_hours"
+            ],
+            "geometry": [
+                "point",
+                "vertex",
+                "area"
+            ],
+            "tags": {
+                "office": "foundation"
+            },
+            "terms": [],
+            "name": "Foundation Office"
         },
         "office/government": {
             "icon": "commercial",
@@ -11720,6 +11826,57 @@
                 "value": "register_office"
             },
             "name": "Register Office"
+        },
+        "office/government/tax": {
+            "icon": "town-hall",
+            "fields": [
+                "name",
+                "address",
+                "building_area",
+                "opening_hours",
+                "operator"
+            ],
+            "geometry": [
+                "point",
+                "area"
+            ],
+            "terms": [
+                "fiscal authorities",
+                "revenue office",
+                "tax office"
+            ],
+            "tags": {
+                "office": "government",
+                "government": "tax"
+            },
+            "reference": {
+                "key": "government",
+                "value": "tax"
+            },
+            "name": "Tax and Revenue Office"
+        },
+        "office/guide": {
+            "icon": "commercial",
+            "fields": [
+                "name",
+                "address",
+                "building_area",
+                "opening_hours"
+            ],
+            "geometry": [
+                "point",
+                "vertex",
+                "area"
+            ],
+            "tags": {
+                "office": "guide"
+            },
+            "terms": [
+                "dive guide",
+                "mountain guide",
+                "tour guide"
+            ],
+            "name": "Guide Office"
         },
         "office/insurance": {
             "icon": "commercial",
@@ -11808,6 +11965,27 @@
             ],
             "name": "Notary Office"
         },
+        "office/moving_company": {
+            "icon": "commercial",
+            "fields": [
+                "name",
+                "address",
+                "building_area",
+                "opening_hours"
+            ],
+            "geometry": [
+                "point",
+                "vertex",
+                "area"
+            ],
+            "tags": {
+                "office": "moving_company"
+            },
+            "terms": [
+                "relocation"
+            ],
+            "name": "Moving Company Office"
+        },
         "office/newspaper": {
             "icon": "commercial",
             "fields": [
@@ -11847,6 +12025,25 @@
             "terms": [],
             "name": "NGO Office"
         },
+        "office/notary": {
+            "icon": "commercial",
+            "fields": [
+                "name",
+                "address",
+                "building_area",
+                "opening_hours"
+            ],
+            "geometry": [
+                "point",
+                "vertex",
+                "area"
+            ],
+            "tags": {
+                "office": "notary"
+            },
+            "terms": [],
+            "name": "Notary Office"
+        },
         "office/political_party": {
             "icon": "commercial",
             "fields": [
@@ -11865,6 +12062,52 @@
             },
             "terms": [],
             "name": "Political Party"
+        },
+        "office/private_investigator": {
+            "icon": "commercial",
+            "fields": [
+                "name",
+                "address",
+                "building_area",
+                "opening_hours"
+            ],
+            "geometry": [
+                "point",
+                "vertex",
+                "area"
+            ],
+            "tags": {
+                "office": "private_investigator"
+            },
+            "terms": [
+                "PI",
+                "private eye",
+                "private detective"
+            ],
+            "name": "Private Investigator Office"
+        },
+        "office/quango": {
+            "icon": "commercial",
+            "fields": [
+                "name",
+                "address",
+                "building_area",
+                "opening_hours"
+            ],
+            "geometry": [
+                "point",
+                "vertex",
+                "area"
+            ],
+            "tags": {
+                "office": "quango"
+            },
+            "terms": [
+                "Quasi-Autonomous Non-Government Organisation",
+                "Quasi-Autonomous Non-Government Organization",
+                "Quasi-Autonomous NGO"
+            ],
+            "name": "Quango Office"
         },
         "office/research": {
             "icon": "commercial",
@@ -11902,7 +12145,29 @@
                 "office": "surveyor"
             },
             "terms": [],
-            "name": "Surveyor"
+            "name": "Surveyor Office"
+        },
+        "office/tax_advisor": {
+            "icon": "commercial",
+            "fields": [
+                "name",
+                "address",
+                "building_area",
+                "opening_hours"
+            ],
+            "geometry": [
+                "point",
+                "vertex",
+                "area"
+            ],
+            "tags": {
+                "office": "tax_advisor"
+            },
+            "terms": [
+                "tax",
+                "tax consultant"
+            ],
+            "name": "Tax Advisor Office"
         },
         "office/telecommunication": {
             "icon": "commercial",
@@ -11941,6 +12206,29 @@
             },
             "terms": [],
             "name": "Therapist"
+        },
+        "office/water_utility": {
+            "icon": "commercial",
+            "fields": [
+                "name",
+                "address",
+                "building_area",
+                "opening_hours",
+                "operator"
+            ],
+            "geometry": [
+                "point",
+                "vertex",
+                "area"
+            ],
+            "tags": {
+                "office": "water_utility"
+            },
+            "terms": [
+                "water board",
+                "utility"
+            ],
+            "name": "Water Utility Office"
         },
         "piste": {
             "icon": "skiing",

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -11498,6 +11498,29 @@
             "terms": [],
             "name": "Architect"
         },
+        "office/association": {
+            "icon": "commercial",
+            "fields": [
+                "name",
+                "address",
+                "building_area",
+                "opening_hours"
+            ],
+            "geometry": [
+                "point",
+                "vertex",
+                "area"
+            ],
+            "tags": {
+                "office": "association"
+            },
+            "terms": [
+                "organization",
+                "non-profit",
+                "society"
+            ],
+            "name": "Association"
+        },
         "office/company": {
             "icon": "commercial",
             "fields": [

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -11479,6 +11479,31 @@
             "terms": [],
             "name": "Administrative Office"
         },
+        "office/advertising_agency": {
+            "icon": "commercial",
+            "fields": [
+                "name",
+                "address",
+                "building_area",
+                "opening_hours"
+            ],
+            "geometry": [
+                "point",
+                "vertex",
+                "area"
+            ],
+            "tags": {
+                "office": "advertising_agency"
+            },
+            "terms": [
+                "ad",
+                "ad agency",
+                "advert agency",
+                "advertising",
+                "marketing"
+            ],
+            "name": "Association"
+        },
         "office/architect": {
             "icon": "commercial",
             "fields": [

--- a/data/presets/presets/office/adoption_agency.json
+++ b/data/presets/presets/office/adoption_agency.json
@@ -12,8 +12,8 @@
       "area"
   ],
   "tags": {
-      "office": "surveyor"
+      "office": "adoption_agency"
   },
   "terms": [],
-  "name": "Surveyor Office"
+  "name": "Adoption Agency"
 }

--- a/data/presets/presets/office/advertising_agency.json
+++ b/data/presets/presets/office/advertising_agency.json
@@ -1,0 +1,25 @@
+{
+  "icon": "commercial",
+  "fields": [
+      "name",
+      "address",
+      "building_area",
+      "opening_hours"
+  ],
+  "geometry": [
+      "point",
+      "vertex",
+      "area"
+  ],
+  "tags": {
+      "office": "advertising_agency"
+  },
+  "terms": [
+    "ad",
+    "ad agency",
+    "advert agency",
+    "advertising",
+    "marketing"
+  ],
+  "name": "Association"
+}

--- a/data/presets/presets/office/association.json
+++ b/data/presets/presets/office/association.json
@@ -15,8 +15,8 @@
       "office": "association"
   },
   "terms": [
-    "organization",
     "non-profit",
+    "organization",
     "society"
   ],
   "name": "Association"

--- a/data/presets/presets/office/association.json
+++ b/data/presets/presets/office/association.json
@@ -1,0 +1,23 @@
+{
+  "icon": "commercial",
+  "fields": [
+      "name",
+      "address",
+      "building_area",
+      "opening_hours"
+  ],
+  "geometry": [
+      "point",
+      "vertex",
+      "area"
+  ],
+  "tags": {
+      "office": "association"
+  },
+  "terms": [
+    "organization",
+    "non-profit",
+    "society"
+  ],
+  "name": "Association"
+}

--- a/data/presets/presets/office/association.json
+++ b/data/presets/presets/office/association.json
@@ -15,9 +15,11 @@
       "office": "association"
   },
   "terms": [
+    "association",
     "non-profit",
+    "nonprofit",
     "organization",
     "society"
   ],
-  "name": "Association"
+  "name": "Nonprofit Organization Office"
 }

--- a/data/presets/presets/office/charity.json
+++ b/data/presets/presets/office/charity.json
@@ -12,8 +12,10 @@
       "area"
   ],
   "tags": {
-      "office": "surveyor"
+      "office": "charity"
   },
-  "terms": [],
-  "name": "Surveyor Office"
+  "terms": [
+    "charitable organization"
+  ],
+  "name": "Charity Office"
 }

--- a/data/presets/presets/office/energy_supplier.json
+++ b/data/presets/presets/office/energy_supplier.json
@@ -12,8 +12,13 @@
       "area"
   ],
   "tags": {
-      "office": "surveyor"
+      "office": "energy_supplier"
   },
-  "terms": [],
-  "name": "Surveyor Office"
+  "terms": [
+    "electricity",
+    "energy company",
+    "energy utility",
+    "gas utility"
+  ],
+  "name": "Energy Supplier Office"
 }

--- a/data/presets/presets/office/forestry.json
+++ b/data/presets/presets/office/forestry.json
@@ -12,8 +12,10 @@
       "area"
   ],
   "tags": {
-      "office": "surveyor"
+      "office": "forestry"
   },
-  "terms": [],
-  "name": "Surveyor Office"
+  "terms": [
+    "forest"
+  ],
+  "name": "Forestry Office"
 }

--- a/data/presets/presets/office/foundation.json
+++ b/data/presets/presets/office/foundation.json
@@ -12,8 +12,8 @@
       "area"
   ],
   "tags": {
-      "office": "surveyor"
+      "office": "foundation"
   },
   "terms": [],
-  "name": "Surveyor Office"
+  "name": "Foundation Office"
 }

--- a/data/presets/presets/office/government/tax.json
+++ b/data/presets/presets/office/government/tax.json
@@ -1,0 +1,28 @@
+{
+  "icon": "town-hall",
+  "fields": [
+      "name",
+      "address",
+      "building_area",
+      "opening_hours",
+      "operator"
+  ],
+  "geometry": [
+      "point",
+      "area"
+  ],
+  "terms": [
+      "fiscal authorities",
+      "revenue office",
+      "tax office"
+  ],
+  "tags": {
+      "office": "government",
+      "government": "tax"
+  },
+  "reference": {
+      "key": "government",
+      "value": "tax"
+  },
+  "name": "Tax and Revenue Office"
+}

--- a/data/presets/presets/office/guide.json
+++ b/data/presets/presets/office/guide.json
@@ -12,8 +12,12 @@
       "area"
   ],
   "tags": {
-      "office": "surveyor"
+      "office": "guide"
   },
-  "terms": [],
-  "name": "Surveyor Office"
+  "terms": [
+    "dive guide",
+    "mountain guide",
+    "tour guide"
+  ],
+  "name": "Guide Office"
 }

--- a/data/presets/presets/office/moving_company.json
+++ b/data/presets/presets/office/moving_company.json
@@ -12,8 +12,10 @@
       "area"
   ],
   "tags": {
-      "office": "surveyor"
+      "office": "moving_company"
   },
-  "terms": [],
-  "name": "Surveyor Office"
+  "terms": [
+    "relocation"
+  ],
+  "name": "Moving Company Office"
 }

--- a/data/presets/presets/office/notary.json
+++ b/data/presets/presets/office/notary.json
@@ -12,8 +12,8 @@
       "area"
   ],
   "tags": {
-      "office": "surveyor"
+      "office": "notary"
   },
   "terms": [],
-  "name": "Surveyor Office"
+  "name": "Notary Office"
 }

--- a/data/presets/presets/office/private_investigator.json
+++ b/data/presets/presets/office/private_investigator.json
@@ -12,8 +12,12 @@
       "area"
   ],
   "tags": {
-      "office": "surveyor"
+      "office": "private_investigator"
   },
-  "terms": [],
-  "name": "Surveyor Office"
+  "terms": [
+    "PI",
+    "private eye",
+    "private detective"
+  ],
+  "name": "Private Investigator Office"
 }

--- a/data/presets/presets/office/quango.json
+++ b/data/presets/presets/office/quango.json
@@ -12,8 +12,12 @@
       "area"
   ],
   "tags": {
-      "office": "surveyor"
+      "office": "quango"
   },
-  "terms": [],
-  "name": "Surveyor Office"
+  "terms": [
+    "Quasi-Autonomous Non-Government Organisation",
+    "Quasi-Autonomous Non-Government Organization",
+    "Quasi-Autonomous NGO"
+  ],
+  "name": "Quango Office"
 }

--- a/data/presets/presets/office/surveyor.json
+++ b/data/presets/presets/office/surveyor.json
@@ -12,14 +12,8 @@
       "area"
   ],
   "tags": {
-      "office": "advertising_agency"
+      "office": "surveyor"
   },
-  "terms": [
-    "ad",
-    "ad agency",
-    "advert agency",
-    "advertising",
-    "marketing"
-  ],
-  "name": "Advertising Agency"
+  "terms": [],
+  "name": "Surveyor"
 }

--- a/data/presets/presets/office/tax_advisor.json
+++ b/data/presets/presets/office/tax_advisor.json
@@ -12,8 +12,11 @@
       "area"
   ],
   "tags": {
-      "office": "surveyor"
+      "office": "tax_advisor"
   },
-  "terms": [],
-  "name": "Surveyor Office"
+  "terms": [
+    "tax",
+    "tax consultant"
+  ],
+  "name": "Tax Advisor Office"
 }

--- a/data/presets/presets/office/water_utility.json
+++ b/data/presets/presets/office/water_utility.json
@@ -4,7 +4,8 @@
       "name",
       "address",
       "building_area",
-      "opening_hours"
+      "opening_hours",
+      "operator"
   ],
   "geometry": [
       "point",
@@ -12,8 +13,11 @@
       "area"
   ],
   "tags": {
-      "office": "surveyor"
+      "office": "water_utility"
   },
-  "terms": [],
-  "name": "Surveyor Office"
+  "terms": [
+    "water board",
+    "utility"
+  ],
+  "name": "Water Utility Office"
 }

--- a/data/taginfo.json
+++ b/data/taginfo.json
@@ -2171,6 +2171,10 @@
         },
         {
             "key": "office",
+            "value": "advertising_agency"
+        },
+        {
+            "key": "office",
             "value": "architect"
         },
         {

--- a/data/taginfo.json
+++ b/data/taginfo.json
@@ -2171,6 +2171,10 @@
         },
         {
             "key": "office",
+            "value": "adoption_agency"
+        },
+        {
+            "key": "office",
             "value": "advertising_agency"
         },
         {
@@ -2180,6 +2184,10 @@
         {
             "key": "office",
             "value": "association"
+        },
+        {
+            "key": "office",
+            "value": "charity"
         },
         {
             "key": "office",
@@ -2199,6 +2207,10 @@
         },
         {
             "key": "office",
+            "value": "energy_supplier"
+        },
+        {
+            "key": "office",
             "value": "estate_agent"
         },
         {
@@ -2207,11 +2219,27 @@
         },
         {
             "key": "office",
+            "value": "forestry"
+        },
+        {
+            "key": "office",
+            "value": "foundation"
+        },
+        {
+            "key": "office",
             "value": "government"
         },
         {
             "key": "government",
             "value": "register_office"
+        },
+        {
+            "key": "government",
+            "value": "tax"
+        },
+        {
+            "key": "office",
+            "value": "guide"
         },
         {
             "key": "office",
@@ -2231,6 +2259,10 @@
         },
         {
             "key": "office",
+            "value": "moving_company"
+        },
+        {
+            "key": "office",
             "value": "newspaper"
         },
         {
@@ -2239,7 +2271,19 @@
         },
         {
             "key": "office",
+            "value": "notary"
+        },
+        {
+            "key": "office",
             "value": "political_party"
+        },
+        {
+            "key": "office",
+            "value": "private_investigator"
+        },
+        {
+            "key": "office",
+            "value": "quango"
         },
         {
             "key": "office",
@@ -2251,11 +2295,19 @@
         },
         {
             "key": "office",
+            "value": "tax_advisor"
+        },
+        {
+            "key": "office",
             "value": "telecommunication"
         },
         {
             "key": "office",
             "value": "therapist"
+        },
+        {
+            "key": "office",
+            "value": "water_utility"
         },
         {
             "key": "piste:type"

--- a/data/taginfo.json
+++ b/data/taginfo.json
@@ -2175,6 +2175,10 @@
         },
         {
             "key": "office",
+            "value": "association"
+        },
+        {
+            "key": "office",
             "value": "company"
         },
         {

--- a/data/taginfo.json
+++ b/data/taginfo.json
@@ -2247,6 +2247,10 @@
         },
         {
             "key": "office",
+            "value": "surveyor"
+        },
+        {
+            "key": "office",
             "value": "telecommunication"
         },
         {

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -4606,6 +4606,10 @@
                     "name": "Architect",
                     "terms": ""
                 },
+                "office/association": {
+                    "name": "Association",
+                    "terms": "organization,non-profit,society"
+                },
                 "office/company": {
                     "name": "Company Office",
                     "terms": ""

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -4602,6 +4602,10 @@
                     "name": "Administrative Office",
                     "terms": ""
                 },
+                "office/adoption_agency": {
+                    "name": "Adoption Agency",
+                    "terms": ""
+                },
                 "office/advertising_agency": {
                     "name": "Advertising Agency",
                     "terms": "ad,ad agency,advert agency,advertising,marketing"
@@ -4611,8 +4615,12 @@
                     "terms": ""
                 },
                 "office/association": {
-                    "name": "Association",
-                    "terms": "non-profit,organization,society"
+                    "name": "Nonprofit Organization Office",
+                    "terms": "association,non-profit,nonprofit,organization,society"
+                },
+                "office/charity": {
+                    "name": "Charity Office",
+                    "terms": "charitable organization"
                 },
                 "office/company": {
                     "name": "Company Office",
@@ -4630,12 +4638,24 @@
                     "name": "Employment Agency",
                     "terms": "job"
                 },
+                "office/energy_supplier": {
+                    "name": "Energy Supplier Office",
+                    "terms": "electricity,energy company,energy utility,gas utility"
+                },
                 "office/estate_agent": {
                     "name": "Real Estate Office",
                     "terms": ""
                 },
                 "office/financial": {
                     "name": "Financial Office",
+                    "terms": ""
+                },
+                "office/forestry": {
+                    "name": "Forestry Office",
+                    "terms": "forest"
+                },
+                "office/foundation": {
+                    "name": "Foundation Office",
                     "terms": ""
                 },
                 "office/government": {
@@ -4645,6 +4665,14 @@
                 "office/government/register_office": {
                     "name": "Register Office",
                     "terms": "clerk,marriage,death,birth,certificate"
+                },
+                "office/government/tax": {
+                    "name": "Tax and Revenue Office",
+                    "terms": "fiscal authorities,revenue office,tax office"
+                },
+                "office/guide": {
+                    "name": "Guide Office",
+                    "terms": "dive guide,mountain guide,tour guide"
                 },
                 "office/insurance": {
                     "name": "Insurance Office",
@@ -4662,6 +4690,10 @@
                     "name": "Notary Office",
                     "terms": "clerk,signature,wills,deeds,estate"
                 },
+                "office/moving_company": {
+                    "name": "Moving Company Office",
+                    "terms": "relocation"
+                },
                 "office/newspaper": {
                     "name": "Newspaper",
                     "terms": ""
@@ -4670,17 +4702,33 @@
                     "name": "NGO Office",
                     "terms": ""
                 },
+                "office/notary": {
+                    "name": "Notary Office",
+                    "terms": ""
+                },
                 "office/political_party": {
                     "name": "Political Party",
                     "terms": ""
+                },
+                "office/private_investigator": {
+                    "name": "Private Investigator Office",
+                    "terms": "PI,private eye,private detective"
+                },
+                "office/quango": {
+                    "name": "Quango Office",
+                    "terms": "Quasi-Autonomous Non-Government Organisation,Quasi-Autonomous Non-Government Organization,Quasi-Autonomous NGO"
                 },
                 "office/research": {
                     "name": "Research Office",
                     "terms": ""
                 },
                 "office/surveyor": {
-                    "name": "Surveyor",
+                    "name": "Surveyor Office",
                     "terms": ""
+                },
+                "office/tax_advisor": {
+                    "name": "Tax Advisor Office",
+                    "terms": "tax,tax consultant"
                 },
                 "office/telecommunication": {
                     "name": "Telecom Office",
@@ -4689,6 +4737,10 @@
                 "office/therapist": {
                     "name": "Therapist",
                     "terms": ""
+                },
+                "office/water_utility": {
+                    "name": "Water Utility Office",
+                    "terms": "water board,utility"
                 },
                 "piste": {
                     "name": "Piste/Ski Trail",

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -4603,7 +4603,7 @@
                     "terms": ""
                 },
                 "office/advertising_agency": {
-                    "name": "Association",
+                    "name": "Advertising Agency",
                     "terms": "ad,ad agency,advert agency,advertising,marketing"
                 },
                 "office/architect": {
@@ -4612,7 +4612,7 @@
                 },
                 "office/association": {
                     "name": "Association",
-                    "terms": "organization,non-profit,society"
+                    "terms": "non-profit,organization,society"
                 },
                 "office/company": {
                     "name": "Company Office",
@@ -4676,6 +4676,10 @@
                 },
                 "office/research": {
                     "name": "Research Office",
+                    "terms": ""
+                },
+                "office/surveyor": {
+                    "name": "Surveyor",
                     "terms": ""
                 },
                 "office/telecommunication": {

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -4602,6 +4602,10 @@
                     "name": "Administrative Office",
                     "terms": ""
                 },
+                "office/advertising_agency": {
+                    "name": "Association",
+                    "terms": "ad,ad agency,advert agency,advertising,marketing"
+                },
                 "office/architect": {
                     "name": "Architect",
                     "terms": ""


### PR DESCRIPTION
Adds association, advertising_agency, and surveyor office presets as requested in #4489. 

This is my first time contributing, so I'm very open to feedback!!

I also noticed there were several other presets missing that are on the [OSM Wiki](https://wiki.openstreetmap.org/wiki/Key:office) (see below). Should those be added as part of a separate issue?

Here are the other ones on the OSM Wiki:
- adoption_agency
- charity
- energy_supplier
- forestry
- foundation
- guide
- logistics
- moving_company
- notary
- private_investigator
- quango
- religion
- tax
- tax_advisor
- travel_agent
- water_utility