### PR TITLE
Changed styling of "Worldwide search.." button

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -902,6 +902,18 @@ a.hide-toggle {
     border-radius: 0;
 }
 
+.geocode-item {
+    width: 50%;
+    background-color: #ccc;
+    left: 25%;
+    margin-top: 30px;
+    border-radius: 2px;
+}
+
+.geocode-item:hover {
+    background-color: #aaa;
+}
+
 .feature-list-item {
     background-color: #fff;
     font-weight: bold;


### PR DESCRIPTION
Fixes #5373 

Default:
![image](https://user-images.githubusercontent.com/4670502/46614434-be266200-cb0d-11e8-8259-079b66a3c77c.png)

Hover:
![image](https://user-images.githubusercontent.com/4670502/46614569-1493a080-cb0e-11e8-8b59-7a008200da86.png)

I've given it a simple grey styling, but can change it if something else would be better?



