### PR TITLE
 Issue #4819 : Increase max height of combobox, so they can show more…

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -1886,7 +1886,7 @@ div.combobox {
     box-shadow: 0 4px 10px 1px rgba(0,0,0,.2);
     margin-top: -1px;
     background: white;
-    max-height: 120px;
+    max-height: 245px;
     overflow-y: auto;
     overflow-x: hidden;
     border: 1px solid #ccc;


### PR DESCRIPTION
#4819  item : 

Nothing terrible, I changed max-height css property of combo box to 245px. It increase the maximum shown items by 4.  (Now 8 items)

![dropdown max](https://user-images.githubusercontent.com/19627701/36575155-5d4ca7c2-1817-11e8-8753-1b860b46937e.png)