### PR TITLE
Fix shellbang

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 # This is an example script that shows how to pull the latest version
 # of iD and replace the version string with a git short hash.

--- a/scripts/txpush.sh
+++ b/scripts/txpush.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 # This script runs on TravisCI to push new translation strings to transifex
 


### PR DESCRIPTION
fixed missing `!` in shellbang. You can check which shell is using with `readlink /proc/$$/exe` in the scirpt. (On my Ubuntu:16.04, it's using `/bin/dash` right now)