### PR TITLE
Added a bus guideway preset

### DIFF
--- a/css/30_highways.css
+++ b/css/30_highways.css
@@ -215,6 +215,21 @@ path.casing.tag-residential {
     stroke:#444;
 }
 
+.preset-icon .icon.highway-bus_guideway {
+    color: #fff;
+    fill: #444;
+}
+path.stroke.tag-highway-bus_guideway,
+path.stroke.tag-bus_guideway {
+    stroke:#fff;
+    stroke-linecap: butt;
+    stroke-dasharray: 12, 16;
+}
+path.casing.tag-highway-bus_guideway,
+path.casing.tag-bus_guideway {
+    stroke:#66a3ff;
+}
+
 .preset-icon .icon.highway-unclassified {
     color: #dcd9b9;
     fill: #444;
@@ -270,6 +285,7 @@ path.shadow.tag-highway-corridor,
 path.shadow.tag-highway-pedestrian,
 path.shadow.tag-highway-steps,
 path.shadow.tag-path,
+path.shadow.tag-highway-bus_guideway,
 path.shadow.tag-footway,
 path.shadow.tag-cycleway,
 path.shadow.tag-bridleway,
@@ -286,6 +302,7 @@ path.casing.tag-highway-corridor,
 path.casing.tag-highway-pedestrian,
 path.casing.tag-highway-steps,
 path.casing.tag-path,
+path.casing.tag-highway-bus_guideway,
 path.casing.tag-footway,
 path.casing.tag-cycleway,
 path.casing.tag-bridleway,
@@ -302,6 +319,7 @@ path.stroke.tag-highway-corridor,
 path.stroke.tag-highway-pedestrian,
 path.stroke.tag-highway-steps,
 path.stroke.tag-path,
+path.stroke.tag-highway-bus_guideway,
 path.stroke.tag-footway,
 path.stroke.tag-cycleway,
 path.stroke.tag-bridleway,
@@ -350,6 +368,7 @@ path.stroke.tag-steps {
 .low-zoom path.shadow.tag-highway-pedestrian,
 .low-zoom path.shadow.tag-highway-steps,
 .low-zoom path.shadow.tag-path,
+.low-zoom path.shadow.tag-highway-bus_guideway,
 .low-zoom path.shadow.tag-footway,
 .low-zoom path.shadow.tag-cycleway,
 .low-zoom path.shadow.tag-bridleway,
@@ -366,6 +385,7 @@ path.stroke.tag-steps {
 .low-zoom path.casing.tag-highway-pedestrian,
 .low-zoom path.casing.tag-highway-steps,
 .low-zoom path.casing.tag-path,
+.low-zoom path.casing.tag-highway-bus_guideway,
 .low-zoom path.casing.tag-footway,
 .low-zoom path.casing.tag-cycleway,
 .low-zoom path.casing.tag-bridleway,
@@ -382,6 +402,7 @@ path.stroke.tag-steps {
 .low-zoom path.stroke.tag-highway-pedestrian,
 .low-zoom path.stroke.tag-highway-steps,
 .low-zoom path.stroke.tag-path,
+.low-zoom path.stroke.tag-highway-bus_guideway,
 .low-zoom path.stroke.tag-footway,
 .low-zoom path.stroke.tag-cycleway,
 .low-zoom path.stroke.tag-bridleway,

--- a/css/30_highways.css
+++ b/css/30_highways.css
@@ -223,11 +223,17 @@ path.stroke.tag-highway-bus_guideway,
 path.stroke.tag-bus_guideway {
     stroke:#fff;
     stroke-linecap: butt;
-    stroke-dasharray: 12, 16;
+    stroke-dasharray: 8, 8;
+    stroke-width: 1;
+}
+
+.low-zoom path.stroke.tag-highway-bus_guideway,
+.low-zoom path.stroke.tag-bus_guideway {
+    stroke-dasharray: 4, 4;
 }
 path.casing.tag-highway-bus_guideway,
 path.casing.tag-bus_guideway {
-    stroke:#66a3ff;
+    stroke:#58a9ed;
 }
 
 .preset-icon .icon.highway-unclassified {
@@ -319,7 +325,6 @@ path.stroke.tag-highway-corridor,
 path.stroke.tag-highway-pedestrian,
 path.stroke.tag-highway-steps,
 path.stroke.tag-path,
-path.stroke.tag-highway-bus_guideway,
 path.stroke.tag-footway,
 path.stroke.tag-cycleway,
 path.stroke.tag-bridleway,

--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -3096,6 +3096,10 @@ en:
         name: Bridle Path
         # 'terms: bridleway,equestrian,horse'
         terms: '<translate with synonyms or related terms for ''Bridle Path'', separated by commas>'
+      highway/bus_guideway:
+        # 'highway=bus_guideway, access=no, bus=designated'
+        name: Bus Guideway
+        terms: '<translate with synonyms or related terms for ''Bus Guideway'', separated by commas>'
       highway/bus_stop:
         # highway=bus_stop
         name: Bus Stop / Platform

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -6933,7 +6933,8 @@
             "icon": "bus",
             "fields": [
                 "name",
-                "operator"
+                "operator",
+                "oneway"
             ],
             "geometry": [
                 "line"

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -6929,6 +6929,23 @@
             ],
             "name": "Bridle Path"
         },
+        "highway/bus_guideway": {
+            "icon": "bus",
+            "fields": [
+                "name",
+                "operator"
+            ],
+            "geometry": [
+                "line"
+            ],
+            "tags": {
+                "highway": "bus_guideway",
+                "access": "no",
+                "bus": "designated"
+            },
+            "terms": [],
+            "name": "Bus Guideway"
+        },
         "highway/corridor": {
             "icon": "highway-footway",
             "fields": [

--- a/data/presets/presets/highway/bus_guideway.json
+++ b/data/presets/presets/highway/bus_guideway.json
@@ -2,7 +2,8 @@
     "icon": "bus",
     "fields": [
         "name",
-        "operator"
+        "operator",
+        "oneway"
     ],
     "geometry": [
         "line"

--- a/data/presets/presets/highway/bus_guideway.json
+++ b/data/presets/presets/highway/bus_guideway.json
@@ -1,0 +1,17 @@
+{
+    "icon": "bus",
+    "fields": [
+        "name",
+        "operator"
+    ],
+    "geometry": [
+        "line"
+    ],
+    "tags": {
+        "highway": "bus_guideway",
+        "access": "no",
+        "bus": "designated"
+    },
+    "terms": [],
+    "name": "Bus Guideway"
+}

--- a/data/taginfo.json
+++ b/data/taginfo.json
@@ -1333,6 +1333,10 @@
             "value": "bridleway"
         },
         {
+            "key": "bus",
+            "value": "designated"
+        },
+        {
             "key": "highway",
             "value": "corridor"
         },

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -3976,6 +3976,10 @@
                     "name": "Bridle Path",
                     "terms": "bridleway,equestrian,horse"
                 },
+                "highway/bus_guideway": {
+                    "name": "Bus Guideway",
+                    "terms": ""
+                },
                 "highway/corridor": {
                     "name": "Indoor Corridor",
                     "terms": "gallery,hall,hallway,indoor,passage,passageway"


### PR DESCRIPTION
There has been no activity for almost 3 weeks on issue #4638, so I picked it up.

I edited the CSS file to get the guideways to look as similar as possible to the picture posted in the issue.

For reference, here is how it looks now
![bus_guideway](https://user-images.githubusercontent.com/23237195/35144842-16cce5b8-fd06-11e7-9a25-d5beca032f0c.PNG)

I tried to reuse existing CSS as much as possible and I added oneway to the list of tags suggested in the [wiki](https://wiki.openstreetmap.org/wiki/Tag:highway%3Dbus_guideway) to fit the example given.