### PR TITLE
use 22 as maxZoom for Esri imagery (selectively)

### DIFF
--- a/modules/renderer/background_source.js
+++ b/modules/renderer/background_source.js
@@ -338,7 +338,7 @@ rendererBackgroundSource.Esri = function(data) {
             }
 
             // if any tiles are missing at level 20 we restrict maxZoom to 19
-            esri.scaleExtent[1] = (hasTiles ? 20 : 19);
+            esri.scaleExtent[1] = (hasTiles ? 22 : 19);
         });
     };
 

--- a/modules/renderer/background_source.js
+++ b/modules/renderer/background_source.js
@@ -299,6 +299,11 @@ rendererBackgroundSource.Bing = function(data, dispatch) {
 
 
 rendererBackgroundSource.Esri = function(data) {
+    // in addition to using the tilemap at zoom level 20, overzoom real tiles - #4327 (deprecated technique, but it works)
+    if (data.template.match(/blankTile/) === null) {
+        data.template = data.template + '?blankTile=false';
+    }
+
     var esri = rendererBackgroundSource(data);
     var cache = {};
     var inflight = {};


### PR DESCRIPTION
we actually serve the goods at 5cm in select locations!

![new zealand](https://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/21/1354434/2029272)