### PR TITLE
fix browser-specific Date() issues in notes

### DIFF
--- a/modules/ui/note_comments.js
+++ b/modules/ui/note_comments.js
@@ -99,6 +99,7 @@ export function uiNoteComments() {
         if (!s) return null;
         var detected = utilDetect();
         var options = { day: 'numeric', month: 'short', year: 'numeric' };
+        s = s.replace(/-/g, '/'); // fix browser-specific Date() issues
         var d = new Date(s);
         if (isNaN(d.getTime())) return null;
         return d.toLocaleDateString(detected.locale, options);


### PR DESCRIPTION
fixes #5154 by replacing "-" with "/" in note comment Date strings like "2018-07-05 20:27:09 UTC"