### PR TITLE
Adds custom CSS styling for ferry routes

### DIFF
--- a/css/45_waterways.css
+++ b/css/45_waterways.css
@@ -4,7 +4,6 @@
     fill: #77d3de;
 }
 .preset-icon .icon.iD-category-water,
-.preset-icon .icon.tag-route-ferry,
 .preset-icon .icon.tag-type-waterway,
 .preset-icon .icon.tag-waterway {
     color: #77d3de;
@@ -95,3 +94,26 @@ path.area.fill.tag-waterway-fuel {
     fill: rgba(255, 255, 255, 0.3);
 }
 
+/* ferry routes  */
+.preset-icon .icon.tag-route-ferry {
+    color: #58a9ed;
+    fill: #fff;
+}
+path.shadow.tag-route-ferry {
+    stroke-width: 16;
+}
+path.stroke.tag-route-ferry {
+    stroke-width: 3;
+    stroke-linecap: butt;
+    stroke-dasharray: 12,8;
+}
+.low-zoom path.shadow.tag-route-ferry {
+    stroke-width: 12;
+}
+.low-zoom path.stroke.tag-route-ferry {
+    stroke-width: 2;
+    stroke-dasharray: 6,4;
+}
+path.stroke.tag-route-ferry {
+    stroke: #58a9ed;
+}

--- a/modules/svg/tag_classes.js
+++ b/modules/svg/tag_classes.js
@@ -6,7 +6,7 @@ export function svgTagClasses() {
     var primaries = [
         'building', 'highway', 'railway', 'waterway', 'aeroway',
         'motorway', 'boundary', 'power', 'amenity', 'natural', 'landuse',
-        'leisure', 'military', 'place', 'man_made'
+        'leisure', 'military', 'place', 'man_made', 'route'
     ];
     var statuses = [
         'proposed', 'construction', 'disused', 'abandoned', 'dismantled',


### PR DESCRIPTION
Closes #5414.

I decided a simple dashed line without casing was the way to go with this one. Ferry routes are often shown this way, and generally the water will provide a nice flat background. I used the cycling path blue because it looked better than the waterway or ditch colors and these features are closer to paths than waterways anyway.

<img width="1280" alt="screen shot 2018-10-18 at 6 29 25 pm" src="https://user-images.githubusercontent.com/2046746/47192812-2a6e4600-d304-11e8-8230-14c2612faac3.png">
<img width="1273" alt="screen shot 2018-10-18 at 6 29 06 pm" src="https://user-images.githubusercontent.com/2046746/47192813-2a6e4600-d304-11e8-90c0-baf751bf825f.png">

<img width="768" alt="screen shot 2018-10-18 at 6 39 14 pm" src="https://user-images.githubusercontent.com/2046746/47192995-78d01480-d305-11e8-8acd-46960f7a9aff.png">
<img width="656" alt="screen shot 2018-10-18 at 6 38 31 pm" src="https://user-images.githubusercontent.com/2046746/47192996-78d01480-d305-11e8-83d9-5d7a3d5515fc.png">
