### PR TITLE
Highlight the changeset editor when the comment is empty

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -1834,6 +1834,28 @@ input[type=number] {
     text-align: center;
 }
 
+/* Changeset editor while comment text is empty */
+
+.form-field-comment:not(.present) #preset-input-comment {
+    border-color: rgb(230, 100, 100);
+}
+
+.form-field-comment:not(.present) .form-label {
+    border-color: rgb(230, 100, 100);
+    background: rgba(230, 100, 100, 0.2);
+}
+
+.form-field-comment:not(.present) .form-label {
+}
+
+.form-field-comment:not(.present) .form-label-button-wrap {
+    border-color: rgb(230, 100, 100);
+}
+
+.form-field-comment:not(.present) button {
+    border-color: rgb(230, 100, 100);
+}
+
 /* combobox dropdown */
 
 div.combobox {


### PR DESCRIPTION
Change the style of the changeset editor when the comment is empty to explicitly indicate the user what he has to do.

This PR is a minimal change to fix #4613. It only modifies the CSS for the changeset editor.

I've just seen there is another PR for this issue (https://github.com/openstreetmap/iD/pull/4621) which implements some other features that might be helpfull. I still submit mine in case a simpler fix is preferable (also, it's my first one for iD and I chose a "good first issue").

(closes #4613)