### PR TITLE
Add ref:isil=* for libraries

### DIFF
--- a/data/presets/fields/ref/isil.json
+++ b/data/presets/fields/ref/isil.json
@@ -1,0 +1,5 @@
+{
+    "key": "ref:isil",
+    "type": "text",
+    "label": "International Standard Identifier for Libraries and Related Organisations"
+}

--- a/data/presets/fields/ref/isil.json
+++ b/data/presets/fields/ref/isil.json
@@ -1,5 +1,5 @@
 {
     "key": "ref:isil",
     "type": "text",
-    "label": "International Standard Identifier for Libraries and Related Organisations"
+    "label": "ISIL Code"
 }

--- a/data/presets/presets/amenity/library.json
+++ b/data/presets/presets/amenity/library.json
@@ -8,7 +8,8 @@
         "opening_hours",
         "internet_access",
         "internet_access/fee",
-        "internet_access/ssid"
+        "internet_access/ssid",
+        "ref/isil"
     ],
     "geometry": [
         "point",


### PR DESCRIPTION
I added the `ref:isil=*` tag to the library preset.

Its usage is documented here: https://wiki.openstreetmap.org/wiki/Key:ref:isil