### PR TITLE
fix: traffic signs to new endpoint

### DIFF
--- a/modules/services/mapillary.js
+++ b/modules/services/mapillary.js
@@ -130,7 +130,7 @@ function loadNextTilePage(which, currZoom, url, tile) {
                     });
                     return false;  // because no `d` data worth loading into an rbush
 
-                } else if (which === 'objects') {
+                } else if (which === 'map_features') {
                     d = {
                         loc: loc,
                         key: feature.properties.key,
@@ -162,7 +162,7 @@ function loadNextTilePage(which, currZoom, url, tile) {
 
             if (which === 'images' || which === 'sequences') {
                 dispatch.call('loadedImages');
-            } else if (which === 'objects') {
+            } else if (which === 'map_features') {
                 dispatch.call('loadedSigns');
             }
 
@@ -335,7 +335,7 @@ export default {
     loadSigns: function(context, projection) {
         // if we are looking at signs, we'll actually need to fetch images too
         loadTiles('images', apibase + 'images?', projection);
-        loadTiles('objects', apibase + 'objects?', projection);
+        loadTiles('map_features', apibase + 'map_features?layers=trafficsigns&', projection);
     },
 
 
@@ -636,7 +636,7 @@ export default {
 
 
         function loadDetection(detectionKey) {
-            var url = apibase + 'detections/' +
+            var url = apibase + 'image_detections/' +
                     detectionKey + '?' + utilQsString({ client_id: clientId });
 
             d3_request(url)


### PR DESCRIPTION
iD was using the old `v3/objects` API and needs to be `v3/map_features` with the parameter `layers=trafficsigns` set. Also changed `v3/detections` to `v3/image_detections` API although I think this is not used right now.