### PR TITLE
Adds the member geometry type to the label of non-downloaded relation members

### DIFF
--- a/modules/ui/raw_member_editor.js
+++ b/modules/ui/raw_member_editor.js
@@ -141,7 +141,14 @@ export function uiRawMemberEditor(context) {
 
                     } else {
                         var incompleteLabel = d3_select(this).append('label')
-                            .attr('class', 'form-label')
+                            .attr('class', 'form-label');
+                        
+                        incompleteLabel.append('span')
+                            .attr('class', 'member-entity-type')
+                            .text(t('inspector.'+d.type, { id: d.id }));
+
+                        incompleteLabel.append('span')
+                            .attr('class', 'member-entity-name')
                             .text(t('inspector.incomplete', { id: d.id }));
 
                         var wrap = incompleteLabel.append('div')


### PR DESCRIPTION
With #5396 merged, users can now manually download individual members. The issue is that that it is difficult to tell what the member is before it is downloaded. While the member's role is shown in the input field and its index is indicated by its list order, its geometry type is available but hidden. This PR adds the type (node, way, or relation) to the non-downloaded member's label. This should make it slightly easier for users to determine what members to try downloading, as well as surface potential mistakes such as `node` members with `north` or `south` roles.

A potential drawback is that novice users may be confused by the node/way terminology since iD hides it behind points, lines, and areas, but I don't think that novice users will be editing complex relations anyway.

<img width="358" alt="screen shot 2018-10-11 at 7 36 21 pm" src="https://user-images.githubusercontent.com/2046746/46844715-1a4ae980-cd8d-11e8-9950-0ff28fabbec5.png">