### PR TITLE
Added button to close Map controls.

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -2727,12 +2727,12 @@ div.full-screen > button:hover {
     position: fixed;
     top: 60px;
     bottom: 30px;
-    padding: 20px 50px 20px 20px;
+    padding: 5px 35px 5px 5px;
     right: 0;
     overflow: auto;
 }
 [dir='rtl'] .map-overlay.content {
-    padding: 20px 20px 20px 50px;
+    padding: 5px 5px 5px 35px;
     left: 0;
     right: auto !important;
 }

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -2727,12 +2727,12 @@ div.full-screen > button:hover {
     position: fixed;
     top: 60px;
     bottom: 30px;
-    padding: 5px 35px 5px 5px;
+    padding: 2px 50px 20px 20px;
     right: 0;
     overflow: auto;
 }
 [dir='rtl'] .map-overlay.content {
-    padding: 5px 5px 5px 35px;
+    padding: 2px 20px 20px 50px;
     left: 0;
     right: auto !important;
 }

--- a/modules/ui/background.js
+++ b/modules/ui/background.js
@@ -351,6 +351,11 @@ export function uiBackground(context) {
             .call(paneTooltip);
 
         pane
+            .append('button')
+            .on('click', function() { uiBackground.hidePane(); })
+            .call(svgIcon('#icon-close'));
+
+        pane
             .append('h2')
             .text(t('background.title'));
 

--- a/modules/ui/help.js
+++ b/modules/ui/help.js
@@ -382,6 +382,11 @@ export function uiHelp(context) {
             .call(tooltipBehavior);
         var shown = false;
 
+        pane
+            .append('button')
+            .on('click', function() { uiHelp.hidePane(); })
+            .call(svgIcon('#icon-close'));
+
 
         var toc = pane
             .append('ul')

--- a/modules/ui/map_data.js
+++ b/modules/ui/map_data.js
@@ -458,6 +458,11 @@ export function uiMapData(context) {
 
 
         pane
+            .append('button')
+            .on('click', function() { uiMapData.hidePane(); })
+            .call(svgIcon('#icon-close'));
+
+        pane
             .append('h2')
             .text(t('map_data.title'));
 


### PR DESCRIPTION
Ref. #4599
I have added a button for closing the Background Settings, Map Data, and Help side menus. This is how it looks.

<img width="334" alt="screen shot 2018-03-18 at 5 28 10 pm" src="https://user-images.githubusercontent.com/17474532/37565623-9b987a4c-2ad2-11e8-9242-e10d67f1b1e4.png">

<img width="637" alt="screen shot 2018-03-18 at 5 28 30 pm" src="https://user-images.githubusercontent.com/17474532/37565627-bd64060a-2ad2-11e8-99bf-96f48b97d018.png">



@bhousel @jidanni I have reduced the padding as discussed in the issue, but I think the frontend part can be improved. What do you suggest?
