### PR TITLE
Pluralize localizable strings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -252,6 +252,17 @@ to iD, only display them in the interface through the `t()` function.
 Then, add the new string to `data/core.yaml`. The translation system, Transifex,
 will automatically detect the change.
 
+If you need to insert something into the string programmatically, insert a
+`{token}` into the string in the YAML file. If the token is a number that can
+affect how surrounding words are pluralized, define the singular and plural
+forms separately like this:
+
+```yaml
+    changes:
+      one: "1 Change"
+      other: "{count} Changes"
+```
+
 If you are updating an existing string, update it in `data/core/yaml` and run
 `npm run build` to generate the `en.json` file automatically, then commit both
 modified files.

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -92,7 +92,9 @@ en:
         line: Deleted a line.
         area: Deleted an area.
         relation: Deleted a relation.
-        multiple: "Deleted {n} features."
+        multiple:
+          one: "Deleted a feature."
+          other: "Deleted {n} features."
       too_large:
         single: This feature can't be deleted because not enough of it is currently visible.
         multiple: These features can't be deleted because not enough of them are currently visible.
@@ -129,7 +131,9 @@ en:
       title: Merge
       description: Merge these features.
       key: C
-      annotation: "Merged {n} features."
+      annotation:
+        one: "Merged a feature."
+        other: "Merged {n} features."
       not_eligible: These features can't be merged.
       not_adjacent: These features can't be merged because their endpoints aren't connected.
       restriction: "These features can't be merged because it would damage a \"{relation}\" relation."
@@ -221,7 +225,9 @@ en:
       annotation:
         line: Split a line.
         area: Split an area boundary.
-        multiple: "Split {n} lines/area boundaries."
+        multiple:
+          one: "Split a line/area boundary."
+          other: "Split {n} lines/area boundaries."
       not_eligible: Lines can't be split at their beginning or end.
       multiple_ways: There are too many lines here to split.
       connected_to_hidden: This can't be split because it is connected to a hidden feature.
@@ -281,8 +287,12 @@ en:
   report_a_bug: Report a bug
   help_translate: Help translate
   feature_info:
-    hidden_warning: "{count} hidden features"
-    hidden_details: "These features are currently hidden: {details}"
+    hidden_warning:
+      one: "1 hidden feature"
+      other: "{count} hidden features"
+    hidden_details:
+      one: "This feature is currently hidden: {details}"
+      other: "These features are currently hidden: {details}"
   status:
     error: Unable to connect to API.
     offline: The API is offline. Please try editing later.
@@ -295,7 +305,9 @@ en:
     request_review: "I would like someone to review my edits."
     save: Upload
     cancel: Cancel
-    changes: "{count} Changes"
+    changes:
+      one: "1 Change"
+      other: "{count} Changes"
     download_changes: Download osmChange file
     warnings: Warnings
     modified: Modified
@@ -307,7 +319,9 @@ en:
     google_warning_link: https://www.openstreetmap.org/copyright
   contributors:
     list: "Edits by {users}"
-    truncated_list: "Edits by {users} and {count} others"
+    truncated_list:
+      one: "Edits by {users} and someone else"
+      other: "Edits by {users} and {count} others"
   info_panels:
     key: I
     background:
@@ -327,7 +341,9 @@ en:
     history:
       key: H
       title: History
-      selected: "{n} selected"
+      selected:
+        one: "1 selected"
+        other: "{n} selected"
       no_history: "No History (New Feature)"
       version: Version
       last_edit: Last Edit
@@ -342,7 +358,9 @@ en:
     measurement:
       key: M
       title: Measurement
-      selected: "{n} selected"
+      selected:
+        one: "1 selected"
+        other: "{n} selected"
       geometry: Geometry
       closed_line: closed line
       closed_area: closed area
@@ -381,7 +399,9 @@ en:
     new_relation: New relation...
     role: Role
     choose: Select feature type
-    results: "{n} results for {search}"
+    results:
+      one: "1 result for {search}"
+      other: "{n} results for {search}"
     reference: View on OpenStreetMap Wiki
     back_tooltip: Change feature
     remove: Remove
@@ -578,7 +598,9 @@ en:
     untagged_relation_tooltip: "Select a feature type that describes what this relation is."
     many_deletions: "You're deleting {n} features: {p} nodes, {l} lines, {a} areas, {r} relations. Are you sure you want to do this? This will delete them from the map that everyone else sees on openstreetmap.org."
     tag_suggests_area: "The tag {tag} suggests line should be area, but it is not an area"
-    deprecated_tags: "Deprecated tags: {tags}"
+    deprecated_tags:
+      one: "Deprecated tag: {tags}"
+      other: "Deprecated tags: {tags}"
   zoom:
     in: Zoom in
     out: Zoom out
@@ -920,7 +942,9 @@ en:
       words: "This walkthrough will introduce some new words and concepts. When we introduce a new word, we'll use *italics*."
       mouse: "You can use any input device to edit the map, but this walkthrough assumes you have a mouse with left and right buttons. **If you want to attach a mouse, do so now, then click OK.**"
       leftclick: "When this tutorial asks you to click or double-click, we mean with the left button. On a trackpad it might be a single-click or single-finger tap. **Left-click {num} times.**"
-      rightclick: "Sometimes we'll also ask you to right-click. This might be the same as control-click, or two-finger tap on a trackpad. Your keyboard might even have a 'menu' key that works like right-click. **Right-click {num} times.**"
+      rightclick:
+        one: "Sometimes we'll also ask you to right-click. This might be the same as control-click, or two-finger tap on a trackpad. Your keyboard might even have a 'menu' key that works like right-click. **Right-click once.**"
+        other: "Sometimes we'll also ask you to right-click. This might be the same as control-click, or two-finger tap on a trackpad. Your keyboard might even have a 'menu' key that works like right-click. **Right-click {num} times.**"
       chapters: "So far, so good! You can use the buttons below to skip chapters at any time or to restart a chapter if you get stuck. Let's begin! **Click '{next}' to continue.**"
     navigation:
       title: "Navigation"

--- a/data/index.js
+++ b/data/index.js
@@ -1,5 +1,6 @@
 export { wikipedia as dataWikipedia } from 'wmf-sitematrix';
 export { default as dataSuggestions } from 'name-suggestion-index/name-suggestions.json';
+export { default as plurals } from 'cldr-core/supplemental/plurals.json';
 
 export { dataAddressFormats } from './address-formats.json';
 export { dataDeprecated } from './deprecated.json';

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -119,7 +119,10 @@
                     "line": "Deleted a line.",
                     "area": "Deleted an area.",
                     "relation": "Deleted a relation.",
-                    "multiple": "Deleted {n} features."
+                    "multiple": {
+                        "one": "Deleted a feature.",
+                        "other": "Deleted {n} features."
+                    }
                 },
                 "too_large": {
                     "single": "This feature can't be deleted because not enough of it is currently visible.",
@@ -167,7 +170,10 @@
                 "title": "Merge",
                 "description": "Merge these features.",
                 "key": "C",
-                "annotation": "Merged {n} features.",
+                "annotation": {
+                    "one": "Merged a feature.",
+                    "other": "Merged {n} features."
+                },
                 "not_eligible": "These features can't be merged.",
                 "not_adjacent": "These features can't be merged because their endpoints aren't connected.",
                 "restriction": "These features can't be merged because it would damage a \"{relation}\" relation.",
@@ -286,7 +292,10 @@
                 "annotation": {
                     "line": "Split a line.",
                     "area": "Split an area boundary.",
-                    "multiple": "Split {n} lines/area boundaries."
+                    "multiple": {
+                        "one": "Split a line/area boundary.",
+                        "other": "Split {n} lines/area boundaries."
+                    }
                 },
                 "not_eligible": "Lines can't be split at their beginning or end.",
                 "multiple_ways": "There are too many lines here to split.",
@@ -358,8 +367,14 @@
         "report_a_bug": "Report a bug",
         "help_translate": "Help translate",
         "feature_info": {
-            "hidden_warning": "{count} hidden features",
-            "hidden_details": "These features are currently hidden: {details}"
+            "hidden_warning": {
+                "one": "1 hidden feature",
+                "other": "{count} hidden features"
+            },
+            "hidden_details": {
+                "one": "This feature is currently hidden: {details}",
+                "other": "These features are currently hidden: {details}"
+            }
         },
         "status": {
             "error": "Unable to connect to API.",
@@ -374,7 +389,10 @@
             "request_review": "I would like someone to review my edits.",
             "save": "Upload",
             "cancel": "Cancel",
-            "changes": "{count} Changes",
+            "changes": {
+                "one": "1 Change",
+                "other": "{count} Changes"
+            },
             "download_changes": "Download osmChange file",
             "warnings": "Warnings",
             "modified": "Modified",
@@ -387,7 +405,10 @@
         },
         "contributors": {
             "list": "Edits by {users}",
-            "truncated_list": "Edits by {users} and {count} others"
+            "truncated_list": {
+                "one": "Edits by {users} and someone else",
+                "other": "Edits by {users} and {count} others"
+            }
         },
         "info_panels": {
             "key": "I",
@@ -409,7 +430,10 @@
             "history": {
                 "key": "H",
                 "title": "History",
-                "selected": "{n} selected",
+                "selected": {
+                    "one": "1 selected",
+                    "other": "{n} selected"
+                },
                 "no_history": "No History (New Feature)",
                 "version": "Version",
                 "last_edit": "Last Edit",
@@ -426,7 +450,10 @@
             "measurement": {
                 "key": "M",
                 "title": "Measurement",
-                "selected": "{n} selected",
+                "selected": {
+                    "one": "1 selected",
+                    "other": "{n} selected"
+                },
                 "geometry": "Geometry",
                 "closed_line": "closed line",
                 "closed_area": "closed area",
@@ -470,7 +497,10 @@
             "new_relation": "New relation...",
             "role": "Role",
             "choose": "Select feature type",
-            "results": "{n} results for {search}",
+            "results": {
+                "one": "1 result for {search}",
+                "other": "{n} results for {search}"
+            },
             "reference": "View on OpenStreetMap Wiki",
             "back_tooltip": "Change feature",
             "remove": "Remove",
@@ -701,7 +731,10 @@
             "untagged_relation_tooltip": "Select a feature type that describes what this relation is.",
             "many_deletions": "You're deleting {n} features: {p} nodes, {l} lines, {a} areas, {r} relations. Are you sure you want to do this? This will delete them from the map that everyone else sees on openstreetmap.org.",
             "tag_suggests_area": "The tag {tag} suggests line should be area, but it is not an area",
-            "deprecated_tags": "Deprecated tags: {tags}"
+            "deprecated_tags": {
+                "one": "Deprecated tag: {tags}",
+                "other": "Deprecated tags: {tags}"
+            }
         },
         "zoom": {
             "in": "Zoom in",
@@ -1071,7 +1104,10 @@
                 "words": "This walkthrough will introduce some new words and concepts. When we introduce a new word, we'll use *italics*.",
                 "mouse": "You can use any input device to edit the map, but this walkthrough assumes you have a mouse with left and right buttons. **If you want to attach a mouse, do so now, then click OK.**",
                 "leftclick": "When this tutorial asks you to click or double-click, we mean with the left button. On a trackpad it might be a single-click or single-finger tap. **Left-click {num} times.**",
-                "rightclick": "Sometimes we'll also ask you to right-click. This might be the same as control-click, or two-finger tap on a trackpad. Your keyboard might even have a 'menu' key that works like right-click. **Right-click {num} times.**",
+                "rightclick": {
+                    "one": "Sometimes we'll also ask you to right-click. This might be the same as control-click, or two-finger tap on a trackpad. Your keyboard might even have a 'menu' key that works like right-click. **Right-click once.**",
+                    "other": "Sometimes we'll also ask you to right-click. This might be the same as control-click, or two-finger tap on a trackpad. Your keyboard might even have a 'menu' key that works like right-click. **Right-click {num} times.**"
+                },
                 "chapters": "So far, so good! You can use the buttons below to skip chapters at any time or to restart a chapter if you get stuck. Let's begin! **Click '{next}' to continue.**"
             },
             "navigation": {
@@ -6601,7 +6637,7 @@
                 "attribution": {
                     "text": "Terms & Feedback"
                 },
-                "description": "Imagery boundaries and capture dates. Labels appear at zoom level 13 and higher.",
+                "description": "Imagery boundaries and capture dates. Labels appear at zoom level 14 and higher.",
                 "name": "DigitalGlobe Premium Imagery Vintage"
             },
             "DigitalGlobe-Standard": {
@@ -6615,7 +6651,7 @@
                 "attribution": {
                     "text": "Terms & Feedback"
                 },
-                "description": "Imagery boundaries and capture dates. Labels appear at zoom level 13 and higher.",
+                "description": "Imagery boundaries and capture dates. Labels appear at zoom level 14 and higher.",
                 "name": "DigitalGlobe Standard Imagery Vintage"
             },
             "EsriWorldImagery": {
@@ -6624,13 +6660,6 @@
                 },
                 "description": "Esri world imagery.",
                 "name": "Esri World Imagery"
-            },
-            "EsriWorldImageryClarity": {
-                "attribution": {
-                    "text": "Terms & Feedback"
-                },
-                "description": "Esri archive imagery that may be clearer and more accurate than the default layer.",
-                "name": "Esri World Imagery (Clarity) Beta"
             },
             "MAPNIK": {
                 "attribution": {
@@ -6699,37 +6728,33 @@
                 "description": "Yellow = Public domain map data from the US Census. Red = Data not found in OpenStreetMap",
                 "name": "TIGER Roads 2017"
             },
-            "US_Forest_Service_roads_overlay": {
-                "description": "Highway: Green casing = unclassified. Brown casing = track. Surface: gravel = light brown fill, Asphalt = black, paved = gray, ground =white, concrete = blue, grass = green. Seasonal = white bars",
-                "name": "U.S. Forest Roads Overlay"
-            },
             "Waymarked_Trails-Cycling": {
                 "attribution": {
-                    "text": "© waymarkedtrails.org, OpenStreetMap contributors, CC by-SA 3.0"
+                    "text": "© Sarah Hoffmann, CC by-SA 3.0, map data OpenStreetMap contributors, ODbL 1.0"
                 },
                 "name": "Waymarked Trails: Cycling"
             },
             "Waymarked_Trails-Hiking": {
                 "attribution": {
-                    "text": "© waymarkedtrails.org, OpenStreetMap contributors, CC by-SA 3.0"
+                    "text": "© Sarah Hoffmann, CC by-SA 3.0, map data OpenStreetMap contributors, ODbL 1.0"
                 },
                 "name": "Waymarked Trails: Hiking"
             },
             "Waymarked_Trails-MTB": {
                 "attribution": {
-                    "text": "© waymarkedtrails.org, OpenStreetMap contributors, CC by-SA 3.0"
+                    "text": "© Sarah Hoffmann, CC by-SA 3.0, map data OpenStreetMap contributors, ODbL 1.0"
                 },
                 "name": "Waymarked Trails: MTB"
             },
             "Waymarked_Trails-Skating": {
                 "attribution": {
-                    "text": "© waymarkedtrails.org, OpenStreetMap contributors, CC by-SA 3.0"
+                    "text": "© Sarah Hoffmann, CC by-SA 3.0, map data OpenStreetMap contributors, ODbL 1.0"
                 },
                 "name": "Waymarked Trails: Skating"
             },
             "Waymarked_Trails-Winter_Sports": {
                 "attribution": {
-                    "text": "© waymarkedtrails.org, OpenStreetMap contributors, CC by-SA 3.0"
+                    "text": "© Michael Spreng, CC by-SA 3.0, map data OpenStreetMap contributors, ODbL 1.0"
                 },
                 "name": "Waymarked Trails: Winter Sports"
             },
@@ -6737,7 +6762,7 @@
                 "attribution": {
                     "text": "basemap.at"
                 },
-                "description": "Basemap of Austria, based on government data.",
+                "description": "Basemap of Austria, based on goverment data.",
                 "name": "basemap.at"
             },
             "basemap.at-orthofoto": {
@@ -6799,7 +6824,7 @@
             },
             "stamen-terrain-background": {
                 "attribution": {
-                    "text": "Map tiles by Stamen Design, under CC BY 3.0. Data by OpenStreetMap, under ODbL"
+                    "text": "Map tiles by Stamen Design, under CC BY 3.0"
                 },
                 "name": "Stamen Terrain"
             },

--- a/modules/util/index.js
+++ b/modules/util/index.js
@@ -13,6 +13,7 @@ export { utilGetAllNodes } from './util';
 export { utilGetPrototypeOf } from './util';
 export { utilGetSetValue } from './get_set_value';
 export { utilIdleWorker} from './idle_worker';
+export { t } from './locale';
 export { utilNoAuto } from './util';
 export { utilPrefixCSSProperty } from './util';
 export { utilPrefixDOMProperty } from './util';

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
   "dependencies": {
     "@mapbox/sexagesimal": "1.1.0",
     "@mapbox/togeojson": "0.16.0",
+    "cldr-core": "^33.0.0",
+    "cldrpluralruleparser": "^1.3.1",
     "diacritics": "1.3.0",
     "lodash-es": "4.17.10",
     "marked": "0.3.19",

--- a/test/index.html
+++ b/test/index.html
@@ -131,6 +131,7 @@
     <script src='spec/ui/fields/wikipedia.js'></script>
 
     <script src='spec/util/clean_tags.js'></script>
+    <script src='spec/util/locale.js'></script>
     <script src='spec/util/session_mutex.js'></script>
     <script src='spec/util/suggest_names.js'></script>
     <script src='spec/util/util.js'></script>

--- a/test/spec/util/locale.js
+++ b/test/spec/util/locale.js
@@ -1,0 +1,22 @@
+describe('iD.locale', function() {
+    var t = iD.t;
+
+    describe('t', function() {
+        it('translates an unpluralized string', function() {
+            expect(t('commit.cancel', 'en')).to.equal('Cancel');
+        });
+    });
+
+    describe('t', function() {
+        it('translates a pluralized string', function() {
+            expect(t('commit.changes', { count: 0 }, 'en')).to.equal('0 Changes');
+            expect(t('commit.changes', { count: 1 }, 'en')).to.equal('1 Change');
+            expect(t('commit.changes', { count: 2 }, 'en')).to.equal('2 Changes');
+        });
+        it('translates a pluralized string with non-numeric tokens', function() {
+            expect(t('contributors.truncated_list', { users: 'DaveHansenTiger', count: 0 }, 'en')).to.equal('Edits by DaveHansenTiger and 0 others');
+            expect(t('contributors.truncated_list', { users: 'DaveHansenTiger', count: 1 }, 'en')).to.equal('Edits by DaveHansenTiger and someone else');
+            expect(t('contributors.truncated_list', { users: 'DaveHansenTiger', count: 2 }, 'en')).to.equal('Edits by DaveHansenTiger and 2 others');
+        });
+    });
+});


### PR DESCRIPTION
UI strings that include counts now use the appropriate plural form in English and (once translations are updated) in other languages. When looking up a translation and one of the tokens is numeric, look one level deeper in the translation file for the CLDR plural form corresponding to the numeric token.

<img src="https://user-images.githubusercontent.com/1231218/38302375-42f4e37a-37b7-11e8-8f01-405f6c755f34.png" width="392" alt="singular"> <img src="https://user-images.githubusercontent.com/1231218/38302377-44e7e7f4-37b7-11e8-9611-1c5a22627069.png" width="392" alt="plural">

In order to support this feature for all the languages that iD supports, with all their varying pluralization rules, this change introduces dependencies on:

* [cldr-core](https://github.com/unicode-cldr/cldr-core/), which supplies plural rules for a _number_ of languages (part of [cldr-data](https://github.com/rxaviers/cldr-data-npm/))
* [CLDRPluralRuleParser](https://github.com/santhoshtr/CLDRPluralRuleParser/), which parses a plural rule, determining whether it matches the given number (used by MediaWiki)

This works locally using `npm start`, but I’d like someone to double-check that I’m including these dependencies correctly. (All we need is a single JSON file from cldr-core, not the entire package.)

Keying off numbers in token replacements means any number formatting that occurs before calling `t()` will defeat the pluralization logic therein. Unlike the unit formatting that occurs in `t()`’s callers (as of #4672), number formatting needs to happen inside `t()`.

More to come:

* [x] Depend on cldr-core and CLDRPluralRuleParser
* [x] Look up pluralized translations in `t()`
* [x] Pluralize some strings in core.yaml
* [ ] Move number formatting into `t()`
* [ ] Combine manually pluralized strings like `restriction.controls.via_up_to_one`/`restriction.controls.via_up_to_two`
* [ ] Break up `validations.many_deletions` into strings with one pluralized word each
* [x] Mention plural format in contributing documentation
* [ ] Update changelog

Fixes #597.