### PR TITLE
Describe relation in tooltip in add membership list

### DIFF
--- a/modules/ui/raw_membership_editor.js
+++ b/modules/ui/raw_membership_editor.js
@@ -1,5 +1,6 @@
 import _extend from 'lodash-es/extend';
 import _filter from 'lodash-es/filter';
+import _forEach from 'lodash-es/forEach';
 import _groupBy from 'lodash-es/groupBy';
 
 import {
@@ -113,6 +114,10 @@ export function uiRawMembershipEditor(context) {
             group.forEach(function(obj) {
                 obj.value += ' ' + obj.relation.id;
             });
+        });
+
+        _forEach(result, function(obj) {
+            obj.title = obj.value;
         });
 
         result.unshift(newRelation);


### PR DESCRIPTION
In the dropdown for adding the current selection to a relation, each item now has a tooltip showing the same text as the item’s title, handy for situations where the title gets truncated:

<img width="413" alt="route_master" src="https://user-images.githubusercontent.com/1231218/34920855-73c1afaa-f92e-11e7-8ac4-6455d874b19c.png">

This tooltip is similar to the one in the preset and tag editors. It addresses one of the pieces of feedback in https://github.com/openstreetmap/iD/issues/4565#issuecomment-357529846.