### PR TITLE
changelog: fix typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2954,7 +2954,7 @@ _Map traffic signals, stop signs, benches, crossings, street lamps, fountains, t
 * Trim tag keys, and prevent duplicate tag keys (#2043)
 * Fix inline tag help for fields that handle multiple tags
 * Add 'width', 'length', 'lit' for appropriate presets (cycleways, sidewalks, sports pitch, etc)
-* Render embarkment/cutting with dashed casing
+* Render embankment/cutting with dashed casing
 * Rendering fixes for buildings, tunnels
 * Add population field for various place presets
 * Improvements to circularize action (#2194)


### PR DESCRIPTION
I guess https://github.com/openstreetmap/iD/search?q=embarkment&type=Code is a typo, since the preset is https://github.com/openstreetmap/iD/blob/master/data/presets/presets/embankment.json and the wiki page as well https://wiki.openstreetmap.org/wiki/DE:Key:embankment