### PR TITLE
Adds a button that lets users manually download individual relation members

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1,5 +1,6 @@
 en:
   icons:
+    download: download
     information: info
     remove: remove
     undo: undo

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -1,6 +1,7 @@
 {
     "en": {
         "icons": {
+            "download": "download",
             "information": "info",
             "remove": "remove",
             "undo": "undo"

--- a/modules/ui/raw_member_editor.js
+++ b/modules/ui/raw_member_editor.js
@@ -23,9 +23,24 @@ export function uiRawMemberEditor(context) {
     var taginfo = services.taginfo,
         _entityID;
 
+    function downloadMember(d) {
+        d3_event.preventDefault();
+        // display the loading indicator
+        d3_select(this.parentNode).classed('tag-reference-loading', true);
+        context.loadEntity(d.id);
+    }
+
 
     function selectMember(d) {
         d3_event.preventDefault();
+
+        var entity = context.entity(d.id);
+        var mapExtent = context.map().extent();
+        if (!entity.intersects(mapExtent, context.graph())) {
+            // zoom to the entity if its extent is not visible now
+            context.map().zoomTo(entity);
+        }
+
         context.enter(modeSelect(context, [d.id]));
     }
 
@@ -125,9 +140,19 @@ export function uiRawMemberEditor(context) {
                             .text(function(d) { return utilDisplayName(d.member); });
 
                     } else {
-                        d3_select(this).append('label')
+                        var incompleteLabel = d3_select(this).append('label')
                             .attr('class', 'form-label')
                             .text(t('inspector.incomplete', { id: d.id }));
+
+                        var wrap = incompleteLabel.append('div')
+                            .attr('class', 'form-label-button-wrap');
+
+                        wrap.append('button')
+                            .attr('class', 'download-icon')
+                            .attr('title', t('icons.download'))
+                            .attr('tabindex', -1)
+                            .call(svgIcon('#iD-icon-load'))
+                            .on('click', downloadMember);
                     }
                 });
 


### PR DESCRIPTION
This is a complete version of the very stale #2284. Differences:
- Only individual members can be downloaded, one at a time.
- The map now zooms to relation members selected from the sidebar if they're not visible. This is especially needed since manually downloaded members are often offscreen, but it useful anytime a member is offscreen.
- A download icon is provided.
- Tooltip text is added.

**Hover**
<img width="1280" alt="screen shot 2018-10-10 at 8 44 19 pm" src="https://user-images.githubusercontent.com/2046746/46779640-8ebe5380-cccd-11e8-9af8-2dc17ecc9173.png">
**Downloading**
<img width="1280" alt="screen shot 2018-10-10 at 8 44 21 pm" src="https://user-images.githubusercontent.com/2046746/46779639-8ebe5380-cccd-11e8-9c87-18435111e8ed.png">
**Downloaded**
<img width="1280" alt="screen shot 2018-10-10 at 8 44 23 pm" src="https://user-images.githubusercontent.com/2046746/46779638-8e25bd00-cccd-11e8-8dc8-b321ea5e16e7.png">
**Selected (zooms to member)**
<img width="1280" alt="screen shot 2018-10-10 at 8 47 43 pm" src="https://user-images.githubusercontent.com/2046746/46779687-c0371f00-cccd-11e8-9bdc-d76a2d11e0df.png">