### PR TITLE
Add religion and denomination fields to wayside shrine

### DIFF
--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -8241,6 +8241,8 @@
             "icon": "landmark",
             "fields": [
                 "name",
+                "religion",
+                "denomination"
                 "inscription"
             ],
             "geometry": [

--- a/data/presets/presets/historic/wayside_shrine.json
+++ b/data/presets/presets/historic/wayside_shrine.json
@@ -2,6 +2,8 @@
     "icon": "landmark",
     "fields": [
         "name",
+        "religion",
+        "denomination",
         "inscription"
     ],
     "geometry": [


### PR DESCRIPTION
Recently the OpenStreetMap Carto developers wanted to render historic=wayside_shrine (see gravitystorm/openstreetmap-carto#3003 (PR) and gravitystorm/openstreetmap-carto#131 (issue)). The problem was, that only 30% of wayside shrines had a religion tag and therefore a universal icon (for non-christian shrines) became neccessary.

With this PR, mappers can easily add religion and denomination tags to wayside shrines to get a higher religion information coverage for them.