### PR TITLE
Added smoking area preset

### DIFF
--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -2183,6 +2183,10 @@ en:
         name: Shower
         # 'terms: rain closet'
         terms: '<translate with synonyms or related terms for ''Shower'', separated by commas>'
+      amenity/smoking_area:
+        # amenity=smoking_area
+        name: Smoking Area
+        terms: '<translate with synonyms or related terms for ''Smoking Area'', separated by commas>'
       amenity/social_facility:
         # amenity=social_facility
         name: Social Facility

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -2817,6 +2817,25 @@
             },
             "name": "Shower"
         },
+        "amenity/smoking_area": {
+            "fields": [
+                "name",
+                "shelter",
+                "bin",
+                "bench",
+                "opening_hours"
+            ],
+            "geometry": [
+                "point",
+                "vertex",
+                "area"
+            ],
+            "terms": [],
+            "tags": {
+                "amenity": "smoking_area"
+            },
+            "name": "Smoking Area"
+        },
         "amenity/social_facility": {
             "icon": "poi-social-facility",
             "fields": [

--- a/data/presets/presets/amenity/smoking_area.json
+++ b/data/presets/presets/amenity/smoking_area.json
@@ -1,0 +1,20 @@
+{
+    "fields": [
+        "name",
+        "shelter",
+        "bin",
+        "bench",
+        "opening_hours"
+    ],
+    "geometry": [
+        "point",
+        "vertex",
+        "area"
+    ],
+    "terms": [
+    ],
+    "tags": {
+        "amenity": "smoking_area"
+    },
+    "name": "Smoking Area"
+}

--- a/data/taginfo.json
+++ b/data/taginfo.json
@@ -509,6 +509,10 @@
         },
         {
             "key": "amenity",
+            "value": "smoking_area"
+        },
+        {
+            "key": "amenity",
             "value": "social_facility"
         },
         {

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -3144,6 +3144,10 @@
                     "name": "Shower",
                     "terms": "rain closet"
                 },
+                "amenity/smoking_area": {
+                    "name": "Smoking Area",
+                    "terms": ""
+                },
                 "amenity/social_facility": {
                     "name": "Social Facility",
                     "terms": ""


### PR DESCRIPTION
Issue #4701.

I have added a smoking area preset.
I haven't found any fitting icon in the maki set, so I have left the icon field blank. Let me know if using a placeholder such as circle or marker is preferred.