### PR TITLE
Name fields added to missing presets 

### DIFF
--- a/data/presets/presets/amenity/parking.json
+++ b/data/presets/presets/amenity/parking.json
@@ -1,6 +1,7 @@
 {
     "icon": "parking",
     "fields": [
+        "name",
         "operator",
         "parking",
         "capacity",

--- a/data/presets/presets/leisure/pitch.json
+++ b/data/presets/presets/leisure/pitch.json
@@ -1,6 +1,7 @@
 {
     "icon": "pitch",
     "fields": [
+        "name",
         "sport",
         "surface",
         "lit"


### PR DESCRIPTION
added name fields to missing presets leisure=pitch and amenity=parking. #4857 