### PR TITLE
Use remove-flow-types directly

### DIFF
--- a/build_src.js
+++ b/build_src.js
@@ -7,7 +7,7 @@ const commonjs = require('rollup-plugin-commonjs');
 const json = require('rollup-plugin-json');
 const includePaths = require('rollup-plugin-includepaths');
 const colors = require('colors/safe');
-const flow = require('rollup-plugin-flow');
+const flowRemoveTypes = require('flow-remove-types');
 
 
 module.exports = function buildSrc() {
@@ -72,4 +72,16 @@ function unlink(f) {
     try {
         fs.unlinkSync(f);
     } catch (e) { /* noop */ }
+}
+
+// Using this instead of rollup-plugin-flow due to
+// https://github.com/leebyron/rollup-plugin-flow/issues/5
+function flow() {
+    return {
+        name: 'flow-remove-types',
+        transform: (code) => ({
+            code: flowRemoveTypes(code).toString(),
+            map: null
+        })
+    };
 }

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "request": "^2.85.0",
     "rollup": "~0.56.3",
     "rollup-plugin-commonjs": "^9.0.0",
-    "rollup-plugin-flow": "^1.1.1",
     "rollup-plugin-includepaths": "^0.2.2",
     "rollup-plugin-json": "^2.2.0",
     "rollup-plugin-node-resolve": "^3.2.0",


### PR DESCRIPTION
Referencing this external issue https://github.com/leebyron/rollup-plugin-flow/issues/5

I have stolen the workaround from [mapbox-gl-js](https://github.com/mapbox/mapbox-gl-js/blob/master/build/rollup_plugins.js#L41-L51), thanks to @anandthakker.

(closes https://github.com/openstreetmap/iD/issues/4874) 