### PR TITLE
Polish Address Format fix

### DIFF
--- a/data/address-formats.json
+++ b/data/address-formats.json
@@ -24,7 +24,7 @@
             ]
         },
         {
-            "countryCodes": ["at", "ch", "de", "si"],
+            "countryCodes": ["at", "ch", "de", "si", "pl"],
             "format": [
                 ["street", "housenumber"],
                 ["postcode", "city"]
@@ -40,14 +40,6 @@
             "format": [
                 ["street", "housenumber", "unit"],
                 ["postcode", "city"]
-            ]
-        },
-        {
-            "countryCodes": ["pl"],
-            "format": [
-                ["street", "housenumber"],
-                ["postcode"],
-                ["place", "city"]
             ]
         },
         {


### PR DESCRIPTION
The current Polish address fields format includes `addr:place` alongside `addr:street`, which could make it prone to inexperienced users to enter both fileds - and this is, according to [OSM Wiki](https://wiki.openstreetmap.org/wiki/Key:addr:place), an error.

This PR simply removes the `addr:place` format. Main discussion on implementing `addr:place` is held under #2898.

Also, the Polish placeholders for `addr:place` and `addr:city` are the same ("Miejscowość"), which only makes more confusion.