### PR TITLE
Copy/Paste tags between objects with Ctrl-C/Ctrl-V

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1042,8 +1042,8 @@ en:
         delete: "Delete selected features"
       commands:
         title: "Commands"
-        copy: "Copy selected features"
-        paste: "Paste copied features"
+        copy: "Copy selected features and tags"
+        paste: "Paste copied features or tags"
         undo: "Undo last action"
         redo: "Redo last action"
         save: "Save changes"

--- a/modules/actions/index.js
+++ b/modules/actions/index.js
@@ -20,6 +20,7 @@ export { actionJoin } from './join';
 export { actionMerge } from './merge';
 export { actionMergePolygon } from './merge_polygon';
 export { actionMergeRemoteChanges } from './merge_remote_changes';
+export { actionMergeTags } from './merge_tags';
 export { actionMove } from './move';
 export { actionMoveNode } from './move_node';
 export { actionNoop } from './noop';

--- a/modules/actions/merge_tags.js
+++ b/modules/actions/merge_tags.js
@@ -1,0 +1,23 @@
+export function actionMergeTags(idsFrom, idsTo) {
+
+    // Merge all tags from entities whose id is in idsFrom
+    // into every entity whose id is in idsTo
+
+    return function(graphFrom) {
+
+        var graphTo = graphFrom;
+
+        idsTo.forEach(function(idTo) {
+            var entityTo = graphTo.entity(idTo);
+
+            idsFrom.forEach(function(id) {
+                var entityFrom = graphTo.entity(id);
+                entityTo = entityTo.mergeTags(entityFrom.tags);
+            });
+
+            graphTo = graphTo.replace(entityTo);
+        });
+
+        return graphTo;
+    };
+}

--- a/modules/behavior/index.js
+++ b/modules/behavior/index.js
@@ -10,5 +10,6 @@ export { behaviorHover } from './hover';
 export { behaviorLasso } from './lasso';
 export { behaviorOperation } from './operation';
 export { behaviorPaste } from './paste';
+export { behaviorPasteTags } from './paste_tags';
 export { behaviorSelect } from './select';
 export { behaviorTail } from './tail';

--- a/modules/behavior/paste_tags.js
+++ b/modules/behavior/paste_tags.js
@@ -1,0 +1,39 @@
+import {
+    event as d3_event,
+    select as d3_select
+} from 'd3-selection';
+
+import { d3keybinding as d3_keybinding } from '../lib/d3.keybinding.js';
+
+import {
+    actionMergeTags
+} from '../actions';
+
+import { uiCmd } from '../ui';
+
+
+export function behaviorPasteTags(context) {
+    var keybinding = d3_keybinding('paste');
+
+
+    function doPasteTags() {
+        d3_event.preventDefault();
+        var action = actionMergeTags(context.copyIDs(), context.selectedIDs());
+        context.perform(action);
+    }
+
+
+    function pasteTags() {
+        keybinding.on(uiCmd('⌘V'), doPasteTags);
+        d3_select(document).call(keybinding);
+        return pasteTags;
+    }
+
+
+    pasteTags.off = function() {
+        d3_select(document).call(keybinding.off);
+    };
+
+
+    return pasteTags;
+}

--- a/modules/modes/select.js
+++ b/modules/modes/select.js
@@ -19,7 +19,7 @@ import {
     behaviorCopy,
     behaviorHover,
     behaviorLasso,
-    behaviorPaste,
+    behaviorPasteTags,
     behaviorSelect
 } from '../behavior';
 
@@ -58,7 +58,7 @@ export function modeSelect(context, selectedIDs) {
         timeout = null,
         behaviors = [
             behaviorCopy(context),
-            behaviorPaste(context),
+            behaviorPasteTags(context),
             behaviorBreathe(context),
             behaviorHover(context),
             behaviorSelect(context),


### PR DESCRIPTION
Dear community, 

Thank you to all what you did with iD. Here is a proposal that solves parts of #839, being able to copy tags between objects:

1) It implements a simple `actionMergeTags(idsFrom, idsTo)` that iterates over the existing `entity.mergeTags()` (tags are actually *merged*) and then a `behaviorPasteTags `that pastes/merges all tags from previously copied entities in `context.copyIDs()` onto every selected entity. Thus: 
  - When several objects were copied, all their tags are copied - I am not sure that this is so useful, but we have to deal with these multiple copied entities.
  - When several objects are selected, the tags are pasted/merged onto all selected objects - making easy to copy a same set of tags to a bunch of objects. This partially answer to #1761. This may be dangerous for area-based selections, see https://github.com/openstreetmap/iD/issues/839#issuecomment-195622518, but we could assume that people doing such selections know what they are doing.

2) What should be the keybinding to trigger this behavior ? One solution much liked in #839 could be to have something like `Ctrl+shift+V`. Here we explore another possibility. In my favorite text editor, when something is selected, `Ctrl+V` replaces this selected thing with the copied content. This is not the case in iD, when one does not really understand what was the effect of having selected something when one later presses `Ctrl+V`. As suggested by @yvecai in https://github.com/openstreetmap/iD/issues/839#issuecomment-336423621, the proposal here is thus to use the same `Ctrl+V` to paste/merge tags onto the *existing* selected objects when we are in `modeSelect`. (Nothing is thus changed in `modeBrowse`, `Ctrl+V` still copies objects there.) Anyway, we have to think whether this is an acceptable idea, or whether `Ctrl+shift+V` as previously proposed would be better.

What this proposal does not solve is to partially copy tags. This would requires UI work such as drafted by https://github.com/openstreetmap/iD/issues/839#issuecomment-274321929. Anyway, with this proposal one can still duplicate an object, remove the unwanted tags, and copy/paste the remaining tags to the desired objects.