### PR TITLE
Adds custom CSS to man_made=pipeline features

### DIFF
--- a/css/50_misc.css
+++ b/css/50_misc.css
@@ -1,9 +1,11 @@
-/* power */
+/* power and pipeline */
 .preset-icon .icon.tag-man_made-pipeline,
 .preset-icon .icon.tag-power {
     color: #939393;
     fill: #939393;
 }
+
+/* power */
 
 path.stroke.tag-power {
     stroke: #939393;
@@ -13,6 +15,21 @@ path.casing.tag-power {
     stroke: none;
 }
 
+/* pipeline */
+
+path.stroke.tag-man_made-pipeline {
+    stroke: #CBD0D8;
+    stroke-linecap: butt;
+    stroke-width: 3;
+    stroke-dasharray: 80, 1.25;
+}
+path.casing.tag-man_made-pipeline {
+    stroke: #666;
+    stroke-width: 4.5;
+}
+.low-zoom path.stroke.tag-man_made-pipeline {
+    stroke-dasharray: 40, 1;
+}
 
 /* boundaries */
 path.stroke.tag-boundary {
@@ -145,10 +162,12 @@ path.casing.tag-highway-bridleway.tag-bridge {
 
 
 /* tunnels */
-path.stroke.tag-tunnel {
+path.stroke.tag-tunnel,
+path.line.stroke.tag-location-underground {
     stroke-opacity: 0.3;
 }
-path.casing.tag-tunnel {
+path.casing.tag-tunnel,
+path.line.casing.tag-location-underground {
     stroke-opacity: 0.5;
     stroke-linecap: butt;
     stroke-dasharray: none;
@@ -325,4 +344,3 @@ path.stroke.tag-crossing.tag-crossing-zebra {
 .low-zoom path.stroke.tag-crossing.tag-crossing-zebra {
     stroke-dasharray: 3, 2;
 }
-

--- a/modules/svg/tag_classes.js
+++ b/modules/svg/tag_classes.js
@@ -15,7 +15,7 @@ export function svgTagClasses() {
     var secondaries = [
         'oneway', 'bridge', 'tunnel', 'embankment', 'cutting', 'barrier',
         'surface', 'tracktype', 'footway', 'crossing', 'service', 'sport',
-        'public_transport'
+        'public_transport', 'location'
     ];
     var tagClassRe = /^tag-/;
     var _tags = function(entity) { return entity.tags; };


### PR DESCRIPTION
Closes #5391. Also: 

- Adds `location` as a secondary tag class
- Adds the `tunnel` styling to lines tagged `location=underground`

Pull the branch and demo at: http://localhost:8080/#background=Bing&disable_features=boundaries&map=18.14/39.90831/-75.21685

<img width="701" alt="screen shot 2018-10-09 at 6 39 10 pm" src="https://user-images.githubusercontent.com/2046746/46708488-afb27600-cbf3-11e8-8c2e-87ceefebe4bc.png">
<img width="500" alt="screen shot 2018-10-09 at 6 38 50 pm" src="https://user-images.githubusercontent.com/2046746/46708489-afb27600-cbf3-11e8-8fda-4b3ea35cd776.png">
<img width="537" alt="screen shot 2018-10-09 at 6 37 01 pm" src="https://user-images.githubusercontent.com/2046746/46708490-afb27600-cbf3-11e8-919c-10aad2d855cd.png">
<img width="344" alt="screen shot 2018-10-09 at 6 36 47 pm" src="https://user-images.githubusercontent.com/2046746/46708491-afb27600-cbf3-11e8-99e4-ff91af55bbba.png">
