### PR TITLE
add number of nodes information to measurement panel

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -318,6 +318,7 @@ en:
       location: Location
       metric: Metric
       imperial: Imperial
+      node_count: Number of nodes
   geometry:
     point: point
     vertex: vertex

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -397,7 +397,8 @@
                 "centroid": "Centroid",
                 "location": "Location",
                 "metric": "Metric",
-                "imperial": "Imperial"
+                "imperial": "Imperial",
+                "node_count": "Number of nodes"
             }
         },
         "geometry": {

--- a/modules/ui/panels/measurement.js
+++ b/modules/ui/panels/measurement.js
@@ -42,6 +42,14 @@ export function uiPanelMeasurement(context) {
         return result;
     }
 
+    function nodeCount(feature) {
+      if (feature.type === 'LineString') return feature.coordinates.length;
+
+      if (feature.type === 'Polygon') {
+          return feature.coordinates[0].length - 1;
+      }
+    }
+
 
     function displayLength(m) {
         var d = m * (isImperial ? 3.28084 : 1),
@@ -170,6 +178,15 @@ export function uiPanelMeasurement(context) {
                     (closed ? t('info_panels.measurement.closed') + ' ' : '') + t('geometry.' + geometry)
                 );
 
+            if (entity.type !== 'relation') {
+                list
+                    .append('li')
+                    .text(t('info_panels.measurement.node_count') + ':')
+                    .append('span')
+                    .text(nodeCount(feature)
+                    );
+            }
+
             if (closed) {
                 var area = steradiansToSqmeters(entity.area(resolver));
                 list
@@ -178,6 +195,7 @@ export function uiPanelMeasurement(context) {
                     .append('span')
                     .text(displayArea(area));
             }
+
 
             list
                 .append('li')
@@ -192,7 +210,6 @@ export function uiPanelMeasurement(context) {
                 .text(
                     centroid[1].toFixed(OSM_PRECISION) + ', ' + centroid[0].toFixed(OSM_PRECISION)
                 );
-
 
             var toggle  = isImperial ? 'imperial' : 'metric';
 


### PR DESCRIPTION
As OSM has a limit of 2000 nodes in a way, some users asked me if this information could be available in iD, so I added it to the measurement panel.