### PR TITLE
added column in presets/presets/advertising

### DIFF
--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -1684,14 +1684,14 @@ en:
         # 'addr:*=*'
         name: Address
         terms: '<translate with synonyms or related terms for ''Address'', separated by commas>'
-      advertising/advertising_column:
-        # advertising=advertising_column
-        name: Advertising Column
-        terms: '<translate with synonyms or related terms for ''Advertising Column'', separated by commas>'
       advertising/billboard:
         # advertising=billboard
         name: Billboard
         terms: '<translate with synonyms or related terms for ''Billboard'', separated by commas>'
+      advertising/column:
+        # advertising=column
+        name: Advertising Column
+        terms: '<translate with synonyms or related terms for ''Advertising Column'', separated by commas>'
       aerialway:
         # aerialway=*
         name: Aerialway

--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -1684,14 +1684,14 @@ en:
         # 'addr:*=*'
         name: Address
         terms: '<translate with synonyms or related terms for ''Address'', separated by commas>'
+      advertising/advertising_column:
+        # advertising=advertising_column
+        name: Advertising Column
+        terms: '<translate with synonyms or related terms for ''Advertising Column'', separated by commas>'
       advertising/billboard:
         # advertising=billboard
         name: Billboard
         terms: '<translate with synonyms or related terms for ''Billboard'', separated by commas>'
-      advertising/column:
-        # advertising=column
-        name: Column
-        terms: '<translate with synonyms or related terms for ''Column'', separated by commas>'
       aerialway:
         # aerialway=*
         name: Aerialway

--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -1688,6 +1688,10 @@ en:
         # advertising=billboard
         name: Billboard
         terms: '<translate with synonyms or related terms for ''Billboard'', separated by commas>'
+      advertising/column:
+        # advertising=column
+        name: Column
+        terms: '<translate with synonyms or related terms for ''Column'', separated by commas>'
       aerialway:
         # aerialway=*
         name: Aerialway

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -197,6 +197,20 @@
             },
             "name": "Billboard"
         },
+        "advertising/column": {
+            "fields": [
+                "direction",
+                "lit"
+            ],
+            "geometry": [
+                "point",
+                "vertex"
+            ],
+            "tags": {
+                "advertising": "column"
+            },
+            "name": "Column"
+        },
         "aerialway/station": {
             "icon": "aerialway",
             "geometry": [

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -182,6 +182,20 @@
             "name": "Address",
             "matchScore": 0.15
         },
+        "advertising/advertising_column": {
+            "fields": [
+                "direction",
+                "lit"
+            ],
+            "geometry": [
+                "point",
+                "area"
+            ],
+            "tags": {
+                "advertising": "advertising_column"
+            },
+            "name": "Advertising Column"
+        },
         "advertising/billboard": {
             "fields": [
                 "direction",
@@ -196,20 +210,6 @@
                 "advertising": "billboard"
             },
             "name": "Billboard"
-        },
-        "advertising/column": {
-            "fields": [
-                "direction",
-                "lit"
-            ],
-            "geometry": [
-                "point",
-                "vertex"
-            ],
-            "tags": {
-                "advertising": "column"
-            },
-            "name": "Column"
         },
         "aerialway/station": {
             "icon": "aerialway",

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -182,20 +182,6 @@
             "name": "Address",
             "matchScore": 0.15
         },
-        "advertising/advertising_column": {
-            "fields": [
-                "direction",
-                "lit"
-            ],
-            "geometry": [
-                "point",
-                "area"
-            ],
-            "tags": {
-                "advertising": "advertising_column"
-            },
-            "name": "Advertising Column"
-        },
         "advertising/billboard": {
             "fields": [
                 "direction",
@@ -210,6 +196,20 @@
                 "advertising": "billboard"
             },
             "name": "Billboard"
+        },
+        "advertising/column": {
+            "fields": [
+                "direction",
+                "lit"
+            ],
+            "geometry": [
+                "point",
+                "area"
+            ],
+            "tags": {
+                "advertising": "column"
+            },
+            "name": "Advertising Column"
         },
         "aerialway/station": {
             "icon": "aerialway",

--- a/data/presets/presets/advertising/advertising_column.json
+++ b/data/presets/presets/advertising/advertising_column.json
@@ -5,10 +5,10 @@
     ],
     "geometry": [
         "point",
-        "vertex"
+        "area"
     ],
     "tags": {
-        "advertising": "column"
+        "advertising": "advertising_column"
     },
-    "name": "Column"
+    "name": "Advertising Column"
 }

--- a/data/presets/presets/advertising/column.json
+++ b/data/presets/presets/advertising/column.json
@@ -1,0 +1,14 @@
+{
+    "fields": [
+       "direction",
+       "lit"
+    ],
+    "geometry": [
+        "point",
+        "vertex"
+    ],
+    "tags": {
+        "advertising": "column"
+    },
+    "name": "Column"
+}

--- a/data/presets/presets/advertising/column.json
+++ b/data/presets/presets/advertising/column.json
@@ -8,7 +8,7 @@
         "area"
     ],
     "tags": {
-        "advertising": "advertising_column"
+        "advertising": "column"
     },
     "name": "Advertising Column"
 }

--- a/data/taginfo.json
+++ b/data/taginfo.json
@@ -110,20 +110,20 @@
         },
         {
             "key": "advertising",
-            "value": "advertising_column",
-            "description": "Advertising Column",
-            "object_types": [
-                "node",
-                "area"
-            ]
-        },
-        {
-            "key": "advertising",
             "value": "billboard",
             "description": "Billboard",
             "object_types": [
                 "node",
                 "way"
+            ]
+        },
+        {
+            "key": "advertising",
+            "value": "column",
+            "description": "Advertising Column",
+            "object_types": [
+                "node",
+                "area"
             ]
         },
         {

--- a/data/taginfo.json
+++ b/data/taginfo.json
@@ -118,6 +118,14 @@
             ]
         },
         {
+            "key": "advertising",
+            "value": "column",
+            "description": "Column",
+            "object_types": [
+                "node"
+            ]
+        },
+        {
             "key": "aerialway",
             "value": "station",
             "description": "Aerialway Station",

--- a/data/taginfo.json
+++ b/data/taginfo.json
@@ -110,19 +110,20 @@
         },
         {
             "key": "advertising",
+            "value": "advertising_column",
+            "description": "Advertising Column",
+            "object_types": [
+                "node",
+                "area"
+            ]
+        },
+        {
+            "key": "advertising",
             "value": "billboard",
             "description": "Billboard",
             "object_types": [
                 "node",
                 "way"
-            ]
-        },
-        {
-            "key": "advertising",
-            "value": "column",
-            "description": "Column",
-            "object_types": [
-                "node"
             ]
         },
         {

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -2807,12 +2807,12 @@
                     "name": "Address",
                     "terms": ""
                 },
-                "advertising/billboard": {
-                    "name": "Billboard",
+                "advertising/advertising_column": {
+                    "name": "Advertising Column",
                     "terms": ""
                 },
-                "advertising/column": {
-                    "name": "Column",
+                "advertising/billboard": {
+                    "name": "Billboard",
                     "terms": ""
                 },
                 "aerialway/station": {

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -2811,6 +2811,10 @@
                     "name": "Billboard",
                     "terms": ""
                 },
+                "advertising/column": {
+                    "name": "Column",
+                    "terms": ""
+                },
                 "aerialway/station": {
                     "name": "Aerialway Station",
                     "terms": ""
@@ -6665,7 +6669,7 @@
                 "attribution": {
                     "text": "basemap.at"
                 },
-                "description": "Basemap of Austria, based on goverment data.",
+                "description": "Basemap of Austria, based on government data.",
                 "name": "basemap.at"
             },
             "basemap.at-orthofoto": {
@@ -6727,7 +6731,7 @@
             },
             "stamen-terrain-background": {
                 "attribution": {
-                    "text": "Map tiles by Stamen Design, under CC BY 3.0"
+                    "text": "Map tiles by Stamen Design, under CC BY 3.0. Data by OpenStreetMap, under ODbL"
                 },
                 "name": "Stamen Terrain"
             },

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -2807,12 +2807,12 @@
                     "name": "Address",
                     "terms": ""
                 },
-                "advertising/advertising_column": {
-                    "name": "Advertising Column",
-                    "terms": ""
-                },
                 "advertising/billboard": {
                     "name": "Billboard",
+                    "terms": ""
+                },
+                "advertising/column": {
+                    "name": "Advertising Column",
                     "terms": ""
                 },
                 "aerialway/station": {


### PR DESCRIPTION
I copied `billboard.json` and used this as the base for `column.json`.

I removed the `line` field, since this doesn't make sense for a column. Debating `point`, since a column would have a not-ignorable "width" as well, giving it a shape when looked from above. I left `point` in there nonetheless. It could be used for a thin column, like a tube or pole, though I doubt there are many poles used by advertisers.

Refs:https://github.com/openstreetmap/iD/issues/4961