### PR TITLE
do not stop mapillary autoplaying if _mlyViewer is not initialized (closes #4804) 

### DIFF
--- a/modules/services/mapillary.js
+++ b/modules/services/mapillary.js
@@ -491,7 +491,7 @@ export default {
     hideViewer: function() {
         _mlySelectedImage = null;
 
-        if (!_mlyFallback) {
+        if (!_mlyFallback && _mlyViewer) {
             _mlyViewer.getComponent('sequence').stop();
         }
 


### PR DESCRIPTION
If we don't open the image viewer, _mlyViewer is not initialized and when we toggle off the layer, an exception is throw because _mlyViewer is not valid.