### PR TITLE
Kiosk levels

### DIFF
--- a/data/presets/presets/shop/kiosk.json
+++ b/data/presets/presets/shop/kiosk.json
@@ -14,6 +14,7 @@
     ],
     "tags": {
         "shop": "kiosk"
+        "building:levels": "1"
     },
     "name": "Kiosk"
 }

--- a/data/presets/presets/shop/kiosk.json
+++ b/data/presets/presets/shop/kiosk.json
@@ -5,6 +5,7 @@
         "operator",
         "address",
         "building_area",
+        "levels",
         "opening_hours",
         "payment_multi"
     ],


### PR DESCRIPTION
Apologies if this is not the way to assign default preset features, but since most (if not all) kiosks are 1-level, this would help with correct 3d-rendering if one was to be added with building=yes