### PR TITLE
Add field for industrial=*

### DIFF
--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -686,6 +686,9 @@ en:
       indoor:
         # indoor=*
         label: Indoor
+      industrial:
+        # industrial=*
+        label: Type
       information:
         # information=*
         label: Type

--- a/data/presets/fields.json
+++ b/data/presets/fields.json
@@ -951,7 +951,7 @@
             "type": "check",
             "label": "Indoor"
         },
-        "indoor": {
+        "industrial": {
             "key": "industrial",
             "type": "combo",
             "label": "Type"

--- a/data/presets/fields.json
+++ b/data/presets/fields.json
@@ -951,6 +951,11 @@
             "type": "check",
             "label": "Indoor"
         },
+        "indoor": {
+            "key": "industrial",
+            "type": "combo",
+            "label": "Type"
+        },
         "information": {
             "key": "information",
             "type": "typeCombo",

--- a/data/presets/fields/industrial.json
+++ b/data/presets/fields/industrial.json
@@ -1,0 +1,5 @@
+{
+    "key": "industrial",
+    "type": "combo",
+    "label": "Type"
+}

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -8588,7 +8588,8 @@
         "landuse/industrial": {
             "icon": "industry",
             "fields": [
-                "name"
+                "name",
+                "industrial"
             ],
             "geometry": [
                 "area"

--- a/data/presets/presets/landuse/industrial.json
+++ b/data/presets/presets/landuse/industrial.json
@@ -1,7 +1,8 @@
 {
     "icon": "industry",
     "fields": [
-        "name"
+        "name",
+        "industrial"
     ],
     "geometry": [
         "area"

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -1944,6 +1944,9 @@
                 "indoor": {
                     "label": "Indoor"
                 },
+                "industrial": {
+                    "label": "Type"
+                },
                 "information": {
                     "label": "Type"
                 },


### PR DESCRIPTION
This PR adds a field for industrial=*. It is mainly used for landuse=industrial to describe the type of industry. The key has a [wiki page](https://wiki.openstreetmap.org/wiki/Key:industrial) and [over 23k uses](https://taginfo.openstreetmap.org/keys/?key=industrial#overview) at the moment. Is it okay to add this field?