### PR TITLE
Allow Float values in height input box

### DIFF
--- a/modules/ui/fields/input.js
+++ b/modules/ui/fields/input.js
@@ -92,7 +92,7 @@ export function uiFieldText(field, context) {
 
     // parse as a number
     function parsed(val) {
-        return parseInt(val || 0, 10) || 0;
+        return parseFloat(val || 0, 10) || 0;
     }
 
     // clamp number to min/max


### PR DESCRIPTION
Fixes #5184 
Seems to be as simple as switching the parseInt to parseFloat when parsing input values.

Only issue is that it allows float values for all tags set using the input box (i.e. 'motorway lanes', which should presumeably just be an integer! Not sure how to avoid this though, without doing something like `type=integer` or `type=float` in the tag presets json files