### PR TITLE
Restore last imageries used and disable features from local storage

### DIFF
--- a/modules/renderer/background.js
+++ b/modules/renderer/background.js
@@ -386,6 +386,7 @@ export function rendererBackground(context) {
             background.baseLayerSource(
                 background.findSource(requested) ||
                 best ||
+                background.findSource(context.storage('background-last-used')) ||
                 background.findSource('Bing') ||
                 first ||
                 background.findSource('none')

--- a/modules/renderer/features.js
+++ b/modules/renderer/features.js
@@ -72,13 +72,13 @@ export function rendererFeatures(context) {
             var q = utilStringQs(window.location.hash.substring(1));
             var disabled = features.disabled();
             if (disabled.length) {
-                q.disable_features = features.disabled().join(',');
+                q.disable_features = disabled.join(',');
             } else {
                 delete q.disable_features;
             }
             window.location.replace('#' + utilQsString(q, true));
+            context.storage('disabled-features', disabled.join(','));
         }
-
         _hidden = features.hidden();
         dispatch.call('change');
         dispatch.call('redraw');
@@ -478,11 +478,16 @@ export function rendererFeatures(context) {
 
 
     features.init = function() {
+        var storage = context.storage('disabled-features');
+        if (storage) {
+            var storageDisabled = storage.replace(/;/g, ',').split(',');
+            storageDisabled.forEach(features.disable);
+        }
+        
         var q = utilStringQs(window.location.hash.substring(1));
-
         if (q.disable_features) {
-            var disabled = q.disable_features.replace(/;/g, ',').split(',');
-            disabled.forEach(features.disable);
+            var hashDisabled = q.disable_features.replace(/;/g, ',').split(',');
+            hashDisabled.forEach(features.disable);
         }
     };
 

--- a/modules/ui/background.js
+++ b/modules/ui/background.js
@@ -30,7 +30,7 @@ export function uiBackground(context) {
     var key = t('background.key');
 
     var _customSource = context.background().findSource('custom');
-    var _previousBackground;
+    var _previousBackground = context.background().findSource(context.storage('background-previous-last-used'));
     var _shown = false;
 
     var _backgroundList = d3_select(null);
@@ -92,6 +92,8 @@ export function uiBackground(context) {
 
         d3_event.preventDefault();
         _previousBackground = context.background().baseLayerSource();
+        context.storage('background-previous-last-used', _previousBackground.id);
+        context.storage('background-last-used', d.id);
         context.background().baseLayerSource(d);
         _backgroundList.call(updateLayerSelections);
         document.activeElement.blur();


### PR DESCRIPTION
This is part of #2864 but I'll split it in multiple PRs. 
I'd like to save/restore the previous background used too, because you can then use "ctrl+b" shortcut to quickly switch between imageries even in a new tab (In France most of us use imagery from BDOrtho IGN instead of Bing but also Cadastre is another great resource to have and we often switch between them).