### PR TITLE
Add preset for dancing school

### DIFF
--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -3613,6 +3613,11 @@ en:
         name: Dance Hall
         # 'terms: ballroom,jive,swing,tango,waltz'
         terms: '<translate with synonyms or related terms for ''Dance Hall'', separated by commas>'
+      leisure/dancing_school:
+        # leisure=dance, dance:teaching=yes
+        name: Dancing School
+        # 'terms: jive,swing,tango,waltz,dance teaching'
+        terms: '<translate with synonyms or related terms for ''Dancing School'', separated by commas>'
       leisure/dog_park:
         # leisure=dog_park
         name: Dog Park

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -9408,6 +9408,35 @@
             },
             "name": "Dance Hall"
         },
+        "leisure/dancing_school": {
+            "icon": "school",
+            "fields": [
+                "name",
+                "operator",
+                "address",
+                "opening_hours"
+            ],
+            "geometry": [
+                "point",
+                "area"
+            ],
+            "terms": [
+                "jive",
+                "swing",
+                "tango",
+                "waltz",
+                "dance teaching"
+            ],
+            "tags": {
+                "leisure": "dance"
+                "dance:teaching": "yes"
+            },
+            "reference": {
+                "key": "leisure",
+                "value": "dance"
+            },
+            "name": "Dancing School"
+        },
         "leisure/dog_park": {
             "icon": "dog-park",
             "geometry": [

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -9428,7 +9428,7 @@
                 "dance teaching"
             ],
             "tags": {
-                "leisure": "dance"
+                "leisure": "dance",
                 "dance:teaching": "yes"
             },
             "reference": {

--- a/data/presets/presets/leisure/dancing_school.json
+++ b/data/presets/presets/leisure/dancing_school.json
@@ -1,0 +1,29 @@
+{
+    "icon": "school",
+    "fields": [
+        "name",
+        "operator",
+        "address",
+        "opening_hours"
+    ],
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "terms": [
+        "jive",
+        "swing",
+        "tango",
+        "waltz",
+        "dance teaching"
+    ],
+    "tags": {
+        "leisure": "dance",
+        "dance:teaching": "yes"
+    },
+    "reference": {
+        "key": "leisure",
+        "value": "dance"
+    },
+    "name": "Dancing School"
+}

--- a/data/taginfo.json
+++ b/data/taginfo.json
@@ -1778,6 +1778,10 @@
             "value": "dance"
         },
         {
+            "key": "dance:teaching",
+            "value": "yes"
+        },
+        {
             "key": "leisure",
             "value": "dog_park"
         },

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -4453,6 +4453,10 @@
                     "name": "Dance Hall",
                     "terms": "ballroom,jive,swing,tango,waltz"
                 },
+                "leisure/dancing_school": {
+                    "name": "Dancing School",
+                    "terms": "jive,swing,tango,waltz,dance teaching"
+                },
                 "leisure/dog_park": {
                     "name": "Dog Park",
                     "terms": ""


### PR DESCRIPTION
This PR adds a preset for _leisure=dance_ with _dance:teaching=yes_. On the [wiki page](https://wiki.openstreetmap.org/wiki/Tag:leisure%3Ddance) _dance:teaching=*_ is described as an additional tag, telling that "dancers can obtain tuition". _dance:teaching_ currently has [over 700 uses](https://taginfo.openstreetmap.org/keys/dance:teaching#overview). Would you accept this tagging scheme and review the structure?