### PR TITLE
use a tilemap for esri imagery instead of tacking on blankTile=false

### DIFF
--- a/modules/renderer/background_source.js
+++ b/modules/renderer/background_source.js
@@ -6,6 +6,8 @@ import {
   geoMercatorRaw as d3_geoMercatorRaw
 } from 'd3-geo';
 
+import { json as d3_json } from 'd3-request';
+
 import { t } from '../util/locale';
 import { geoExtent, geoPolygonIntersectsPolygon } from '../geo';
 import { jsonpRequest } from '../util/jsonp_request';
@@ -418,9 +420,9 @@ rendererBackgroundSource.Esri = function(data) {
             const tilemapUrl = tileCoord[3].replace(/tile\/[0-9]+\/[0-9]+\/[0-9]+/, 'tilemap') + `/${urlZ}/${urlY}/${urlX}/8/8`;
 
             // make the request and introspect the response from the tilemap server
-            fetch(tilemapUrl)
-            .then(response => response.json())
-            .then(tilemap => {
+            d3_json(tilemapUrl, function (err, tilemap) {
+                if (err || !tilemap) return;
+
                 let tiles = true;
                 for (i=0;i<tilemap.data.length;i++) {
                     // any value of 0 means an individual tile in the grid doesn't exist

--- a/modules/renderer/background_source.js
+++ b/modules/renderer/background_source.js
@@ -310,7 +310,7 @@ rendererBackgroundSource.Esri = function(data) {
         var y = (Math.floor((1 - Math.log(Math.tan(center[1] * Math.PI / 180) + 1 / Math.cos(center[1] * Math.PI / 180)) / Math.PI) / 2 * Math.pow(2, z)));
 
         // fetch an 8x8 grid because responses to leverage cache
-        var tilemapUrl = dummyUrl.replace(/tile\/[0-9]+\/[0-9]+\/[0-9]+/, 'tilemap') + '/' + z + '/' + y + ' /' + '/8/8';
+        var tilemapUrl = dummyUrl.replace(/tile\/[0-9]+\/[0-9]+\/[0-9]+/, 'tilemap') + '/' + z + '/' + y + ' /' + x + '/8/8';
 
         // make the request and introspect the response from the tilemap server
         d3_json(tilemapUrl, function (err, tilemap) {

--- a/modules/ui/notice.js
+++ b/modules/ui/notice.js
@@ -34,6 +34,14 @@ export function uiNotice(context) {
         function disableTooHigh() {
             var canEdit = context.map().zoom() >= context.minEditableZoom();
             div.style('display', canEdit ? 'none' : 'block');
+            // if an Esri basemap is being displayed and native zoom past 19 is enabled, check the tilemap
+            if (canEdit) {
+                var basemap = context.background().baseLayerSource();
+                if (/^EsriWorldImagery/.test(basemap.id) && basemap.scaleExtent[1] > 19) {
+                    var center = context.map().center();
+                    basemap.fetchTilemap(center);
+                }
+            }
         }
 
         context.map()


### PR DESCRIPTION
greetings! :wave:

currently OSM editors are requesting roughly 35 million Esri imagery tiles a month 🎉 and making roughly the same number of requests for tiles that don't exist 🚫.

this PR still needs work, but it introduces support for the 'tilemap' option i described in https://github.com/openstreetmap/iD/issues/4327#issuecomment-328198775

the gist of it is that we can take advantage of a service that indicates whether or not tiles exist in a particular area of interest.

by asking whether tiles are present at zoom level 20 in the current extent of the map as soon as the edit session is instantiated, we'd forgo a _lot_ of unnecessary requests for tiles.