### PR TITLE
Makes the styling of paths with location=underwater the same as location=underground

### DIFF
--- a/css/50_misc.css
+++ b/css/50_misc.css
@@ -163,11 +163,13 @@ path.casing.tag-highway-bridleway.tag-bridge {
 
 /* tunnels */
 path.stroke.tag-tunnel,
-path.line.stroke.tag-location-underground {
+path.line.stroke.tag-location-underground,
+path.line.stroke.tag-location-underwater {
     stroke-opacity: 0.3;
 }
 path.casing.tag-tunnel,
-path.line.casing.tag-location-underground {
+path.line.casing.tag-location-underground,
+path.line.stroke.tag-location-underwater {
     stroke-opacity: 0.5;
     stroke-linecap: butt;
     stroke-dasharray: none;


### PR DESCRIPTION
[location=underwater](https://taginfo.openstreetmap.org/tags/location=underwater#overview) is a lightly-used yet useful tag that could benefit from styling indicating that the features are not visible in imagery.

Example showing both underwater and overhead `power` features with the new styling:

<img width="785" alt="screen shot 2018-10-27 at 10 53 40 am" src="https://user-images.githubusercontent.com/2046746/47607591-d7b51e00-d9d6-11e8-91f4-1476f5a99849.png">