### PR TITLE
Parking preset: Removed address from default fields

### DIFF
--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -2040,8 +2040,7 @@
                 "supervised",
                 "park_ride",
                 "surface",
-                "maxstay",
-                "address"
+                "maxstay"
             ],
             "geometry": [
                 "point",

--- a/data/presets/presets/amenity/parking.json
+++ b/data/presets/presets/amenity/parking.json
@@ -9,8 +9,7 @@
         "supervised",
         "park_ride",
         "surface",
-        "maxstay",
-        "address"
+        "maxstay"
     ],
     "geometry": [
         "point",


### PR DESCRIPTION
closes #4748

I simply removed address from the list of default fields.

The original issue also mentions a preset for multilevel parking that would include the address field and the tag parking=multi-storey. I haven't pushed that change yet because it isn't 100% clear from your comment whether you also want that added. Tell me if I should.