### PR TITLE
reduced search priority for boat builder

### DIFF
--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -5207,6 +5207,7 @@
             "tags": {
                 "craft": "boatbuilder"
             },
+            "matchScore": 0.4,
             "name": "Boat Builder"
         },
         "craft/bookbinder": {

--- a/data/presets/presets/craft/boatbuilder.json
+++ b/data/presets/presets/craft/boatbuilder.json
@@ -14,5 +14,6 @@
     "tags": {
         "craft": "boatbuilder"
     },
+    "matchScore": 0.4,
     "name": "Boat Builder"
 }


### PR DESCRIPTION
Issue:
When drawing an area and typing "build" in the search bar, "boat builder" is the first result and "building" is only second. This doen't sound like something a user would expect and is a bit annoying when drawing buildings.

Solution:
I changed the match Score of the boat builder preset, "build" now returns building as a first result while "builde" yields boat builder.