### PR TITLE
Handle key-value pairs pasted as tags

### DIFF
--- a/modules/ui/raw_tag_editor.js
+++ b/modules/ui/raw_tag_editor.js
@@ -1,4 +1,5 @@
 import _map from 'lodash-es/map';
+import _includes from 'lodash-es/includes';
 
 import { ascending as d3_ascending } from 'd3-array';
 import { dispatch as d3_dispatch } from 'd3-dispatch';
@@ -280,6 +281,15 @@ export function uiRawTagEditor(context) {
                     suffix = +(match[2] || 1);
                 while (_tags[kNew]) {  // rename key if already in use
                     kNew = base + '_' + suffix++;
+                }
+
+                if (_includes(kNew, '=')) {
+                    var splitStr = kNew.split('=').map(function(str) { return str.trim(); }),
+                        key = splitStr[0],
+                        value = splitStr[1];
+
+                    kNew = key;
+                    d.value = value;
                 }
             }
             tag[kOld] = undefined;


### PR DESCRIPTION
Implements the behaviour requested in #5024

When a user pastes a string like 'key=value' into the raw tag editor, it gets split into key and value.