### PR TITLE
Start adding flow annotations, plus updates to build and linting processes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,15 +5,20 @@
         "es6": true
     },
     "extends": [
-        "eslint:recommended"
+        "eslint:recommended",
+        "plugin:flowtype/recommended"
     ],
     "globals": {
         "d3": false
     },
+    "parser": "babel-eslint",
     "parserOptions": {
         "ecmaVersion": 6,
         "sourceType": "module"
     },
+    "plugins": [
+        "flowtype"
+    ],
     "rules": {
         "dot-notation": "error",
         "eqeqeq": ["error", "smart"],
@@ -67,5 +72,10 @@
         "space-unary-ops": "error",
         "wrap-regex": "off",
         "quotes": ["error", "single"]
+    },
+    "settings": {
+        "flowtype": {
+            "onlyFilesWithFlowAnnotation": true
+        }
     }
 }

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,11 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[lints]
+
+[options]
+
+[strict]

--- a/build_src.js
+++ b/build_src.js
@@ -7,12 +7,13 @@ const commonjs = require('rollup-plugin-commonjs');
 const json = require('rollup-plugin-json');
 const includePaths = require('rollup-plugin-includepaths');
 const colors = require('colors/safe');
+const flow = require('rollup-plugin-flow');
 
 
 module.exports = function buildSrc() {
     var cache;
     var building = false;
-    return function() {
+    return function () {
         if (building) return;
 
         // Start clean
@@ -28,9 +29,10 @@ module.exports = function buildSrc() {
             .rollup({
                 input: './modules/id.js',
                 plugins: [
+                    flow(),
                     includePaths({
                         paths: [
-                            'node_modules/d3/node_modules'  // for npm 2
+                            'node_modules/d3/node_modules' // for npm 2
                         ]
                     }),
                     nodeResolve({
@@ -43,7 +45,7 @@ module.exports = function buildSrc() {
                 ],
                 cache: cache
             })
-            .then(function(bundle) {
+            .then(function (bundle) {
                 cache = bundle;
                 return bundle.write({
                     format: 'iife',
@@ -52,11 +54,11 @@ module.exports = function buildSrc() {
                     strict: false
                 });
             })
-            .then(function() {
+            .then(function () {
                 building = false;
                 console.timeEnd(colors.green('src built'));
             })
-            .catch(function(err) {
+            .catch(function (err) {
                 building = false;
                 cache = undefined;
                 console.error(err);
@@ -67,5 +69,7 @@ module.exports = function buildSrc() {
 
 
 function unlink(f) {
-    try { fs.unlinkSync(f); } catch (e) { /* noop */ }
+    try {
+        fs.unlinkSync(f);
+    } catch (e) { /* noop */ }
 }

--- a/modules/util/locale.js
+++ b/modules/util/locale.js
@@ -1,9 +1,10 @@
+// @flow
 var translations = Object.create(null);
 
 export var currentLocale = 'en';
 export var textDirection = 'ltr';
 
-export function setLocale(_) {
+export function setLocale(_: any): void {
     if (translations[_] !== undefined) {
         currentLocale = _;
     } else if (translations[_.split('-')[0]]) {
@@ -11,7 +12,7 @@ export function setLocale(_) {
     }
 }
 
-export function addTranslation(id, value) {
+export function addTranslation(id: string, value: string): void {
     translations[id] = value;
 }
 
@@ -22,12 +23,14 @@ export function addTranslation(id, value) {
  * @param {string} s string identifier
  * @returns {string?} locale string
  */
-export function t(s, o, loc) {
+export function t(s: string, o: any, loc?: string): string {
     loc = loc || currentLocale;
 
     var path = s
         .split('.')
-        .map(function(s) { return s.replace('<TX_DOT>', '.'); })
+        .map(function (s) {
+            return s.replace('<TX_DOT>', '.');
+        })
         .reverse();
 
     var rep = translations[loc];
@@ -35,7 +38,8 @@ export function t(s, o, loc) {
     while (rep !== undefined && path.length) rep = rep[path.pop()];
 
     if (rep !== undefined) {
-        if (o) for (var k in o) rep = rep.replace('{' + k + '}', o[k]);
+        if (o)
+            for (var k in o) rep = rep.replace('{' + k + '}', o[k]);
         return rep;
     }
 
@@ -59,6 +63,6 @@ export function t(s, o, loc) {
  * @param {string} s ltr or rtl
  */
 
-export function setTextDirection(dir) {
+export function setTextDirection(dir: string): void {
     textDirection = dir;
 }

--- a/modules/util/session_mutex.js
+++ b/modules/util/session_mutex.js
@@ -1,10 +1,19 @@
+// @flow
 // A per-domain session mutex backed by a cookie and dead man's
 // switch. If the session crashes, the mutex will auto-release
 // after 5 seconds.
 
-export function utilSessionMutex(name) {
-    var mutex = {},
-        intervalID;
+// This is a type alias (https://flow.org/en/docs/types/aliases/) which allows flow to understand the object returned by utilSessionMutex in other files.
+type utilSessionMutexType = {
+    lock: () => boolean,
+    unlock: () => void,
+    locked: () => boolean
+};
+
+// This accepts a string and returns an object that complies with utilSessionMutexType
+export function utilSessionMutex(name: string): utilSessionMutexType {
+    var mutex = {};
+    var intervalID: ?IntervalID; // This indicates a Maybe type - intervalId can be null so we need to use "?IntervalID", not "IntervalID"
 
     function renew() {
         var expires = new Date();
@@ -12,7 +21,7 @@ export function utilSessionMutex(name) {
         document.cookie = name + '=1; expires=' + expires.toUTCString();
     }
 
-    mutex.lock = function() {
+    mutex.lock = function (): boolean {
         if (intervalID) return true;
         var cookie = document.cookie.replace(new RegExp('(?:(?:^|.*;)\\s*' + name + '\\s*\\=\\s*([^;]*).*$)|^.*$'), '$1');
         if (cookie) return false;
@@ -21,14 +30,14 @@ export function utilSessionMutex(name) {
         return true;
     };
 
-    mutex.unlock = function() {
+    mutex.unlock = function (): void {
         if (!intervalID) return;
         document.cookie = name + '=; expires=Thu, 01 Jan 1970 00:00:00 GMT';
         clearInterval(intervalID);
         intervalID = null;
     };
 
-    mutex.locked = function() {
+    mutex.locked = function (): boolean {
         return !!intervalID;
     };
 

--- a/modules/util/units.js
+++ b/modules/util/units.js
@@ -1,5 +1,6 @@
-import { t } from 'locale';
-import { utilDetect } from 'detect';
+// @flow
+import { t } from './locale';
+import { utilDetect } from './detect';
 
 var OSM_PRECISION = 7;
 var locale = utilDetect().locale;
@@ -10,7 +11,7 @@ var locale = utilDetect().locale;
  * @param {Number} m area in meters
  * @param {Boolean} isImperial true for U.S. customary units; false for metric
  */
-export function displayLength(m, isImperial) {
+export function displayLength(m: number, isImperial: boolean): string {
 	var d = m * (isImperial ? 3.28084 : 1),
 		unit;
 
@@ -31,7 +32,9 @@ export function displayLength(m, isImperial) {
 	}
 
 	return t('units.' + unit, {
-		quantity: d.toLocaleString(locale, { maximumSignificantDigits: 4 })
+		quantity: d.toLocaleString(locale, {
+			maximumSignificantDigits: 4
+		})
 	});
 }
 
@@ -41,12 +44,14 @@ export function displayLength(m, isImperial) {
  * @param {Number} m2 area in square meters
  * @param {Boolean} isImperial true for U.S. customary units; false for metric
  */
-export function displayArea(m2, isImperial) {
+export function displayArea(m2: number, isImperial: boolean): string {
 	var d = m2 * (isImperial ? 10.7639111056 : 1),
-		d1, d2, unit1, unit2, area;
+		d1, d2, area;
+	var unit1: string = '';
+	var unit2: string = '';
 
 	if (isImperial) {
-		if (d >= 6969600) {     // > 0.25mi² show mi²
+		if (d >= 6969600) { // > 0.25mi² show mi²
 			d1 = d / 27878400;
 			unit1 = 'square_miles';
 		} else {
@@ -54,13 +59,13 @@ export function displayArea(m2, isImperial) {
 			unit1 = 'square_feet';
 		}
 
-		if (d > 4356 && d < 43560000) {   // 0.1 - 1000 acres
+		if (d > 4356 && d < 43560000) { // 0.1 - 1000 acres
 			d2 = d / 43560;
 			unit2 = 'acres';
 		}
 
 	} else {
-		if (d >= 250000) {    // > 0.25km² show km²
+		if (d >= 250000) { // > 0.25km² show km²
 			d1 = d / 1000000;
 			unit1 = 'square_kilometers';
 		} else {
@@ -68,21 +73,25 @@ export function displayArea(m2, isImperial) {
 			unit1 = 'square_meters';
 		}
 
-		if (d > 1000 && d < 10000000) {   // 0.1 - 1000 hectares
+		if (d > 1000 && d < 10000000) { // 0.1 - 1000 hectares
 			d2 = d / 10000;
 			unit2 = 'hectares';
 		}
 	}
 
 	area = t('units.' + unit1, {
-		quantity: d1.toLocaleString(locale, { maximumSignificantDigits: 4 })
+		quantity: d1.toLocaleString(locale, {
+			maximumSignificantDigits: 4
+		})
 	});
 
 	if (d2) {
 		return t('units.area_pair', {
 			area1: area,
 			area2: t('units.' + unit2, {
-				quantity: d2.toLocaleString(locale, { maximumSignificantDigits: 2 })
+				quantity: d2.toLocaleString(locale, {
+					maximumSignificantDigits: 2
+				})
 			})
 		});
 	} else {
@@ -90,16 +99,16 @@ export function displayArea(m2, isImperial) {
 	}
 }
 
-function wrap(x, min, max) {
+function wrap(x: number, min: number, max: number): number {
 	var d = max - min;
 	return ((x - min) % d + d) % d + min;
 }
 
-function clamp(x, min, max) {
+function clamp(x: number, min: number, max: number): number {
 	return Math.max(min, Math.min(x, max));
 }
 
-function displayCoordinate(deg, pos, neg) {
+function displayCoordinate(deg: number, pos: any, neg: any): string {
 	var min = (Math.abs(deg) - Math.floor(Math.abs(deg))) * 60,
 		sec = (min - Math.floor(min)) * 60,
 		displayDegrees = t('units.arcdegrees', {
@@ -109,11 +118,17 @@ function displayCoordinate(deg, pos, neg) {
 
 	if (Math.floor(sec) > 0) {
 		displayCoordinate = displayDegrees +
-			t('units.arcminutes', { quantity: Math.floor(min).toLocaleString(locale) }) +
-			t('units.arcseconds', { quantity: Math.round(sec).toLocaleString(locale) });
+			t('units.arcminutes', {
+				quantity: Math.floor(min).toLocaleString(locale)
+			}) +
+			t('units.arcseconds', {
+				quantity: Math.round(sec).toLocaleString(locale)
+			});
 	} else if (Math.floor(min) > 0) {
 		displayCoordinate = displayDegrees +
-			t('units.arcminutes', { quantity: Math.round(min).toLocaleString(locale) });
+			t('units.arcminutes', {
+				quantity: Math.round(min).toLocaleString(locale)
+			});
 	} else {
 		displayCoordinate = t('units.arcdegrees', {
 			quantity: Math.round(Math.abs(deg)).toLocaleString(locale)
@@ -135,7 +150,7 @@ function displayCoordinate(deg, pos, neg) {
  *
  * @param {Array<Number>} coord longitude and latitude
  */
-export function dmsCoordinatePair(coord) {
+export function dmsCoordinatePair(coord: number[]): string {
 	return t('units.coordinate_pair', {
 		latitude: displayCoordinate(clamp(coord[1], -90, 90), 'north', 'south'),
 		longitude: displayCoordinate(wrap(coord[0], -180, 180), 'east', 'west')
@@ -147,9 +162,13 @@ export function dmsCoordinatePair(coord) {
  *
  * @param {Array<Number>} coord longitude and latitude
  */
-export function decimalCoordinatePair(coord) {
+export function decimalCoordinatePair(coord: number[]): string {
 	return t('units.coordinate_pair', {
-		latitude: clamp(coord[1], -90, 90).toLocaleString(locale, { maximumFractionDigits: OSM_PRECISION }),
-		longitude: wrap(coord[0], -180, 180).toLocaleString(locale, { maximumFractionDigits: OSM_PRECISION })
+		latitude: clamp(coord[1], -90, 90).toLocaleString(locale, {
+			maximumFractionDigits: OSM_PRECISION
+		}),
+		longitude: wrap(coord[0], -180, 180).toLocaleString(locale, {
+			maximumFractionDigits: OSM_PRECISION
+		})
 	});
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "license": "ISC",
   "scripts": {
-    "all": "npm-run-all -s clean build dist",
+    "all": "npm-run-all -s clean flow build dist",
     "build": "node development_server.js",
     "clean": "shx rm -f dist/*.js dist/*.map dist/*.css dist/img/*.svg",
     "dist": "npm-run-all -p dist:**",
@@ -23,7 +23,8 @@
     "start": "node development_server.js develop",
     "test": "npm-run-all -s lint build test:**",
     "test:phantom": "phantomjs --web-security=no node_modules/mocha-phantomjs-core/mocha-phantomjs-core.js test/index.html spec",
-    "translations": "node data/update_locales"
+    "translations": "node data/update_locales",
+    "flow": "flow"
   },
   "dependencies": {
     "@mapbox/sexagesimal": "1.1.0",
@@ -39,6 +40,7 @@
   "devDependencies": {
     "@mapbox/maki": "^4.0.0",
     "@std/esm": "^0.22.0",
+    "babel-eslint": "^8.2.2",
     "chai": "^4.1.0",
     "colors": "^1.1.2",
     "concat-files": "^0.1.1",
@@ -46,6 +48,9 @@
     "ecstatic": "^3.0.0",
     "editor-layer-index": "osmlab/editor-layer-index.git#gh-pages",
     "eslint": "^4.3.0",
+    "eslint-plugin-flowtype": "^2.46.1",
+    "flow-bin": "^0.66.0",
+    "flow-remove-types": "^1.2.3",
     "gaze": "^1.1.1",
     "glob": "^7.1.0",
     "happen": "^0.3.1",
@@ -62,6 +67,7 @@
     "request": "^2.81.0",
     "rollup": "~0.55.0",
     "rollup-plugin-commonjs": "~8.3.0",
+    "rollup-plugin-flow": "^1.1.1",
     "rollup-plugin-includepaths": "~0.2.2",
     "rollup-plugin-json": "~2.2.0",
     "rollup-plugin-node-resolve": "~3.0.0",


### PR DESCRIPTION
This is an initial Proof Of Concept for using flow for https://github.com/openstreetmap/iD/issues/3744.  I've added some annotations to a couple of utils files and updated the build process, including using a rollup plugin to remove the annotations during the build.  The build now runs flow as part of the "run all" script and will report any errors found by flow which will prevent the build continuing.

I've also updated the eslint config to be compatible with the flow annotations, which required use of the eslint-babel parser (see https://github.com/eslint/eslint/issues/2157).  I've used the default config for the https://github.com/gajus/eslint-plugin-flowtype plugin.

If this PR looks ok and is along the lines you were thinking, flow annotations could be added gradually to the rest of the codebase.