### PR TITLE
Add fields to Taginfo file

### DIFF
--- a/build_data.js
+++ b/build_data.js
@@ -388,11 +388,11 @@ function generateTaginfo(presets, fields) {
          return;
        }
 
-       var isNewDescription = currentTaginfoEntries[0].description.split(' ,')
+       var isNewDescription = currentTaginfoEntries[0].description.split(', ')
                            .indexOf(tag.description) === -1;
 
        if (isNewDescription) {
-         currentTaginfoEntries[0].description += ", " + tag.description;
+         currentTaginfoEntries[0].description += ', ' + tag.description;
        }
     }
 

--- a/build_data.js
+++ b/build_data.js
@@ -160,14 +160,6 @@ function generateFields(tstrings) {
             }
         }
 
-        if (field.geometry) {
-          t.geometry = field.geometry;
-        }
-
-        if (field.icon) {
-          t.icon = field.icon;
-        }
-
         fields[id] = field;
     });
     return fields;
@@ -304,12 +296,6 @@ function generateTranslations(fields, presets, tstrings) {
         } else {
             delete preset.terms;
         }
-    });
-
-    // remove fields we're not interested in for translation
-    _forEach(translations.fields, function(field) {
-        delete field.icon;
-        delete field.geometry;
     });
 
     return translations;

--- a/build_data.js
+++ b/build_data.js
@@ -14,7 +14,7 @@ const path = require('path');
 const shell = require('shelljs');
 const YAML = require('js-yaml');
 const colors = require('colors/safe');
-const maki = require ('@mapbox/maki');
+const maki = require('@mapbox/maki');
 
 const fieldSchema = require('./data/presets/schema/field.json');
 const presetSchema = require('./data/presets/schema/preset.json');
@@ -349,8 +349,9 @@ function generateTaginfo(presets, fields) {
             tag.value = preset.tags[last];
         }
 
-        if (preset.name)
+        if (preset.name) {
           tag.description = [ preset.name ];
+        }
 
         if (preset.geometry) {
           setObjectType(tag, preset);
@@ -373,15 +374,17 @@ function generateTaginfo(presets, fields) {
                values.forEach(function(value) {
                    var tag = { key:   key,
                                value: value };
-                   if (field.label)
+                   if (field.label) {
                       tag.description = [ field.label ];
+                   }
                    coalesceTags(taginfo, tag);
                });
             }
             else {
                var tag = { key: key };
-               if (field.label)
+               if (field.label) {
                   tag.description = [ field.label ];
+               }
                coalesceTags(taginfo, tag);
             }
         });
@@ -394,9 +397,8 @@ function generateTaginfo(presets, fields) {
 
     function coalesceTags(taginfo, tag) {
 
-       if (!tag.key) {
+       if (!tag.key)
          return;
-       }
 
        var currentTaginfoEntries = taginfo.tags.filter(function(t) {
            return (t.key    === tag.key &&
@@ -408,9 +410,8 @@ function generateTaginfo(presets, fields) {
          return;
        }
 
-       if (!tag.description) {
+       if (!tag.description)
          return;
-       }
 
        if (!currentTaginfoEntries[0].description) {
          currentTaginfoEntries[0].description = [ tag.description ];
@@ -439,8 +440,9 @@ function generateTaginfo(presets, fields) {
                         'area'     : 'area' };
 
       input.geometry.forEach(function(geom) {
-         if (tag.object_types.indexOf(mapping[geom]) === -1)
+         if (tag.object_types.indexOf(mapping[geom]) === -1) {
            tag.object_types.push(mapping[geom]);
+         }
       });
     }
 

--- a/build_data.js
+++ b/build_data.js
@@ -432,11 +432,11 @@ function generateTaginfo(presets, fields) {
 
     function setObjectType(tag, input) {
       tag.object_types = [];
-      const mapping = { "point"    : "node",
-                        "vertex"   : "node",
-                        "line"     : "way",
-                        "relation" : "relation",
-                        "area"     : "area" };
+      const mapping = { 'point'    : 'node',
+                        'vertex'   : 'node',
+                        'line'     : 'way',
+                        'relation' : 'relation',
+                        'area'     : 'area' };
 
       input.geometry.forEach(function(geom) {
          if (tag.object_types.indexOf(mapping[geom]) === -1)

--- a/build_data.js
+++ b/build_data.js
@@ -414,12 +414,12 @@ function generateTaginfo(presets, fields) {
          return;
 
        if (!currentTaginfoEntries[0].description) {
-         currentTaginfoEntries[0].description = [ tag.description ];
+         currentTaginfoEntries[0].description = tag.description;
          return;
        }
 
        var isNewDescription = currentTaginfoEntries[0].description
-                                   .indexOf(tag.description) === -1;
+                                   .indexOf(tag.description[0]) === -1;
 
        if (isNewDescription) {
          currentTaginfoEntries[0].description.push(tag.description[0]);

--- a/build_data.js
+++ b/build_data.js
@@ -348,7 +348,7 @@ function generateTaginfo(presets, fields) {
                });
             }
             else {
-               tag = { key: key };
+               var tag = { key: key };
                taginfo.tags.push(tag);
             }
         });

--- a/build_data.js
+++ b/build_data.js
@@ -67,7 +67,7 @@ module.exports = function buildData() {
         var presets = generatePresets(tstrings);
         var defaults = read('data/presets/defaults.json');
         var translations = generateTranslations(fields, presets, tstrings);
-        var taginfo = generateTaginfo(presets);
+        var taginfo = generateTaginfo(presets, fields);
 
         // Additional consistency checks
         validateCategoryPresets(categories, presets);
@@ -300,7 +300,7 @@ function generateTranslations(fields, presets, tstrings) {
     return translations;
 }
 
-function generateTaginfo(presets) {
+function generateTaginfo(presets, fields) {
     var taginfo = {
         'data_format': 1,
         'data_url': 'https://raw.githubusercontent.com/openstreetmap/iD/master/data/taginfo.json',
@@ -333,6 +333,25 @@ function generateTaginfo(presets) {
         }
 
         taginfo.tags.push(tag);
+    });
+
+    _forEach(fields, function(field) {
+        var keys = field.keys || [ field.key ] || [];
+
+        keys.forEach(function(key) {
+            if (field.strings && field.strings.options) {
+               var values = Object.keys(field.strings.options);
+               values.forEach(function(value) {
+                   var tag = { key:   key,
+                               value: value };
+                   taginfo.tags.push(tag);
+               });
+            }
+            else {
+               tag = { key: key };
+               taginfo.tags.push(tag);
+            }
+        });
     });
 
     return taginfo;

--- a/build_data.js
+++ b/build_data.js
@@ -318,6 +318,7 @@ function generateTaginfo(presets, fields) {
     };
 
     _forEach(presets, function(preset) {
+
         if (preset.suggestion)
             return;
 
@@ -332,10 +333,14 @@ function generateTaginfo(presets, fields) {
             tag.value = preset.tags[last];
         }
 
-        taginfo.tags.push(tag);
+        if (preset.name)
+          tag.description = preset.name;
+
+        coalesceTags(taginfo, tag);
     });
 
     _forEach(fields, function(field) {
+
         var keys = field.keys || [ field.key ] || [];
 
         keys.forEach(function(key) {
@@ -344,15 +349,52 @@ function generateTaginfo(presets, fields) {
                values.forEach(function(value) {
                    var tag = { key:   key,
                                value: value };
-                   taginfo.tags.push(tag);
+                   if (field.label)
+                      tag.description = field.label;
+                   coalesceTags(taginfo, tag);
                });
             }
             else {
                var tag = { key: key };
-               taginfo.tags.push(tag);
+               if (field.label)
+                  tag.description = field.label;
+               coalesceTags(taginfo, tag);
             }
         });
     });
+
+    function coalesceTags(taginfo, tag) {
+
+       if (!tag.key) {
+         return;
+       }
+
+       var currentTaginfoEntries = taginfo.tags.filter(function(t) {
+           return (t.key    === tag.key &&
+                   t.value  === tag.value);
+       });
+
+       if (currentTaginfoEntries.length === 0) {
+         taginfo.tags.push(tag);
+         return;
+       }
+
+       if (!tag.description) {
+         return;
+       }
+
+       if (!currentTaginfoEntries[0].description) {
+         currentTaginfoEntries[0].description = tag.description;
+         return;
+       }
+
+       var isNewDescription = currentTaginfoEntries[0].description.split(' ,')
+                           .indexOf(tag.description) === -1;
+
+       if (isNewDescription) {
+         currentTaginfoEntries[0].description += ", " + tag.description;
+       }
+    }
 
     return taginfo;
 }

--- a/build_data.js
+++ b/build_data.js
@@ -357,7 +357,7 @@ function generateTaginfo(presets, fields) {
         }
 
         if (isMaki(preset.icon)) {
-            tag.icon_url = 'https://raw.githubusercontent.com/mapbox/maki/master/icons/' + preset.icon + '-11.svg';
+            tag.icon_url = 'https://raw.githubusercontent.com/mapbox/maki/master/icons/' + preset.icon + '-15.svg?sanitize=true';
         }
 
         coalesceTags(taginfo, tag);


### PR DESCRIPTION
Gave it a first try.. not quite sure if I covered all combinations in the original json files. I should probably remove those duplicates in `taginfo` as well.

Things like "fields/gender.json" still look pretty strange in the taginfo result. There seem to be some cases, where we don't want a cross product of those string.options values and the keys array.

Supposed to eventually
* fix #4937 
* fix #3598