### PR TITLE
Fixed tooltip location for data layers button

### DIFF
--- a/modules/ui/map_data.js
+++ b/modules/ui/map_data.js
@@ -172,7 +172,7 @@ export function uiMapData(context) {
             .append('label')
             .call(tooltip()
                 .title(t('map_data.layers.osm.tooltip'))
-                .placement('top')
+                .placement('bottom')
             );
 
         labelEnter


### PR DESCRIPTION
A quick (possibly temporary) fix for tooltip placement. Currently, the OpenStreetMap data button under the Map Data > Data Layers menu is cut off by the menu heading.