### PR TITLE
Do not capitalise English words.

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -527,8 +527,8 @@ en:
     tag_suggests_area: "The tag {tag} suggests line should be area, but it is not an area"
     deprecated_tags: "Deprecated tags: {tags}"
   zoom:
-    in: Zoom In
-    out: Zoom Out
+    in: Zoom in
+    out: Zoom out
   cannot_zoom: "Cannot zoom out further in current mode."
   full_screen: Toggle Full Screen
   gpx:

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -499,7 +499,7 @@ en:
     welcome: Welcome to the iD OpenStreetMap editor
     text: "iD is a friendly but powerful tool for contributing to the world's best free world map. This is version {version}. For more information see {website} and report bugs at {github}."
     walkthrough: "Start the Walkthrough"
-    start: "Edit Now"
+    start: "Edit now"
   source_switch:
     live: live
     lose_changes: "You have unsaved changes. Switching the map server will discard them. Are you sure you want to switch servers?"

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -238,7 +238,7 @@ en:
     localized_translation_label: Multilingual name
     localized_translation_language: Choose language
     localized_translation_name: Name
-  zoom_in_edit: Zoom in to Edit
+  zoom_in_edit: Zoom in to edit
   login: login
   logout: logout
   loading_auth: "Connecting to OpenStreetMap..."

--- a/dist/locales/en-GB.json
+++ b/dist/locales/en-GB.json
@@ -310,7 +310,7 @@
             "localized_translation_language": "Choose language",
             "localized_translation_name": "Name"
         },
-        "zoom_in_edit": "Zoom in to Edit",
+        "zoom_in_edit": "Zoom in to edit",
         "login": "login",
         "logout": "logout",
         "loading_auth": "Connecting to OpenStreetMap...",

--- a/dist/locales/en-GB.json
+++ b/dist/locales/en-GB.json
@@ -613,7 +613,7 @@
             "welcome": "Welcome to the iD OpenStreetMap editor",
             "text": "iD is a friendly but powerful tool for contributing to the World's best free World map. This is version {version}. For more information see {website} and report bugs at {github}.",
             "walkthrough": "Start the Walkthrough",
-            "start": "Edit Now"
+            "start": "Edit now"
         },
         "source_switch": {
             "live": "live",

--- a/dist/locales/en-GB.json
+++ b/dist/locales/en-GB.json
@@ -646,8 +646,8 @@
             "deprecated_tags": "Deprecated tags: {tags}"
         },
         "zoom": {
-            "in": "Zoom In",
-            "out": "Zoom Out"
+            "in": "Zoom in",
+            "out": "Zoom out"
         },
         "cannot_zoom": "Cannot zoom out further in current mode.",
         "full_screen": "Toggle Full Screen",

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -613,7 +613,7 @@
             "welcome": "Welcome to the iD OpenStreetMap editor",
             "text": "iD is a friendly but powerful tool for contributing to the world's best free world map. This is version {version}. For more information see {website} and report bugs at {github}.",
             "walkthrough": "Start the Walkthrough",
-            "start": "Edit Now"
+            "start": "Edit now"
         },
         "source_switch": {
             "live": "live",

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -310,7 +310,7 @@
             "localized_translation_language": "Choose language",
             "localized_translation_name": "Name"
         },
-        "zoom_in_edit": "Zoom in to Edit",
+        "zoom_in_edit": "Zoom in to edit",
         "login": "login",
         "logout": "logout",
         "loading_auth": "Connecting to OpenStreetMap...",

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -646,8 +646,8 @@
             "deprecated_tags": "Deprecated tags: {tags}"
         },
         "zoom": {
-            "in": "Zoom In",
-            "out": "Zoom Out"
+            "in": "Zoom in",
+            "out": "Zoom out"
         },
         "cannot_zoom": "Cannot zoom out further in current mode.",
         "full_screen": "Toggle Full Screen",


### PR DESCRIPTION
This PR tries to decapitalise four English words in the interface of iD. In my opinion their capitalisation is not justified as they are not directly referring to a feature name of the app.

E.g. "Zoom in to edit" where edit is the standard English word. If it was referring to the Edit feature it would have to be "Zoom in to use Edit".