### PR TITLE
[KeepRight] Use regex group capture to extract error details

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -695,6 +695,15 @@ en:
           _72:
             title: 'node without tags'
             description: 'This node is not member of any way and doesn''t have any tags.'
+          _73:
+            title: 'tracktype with no highway tag'
+            description: 'This way has a "tracktype" tag but no "highway" tag.'
+          _74:
+            title: 'empty tag'
+            description: 'This {var1} has an empty tag: "{var2}".'
+          _75:
+            title: 'name without tags'
+            description: 'This {var1} has a name ("{var2}") but no other tags.'
           _90:
             title: 'motorways without ref'
             description: 'This way is tagged as motorway and therefore needs a ref nat_ref or int_ref tag.'

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -781,7 +781,7 @@ en:
             description: 'These errors contain self intersecting ways.'
           _211:
             title: ''
-            description: 'This way contains more than one node multiple times. Nodes are {var1}, {var2}. This may or may not be an error.'
+            description: 'This way contains more than one node multiple times. Nodes are {var1}. This may or may not be an error.'
           _212:
             title: ''
             description: 'This way has only two different nodes and contains one of them more than once.'

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -899,13 +899,13 @@ en:
             description: 'There is more than one node in this spot. Offending node IDs: {var1}.'
           _60:
             title: 'depreciated tags'
-            description: 'This {var1} uses deprecated tag {var2}={var3}. Please use {var4} instead!'
+            description: 'This {var1} uses deprecated tag "{var2}"="{var3}". Please use {var4} instead!'
           _300:
             title: 'missing maxspeed'
             description: 'missing maxspeed tag.'
           _360:
             title: 'language unknown'
-            description: 'It would be nice if this {var1} had an additional tag name:XX={var2} where XX shows the language of its name {var2}.'
+            description: 'It would be nice if this {var1} had an additional tag "name:XX"="{var2}" where XX shows the language of its name "{var2}".'
           _390:
             title: 'missing tracktype'
             description: This track doesn't have a tracktype.

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -787,7 +787,7 @@ en:
             description: 'This way has only two different nodes and contains one of them more than once.'
           _220:
             title: 'misspelled tags'
-            description: 'This {var1} is tagged {var2}={var3} where {var4} looks like {var5}.'
+            description: 'This {var1} is tagged {var2}={var3} where "{var4}" looks like "{var5}".'
           _221:
             title: ''
             description: 'The key of this {var1} tag is key {var2}.'
@@ -859,7 +859,7 @@ en:
             description: 'If this roundabout is in a country with right-hand traffic then its orientation goes the wrong way around | If this roundabout is in a country with left-hand traffic then its orientation goes the wrong way around | If this mini_roundabout is in a country with right-hand traffic then its orientation goes the wrong way around | If this mini_roundabout is in a country with left-hand traffic then its orientation goes the wrong way around.'
           _313:
             title: 'faintly connected'
-            description: 'This roundabout has only {var1} other roads connected. Roundabouts typically have three.'
+            description: 'This roundabout has only {var1} other road(s) connected. Roundabouts typically have 3 or more.'
           _320:
             title: '*_link connections'
             description: 'This way is tagged as highway={var1}_link but doesn''t have a connection to any other {var1} or {var1}_link.'
@@ -877,7 +877,7 @@ en:
             description: ''
           _401:
             title: 'missing turn restriction'
-            description: 'ways {var1} and {var2} join in a very sharp angle here and there is no oneway tag or turn restriction that prevents turning from way {var1} to {var2}.'
+            description: 'ways {var1} and {var2} join in a very sharp angle here and there is no oneway tag or turn restriction that prevents turning from way {var3} to {var4}.'
           _402:
             title: 'impossible angles'
             description: 'this way bends in a very sharp angle here.'

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -796,7 +796,7 @@ en:
             description: ''
           _231:
             title: 'mixed layers intersection'
-            description: 'This node is a junction of ways on different layers: {var1}({var2}), {var3}.'
+            description: 'This node is a junction of ways on different layers: {var1}.'
           _232:
             title: 'strange layers'
             description: 'This {var1} is tagged with layer {var2}. This need not be an error but it looks strange.'

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -688,7 +688,7 @@ en:
             description: 'This node is very close but not connected to way #{var1}.'
           _70:
             title: 'missing tags'
-            description: 'This {var1} has an empty tag: {var2}.'
+            description: 'This {var1} has an empty tag: "{var2}".'
           _71:
             title: 'way without tags'
             description: 'This way has no tags.'
@@ -781,22 +781,22 @@ en:
             description: 'These errors contain self intersecting ways.'
           _211:
             title: ''
-            description: 'This way contains more than one node at least twice. Nodes are {var1}. This may or may not be an error.'
+            description: 'This way contains more than one node multiple times. Nodes are {var1}, {var2}. This may or may not be an error.'
           _212:
             title: ''
             description: 'This way has only two different nodes and contains one of them more than once.'
           _220:
             title: 'misspelled tags'
-            description: 'This {var1} is tagged {var2}={var3} where "{var4}" looks like "{var5}".'
+            description: 'This {var1} is tagged "{var2}"="{var3}" where "{var4}" looks like "{var5}".'
           _221:
             title: ''
-            description: 'The key of this {var1} tag is key {var2}.'
+            description: 'This {var1} has a tag with key "key"="{var2}".'
           _230:
             title: 'layer conflicts'
             description: ''
           _231:
             title: 'mixed layers intersection'
-            description: 'This node is a junction of ways on different layers: {var1}.'
+            description: 'This node is a junction of ways on different layers: {var1}({var2}), {var3}.'
           _232:
             title: 'strange layers'
             description: 'This {var1} is tagged with layer {var2}. This need not be an error but it looks strange.'
@@ -829,16 +829,16 @@ en:
             description: 'This turn-restriction has no known restriction type.'
           _292:
             title: 'missing from way'
-            description: 'A turn-restriction needs exactly one {var1} member. This one has {var2}.'
+            description: 'A turn-restriction needs exactly one "from" member. This one has {var1}.'
           _293:
             title: 'missing to way'
-            description: 'A turn-restriction needs exactly one {var1} member. This one has {var2}.'
+            description: 'A turn-restriction needs exactly one "to" member. This one has {var1}.'
           _294:
             title: 'from or to not a way'
-            description: 'From- and To-members of turn restrictions need to be ways. {var1}.'
+            description: '"from" and "to" members of turn restrictions need to be ways. {var1}.'
           _295:
             title: 'via is not on the way ends'
-            description: 'via (node #{var1}) is not the first or the last member of from (way #{var2}).'
+            description: '"via" (node #{var1}) is not the first or the last member of "from" (way #{var2}).'
           _296:
             title: 'wrong restriction angle'
             description: 'restriction type is {var1} but angle is {var2} degrees. Maybe the restriction type is not appropriate?'
@@ -856,7 +856,7 @@ en:
             description: 'This way is part of a roundabout but is not closed-loop. (split carriageways approaching a roundabout should not be tagged as roundabout).'
           _312:
             title: 'wrong direction'
-            description: 'If this roundabout is in a country with right-hand traffic then its orientation goes the wrong way around | If this roundabout is in a country with left-hand traffic then its orientation goes the wrong way around | If this mini_roundabout is in a country with right-hand traffic then its orientation goes the wrong way around | If this mini_roundabout is in a country with left-hand traffic then its orientation goes the wrong way around.'
+            description: 'If this {var1} is in a country with {var2}-hand traffic then its orientation goes the wrong way around'
           _313:
             title: 'faintly connected'
             description: 'This roundabout has only {var1} other road(s) connected. Roundabouts typically have 3 or more.'
@@ -868,10 +868,10 @@ en:
             description: 'This bridge doesn''t have a tag in common with its surrounding ways that shows the purpose of this bridge. There should be one of these tags: {var1}.'
           _370:
             title: 'doubled places'
-            description: 'This node has tags in common with the surrounding way #{var1} and seems to be redundand | This node has tags in common with the surrounding way #{var1} (including the name {var2}) and seems to be redundand.'
+            description: 'This node has tags in common with the surrounding way #{var1} {var2}and seems to be redundant'
           _380:
             title: 'non-physical use of sport-tag'
-            description: 'This way is tagged {var1} but has no physical tag like e.g. leisure, building, amenity or highway.'
+            description: 'This way is tagged "sport"="{var1}" but has no physical tag like e.g. leisure, building, amenity or highway.'
           _400:
             title: 'geometry glitches'
             description: ''

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -957,7 +957,7 @@
                         },
                         "_211": {
                             "title": "",
-                            "description": "This way contains more than one node multiple times. Nodes are {var1}, {var2}. This may or may not be an error."
+                            "description": "This way contains more than one node multiple times. Nodes are {var1}. This may or may not be an error."
                         },
                         "_212": {
                             "title": "",

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -843,6 +843,18 @@
                             "title": "node without tags",
                             "description": "This node is not member of any way and doesn't have any tags."
                         },
+                        "_73": {
+                            "title": "tracktype with no highway tag",
+                            "description": "This way has a \"tracktype\" tag but no \"highway\" tag."
+                        },
+                        "_74": {
+                            "title": "empty tag",
+                            "description": "This {var1} has an empty tag: \"{var2}\"."
+                        },
+                        "_75": {
+                            "title": "name without tags",
+                            "description": "This {var1} has a name (\"{var2}\") but no other tags."
+                        },
                         "_90": {
                             "title": "motorways without ref",
                             "description": "This way is tagged as motorway and therefore needs a ref nat_ref or int_ref tag."

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -1115,7 +1115,7 @@
                         },
                         "_60": {
                             "title": "depreciated tags",
-                            "description": "This {var1} uses deprecated tag {var2}={var3}. Please use {var4} instead!"
+                            "description": "This {var1} uses deprecated tag \"{var2}\"=\"{var3}\". Please use {var4} instead!"
                         },
                         "_300": {
                             "title": "missing maxspeed",
@@ -1123,7 +1123,7 @@
                         },
                         "_360": {
                             "title": "language unknown",
-                            "description": "It would be nice if this {var1} had an additional tag name:XX={var2} where XX shows the language of its name {var2}."
+                            "description": "It would be nice if this {var1} had an additional tag \"name:XX\"=\"{var2}\" where XX shows the language of its name \"{var2}\"."
                         },
                         "_390": {
                             "title": "missing tracktype",

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -833,7 +833,7 @@
                         },
                         "_70": {
                             "title": "missing tags",
-                            "description": "This {var1} has an empty tag: {var2}."
+                            "description": "This {var1} has an empty tag: \"{var2}\"."
                         },
                         "_71": {
                             "title": "way without tags",
@@ -957,7 +957,7 @@
                         },
                         "_211": {
                             "title": "",
-                            "description": "This way contains more than one node at least twice. Nodes are {var1}. This may or may not be an error."
+                            "description": "This way contains more than one node multiple times. Nodes are {var1}, {var2}. This may or may not be an error."
                         },
                         "_212": {
                             "title": "",
@@ -965,11 +965,11 @@
                         },
                         "_220": {
                             "title": "misspelled tags",
-                            "description": "This {var1} is tagged {var2}={var3} where {var4} looks like {var5}."
+                            "description": "This {var1} is tagged \"{var2}\"=\"{var3}\" where \"{var4}\" looks like \"{var5}\"."
                         },
                         "_221": {
                             "title": "",
-                            "description": "The key of this {var1} tag is key {var2}."
+                            "description": "This {var1} has a tag with key \"key\"=\"{var2}\"."
                         },
                         "_230": {
                             "title": "layer conflicts",
@@ -1021,19 +1021,19 @@
                         },
                         "_292": {
                             "title": "missing from way",
-                            "description": "A turn-restriction needs exactly one {var1} member. This one has {var2}."
+                            "description": "A turn-restriction needs exactly one \"from\" member. This one has {var1}."
                         },
                         "_293": {
                             "title": "missing to way",
-                            "description": "A turn-restriction needs exactly one {var1} member. This one has {var2}."
+                            "description": "A turn-restriction needs exactly one \"to\" member. This one has {var1}."
                         },
                         "_294": {
                             "title": "from or to not a way",
-                            "description": "From- and To-members of turn restrictions need to be ways. {var1}."
+                            "description": "\"from\" and \"to\" members of turn restrictions need to be ways. {var1}."
                         },
                         "_295": {
                             "title": "via is not on the way ends",
-                            "description": "via (node #{var1}) is not the first or the last member of from (way #{var2})."
+                            "description": "\"via\" (node #{var1}) is not the first or the last member of \"from\" (way #{var2})."
                         },
                         "_296": {
                             "title": "wrong restriction angle",
@@ -1057,11 +1057,11 @@
                         },
                         "_312": {
                             "title": "wrong direction",
-                            "description": "If this roundabout is in a country with right-hand traffic then its orientation goes the wrong way around | If this roundabout is in a country with left-hand traffic then its orientation goes the wrong way around | If this mini_roundabout is in a country with right-hand traffic then its orientation goes the wrong way around | If this mini_roundabout is in a country with left-hand traffic then its orientation goes the wrong way around."
+                            "description": "If this {var1} is in a country with {var2}-hand traffic then its orientation goes the wrong way around"
                         },
                         "_313": {
                             "title": "faintly connected",
-                            "description": "This roundabout has only {var1} other roads connected. Roundabouts typically have three."
+                            "description": "This roundabout has only {var1} other road(s) connected. Roundabouts typically have 3 or more."
                         },
                         "_320": {
                             "title": "*_link connections",
@@ -1073,11 +1073,11 @@
                         },
                         "_370": {
                             "title": "doubled places",
-                            "description": "This node has tags in common with the surrounding way #{var1} and seems to be redundand | This node has tags in common with the surrounding way #{var1} (including the name {var2}) and seems to be redundand."
+                            "description": "This node has tags in common with the surrounding way #{var1} {var2}and seems to be redundant"
                         },
                         "_380": {
                             "title": "non-physical use of sport-tag",
-                            "description": "This way is tagged {var1} but has no physical tag like e.g. leisure, building, amenity or highway."
+                            "description": "This way is tagged \"sport\"=\"{var1}\" but has no physical tag like e.g. leisure, building, amenity or highway."
                         },
                         "_400": {
                             "title": "geometry glitches",
@@ -1085,7 +1085,7 @@
                         },
                         "_401": {
                             "title": "missing turn restriction",
-                            "description": "ways {var1} and {var2} join in a very sharp angle here and there is no oneway tag or turn restriction that prevents turning from way {var1} to {var2}."
+                            "description": "ways {var1} and {var2} join in a very sharp angle here and there is no oneway tag or turn restriction that prevents turning from way {var3} to {var4}."
                         },
                         "_402": {
                             "title": "impossible angles",

--- a/modules/util/keepRight/errorSchema.json
+++ b/modules/util/keepRight/errorSchema.json
@@ -195,9 +195,8 @@
             },
             "_211": {
                 "title": "",
-                "description": "This way contains more than one node at least twice. Nodes are #(\\d+), ((?:#\\d+(?:, )?)+)\\. This may or may not be an error",
-                "IDs": ["n"],
-                "TODO": "Second group is arbitrary list of node IDs in form: #ID, #ID, #ID...",
+                "description": "This way contains more than one node at least twice\\. Nodes are ((?:#\\d+(?:, )?)+)\\. This may or may not be an error",
+                "IDs": ["211"],
                 "regex": true
             },
             "_212": {

--- a/modules/util/keepRight/errorSchema.json
+++ b/modules/util/keepRight/errorSchema.json
@@ -373,7 +373,7 @@
             },
             "_412": {
                 "title": "domain hijacking",
-                "description": "Possible domain squatting: <a target=_blank href=(.+)>\\1</a>. Suspicious text is: ''(.+)''",
+                "description": "Possible domain squatting: <a target=_blank href=(.+)>\\1</a>\\. Suspicious text is: ''(.+)''",
                 "regex": true
             },
             "_413": {
@@ -385,11 +385,14 @@
         "warnings": {
             "_20": {
                 "title": "multiple nodes on the same spot",
-                "description": "There is more than one node in this spot. Offending node IDs: {$1}"
+                "description": "There is more than one node in this spot\\. Offending node IDs: ((?:#\\d+,?)+)",
+                "IDs": ["20"],
+                "regex": true
             },
             "_60": {
                 "title": "depreciated tags",
-                "description": "This {$1} uses deprecated tag {$2} = {$3}. Please use {$4} instead!"
+                "description": "This (node|way|relation) uses deprecated tag '([\\w:]+)=(.+)'\\. Please use &quot;(.+)&quot; instead!",
+                "regex": true
             },
             "_300": {
                 "title": "missing maxspeed",
@@ -397,7 +400,7 @@
             },
             "_360": {
                 "title": "language unknown",
-                "description": "It would be nice if this (node|way|relation) had an additional tag ''name:XX=(\\.+?)''where XX shows the language of its name ''\\2''",
+                "description": "It would be nice if this (node|way|relation) had an additional tag 'name:XX=(.+)' where XX shows the language of its name '\\2'",
                 "regex": true
             },
             "_390": {

--- a/modules/util/keepRight/errorSchema.json
+++ b/modules/util/keepRight/errorSchema.json
@@ -4,17 +4,20 @@
         "errors": {
             "_30": {
                 "title": "non-closed_areas",
-                "description": "This way is tagged with ''([\\w:]+)=(\\w+)''and should be closed-loop"
+                "description": "This way is tagged with ''([\\w:]+)=(\\w+)''and should be closed-loop",
+                "regex": true
             },
             "_40": {
                 "title": "dead-ended one-ways",
                 "description": "The first node \\(id (\\d+)\\) of this one-way is not connected to any other way",
-                "IDs": ["n"]
+                "IDs": ["n"],
+                "regex": true
             },
             "_41": {
                 "title": "",
                 "description": "The last node \\(id (\\d+)\\) of this one-way is not connected to any other way",
-                "IDs": ["n"]
+                "IDs": ["n"],
+                "regex": true
             },
             "_42": {
                 "title": "",
@@ -27,11 +30,13 @@
             "_50": {
                 "title": "almost-junctions",
                 "description": "This node is very close but not connected to way #(\\d+)",
-                "IDs": ["w"]
+                "IDs": ["w"],
+                "regex": true
             },
             "_70": {
                 "title": "missing tags",
-                "description": "This (node|way|relation) has an empty tag: &quot;([\\w:]+)=&quot;"
+                "description": "This (node|way|relation) has an empty tag: &quot;([\\w:]+)=&quot;",
+                "regex": true
             },
             "_71": {
                 "title": "",
@@ -47,11 +52,13 @@
             },
             "_100": {
                 "title": "places of worship without religion",
-                "description": "This (node|way|relation) is tagged as place of worship and therefore needs a religion tag"
+                "description": "This (node|way|relation) is tagged as place of worship and therefore needs a religion tag",
+                "regex": true
             },
             "_110": {
                 "title": "point of interest without name",
-                "description": "This node is tagged as ([\\w:]+) and therefore needs a name tag"
+                "description": "This node is tagged as ([\\w:]+) and therefore needs a name tag",
+                "regex": true
             },
             "_120": {
                 "title": "ways without nodes",
@@ -71,7 +78,8 @@
             },
             "_170": {
                 "title": "FIXME tagged items",
-                "description": "(.*)"
+                "description": "(.*)",
+                "regex": true
             },
             "_180": {
                 "title": "relations without type",
@@ -84,42 +92,50 @@
             "_191": {
                 "title": "highway-highway",
                 "description": "This (highway) intersects the (highway) #(\\d+) but there is no junction node",
-                "IDs": ["", "", "w"]
+                "IDs": ["", "", "w"],
+                "regex": true
             },
             "_192": {
                 "title": "highway-waterway",
                 "description": "This (highway|waterway) intersects the (highway|waterway) #(\\d+)",
-                "IDs": ["", "", "w"]
+                "IDs": ["", "", "w"],
+                "regex": true
             },
             "_193": {
                 "title": "highway-riverbank",
                 "description": "This (highway|riverbank) intersects the (highway|riverbank) #(\\d+)",
-                "IDs": ["", "", "w"]
+                "IDs": ["", "", "w"],
+                "regex": true
             },
             "_194": {
                 "title": "waterway-waterway",
                 "description": "This (waterway) intersects the (waterway) #(\\d+) but there is no junction node",
-                "IDs": ["", "", "w"]
+                "IDs": ["", "", "w"],
+                "regex": true
             },
             "_195": {
                 "title": "cycleway-cycleway",
                 "description": "This (cycleway/footpath) intersects the (cycleway/footpath) #(\\d+) but there is no junction node",
-                "IDs": ["", "", "w"]
+                "IDs": ["", "", "w"],
+                "regex": true
             },
             "_196": {
                 "title": "highway-cycleway",
                 "description": "This (highway|cycleway/footpath) intersects the (highway|cycleway/footpath) #(\\d+) but there is no junction node",
-                "IDs": ["", "", "w"]
+                "IDs": ["", "", "w"],
+                "regex": true
             },
             "_197": {
                 "title": "cycleway-waterway",
                 "description": "This (waterway|cycleway/footpath) intersects the (waterway|cycleway/footpath) #(\\d+)",
-                "IDs": ["", "", "w"]
+                "IDs": ["", "", "w"],
+                "regex": true
             },
             "_198": {
                 "title": "cycleway-riverbank",
                 "description": "This (riverbank|cycleway/footpath) intersects the (riverbank|cycleway/footpath) #(\\d+)",
-                "IDs": ["", "", "w"]
+                "IDs": ["", "", "w"],
+                "regex": true
             },
             "_200": {
                 "title": "overlapping ways",
@@ -128,42 +144,50 @@
             "_201": {
                 "title": "highway-highway",
                 "description": "This (highway) overlaps the (highway) #(\\d+)",
-                "IDs": ["", "", "w"]
+                "IDs": ["", "", "w"],
+                "regex": true
             },
             "_202": {
                 "title": "highway-waterway",
                 "description": "This (highway|waterway) overlaps the (highway|waterway) #(\\d+)",
-                "IDs": ["", "", "w"]
+                "IDs": ["", "", "w"],
+                "regex": true
             },
             "_203": {
                 "title": "highway-riverbank",
                 "description": "This (highway|riverbank) overlaps the (highway|riverbank) #(\\d+)",
-                "IDs": ["", "", "w"]
+                "IDs": ["", "", "w"],
+                "regex": true
             },
             "_204": {
                 "title": "waterway-waterway",
                 "description": "This (waterway) overlaps the (waterway) #(\\d+)",
-                "IDs": ["", "", "w"]
+                "IDs": ["", "", "w"],
+                "regex": true
             },
             "_205": {
                 "title": "cycleway-cycleway",
                 "description": "This (cycleway/footpath) overlaps the (cycleway/footpath) #(\\d+)",
-                "IDs": ["", "", "w"]
+                "IDs": ["", "", "w"],
+                "regex": true
             },
             "_206": {
                 "title": "highway-cycleway",
                 "description": "This (highway|cycleway/footpath) overlaps the (highway|cycleway/footpath) #(\\d+)",
-                "IDs": ["", "", "w"]
+                "IDs": ["", "", "w"],
+                "regex": true
             },
             "_207": {
                 "title": "cycleway-waterway",
                 "description": "This (waterway|cycleway/footpath) overlaps the (waterway|cycleway/footpath) #(\\d+)",
-                "IDs": ["", "", "w"]
+                "IDs": ["", "", "w"],
+                "regex": true
             },
             "_208": {
                 "title": "cycleway-riverbank",
                 "description": "This (riverbank|cycleway/footpath) overlaps the (riverbank|cycleway/footpath) #(\\d+)",
-                "IDs": ["", "", "w"]
+                "IDs": ["", "", "w"],
+                "regex": true
             },
             "_210": {
                 "title": "loopings",
@@ -172,8 +196,9 @@
             "_211": {
                 "title": "",
                 "description": "This way contains more than one node at least twice. Nodes are #(\\d+), ((?:#\\d+(?:, )?)+)\\. This may or may not be an error",
-                "IDs": ["n", ""],
-                "TODO": "Second group is arbitrary list of node IDs in form: #ID, #ID, #ID..."
+                "IDs": ["n"],
+                "TODO": "Second group is arbitrary list of node IDs in form: #ID, #ID, #ID...",
+                "regex": true
             },
             "_212": {
                 "title": "",
@@ -181,11 +206,13 @@
             },
             "_220": {
                 "title": "misspelled tags",
-                "description": "This (node|way|relation) is tagged '([\\w:]+)=(.+)' where &quot;(\\2|\\3)&quot; looks like &quot;([\\w\\s]+)&quot;"
+                "description": "This (node|way|relation) is tagged '([\\w:]+)=(.+)' where &quot;(\\2|\\3)&quot; looks like &quot;([\\w\\s]+)&quot;",
+                "regex": true
             },
             "_221": {
                 "title": "",
-                "description": "The key of this (node|way|relation)''s tag is ''key'': key=(.+)"
+                "description": "The key of this (node|way|relation)''s tag is ''key'': key=(.+)",
+                "regex": true
             },
             "_230": {
                 "title": "layer conflicts",
@@ -194,11 +221,13 @@
             "_231": {
                 "title": "mixed layers intersection",
                 "description": "This node is a junction of ways on different layers: ((?:#\\d+\\(-?\\d+\\),?)+)",
-                "IDs": ["231"]
+                "IDs": ["231"],
+                "regex": true
             },
             "_232": {
                 "title": "strange layers",
-                "description": "This (bridge|tunnel) is tagged with layer (-?\\d+)\\. This need not be an error but it looks strange"
+                "description": "This (bridge|tunnel) is tagged with layer (-?\\d+)\\. This need not be an error but it looks strange",
+                "regex": true
             },
             "_270": {
                 "title": "motorways connected directly",
@@ -214,19 +243,23 @@
             },
             "_282": {
                 "title": "missing admin level",
-                "description": "The boundary of (.+) has no (?:valid numeric )?admin_level\\..*"
+                "description": "The boundary of (.+) has no (?:valid numeric )?admin_level\\..*",
+                "regex": true
             },
             "_283": {
                 "title": "no closed loop",
-                "description": "The boundary of (.+) is not closed-loop"
+                "description": "The boundary of (.+) is not closed-loop",
+                "regex": true
             },
             "_284": {
                 "title": "splitting boundary",
-                "description": "The boundary of (.+) splits here"
+                "description": "The boundary of (.+) splits here",
+                "regex": true
             },
             "_285": {
                 "title": "admin_level too high",
-                "description": "This boundary-way has admin_level (-?\\d+) but belongs to a relation with lower admin_level (higher priority); it should have the lowest admin_level of all relations"
+                "description": "This boundary-way has admin_level (-?\\d+) but belongs to a relation with lower admin_level (higher priority); it should have the lowest admin_level of all relations",
+                "regex": true
             },
             "_290": {
                 "title": "restrictions",
@@ -234,39 +267,47 @@
             },
             "_291": {
                 "title": "missing type",
-                "description": "This turn-restriction has no (?:known )?restriction type"
+                "description": "This turn-restriction has no (?:known )?restriction type",
+                "regex": true
             },
             "_292": {
                 "title": "missing from way",
-                "description": "A turn-restriction needs exactly one from member\\. This one has (\\d+)"
+                "description": "A turn-restriction needs exactly one from member\\. This one has (\\d+)",
+                "regex": true
             },
             "_293": {
                 "title": "missing to way",
-                "description": "A turn-restriction needs exactly one to member\\. This one has (\\d+)"
+                "description": "A turn-restriction needs exactly one to member\\. This one has (\\d+)",
+                "regex": true
             },
             "_294": {
                 "title": "from or to not a way",
                 "description": "From- and To-members of turn restrictions need to be ways\\. (.+)",
-                "TODO": "Group can be any combination of to/from: to node #ID | from node #ID | to relation #ID | from relation #ID"
+                "TODO": "Group can be any combination of to/from: to node #ID | from node #ID | to relation #ID | from relation #ID",
+                "regex": true
             },
             "_295": {
                 "title": "via is not on the way ends",
                 "description": "via \\(node #(\\d+)\\) is not the first or the last member of from \\(way #(\\d+)\\)",
-                "IDs": ["n", "w"]
+                "IDs": ["n", "w"],
+                "regex": true
             },
             "_296": {
                 "title": "wrong restriction angle",
-                "description": "restriction type is (\\w+) but angle is (\\d+) degrees. Maybe the restriction type is not appropriate?"
+                "description": "restriction type is (\\w+) but angle is (\\d+) degrees. Maybe the restriction type is not appropriate?",
+                "regex": true
             },
             "_297": {
                 "title": "wrong direction of to member",
                 "description": "wrong direction of to way (\\d+)",
-                "IDs": ["w"]
+                "IDs": ["w"],
+                "regex": true
             },
             "_298": {
                 "title": "already restricted by oneway",
                 "description": "entry already prohibited by oneway tag on (\\d+)",
-                "IDs": ["w"]
+                "IDs": ["w"],
+                "regex": true
             },
             "_310": {
                 "title": "roundabouts",
@@ -274,33 +315,39 @@
             },
             "_311": {
                 "title": "not closed loop",
-                "description": "This way is part of a roundabout but is not closed-loop\\. \\(split carriageways approaching a roundabout should not be tagged as roundabout\\)"
+                "description": "This way is part of a roundabout but is not closed-loop. (split carriageways approaching a roundabout should not be tagged as roundabout)"
             },
             "_312": {
                 "title": "wrong direction",
-                "description": "If this ((?:mini_)?roundabout) is in a country with (left|right)-hand traffic then its orientation goes the wrong way around"
+                "description": "If this ((?:mini_)?roundabout) is in a country with (left|right)-hand traffic then its orientation goes the wrong way around",
+                "regex": true
             },
             "_313": {
                 "title": "faintly connected",
-                "description": "This roundabout has only (\\d) other roads connected. Roundabouts typically have three"
+                "description": "This roundabout has only (\\d) other roads connected. Roundabouts typically have three",
+                "regex": true
             },
             "_320": {
                 "title": "*_link connections",
-                "description": "This way is tagged as highway=(\\w+)_link but doesn''t have a connection to any other \\1 or \\1_link"
+                "description": "This way is tagged as highway=(\\w+)_link but doesn''t have a connection to any other \\1 or \\1_link",
+                "regex": true
             },
             "_350": {
                 "title": "bridge-tags",
                 "description": "This bridge does not have a tag in common with its surrounding ways that shows the purpose of this bridge. There should be one of these tags: (.+)",
-                "NOTE": "Group can be arbitrary list of form: key=value,key=value,key=value..."
+                "NOTE": "Group can be arbitrary list of form: key=value,key=value,key=value...",
+                "regex": true
             },
             "_370": {
                 "title": "doubled places",
                 "description": "This node has tags in common with the surrounding way #(\\d+) ((?:\\(including the name '.+'\\) )?)and seems to be redundand",
-                "IDs": ["w", ""]
+                "IDs": ["w"],
+                "regex": true
             },
             "_380": {
                 "title": "non-physical use of sport-tag",
-                "description": "This way is tagged sport=(\\w+) but has no physical tag like e.g. leisure, building, amenity or highway"
+                "description": "This way is tagged sport=(\\w+) but has no physical tag like e.g. leisure, building, amenity or highway",
+                "regex": true
             },
             "_400": {
                 "title": "geometry glitches",
@@ -309,7 +356,8 @@
             "_401": {
                 "title": "missing turn restriction",
                 "description": "ways (\\d+) and (\\d+) join in a very sharp angle here and there is no oneway tag or turn restriction that prevents turning from way (\\1|\\2) to (\\1|\\2)",
-                "IDs": ["w", "w", "w", "w"]
+                "IDs": ["w", "w", "w", "w"],
+                "regex": true
             },
             "_402": {
                 "title": "impossible angles",
@@ -322,15 +370,17 @@
             "_411": {
                 "title": "http error",
                 "description": "The URL \\(<a target=_blank href=(.+)>\\1</a>\\) cannot be opened \\(HTTP status code (\\d+)\\)",
-                "NOTE": "It seems the HTML attributes don't have quotes when the code reads them"
+                "regex": true
             },
             "_412": {
                 "title": "domain hijacking",
-                "description": "Possible domain squatting: <a target=_blank href=(.+)>\\1</a>. Suspicious text is: ''(.+)''"
+                "description": "Possible domain squatting: <a target=_blank href=(.+)>\\1</a>. Suspicious text is: ''(.+)''",
+                "regex": true
             },
             "_413": {
                 "title": "non-match",
-                "description": "Content of the URL (<a target=_blank href=(.+)>\\1</a>) did not contain these keywords: \\((.+)\\)"
+                "description": "Content of the URL (<a target=_blank href=(.+)>\\1</a>) did not contain these keywords: \\((.+)\\)",
+                "regex": true
             }
         },
         "warnings": {
@@ -348,7 +398,8 @@
             },
             "_360": {
                 "title": "language unknown",
-                "description": "It would be nice if this (node|way|relation) had an additional tag ''name:XX=(\\.+?)''where XX shows the language of its name ''\\2''"
+                "description": "It would be nice if this (node|way|relation) had an additional tag ''name:XX=(\\.+?)''where XX shows the language of its name ''\\2''",
+                "regex": true
             },
             "_390": {
                 "title": "missing tracktype",

--- a/modules/util/keepRight/errorSchema.json
+++ b/modules/util/keepRight/errorSchema.json
@@ -24,7 +24,8 @@
             },
             "_50": {
                 "title": "almost-junctions",
-                "description": "This node is very close but not connected to way #{$1}"
+                "description": "This node is very close but not connected to way #(\\d+)",
+                "IDs": ["w"]
             },
             "_70": {
                 "title": "missing tags",
@@ -48,7 +49,7 @@
             },
             "_110": {
                 "title": "point of interest without name",
-                "description": "This node is tagged as {$1} and therefore needs a name tag"
+                "description": "This node is tagged as (\\w+) and therefore needs a name tag"
             },
             "_120": {
                 "title": "ways without nodes",
@@ -68,7 +69,7 @@
             },
             "_170": {
                 "title": "FIXME tagged items",
-                "description": "{$1}"
+                "description": "(.*)"
             },
             "_180": {
                 "title": "relations without type",
@@ -80,7 +81,8 @@
             },
             "_191": {
                 "title": "highway-highway",
-                "description": "This {$1} intersects the {$2} #{$3} but there is no junction node"
+                "description": "This (highway) intersects the (highway) #(\\d+) but there is no junction node",
+                "IDs": ["", "", "w"]
             },
             "_192": {
                 "title": "highway-waterway",
@@ -88,7 +90,8 @@
             },
             "_193": {
                 "title": "highway-riverbank",
-                "description": "This {$1} intersects the {$2} #{$3}"
+                "description": "This (riverbank) intersects the (highway) #(\\d+)",
+                "IDs": ["", "", "w"]
             },
             "_194": {
                 "title": "waterway-waterway",
@@ -100,7 +103,8 @@
             },
             "_196": {
                 "title": "highway-cycleway",
-                "description": "This {$1} intersects the {$2} #{$3} but there is no junction node"
+                "description": "This (\\w+(?:/\\w+)?) intersects the (highway) #(\\d+) but there is no junction node",
+                "IDs": ["", "", "w"]
             },
             "_197": {
                 "title": "cycleway-waterway",
@@ -160,7 +164,7 @@
             },
             "_220": {
                 "title": "misspelled tags",
-                "description": "This {$1} is tagged '{$2}={$3}' where {$4} looks like {$5}"
+                "description": "This (node|way|relation) is tagged '(\\w+)=(\\w+)' where &quot;(\\w+)&quot; looks like &quot;(\\w+)&quot;"
             },
             "_221": {
                 "title": "",
@@ -232,7 +236,7 @@
             },
             "_296": {
                 "title": "wrong restriction angle",
-                "description": "restriction type is {$1} but angle is {$2} degrees. Maybe the restriction type is not appropriate?"
+                "description": "restriction type is (\\w+) but angle is (\\d+) degrees. Maybe the restriction type is not appropriate?"
             },
             "_297": {
                 "title": "wrong direction of to member",
@@ -256,7 +260,7 @@
             },
             "_313": {
                 "title": "faintly connected",
-                "description": "This roundabout has only {$1} other roads connected. Roundabouts typically have three"
+                "description": "This roundabout has only (\\d) other roads connected. Roundabouts typically have three"
             },
             "_320": {
                 "title": "*_link connections",
@@ -272,7 +276,7 @@
             },
             "_380": {
                 "title": "non-physical use of sport-tag",
-                "description": "This way is tagged {$1} but has no physical tag like e.g. leisure, building, amenity or highway"
+                "description": "This way is tagged (sport=\\w+) but has no physical tag like e.g. leisure, building, amenity or highway"
             },
             "_400": {
                 "title": "geometry glitches",
@@ -280,7 +284,8 @@
             },
             "_401": {
                 "title": "missing turn restriction",
-                "description": "ways {$1} and {$2} join in a very sharp angle here and there is no oneway tag or turn restriction that prevents turning from way {$1} to {$2}"
+                "description": "ways (\\d+) and (\\d+) join in a very sharp angle here and there is no oneway tag or turn restriction that prevents turning from way (\\d+) to (\\d+)",
+                "IDs": ["w", "w", "w", "w"]
             },
             "_402": {
                 "title": "impossible angles",
@@ -292,7 +297,8 @@
             },
             "_411": {
                 "title": "http error",
-                "description": "The URL (<a target=''_blank'' href=''{$1}''>{$1}</a>) cannot be opened (HTTP status code {$2})"
+                "description": "The URL \\(<a target=\"_blank\" href=\"(.+?)\">\\1</a>\\) cannot be opened \\(HTTP status code (\\d+)\\)",
+                "TODO": "For some reason this regex doesn't match, possible related to quotes (see _220)"
             },
             "_412": {
                 "title": "domain hijacking",
@@ -318,7 +324,7 @@
             },
             "_360": {
                 "title": "language unknown",
-                "description": "It would be nice if this {$1} had an additional tag ''name:XX={$2}''where XX shows the language of its name ''{$2}''"
+                "description": "It would be nice if this (node|way|relation) had an additional tag ''name:XX=(\\.+?)''where XX shows the language of its name ''\\2''"
             },
             "_390": {
                 "title": "missing tracktype",

--- a/modules/util/keepRight/errorSchema.json
+++ b/modules/util/keepRight/errorSchema.json
@@ -35,8 +35,7 @@
             },
             "_70": {
                 "title": "missing tags",
-                "description": "This (node|way|relation) has an empty tag: &quot;([\\w:]+)=&quot;",
-                "regex": true
+                "description": ""
             },
             "_71": {
                 "title": "",
@@ -45,6 +44,19 @@
             "_72": {
                 "title": "",
                 "description": "This node is not member of any way and does not have any tags"
+            },
+            "_73": {
+                "title": "",
+                "description": "This way has a tracktype tag but no highway tag"
+            },
+            "_74": {
+                "title": "missing tags",
+                "description": "This (node|way|relation) has an empty tag: &quot;([\\w:]+)=&quot;",
+                "regex": true
+            },
+            "_75": {
+                "description": "This (node|way|relation) has a name \\((.+)\\) but no other tag",
+                "regex": true
             },
             "_90": {
                 "title": "motorways without ref",

--- a/modules/util/keepRight/errorSchema.json
+++ b/modules/util/keepRight/errorSchema.json
@@ -4,15 +4,17 @@
         "errors": {
             "_30": {
                 "title": "non-closed_areas",
-                "description": "This way is tagged with ''{$1}={$2}''and should be closed-loop"
+                "description": "This way is tagged with ''([\\w:]+)=(\\w+)''and should be closed-loop"
             },
             "_40": {
                 "title": "dead-ended one-ways",
-                "description": "The first node (id {$1}) of this one-way is not connected to any other way"
+                "description": "The first node \\(id (\\d+)\\) of this one-way is not connected to any other way",
+                "IDs": ["n"]
             },
             "_41": {
                 "title": "",
-                "description": "The last node (id {$1}) of this one-way is not connected to any other way"
+                "description": "The last node \\(id (\\d+)\\) of this one-way is not connected to any other way",
+                "IDs": ["n"]
             },
             "_42": {
                 "title": "",
@@ -29,7 +31,7 @@
             },
             "_70": {
                 "title": "missing tags",
-                "description": "This {$1} has an empty tag: {$2}"
+                "description": "This (node|way|relation) has an empty tag: &quot;([\\w:]+)=&quot;"
             },
             "_71": {
                 "title": "",
@@ -45,11 +47,11 @@
             },
             "_100": {
                 "title": "places of worship without religion",
-                "description": "This {$1} is tagged as place of worship and therefore needs a religion tag"
+                "description": "This (node|way|relation) is tagged as place of worship and therefore needs a religion tag"
             },
             "_110": {
                 "title": "point of interest without name",
-                "description": "This node is tagged as (\\w+) and therefore needs a name tag"
+                "description": "This node is tagged as ([\\w:]+) and therefore needs a name tag"
             },
             "_120": {
                 "title": "ways without nodes",
@@ -86,33 +88,38 @@
             },
             "_192": {
                 "title": "highway-waterway",
-                "description": "This {$1} intersects the {$2} #{$3}"
+                "description": "This (highway|waterway) intersects the (highway|waterway) #(\\d+)",
+                "IDs": ["", "", "w"]
             },
             "_193": {
                 "title": "highway-riverbank",
-                "description": "This (riverbank) intersects the (highway) #(\\d+)",
+                "description": "This (highway|riverbank) intersects the (highway|riverbank) #(\\d+)",
                 "IDs": ["", "", "w"]
             },
             "_194": {
                 "title": "waterway-waterway",
-                "description": "This {$1} intersects the {$2} #{$3} but there is no junction node"
+                "description": "This (waterway) intersects the (waterway) #(\\d+) but there is no junction node",
+                "IDs": ["", "", "w"]
             },
             "_195": {
                 "title": "cycleway-cycleway",
-                "description": "This {$1} intersects the {$2} #{$3} but there is no junction node"
+                "description": "This (cycleway/footpath) intersects the (cycleway/footpath) #(\\d+) but there is no junction node",
+                "IDs": ["", "", "w"]
             },
             "_196": {
                 "title": "highway-cycleway",
-                "description": "This (\\w+(?:/\\w+)?) intersects the (highway) #(\\d+) but there is no junction node",
+                "description": "This (highway|cycleway/footpath) intersects the (highway|cycleway/footpath) #(\\d+) but there is no junction node",
                 "IDs": ["", "", "w"]
             },
             "_197": {
                 "title": "cycleway-waterway",
-                "description": "This {$1} intersects the {$2} #{$3}"
+                "description": "This (waterway|cycleway/footpath) intersects the (waterway|cycleway/footpath) #(\\d+)",
+                "IDs": ["", "", "w"]
             },
             "_198": {
                 "title": "cycleway-riverbank",
-                "description": "This {$1} intersects the {$2} #{$3}"
+                "description": "This (riverbank|cycleway/footpath) intersects the (riverbank|cycleway/footpath) #(\\d+)",
+                "IDs": ["", "", "w"]
             },
             "_200": {
                 "title": "overlapping ways",
@@ -120,35 +127,43 @@
             },
             "_201": {
                 "title": "highway-highway",
-                "description": "This {$1} overlaps the {$2} #{$3}"
+                "description": "This (highway) overlaps the (highway) #(\\d+)",
+                "IDs": ["", "", "w"]
             },
             "_202": {
                 "title": "highway-waterway",
-                "description": "This {$1} overlaps the {$2} #{$3}"
+                "description": "This (highway|waterway) overlaps the (highway|waterway) #(\\d+)",
+                "IDs": ["", "", "w"]
             },
             "_203": {
                 "title": "highway-riverbank",
-                "description": "This {$1} overlaps the {$2} #{$3}"
+                "description": "This (highway|riverbank) overlaps the (highway|riverbank) #(\\d+)",
+                "IDs": ["", "", "w"]
             },
             "_204": {
                 "title": "waterway-waterway",
-                "description": "This {$1} overlaps the {$2} #{$3}"
+                "description": "This (waterway) overlaps the (waterway) #(\\d+)",
+                "IDs": ["", "", "w"]
             },
             "_205": {
                 "title": "cycleway-cycleway",
-                "description": "This {$1} overlaps the {$2} #{$3}"
+                "description": "This (cycleway/footpath) overlaps the (cycleway/footpath) #(\\d+)",
+                "IDs": ["", "", "w"]
             },
             "_206": {
                 "title": "highway-cycleway",
-                "description": "This {$1} overlaps the {$2} #{$3}"
+                "description": "This (highway|cycleway/footpath) overlaps the (highway|cycleway/footpath) #(\\d+)",
+                "IDs": ["", "", "w"]
             },
             "_207": {
                 "title": "cycleway-waterway",
-                "description": "This {$1} overlaps the {$2} #{$3}"
+                "description": "This (waterway|cycleway/footpath) overlaps the (waterway|cycleway/footpath) #(\\d+)",
+                "IDs": ["", "", "w"]
             },
             "_208": {
                 "title": "cycleway-riverbank",
-                "description": "This {$1} overlaps the {$2} #{$3}"
+                "description": "This (riverbank|cycleway/footpath) overlaps the (riverbank|cycleway/footpath) #(\\d+)",
+                "IDs": ["", "", "w"]
             },
             "_210": {
                 "title": "loopings",
@@ -156,7 +171,9 @@
             },
             "_211": {
                 "title": "",
-                "description": "This way contains more than one node at least twice. Nodes are {$1}. This may or may not be an error"
+                "description": "This way contains more than one node at least twice. Nodes are #(\\d+), ((?:#\\d+(?:, )?)+)\\. This may or may not be an error",
+                "IDs": ["n", ""],
+                "TODO": "Second group is arbitrary list of node IDs in form: #ID, #ID, #ID..."
             },
             "_212": {
                 "title": "",
@@ -164,11 +181,11 @@
             },
             "_220": {
                 "title": "misspelled tags",
-                "description": "This (node|way|relation) is tagged '(\\w+)=(\\w+)' where &quot;(\\w+)&quot; looks like &quot;(\\w+)&quot;"
+                "description": "This (node|way|relation) is tagged '([\\w:]+)=(.+)' where &quot;(\\2|\\3)&quot; looks like &quot;([\\w\\s]+)&quot;"
             },
             "_221": {
                 "title": "",
-                "description": "The key of this {$1}''s tag is ''key'': {$2}"
+                "description": "The key of this (node|way|relation)''s tag is ''key'': key=(.+)"
             },
             "_230": {
                 "title": "layer conflicts",
@@ -176,11 +193,13 @@
             },
             "_231": {
                 "title": "mixed layers intersection",
-                "description": "This node is a junction of ways on different layers: {$1}"
+                "description": "This node is a junction of ways on different layers: #(\\d+)\\((-?\\d+)\\),((?:#\\d+\\(-?\\d+\\),?)+)",
+                "IDs": ["w", ""],
+                "TODO": "Third group is arbitrary list of way IDs and their layer value in form: #ID(layer),#ID(layer),#ID(layer)..."
             },
             "_232": {
                 "title": "strange layers",
-                "description": "This {$1} is tagged with layer {$2}. This need not be an error but it looks strange"
+                "description": "This (bridge|tunnel) is tagged with layer (-?\\d+)\\. This need not be an error but it looks strange"
             },
             "_270": {
                 "title": "motorways connected directly",
@@ -189,26 +208,26 @@
             "_280": {
                 "title": "boundaries",
                 "description": "Administrative Boundaries can be expressed either by tagging ways or by adding them to a relation. They should be closed-loop sequences of ways, they must not self-intersect or split and they must have a name and an admin_level."
-                },
+            },
             "_281": {
                 "title": "missing name",
                 "description": "This boundary has no name"
             },
             "_282": {
                 "title": "missing admin level",
-                "description": "The boundary of {$1} has no valid numeric admin_level. Please do not use admin levels like for example 6;7. Always tag the lowest admin_level of all boundaries"
+                "description": "The boundary of (.+) has no (?:valid numeric )?admin_level\\..*"
             },
             "_283": {
                 "title": "no closed loop",
-                "description": "The boundary of {$1} is not closed-loop"
+                "description": "The boundary of (.+) is not closed-loop"
             },
             "_284": {
                 "title": "splitting boundary",
-                "description": "The boundary of {$1} splits here"
+                "description": "The boundary of (.+) splits here"
             },
             "_285": {
                 "title": "admin_level too high",
-                "description": "This boundary-way has admin_level {$1} but belongs to a relation with lower admin_level (higher priority); it should have the lowest admin_level of all relations"
+                "description": "This boundary-way has admin_level (-?\\d+) but belongs to a relation with lower admin_level (higher priority); it should have the lowest admin_level of all relations"
             },
             "_290": {
                 "title": "restrictions",
@@ -216,23 +235,25 @@
             },
             "_291": {
                 "title": "missing type",
-                "description": "This turn-restriction has no known restriction type"
+                "description": "This turn-restriction has no (?:known )?restriction type"
             },
             "_292": {
                 "title": "missing from way",
-                "description": "A turn-restriction needs exactly one {$1} member. This one has {$2}"
+                "description": "A turn-restriction needs exactly one from member\\. This one has (\\d+)"
             },
             "_293": {
                 "title": "missing to way",
-                "description": "A turn-restriction needs exactly one {$1} member. This one has {$2}"
+                "description": "A turn-restriction needs exactly one to member\\. This one has (\\d+)"
             },
             "_294": {
                 "title": "from or to not a way",
-                "description": "From- and To-members of turn restrictions need to be ways. {$1}"
+                "description": "From- and To-members of turn restrictions need to be ways\\. (.+)",
+                "TODO": "Group can be any combination of to/from: to node #ID | from node #ID | to relation #ID | from relation #ID"
             },
             "_295": {
                 "title": "via is not on the way ends",
-                "description": "via (node #{$1}) is not the first or the last member of from (way #{$2})"
+                "description": "via \\(node #(\\d+)\\) is not the first or the last member of from \\(way #(\\d+)\\)",
+                "IDs": ["n", "w"]
             },
             "_296": {
                 "title": "wrong restriction angle",
@@ -240,11 +261,13 @@
             },
             "_297": {
                 "title": "wrong direction of to member",
-                "description": "wrong direction of to way {$1}"
+                "description": "wrong direction of to way (\\d+)",
+                "IDs": ["w"]
             },
             "_298": {
                 "title": "already restricted by oneway",
-                "description": "entry already prohibited by oneway tag on {$1}"
+                "description": "entry already prohibited by oneway tag on (\\d+)",
+                "IDs": ["w"]
             },
             "_310": {
                 "title": "roundabouts",
@@ -252,11 +275,11 @@
             },
             "_311": {
                 "title": "not closed loop",
-                "description": "This way is part of a roundabout but is not closed-loop. (split carriageways approaching a roundabout should not be tagged as roundabout)"
+                "description": "This way is part of a roundabout but is not closed-loop\\. \\(split carriageways approaching a roundabout should not be tagged as roundabout\\)"
             },
             "_312": {
                 "title": "wrong direction",
-                "description": "If this roundabout is in a country with right-hand traffic then its orientation goes the wrong way around | If this roundabout is in a country with left-hand traffic then its orientation goes the wrong way around | If this mini_roundabout is in a country with right-hand traffic then its orientation goes the wrong way around | If this mini_roundabout is in a country with left-hand traffic then its orientation goes the wrong way around"
+                "description": "If this ((?:mini_)?roundabout) is in a country with (left|right)-hand traffic then its orientation goes the wrong way around"
             },
             "_313": {
                 "title": "faintly connected",
@@ -264,19 +287,21 @@
             },
             "_320": {
                 "title": "*_link connections",
-                "description": "This way is tagged as highway={$1}_link but doesn''t have a connection to any other {$1} or {$1}_link"
+                "description": "This way is tagged as highway=(\\w+)_link but doesn''t have a connection to any other \\1 or \\1_link"
             },
             "_350": {
                 "title": "bridge-tags",
-                "description": "This bridge does not have a tag in common with its surrounding ways that shows the purpose of this bridge. There should be one of these tags: {$1}"
+                "description": "This bridge does not have a tag in common with its surrounding ways that shows the purpose of this bridge. There should be one of these tags: (.+)",
+                "NOTE": "Group can be arbitrary list of form: key=value,key=value,key=value..."
             },
             "_370": {
                 "title": "doubled places",
-                "description": "This node has tags in common with the surrounding way #{$1} (tah fix this-->)((including the name ''The Garage'')) and seems to be redundand | This node has tags in common with the surrounding way #{$1} (including the name ''{$2}'') and seems to be redundand"
+                "description": "This node has tags in common with the surrounding way #(\\d+) ((?:\\(including the name '.+'\\) )?)and seems to be redundand",
+                "IDs": ["w", ""]
             },
             "_380": {
                 "title": "non-physical use of sport-tag",
-                "description": "This way is tagged (sport=\\w+) but has no physical tag like e.g. leisure, building, amenity or highway"
+                "description": "This way is tagged sport=(\\w+) but has no physical tag like e.g. leisure, building, amenity or highway"
             },
             "_400": {
                 "title": "geometry glitches",
@@ -284,7 +309,7 @@
             },
             "_401": {
                 "title": "missing turn restriction",
-                "description": "ways (\\d+) and (\\d+) join in a very sharp angle here and there is no oneway tag or turn restriction that prevents turning from way (\\d+) to (\\d+)",
+                "description": "ways (\\d+) and (\\d+) join in a very sharp angle here and there is no oneway tag or turn restriction that prevents turning from way (\\1|\\2) to (\\1|\\2)",
                 "IDs": ["w", "w", "w", "w"]
             },
             "_402": {
@@ -297,16 +322,16 @@
             },
             "_411": {
                 "title": "http error",
-                "description": "The URL \\(<a target=\"_blank\" href=\"(.+?)\">\\1</a>\\) cannot be opened \\(HTTP status code (\\d+)\\)",
-                "TODO": "For some reason this regex doesn't match, possible related to quotes (see _220)"
+                "description": "The URL \\(<a target=_blank href=(.+)>\\1</a>\\) cannot be opened \\(HTTP status code (\\d+)\\)",
+                "NOTE": "It seems the HTML attributes don't have quotes when the code reads them"
             },
             "_412": {
                 "title": "domain hijacking",
-                "description": "Possible domain squatting: <a target=''_blank'' href=''{$1}''>{$1}</a>. Suspicious text is: ''{$2}''"
+                "description": "Possible domain squatting: <a target=_blank href=(.+)>\\1</a>. Suspicious text is: ''(.+)''"
             },
             "_413": {
                 "title": "non-match",
-                "description": "Content of the URL (<a target=''_blank'' href=''{$1}''>{$1}</a>) did not contain these keywords: ({$2})"
+                "description": "Content of the URL (<a target=_blank href=(.+)>\\1</a>) did not contain these keywords: \\((.+)\\)"
             }
         },
         "warnings": {

--- a/modules/util/keepRight/errorSchema.json
+++ b/modules/util/keepRight/errorSchema.json
@@ -281,8 +281,8 @@
             },
             "_294": {
                 "title": "from or to not a way",
-                "description": "From- and To-members of turn restrictions need to be ways\\. (.+)",
-                "TODO": "Group can be any combination of to/from: to node #ID | from node #ID | to relation #ID | from relation #ID",
+                "description": "From- and To-members of turn restrictions need to be ways\\. ((?:(?:from|to) (?:node|relation) #\\d+,?)+)",
+                "IDs": ["294"],
                 "regex": true
             },
             "_295": {

--- a/modules/util/keepRight/errorSchema.json
+++ b/modules/util/keepRight/errorSchema.json
@@ -193,9 +193,8 @@
             },
             "_231": {
                 "title": "mixed layers intersection",
-                "description": "This node is a junction of ways on different layers: #(\\d+)\\((-?\\d+)\\),((?:#\\d+\\(-?\\d+\\),?)+)",
-                "IDs": ["w", ""],
-                "TODO": "Third group is arbitrary list of way IDs and their layer value in form: #ID(layer),#ID(layer),#ID(layer)..."
+                "description": "This node is a junction of ways on different layers: ((?:#\\d+\\(-?\\d+\\),?)+)",
+                "IDs": ["231"]
             },
             "_232": {
                 "title": "strange layers",

--- a/modules/util/keepRight/keepRight_error.js
+++ b/modules/util/keepRight/keepRight_error.js
@@ -104,6 +104,9 @@ export function parseErrorDescriptions(entity) {
     errorTemplate = errorTypes.errors[errorType] || errorTypes.warnings[errorType];
     if (!errorTemplate) return;
 
+    // some descriptions are just fixed text
+    if (!('regex' in errorTemplate)) return;
+
     // regex pattern should match description with variable details captured as groups
     errorDescription = entity.description;
     errorRegex = new RegExp(errorTemplate.description);

--- a/modules/util/keepRight/keepRight_error.js
+++ b/modules/util/keepRight/keepRight_error.js
@@ -141,6 +141,20 @@ export function parseErrorDescriptions(entity) {
         return newList.join(', ');
     }
 
+    // arbitrary node list of form: #ID,#ID,#ID...
+    function parseWarning20(list) {
+        var newList = [];
+        var items = list.split(',');
+
+        items.forEach(function(item) {
+            // ID has # at the front
+            var id = fillPlaceholder('n' + item.slice(1));
+            newList.push(id);
+        });
+
+        return newList.join(', ');
+    }
+
     if (!(entity instanceof krError)) return;
 
     // find the matching template from the error schema
@@ -186,6 +200,9 @@ export function parseErrorDescriptions(entity) {
                     break;
                 case '294':
                     group = parseError294(group);
+                    break;
+                case '20':
+                    group = parseWarning20(group);
             }
         } else if (html_re.test(group)) {
             // escape any html in non-IDs

--- a/modules/util/keepRight/keepRight_error.js
+++ b/modules/util/keepRight/keepRight_error.js
@@ -58,9 +58,6 @@ export function parseErrorDescriptions(entity) {
     var matchingTemplate = errorTypes.errors[errorType] || errorTypes.warnings[errorType];
     if (!matchingTemplate) return;
 
-    var parsedDetails = [];
-    var html_re = new RegExp(/<\/[a-z][\s\S]*>/);
-
     var commonEntities = [
         'node',
         'way',
@@ -85,6 +82,9 @@ export function parseErrorDescriptions(entity) {
         return;
     }
 
+    var parsedDetails = {};
+    var html_re = new RegExp(/<\/[a-z][\s\S]*>/);
+
     // index 0 is the whole match, groups start from 1
     for (var i = 1; i < errorMatch.length; i++) {
         var group = errorMatch[i];
@@ -107,17 +107,10 @@ export function parseErrorDescriptions(entity) {
             group = t('QA.keepRight.entities.' + group);
         }
 
-        parsedDetails.push(group);
+        parsedDetails['var' + i] = group;
     }
 
-    return {
-        var1: parsedDetails[0] || '',
-        var2: parsedDetails[1] || '',
-        var3: parsedDetails[2] || '',
-        var4: parsedDetails[3] || '',
-        var5: parsedDetails[4] || '',
-        var6: parsedDetails[5] || '',
-    };
+    return parsedDetails;
 }
 
 

--- a/modules/util/keepRight/keepRight_error.js
+++ b/modules/util/keepRight/keepRight_error.js
@@ -111,6 +111,36 @@ export function parseErrorDescriptions(entity) {
         return newList.join(', ');
     }
 
+    // arbitrary node/relation list of form: from node #ID,to relation #ID,to node #ID...
+    function parseError294(list) {
+        var newList = [];
+        var items = list.split(',');
+
+        items.forEach(function(item) {
+            var role;
+            var idType;
+            var id;
+
+            // item of form "from/to node/relation #ID"
+            item = item.split(' ');
+
+            // to/from role is more clear in quotes
+            role = '"' + item[0] + '"';
+
+            // first letter of node/relation provides the type
+            idType = item[1].slice(0,1);
+
+            // ID has # at the front
+            id = item[2].slice(1);
+            id = fillPlaceholder(idType + id);
+
+            item = [role, item[1], id].join(' ');
+            newList.push(item);
+        });
+
+        return newList.join(', ');
+    }
+
     if (!(entity instanceof krError)) return;
 
     // find the matching template from the error schema
@@ -153,6 +183,9 @@ export function parseErrorDescriptions(entity) {
                     break;
                 case '231':
                     group = parseError231(group);
+                    break;
+                case '294':
+                    group = parseError294(group);
             }
         } else if (html_re.test(group)) {
             // escape any html in non-IDs

--- a/modules/util/keepRight/keepRight_error.js
+++ b/modules/util/keepRight/keepRight_error.js
@@ -82,8 +82,8 @@ export function parseErrorDescriptions(entity) {
     if (!errorMatch) {
         // TODO: Remove, for regex dev testing
         console.log('Unmatched:', errorType, errorDescription, errorRe);
-        return
-    };
+        return;
+    }
 
     // index 0 is the whole match, groups start from 1
     for (var i = 1; i < errorMatch.length; i++) {

--- a/modules/util/keepRight/keepRight_error.js
+++ b/modules/util/keepRight/keepRight_error.js
@@ -71,7 +71,21 @@ export function parseErrorDescriptions(entity) {
 
     function fillPlaceholder(d) { return '<span><a class="kr_error_description-id">' + d + '</a></span>'; }
 
-    // arbitrary list of form: #ID(layer),#ID(layer),#ID(layer)...
+    // arbitrary node list of form: #ID, #ID, #ID...
+    function parseError211(list) {
+        var newList = [];
+        var items = list.split(', ');
+
+        items.forEach(function(item) {
+            // ID has # at the front
+            var id = fillPlaceholder('n' + item.slice(1));
+            newList.push(id);
+        });
+
+        return newList.join(', ');
+    }
+
+    // arbitrary way list of form: #ID(layer),#ID(layer),#ID(layer)...
     function parseError231(list) {
         var newList = [];
         var items = list.split(',');
@@ -123,18 +137,25 @@ export function parseErrorDescriptions(entity) {
         // index 0 is the whole match, skip it
         if (!index) return;
 
-        // Clean and link IDs if present in the group
+        // link IDs if present in the group
         idType = 'IDs' in errorTemplate ? errorTemplate.IDs[index-1] : '';
         if (idType) {
-            // some errors have more complex ID lists/variance
-            if (idType === '231') {
-                group = parseError231(group);
-            } else if (['n','w','r'].includes(idType)) {
+            switch (idType) {
                 // simple case just needs a linking span
-                group = fillPlaceholder(idType + group);
+                case 'n':
+                case 'w':
+                case 'r':
+                    group = fillPlaceholder(idType + group);
+                    break;
+                // some errors have more complex ID lists/variance
+                case '211':
+                    group = parseError211(group);
+                    break;
+                case '231':
+                    group = parseError231(group);
             }
         } else if (html_re.test(group)) {
-            // escape any html
+            // escape any html in non-IDs
             group = '\\' +  group + '\\';
         }
 


### PR DESCRIPTION
As discussed [here](https://github.com/openstreetmap/iD/pull/5201#issuecomment-417714858), this PR improves the extraction of details from error descriptions by directly using regex group capture instead of splitting the strings and using a lot of logic to figure out what's what (effectively re-implementing the same group capture behaviour).

Advantages of this approach:
- Can precisely extract what we want, no relying on space characters to split the string nicely.
  - No need to handle edge cases in the code like this:
https://github.com/openstreetmap/iD/blob/74e06d47472af3c32c8b8012f5b89b5f1af43763/modules/util/keepRight/keepRight_error.js#L66-L73
- Less looping and calls to regex `.test()/.match()` methods.
- We're being more explicit about what we expect in the error strings (aka `\d+` shows that we expect a number whereas `{$1}` didn't). This is a minor maintainability improvement.
- Can easily handle errors that have multiple possible string templates (see types 312 and 282).

Side effect of this approach:

- I've changed the way that IDs are identified. The code to identify IDs and their type (node/way/relation) was a bit clumsy (and wouldn't correctly handle some cases) especially with some inconsistencies in the error messages it had to account for. It became a bit more so once the code was no longer looping over every word. So instead I've added an extra optional `"IDs"`  key to the `errorSchema.json` which provides an array of strings where the indices correspond to the regex groups ([see here](https://github.com/SilentSpike/iD/blob/eb78395ee8132114d773f80f4b0c2497b91f1081/modules/util/keepRight/errorSchema.json#L82-L85)). This let's us explicitly tell the code which groups capture an ID and what type of ID they are (`"n"/"w"/"r"`).
  - It seems there are a couple of cases where strings can have an arbitrary list of node/way/relation IDs depending on the geometry involved in the error. For getting the IDs in these cases I'm capturing the whole list as a group and parsing those with unique code (see error types 211, 231 and 294).
- To make life easier I've added a `"regex"` key to the `errorSchema.json` so that errors where the message is fixed aren't parsed for details at all (saves us having to escape any special regex characters and prevents needlessly matching a fixed string for many errors). However, it might actually make more sense to just remove these messages all together from the file since we don't need that data for anything.