### PR TITLE
Added a background for labels of gpx waypoints

### DIFF
--- a/css/20_map.css
+++ b/css/20_map.css
@@ -260,5 +260,13 @@ path.gpx {
 }
 
 text.gpx {
+    fill: #444;
+}
+
+rect.gpxtag {
+    fill: #ddd;
+}
+
+rect.gpxborder {
     fill: #ff26d4;
 }

--- a/modules/svg/gpx.js
+++ b/modules/svg/gpx.js
@@ -57,10 +57,15 @@ export function svgGpx(projection, context, dispatch) {
         svgGpx.initialized = true;
     }
 
+    function getBB(selection) {
+        selection.each(function(d){d.bbox = this.getBBox();})
+    }
 
     function drawGpx(selection) {
         var geojson = svgGpx.geojson,
             enabled = svgGpx.enabled;
+        var margin_size = 2; // margin between the text in the tag and the border of the tag
+        var border_size = 1; // pixel size of the tag's border
 
         layer = selection.selectAll('.layer-gpx')
             .data(enabled ? [0] : []);
@@ -95,8 +100,16 @@ export function svgGpx(projection, context, dispatch) {
 
         var labels = layer.selectAll('text')
             .data(showLabels && geojson.features ? geojson.features : []);
+        var labelTags = layer.selectAll('.gpxtag')
+            .data(showLabels && geojson.features ? geojson.features : []);
+        var labelBorders = layer.selectAll('.gpxborder')
+            .data(showLabels && geojson.features ? geojson.features : []);
 
         labels.exit()
+            .remove();
+        labelTags.exit()
+            .remove();
+        labelBorders.exit()
             .remove();
 
         labels = labels.enter()
@@ -107,7 +120,7 @@ export function svgGpx(projection, context, dispatch) {
         labels
             .text(function(d) {
                 return d.properties.desc || d.properties.name;
-            })
+            }).call(getBB)
             .attr('x', function(d) {
                 var centroid = path.centroid(d);
                 return centroid[0] + 7;
@@ -116,6 +129,41 @@ export function svgGpx(projection, context, dispatch) {
                 var centroid = path.centroid(d);
                 return centroid[1];
             });
+
+
+        labelBorders = labelBorders.enter()
+            .insert('rect', 'text')
+            .attr('class', 'gpxborder')
+            .merge(labelBorders);
+
+        labelBorders
+            .attr("width", function(d){return d.bbox.width + (2*margin_size + 2*border_size)})
+            .attr("height", function(d){return d.bbox.height + (2*margin_size + 2*border_size)})
+            .attr('x', function(d) {
+                var centroid = path.centroid(d);
+                return centroid[0] + 7 - margin_size - border_size;
+            })
+            .attr('y', function(d) {
+                var centroid = path.centroid(d);
+                return centroid[1] - d.bbox.height + margin_size - border_size;
+            })
+
+        labelTags = labelTags.enter()
+            .insert('rect', 'text')
+            .attr('class', 'gpxtag')
+            .merge(labelTags);
+
+        labelTags
+            .attr("width", function(d){return d.bbox.width + (2*margin_size)})
+            .attr("height", function(d){return d.bbox.height + (2*margin_size)})
+            .attr('x', function(d) {
+                var centroid = path.centroid(d);
+                return centroid[0] + 7 - margin_size;
+            })
+            .attr('y', function(d) {
+                var centroid = path.centroid(d);
+                return centroid[1] - d.bbox.height + margin_size;
+            })
 
     }
 


### PR DESCRIPTION
I didn't notice the work in progress tag and the existing pull request on issue #4617 so I started working on it.

I have used a slightly different approach than the other contributor by adding a background to the text instead of a halo.

I am just putting it here in case you find it useful

Here is how it looks
![gpxtags](https://user-images.githubusercontent.com/23237195/35220723-b70167a2-ff77-11e7-8586-c8d4e23cada3.PNG)
