### PR TITLE
Update column.json

### DIFF
--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -12,7 +12,7 @@
     "waterway": {"fields": ["name", "waterway"], "geometry": ["point", "vertex", "line", "area"], "tags": {"waterway": "*"}, "searchable": false, "name": "Waterway"},
     "address": {"fields": ["address"], "geometry": ["point", "vertex", "area"], "tags": {"addr:*": "*"}, "addTags": {}, "removeTags": {}, "reference": {"key": "addr"}, "name": "Address", "matchScore": 0.15},
     "advertising/billboard": {"fields": ["direction", "lit"], "geometry": ["point", "vertex", "line"], "tags": {"advertising": "billboard"}, "name": "Billboard"},
-    "advertising/column": {"fields": ["direction", "lit"], "geometry": ["point", "area"], "tags": {"advertising": "column"}, "name": "Advertising Column"},
+    "advertising/column": {"fields": ["lit"], "geometry": ["point", "area"], "tags": {"advertising": "column"}, "name": "Advertising Column"},
     "aerialway/station": {"icon": "maki-aerialway", "geometry": ["point", "vertex", "area"], "fields": ["aerialway/access", "aerialway/summer/access", "elevation", "building_area"], "tags": {"aerialway": "station"}, "name": "Aerialway Station", "searchable": false},
     "aerialway/cable_car": {"geometry": ["line"], "terms": ["tramway", "ropeway"], "fields": ["name", "aerialway/occupancy", "aerialway/capacity", "aerialway/duration", "aerialway/heating"], "tags": {"aerialway": "cable_car"}, "name": "Cable Car"},
     "aerialway/chair_lift": {"geometry": ["line"], "fields": ["name", "aerialway/occupancy", "aerialway/capacity", "aerialway/duration", "aerialway/bubble", "aerialway/heating"], "tags": {"aerialway": "chair_lift"}, "name": "Chair Lift"},

--- a/data/presets/presets/advertising/column.json
+++ b/data/presets/presets/advertising/column.json
@@ -1,6 +1,5 @@
 {
     "fields": [
-       "direction",
        "lit"
     ],
     "geometry": [


### PR DESCRIPTION
An ad-column is a round thing the way I know it and the way it is shown in the wiki (https://wiki.openstreetmap.org/wiki/Tag:advertising%3Dcolumn). So the direction key as preset does not make sense. There seems to be no relevant usage of this combination as well (https://taginfo.openstreetmap.org/tags/advertising=column#combinations).