### PR TITLE
Adds highlighting of relation members in the map when hovering on their list item

### DIFF
--- a/css/20_map.css
+++ b/css/20_map.css
@@ -265,6 +265,18 @@ text.point {
     opacity: 0.8;
 }
 
+/* Highlighting */
+
+g.point.highlighted .shadow,
+path.shadow.highlighted {
+    stroke-opacity: 0.95;
+    stroke: #7092ff;
+}
+g.vertex.highlighted .shadow {
+    stroke-width: 7;
+    stroke-opacity: 0.95;
+    stroke: #7092ff;
+}
 
 /* Turn Restrictions */
 

--- a/modules/ui/raw_member_editor.js
+++ b/modules/ui/raw_member_editor.js
@@ -122,6 +122,16 @@ export function uiRawMemberEditor(context) {
             enter
                 .each(function(d) {
                     if (d.member) {
+
+                        // highlight the member feature in the map while hovering on the list item
+                        var selectorPrefix = d.type === 'node' ? 'g.' : 'path.';
+                        d3_select(this).on('mouseover', function() {
+                            context.surface().selectAll(selectorPrefix+d.id).classed('related', true);
+                        });
+                        d3_select(this).on('mouseout', function() {
+                            context.surface().selectAll(selectorPrefix+d.id).classed('related', false);
+                        });
+
                         var label = d3_select(this).append('label')
                             .attr('class', 'form-label')
                             .append('a')
@@ -142,7 +152,7 @@ export function uiRawMemberEditor(context) {
                     } else {
                         var incompleteLabel = d3_select(this).append('label')
                             .attr('class', 'form-label');
-                        
+
                         incompleteLabel.append('span')
                             .attr('class', 'member-entity-type')
                             .text(t('inspector.'+d.type, { id: d.id }));

--- a/modules/ui/raw_member_editor.js
+++ b/modules/ui/raw_member_editor.js
@@ -126,10 +126,10 @@ export function uiRawMemberEditor(context) {
                         // highlight the member feature in the map while hovering on the list item
                         var selectorPrefix = d.type === 'node' ? 'g.' : 'path.';
                         d3_select(this).on('mouseover', function() {
-                            context.surface().selectAll(selectorPrefix+d.id).classed('related', true);
+                            context.surface().selectAll(selectorPrefix+d.id).classed('highlighted', true);
                         });
                         d3_select(this).on('mouseout', function() {
-                            context.surface().selectAll(selectorPrefix+d.id).classed('related', false);
+                            context.surface().selectAll(selectorPrefix+d.id).classed('highlighted', false);
                         });
 
                         var label = d3_select(this).append('label')


### PR DESCRIPTION
This lets users see what feature the member refers to before selecting it, reducing the need for guessing.

![ezgif-1-ae0af1a4c3b9](https://user-images.githubusercontent.com/2046746/46911850-52ccfd80-cf1c-11e8-8c2c-5e260042b6e6.gif)