### PR TITLE
Changed tourist attraction icon from monument to star

### DIFF
--- a/data/presets/presets/tourism/attraction.json
+++ b/data/presets/presets/tourism/attraction.json
@@ -1,5 +1,5 @@
 {
-    "icon": "monument",
+    "icon": "star",
     "fields": [
         "name",
         "operator",


### PR DESCRIPTION
If merged this will close #4563.

For example, the London Eye (classes as a tourist attraction) previously had a monument icon:

![screen shot 2017-12-02 at 12 24 09](https://user-images.githubusercontent.com/13594621/33515538-071548fa-d75d-11e7-9c40-38937331bf49.png)

It will now have a star icon:

![screen shot 2017-12-02 at 12 22 31](https://user-images.githubusercontent.com/13594621/33515540-0c2da01c-d75d-11e7-9194-76b23b4471bc.png)

This pull request was made as a part of 24 Pull Requests. 
#codebar24PR2017