### PR TITLE
Fixed using help's navigation buttons not resetting the help pane to the top

### DIFF
--- a/modules/ui/help.js
+++ b/modules/ui/help.js
@@ -318,7 +318,7 @@ export function uiHelp(context) {
 
         function clickHelp(d, i) {
             var rtl = (textDirection === 'rtl');
-            pane.property('scrollTop', 0);
+            content.property('scrollTop', 0);
             doctitle.html(d.title);
 
             body.html(d.html);


### PR DESCRIPTION
Fixes #5439. Additionally fixes the same unwanted behaviour when the buttons on help's navigation pane on the right are pressed.