### PR TITLE
Kiosk name update

### DIFF
--- a/data/presets/presets/shop/kiosk.json
+++ b/data/presets/presets/shop/kiosk.json
@@ -14,5 +14,5 @@
     "tags": {
         "shop": "kiosk"
     },
-    "name": "News Kiosk"
+    "name": "Kiosk"
 }


### PR DESCRIPTION
Wiki makes no mention of it being specifically a "news" kiosk, describing it instead as selling various things. Is this country-specific usage?