### PR TITLE
Restore area fill from local storage including wireframe (Closes #2864)

### DIFF
--- a/modules/ui/map_data.js
+++ b/modules/ui/map_data.js
@@ -21,7 +21,7 @@ export function uiMapData(context) {
     var fills = ['wireframe', 'partial', 'full'];
 
     var _fillDefault = context.storage('area-fill') || 'partial';
-    var _fillSelected = _fillDefault;
+    var _fillSelected = _fillDefault !== 'wireframe' ? _fillDefault : 'partial';
     var _shown = false;
     var _dataLayerContainer = d3_select(null);
     var _fillList = d3_select(null);
@@ -57,8 +57,8 @@ export function uiMapData(context) {
         _fillSelected = d;
         if (d !== 'wireframe') {
             _fillDefault = d;
-            context.storage('area-fill', d);
         }
+        context.storage('area-fill', d);
         update();
     }
 


### PR DESCRIPTION
Actually area fill was already partly saved in local storage, except for `wireframe` -- I changed logic a bit so that this preference can be saved too.