### PR TITLE
Fixed click counter persisting

### DIFF
--- a/modules/ui/curtain.js
+++ b/modules/ui/curtain.js
@@ -221,9 +221,6 @@ export function uiCurtain() {
         }
 
         curtain.cut(box, options.duration);
-        
-        //remove any leftover .counter elements 
-        tooltip.selectAll('.counter').remove();
 
         return tooltip;
     };

--- a/modules/ui/curtain.js
+++ b/modules/ui/curtain.js
@@ -221,6 +221,9 @@ export function uiCurtain() {
         }
 
         curtain.cut(box, options.duration);
+        
+        //remove any leftover .counter elements 
+        tooltip.selectAll('.counter').remove();
 
         return tooltip;
     };

--- a/modules/ui/intro/welcome.js
+++ b/modules/ui/intro/welcome.js
@@ -137,7 +137,7 @@ export function uiIntroWelcome(context, reveal) {
         );
     }
 
-
+    
     chapter.enter = function() {
         welcome();
     };
@@ -145,6 +145,9 @@ export function uiIntroWelcome(context, reveal) {
 
     chapter.exit = function() {
         listener.off();
+        var tooltip = d3_select('.curtain-tooltip.intro-mouse')
+            .selectAll('.counter')
+            .remove();
     };
 
 


### PR DESCRIPTION
Fixes #4605

The code that controls the left click and right click portions of the welcome walkthrough removes the click counter element upon successfully clicking the required 5 times then moving onto the next chapter of the walkthrough. It does not take into account the possibility of the user clicking onto a later portion of the walkthrough while the clicking portions still have not been completed, skipping the deletion of the element altogether.

This fix adds a line to curtain.js that deletes any leftover counter elements when constructing the new tooltip.

![id-fix](https://user-images.githubusercontent.com/16764878/34364273-23e6d324-ea52-11e7-93be-e4fc7a2baaa7.gif)
