### PR TITLE
added support for kerb barrier preset

### DIFF
--- a/data/presets/categories/barrier.json
+++ b/data/presets/categories/barrier.json
@@ -8,6 +8,7 @@
         "barrier/ditch",
         "barrier/gate",
         "barrier/hedge",
+        "barrier/kerb",
         "barrier"
     ]
 }

--- a/data/presets/presets/barrier/kerb.json
+++ b/data/presets/presets/barrier/kerb.json
@@ -1,0 +1,14 @@
+{
+    "icon": "wheelchair",
+    "fields": [
+        "access"
+    ],
+    "geometry": [
+        "point",
+        "vertex"
+    ],
+    "tags": {
+        "barrier": "kerb"
+    },
+    "name": "Kerb"
+}

--- a/data/presets/presets/barrier/kerb.json
+++ b/data/presets/presets/barrier/kerb.json
@@ -1,10 +1,10 @@
 {
     "icon": "wheelchair",
     "fields": [
-        "access"
+        "tactile_paving",
+        "kerb"
     ],
     "geometry": [
-        "point",
         "vertex"
     ],
     "tags": {


### PR DESCRIPTION
Hi there,

I saw issue #4702 and this looked like a good place to get acquainted with the codebase and start contributing. I went ahead and wrote  kerb.json file as well, I was a little unsure of which icon to use so I went with 'wheelchair' from the [maki icon set](https://www.mapbox.com/maki-icons/). 

It might be a good idea to create icons to differentiate between wheelchair friendly and unfriendly barriers. Happy to draft up a proper issue/proposal for that as well n_n

Hope this helps!
-Jason