### PR TITLE
add public_transport tag to the bus_stop preset

### DIFF
--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -1102,6 +1102,14 @@ en:
       product:
         # product=*
         label: Products
+      public_transport_stop:
+        # public_transport=*
+        label: Stop type
+        options:
+          # public_transport=platform
+          platform: Where the passengers wait
+          # public_transport=stop_position
+          stop_position: Where the bus stops on the road
       railway:
         # railway=*
         label: Type

--- a/data/presets/fields.json
+++ b/data/presets/fields.json
@@ -1468,6 +1468,17 @@
             "type": "semiCombo",
             "label": "Products"
         },
+        "public_transport_stop": {
+            "key": "public_transport",
+            "type": "combo",
+            "label": "Stop type",
+            "strings": {
+                "options": {
+                    "platform": "Where the passengers wait",
+                    "stop_position": "Where the bus stops on the road"
+                }
+            }
+        },
         "railway": {
             "key": "railway",
             "type": "typeCombo",

--- a/data/presets/fields/public_transport_stop.json
+++ b/data/presets/fields/public_transport_stop.json
@@ -1,0 +1,11 @@
+{
+    "key": "public_transport",
+    "type": "combo",
+    "label": "Stop type",
+    "strings": {
+        "options": {
+            "platform": "Where the passengers wait",
+            "stop_position": "Where the bus stops on the road"
+        }
+    }
+}

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -6660,6 +6660,7 @@
                 "name",
                 "network",
                 "operator",
+                "public_transport_stop",
                 "bench",
                 "shelter"
             ],

--- a/data/presets/presets/highway/bus_stop.json
+++ b/data/presets/presets/highway/bus_stop.json
@@ -4,6 +4,7 @@
         "name",
         "network",
         "operator",
+        "public_transport_stop",
         "bench",
         "shelter"
     ],

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -2172,6 +2172,13 @@
                 "product": {
                     "label": "Products"
                 },
+                "public_transport_stop": {
+                    "label": "Stop type",
+                    "options": {
+                        "platform": "Where the passengers wait",
+                        "stop_position": "Where the bus stops on the road"
+                    }
+                },
                 "railway": {
                     "label": "Type"
                 },


### PR DESCRIPTION
This PR add a field to the bus stop preset, to fill the public_transport tag
![ptv2](https://user-images.githubusercontent.com/919962/33239903-a1dc0e56-d2ac-11e7-8c22-34c5d306f12a.png)

Do I need to do something more to handle the translations ?

I did not manage to get the tests run, it gets stuck at the `iD.uiFieldWikipedia` doing nothing 😣