### PR TITLE
Add field `heights` to tag for `barrier=retaining_wall`

### DIFF
--- a/data/presets/presets/barrier/retaining_wall.json
+++ b/data/presets/presets/barrier/retaining_wall.json
@@ -1,4 +1,7 @@
 {
+    "fields": [
+        "height"
+    ],
     "geometry": [
         "line",
         "area"


### PR DESCRIPTION
The `retaining_wall` behaves the same as a [`hedge`]( https://github.com/openstreetmap/iD/blob/mast/data/presets/presets/barrier/hedge.json), then.

Wiki-Page: https://wiki.openstreetmap.org/wiki/Tag:barrier%3Dretaining_wall

Do you need anything else for this PR?