### PR TITLE
Add preset for motorcycle_repair

### DIFF
--- a/data/presets/presets/shop/motorcycle_repair.json
+++ b/data/presets/presets/shop/motorcycle_repair.json
@@ -1,0 +1,28 @@
+{
+    "icon": "scooter",
+    "fields": [
+        "name",
+        "operator",
+        "address",
+        "building_area",
+        "service/vehicle",
+        "opening_hours",
+        "payment_multi"
+    ],
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "terms": [
+        "auto",
+        "garage",
+        "service",
+        "motorcycle"
+        "bike",
+        "bike repair"
+    ],
+    "tags": {
+        "shop": "motorcycle_repair"
+    },
+    "name": "Motorcycle Repair Shop"
+}


### PR DESCRIPTION
The tag already exists - https://wiki.openstreetmap.org/wiki/Tag:shop%3Dmotorcycle_repair

This could help people tag the POI right.