### PR TITLE
Add capacity to playground:swing-preset

### DIFF
--- a/data/presets/presets/playground/swing.json
+++ b/data/presets/presets/playground/swing.json
@@ -1,6 +1,7 @@
 {
     "icon": "maki-playground",
     "fields": [
+        "capacity",
         "playground/baby",
         "wheelchair"
     ],


### PR DESCRIPTION
The capacity defines, if there is one swing on the structure or more. A lot of playgrounds have one structure with two swings on it.

Wiki Capacity https://wiki.openstreetmap.org/wiki/Key:capacity
Wiki Playground https://wiki.openstreetmap.org/wiki/Key:playground (which does not reference capacity)

