### PR TITLE
Use Web Workers(wip)

### DIFF
--- a/modules/util/walkie_talkie.js
+++ b/modules/util/walkie_talkie.js
@@ -1,0 +1,46 @@
+var isWorker =
+    typeof WorkerGlobalScope !== 'undefined' &&
+    self instanceof WorkerGlobalScope;
+
+export function createWorker(path) {
+    var workerInstance;
+    var uid = 0;
+    var conversations = {};
+
+    if (isWorker) {
+        workerInstance = self;
+        workerInstance.onmessage = function(event) {
+            var data = event.data;
+            var uid = data.uid;
+            var payload = data.payload;
+            workerInstance.processMessage(payload, function(error, reply) {
+                workerInstance.postMessage({
+                    reply: reply,
+                    error: error,
+                    uid: uid
+                });
+            });
+        };
+    } else {
+        workerInstance = new Worker(path);
+        workerInstance.addEventListener('message', function(event) {
+            var data = event.data;
+            var reply = data.reply;
+            var error = data.error;
+            var uid = data.uid;
+            conversations[uid](error, reply);
+            delete conversations[uid];
+        });
+    }
+
+    return {
+        sendMessage: function(payload, done) {
+            if (!isWorker) {
+                workerInstance.postMessage({ uid: ++uid, payload: payload });
+                conversations[uid] = function(error, reply) {
+                    done(error, reply);
+                };
+            }
+        }
+    };
+}

--- a/modules/util/worker_handler.js
+++ b/modules/util/worker_handler.js
@@ -1,0 +1,21 @@
+import { createWorker } from './walkie_talkie';
+
+var workerInstance = createWorker('dist/iD-worker.js');
+
+export function parseBboxEntities(url, done) {
+    workerInstance.sendMessage(
+        { type: 'PARSE_BBOX_ENTITIES', url: url },
+        function(error, reply) {
+            done(error, reply);
+        }
+    );
+}
+
+export function authdParseBboxEntities(xhrParams, done) {
+    workerInstance.sendMessage(
+        { type: 'AUTHD_PARSE_BBOX_ENTITIES', xhrParams: xhrParams },
+        function(error, reply) {
+            done(error, reply);
+        }
+    );
+}

--- a/modules/worker.js
+++ b/modules/worker.js
@@ -1,0 +1,19 @@
+import { workerParseBbox, workerAuthdParseBbox } from './worker/parse_bbox';
+import { createWorker } from './util/walkie_talkie';
+
+createWorker();
+
+self.processMessage = function(payload, done) {
+    switch (payload.type) {
+        case 'PARSE_BBOX_ENTITIES': {
+            return workerParseBbox(payload.url, done);
+        }
+        case 'AUTHD_PARSE_BBOX_ENTITIES': {
+            return workerAuthdParseBbox(payload.xhrParams, done);
+        }
+        default: {
+            done('Unknown type:' + payload.type);
+            console.error('Unknown type:' + payload.type);
+        }
+    }
+};

--- a/modules/worker/parse_bbox.js
+++ b/modules/worker/parse_bbox.js
@@ -1,0 +1,56 @@
+import { xml as d3_xml } from 'd3-request';
+import { parser } from 'idly-faster-osm-parser';
+import ohauth from 'ohauth';
+
+var isWorker =
+    typeof WorkerGlobalScope !== 'undefined' &&
+    self instanceof WorkerGlobalScope;
+
+if (!isWorker) {
+    throw new Error('this function can only be executed inside Web Worker');
+}
+
+export function workerParseBbox(url, done) {
+    requestRawXml(url, function(error, xml) {
+        if (error) {
+            return done(error);
+        }
+        done(null, processRawXml(xml));
+    });
+}
+
+export function workerAuthdParseBbox(xhrParams, done) {
+    var params = xhrParams;
+    params.push(callback);
+
+    ohauth.xhr.apply(ohauth, params);
+
+    function callback(error, data) {
+        if (error) {
+            return done(error);
+        }
+        done(null, processRawXml(data.responseText));
+    }
+}
+
+function requestRawXml(url, done) {
+    return d3_xml(url)
+        .mimeType('text/plain')
+        .response(function(xhr) {
+            return xhr.responseText;
+        })
+        .get(done);
+}
+
+function processRawXml(xmlText) {
+    return parser(xmlText).map(r => {
+        Object.assign(
+            r,
+            r.attributes,
+            r.loc ? { loc: [r.loc.lon, r.loc.lat] } : undefined
+        );
+        delete r.attributes;
+        delete r.type;
+        return r;
+    });
+}

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "marked": "0.5.1",
     "martinez-polygon-clipping": "0.5.0",
     "node-diff3": "1.0.0",
-    "osm-auth": "1.0.2",
+    "osm-auth": "github:osmlab/osm-auth#get-xhr-params",
     "pannellum": "2.4.1",
     "q": "1.5.1",
     "rbush": "2.0.2",


### PR DESCRIPTION
This brings in support for web workers in iD. The goal of this PR is to offload some work from the main iD process to a thread.  As a first attempt, I am trying to only parse the node, ways, relations in the web worker and then sending a simple JSON back to the main thread. 

There are a bunch of things that need to be fixed, for eg tests, renaming `idly-faster-osm-parser` -> `osm-bizly`, remove es6 code, get the changes in osm-auth merged, etc. 

@bhousel what do you think about the overall changes/code flow?