### PR TITLE
Remove addr:unit for addresses in Ukraine

### DIFF
--- a/data/address-formats.json
+++ b/data/address-formats.json
@@ -130,7 +130,7 @@
             "countryCodes": ["ua"],
             "format": [
                 ["housenumber", "postcode"],
-                ["street", "unit"]
+                ["street"]
             ]
         },
         {


### PR DESCRIPTION
`addr:unit` isn't a common part of addresses in Ukraine 🤷‍♂️