### PR TITLE
Restore address format for ["fr", "lu", "mo"]

### DIFF
--- a/data/address-formats.json
+++ b/data/address-formats.json
@@ -53,7 +53,7 @@
         {
             "countryCodes": ["fr", "lu", "mo"],
             "format": [
-                ["unit","housenumber", "street"],
+                ["housenumber", "street"],
                 ["postcode", "city"]
             ]
         },


### PR DESCRIPTION
addr:unit is not standard in addressing for France
in France : 800 addr:unit / 4 000 000 addr:housenumber = 0,0002 (0,02%)

This partly reverts https://github.com/openstreetmap/iD/pull/4235/commits/de6b4fb6a20b2a3438b4159192e2b54682fab2e5 in https://github.com/openstreetmap/iD/pull/4235