### PR TITLE
Fixing a bug in displaying read-only tags for entities

### DIFF
--- a/modules/ui/raw_tag_editor.js
+++ b/modules/ui/raw_tag_editor.js
@@ -207,7 +207,8 @@ export function uiRawTagEditor(context) {
 
 
         function bindTypeahead(key, value) {
-            if (isReadOnly({ key: key })) return;
+            if (isReadOnly(key.datum())) return;
+
             var geometry = context.geometry(_entityID);
 
             key.call(d3_combobox()


### PR DESCRIPTION
The normal flow of current *iD editor* code does not display read-only tags for entities. However, for my company's needs we needed to have that ability. Once we created read-only tags list (more accurately, a RegExp list), we got the exception shown below.

The root-cause is wrong invocation of `isReadOnly` from `bindTypehead`.
The resolution is rather simple and demonstrated below...

![exception screenshot](https://sbiccq.db.files.1drv.com/y4mM_uov2g2L3ux7yjogUFPBKwWvzNyYvSnCSqv3gbMqheXesVtO0yrNCCyH917STxXDuoo-51Mc4v4sSJ0Mx4eUO94VzqXLllbqNqBSra_uYmZgUHj97LaILt3xtkmJxC8yBLmJxwDyiH5deQL3Ur2_0qB5A3otB0QRpgfiClJ934fbrKBoAh2cW6eGNadW_pShus-NfkQhcDd6m-zulH-rg?width=660&height=313&cropmode=none)