### PR TITLE
Add selected features to minimap

### DIFF
--- a/css/55_cursors.css
+++ b/css/55_cursors.css
@@ -6,6 +6,7 @@
 }
 
 .map-in-map,
+.map-in-map #map-in-map-features .map-in-map-selection, /* extra specific to over-ride later assignments */
 #map {
     cursor: auto; /* Opera */
     cursor: url(img/cursor-grab.png) 9 9, auto; /* FF */

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -3259,6 +3259,17 @@ img.tile-debug {
     stroke-width: 5;
 }
 
+.map-in-map-selection {
+    stroke: #f60;
+    fill: #f90;
+    stroke-width: 3;
+}
+
+.map-in-map-selection.line {
+    fill: none;
+    stroke-width: 5;
+}
+
 
 /* Debug Data
 ------------------------------------------------------- */

--- a/modules/ui/map_in_map.js
+++ b/modules/ui/map_in_map.js
@@ -318,11 +318,11 @@ export function uiMapInMap(context) {
                 .append('path')
                 .merge(path)
                 .attr('d', getPath)
-                .attr("class", function(d, i) {
+                .attr("class", function(d) {
                     return d.properties.classList;
                 })
                 .classed('map-in-map-selection', true)
-                .style("fill", function(d, i) {
+                .style("fill", function(d) {
                     return (d.geometry.type === "Point" || d.properties.classList.includes("fill")) ? "#f00" : "none";
                 })
 

--- a/modules/ui/map_in_map.js
+++ b/modules/ui/map_in_map.js
@@ -253,12 +253,12 @@ export function uiMapInMap(context) {
             viewport = viewport.enter()
                 .append('svg')
                 .attr('class', 'map-in-map-viewport')
-                .each(function(d) {
+                .each(function() {
                     d3_select(this).append('g')
-                        .attr('id', 'map-in-map-features')
+                        .attr('id', 'map-in-map-features');
 
                     d3_select(this).append('g')
-                        .attr('id', 'map-in-map-bbox')
+                        .attr('id', 'map-in-map-bbox');
                 })
                 .merge(viewport);
 
@@ -266,33 +266,33 @@ export function uiMapInMap(context) {
 
             var selected = getSelectedElements();
 
-            var geojson = { "name": "Minimap Features",
-                            "type": "FeatureCollection",
-                            "features": []
+            var geojson = { 'name':'Minimap Features',
+                            'type': 'FeatureCollection',
+                            'features': []
                         };
 
             selected.forEach(function(obj) {
                 var classList = obj.classList.value;
-                var feature = { "type": "Feature",
-                                "geometry": {
-                                    "type": "",
-                                    "coordinates": []
+                var feature = { 'type': 'Feature',
+                                'geometry': {
+                                    'type': '',
+                                    'coordinates': []
                                 },
-                                "properties": {
-                                    "id": obj.__data__.id,
-                                    "classList": classList
+                                'properties': {
+                                    'id': obj.__data__.id,
+                                    'classList': classList
                                 }
                             };
                 var nodes = [];
 
-                if (classList.includes("area")) {
+                if (classList.includes('area')) {
                     feature.geometry.type = 'Polygon';
                     nodes = obj.__data__.nodes;
                     feature.geometry.coordinates.push([]);
                     nodes.forEach(function(n) {
                         feature.geometry.coordinates[0].push(context.graph().hasEntity(n).loc);
                     });
-                } else if (classList.includes("line")) {
+                } else if (classList.includes('line')) {
                     feature.geometry.type = 'LineString';
                     nodes = obj.__data__.nodes;
                     nodes.forEach(function(n) {
@@ -301,12 +301,12 @@ export function uiMapInMap(context) {
                 } else if (/point|vertex/.test(classList)) {
                     if (!obj.__data__.loc) return;
                     feature.geometry.type = 'Point';
-                    feature.geometry.coordinates = obj.__data__.loc
+                    feature.geometry.coordinates = obj.__data__.loc;
                 } else {
                     return;
                 }
 
-                geojson["features"].push(feature);
+                geojson.features.push(feature);
             });
 
             var path = viewport.select('#map-in-map-features').selectAll('.map-in-map-selection')
@@ -319,13 +319,13 @@ export function uiMapInMap(context) {
                 .append('path')
                 .merge(path)
                 .attr('d', getPath)
-                .attr("class", function(d) {
+                .attr('class', function(d) {
                     return d.properties.classList;
                 })
                 .classed('map-in-map-selection', true)
-                .style("fill", function(d) {
-                    return (d.geometry.type === "Point" || d.properties.classList.includes("fill")) ? "#f00" : "none";
-                })
+                .style('fill', function(d) {
+                    return (d.geometry.type === 'Point' || d.properties.classList.includes('fill')) ? '#f00' : 'none';
+                });
 
             path
                 .exit()
@@ -335,7 +335,7 @@ export function uiMapInMap(context) {
             if (gesture !== 'pan') {
                 var bbox = { type: 'Polygon', coordinates: [context.map().extent().polygon()] };
 
-                var path = viewport.select('#map-in-map-bbox').selectAll('.map-in-map-bbox')
+                path = viewport.select('#map-in-map-bbox').selectAll('.map-in-map-bbox')
                     .data([bbox]);
 
                 path.enter()
@@ -390,17 +390,17 @@ export function uiMapInMap(context) {
 
         function getSelectedElements() {
             var query_selector = utilEntityOrMemberSelector(context.selectedIDs(), context.graph())
-                                    .split(",")
+                                    .split(',')
                                     .map(function(s) {
                                         return '#map ' + s;
                                     })
                                     .join(', ');
 
-            selected = Array.from(d3_selectAll(query_selector)._groups[0]);
+            var selected = Array.from(d3_selectAll(query_selector)._groups[0]);
 
             for (var i = 0; i < selected.length; i++) {
-                if (selected[i].__data__["members"]) {
-                    selected.concat(selected[i].__data__["members"]);
+                if (selected[i].__data__.members) {
+                    selected.concat(selected[i].__data__.members);
                     selected[i] = null;
                 }
             }

--- a/modules/ui/map_in_map.js
+++ b/modules/ui/map_in_map.js
@@ -285,26 +285,7 @@ export function uiMapInMap(context) {
                             };
                 var nodes = [];
 
-                if (classList.includes('area')) {
-                    feature.geometry.type = 'Polygon';
-                    nodes = obj.__data__.nodes;
-                    feature.geometry.coordinates.push([]);
-                    nodes.forEach(function(n) {
-                        feature.geometry.coordinates[0].push(context.graph().hasEntity(n).loc);
-                    });
-                } else if (classList.includes('line')) {
-                    feature.geometry.type = 'LineString';
-                    nodes = obj.__data__.nodes;
-                    nodes.forEach(function(n) {
-                        feature.geometry.coordinates.push(context.graph().hasEntity(n).loc);
-                    });
-                } else if (/point|vertex/.test(classList)) {
-                    if (!obj.__data__.loc) return;
-                    feature.geometry.type = 'Point';
-                    feature.geometry.coordinates = obj.__data__.loc;
-                } else {
-                    return;
-                }
+                feature.geometry = obj.__data__.asGeoJSON(context.graph());
 
                 geojson.features.push(feature);
             });

--- a/modules/ui/map_in_map.js
+++ b/modules/ui/map_in_map.js
@@ -290,7 +290,7 @@ export function uiMapInMap(context) {
                 .attr('d', getPath)
                 .classed('map-in-map-selection', true)
                 .classed('line', function(d) {
-                    return (d.geometry.type === 'LineString') ? true : false;
+                    return d.geometry.type === 'LineString';
                 });
 
             path

--- a/modules/ui/map_in_map.js
+++ b/modules/ui/map_in_map.js
@@ -264,31 +264,21 @@ export function uiMapInMap(context) {
 
             var getPath = d3_geoPath(projection);
 
-            var selected = getSelectedElements();
-
             var geojson = { 'name':'Minimap Features',
                             'type': 'FeatureCollection',
                             'features': []
                         };
 
-            selected.forEach(function(obj) {
-                var classList = obj.classList.value;
-                var feature = { 'type': 'Feature',
-                                'geometry': {
-                                    'type': '',
-                                    'coordinates': []
-                                },
-                                'properties': {
-                                    'id': obj.__data__.id,
-                                    'classList': classList
-                                }
-                            };
-                var nodes = [];
+            context.selectedIDs()
+                .map(context.entity)
+                .forEach(function(obj) {
+                    var feature = { 'type': 'Feature'
+                                };
 
-                feature.geometry = obj.__data__.asGeoJSON(context.graph());
+                    feature.geometry = obj.asGeoJSON(context.graph());
 
-                geojson.features.push(feature);
-            });
+                    geojson.features.push(feature);
+                });
 
             var path = viewport.select('#map-in-map-features').selectAll('.map-in-map-selection')
                 .data(geojson.features);
@@ -300,13 +290,14 @@ export function uiMapInMap(context) {
                 .append('path')
                 .merge(path)
                 .attr('d', getPath)
-                .attr('class', function(d) {
-                    return d.properties.classList;
-                })
                 .classed('map-in-map-selection', true)
                 .style('fill', function(d) {
-                    return (d.geometry.type === 'Point' || d.properties.classList.includes('fill')) ? '#f00' : 'none';
-                });
+                    return (d.geometry.type === 'Point' || d.geometry.type === 'Polygon') ? '#f90' : 'none';
+                })
+                .style('stroke-width', function(d) {
+                    return (d.geometry.type === 'LineString') ? 5 : 3;
+                })
+                .style('stroke', '#f60');
 
             path
                 .exit()
@@ -367,28 +358,6 @@ export function uiMapInMap(context) {
                         redraw();
                     });
             }
-        }
-
-        function getSelectedElements() {
-            var query_selector = utilEntityOrMemberSelector(context.selectedIDs(), context.graph())
-                                    .split(',')
-                                    .map(function(s) {
-                                        return '#map ' + s;
-                                    })
-                                    .join(', ');
-
-            var selected = Array.from(d3_selectAll(query_selector)._groups[0]);
-
-            for (var i = 0; i < selected.length; i++) {
-                if (selected[i].__data__.members) {
-                    selected.concat(selected[i].__data__.members);
-                    selected[i] = null;
-                }
-            }
-
-            return selected.filter(function(s) {
-                return s !== null;
-            });
         }
 
 

--- a/modules/ui/map_in_map.js
+++ b/modules/ui/map_in_map.js
@@ -2,8 +2,7 @@ import { geoPath as d3_geoPath } from 'd3-geo';
 
 import {
     event as d3_event,
-    select as d3_select,
-    selectAll as d3_selectAll
+    select as d3_select
 } from 'd3-selection';
 
 import {
@@ -26,7 +25,6 @@ import { rendererTileLayer } from '../renderer';
 import { svgDebug, svgData } from '../svg';
 import { utilSetTransform } from '../util';
 import { utilGetDimensions } from '../util/dimensions';
-import { utilEntityOrMemberSelector } from '../util';
 
 
 export function uiMapInMap(context) {

--- a/modules/ui/map_in_map.js
+++ b/modules/ui/map_in_map.js
@@ -266,12 +266,13 @@ export function uiMapInMap(context) {
 
             var selected = getSelectedElements();
 
-            var geojson = { "name": "feature",
+            var geojson = { "name": "Minimap Features",
                             "type": "FeatureCollection",
                             "features": []
                         };
 
             selected.forEach(function(obj) {
+                var classList = obj.classList.value;
                 var feature = { "type": "Feature",
                                 "geometry": {
                                     "type": "",
@@ -279,25 +280,25 @@ export function uiMapInMap(context) {
                                 },
                                 "properties": {
                                     "id": obj.__data__.id,
-                                    "classList": obj.classList.value
+                                    "classList": classList
                                 }
                             };
                 var nodes = [];
 
-                if (obj.classList.value.includes("area")) {
+                if (classList.includes("area")) {
                     feature.geometry.type = 'Polygon';
                     nodes = obj.__data__.nodes;
                     feature.geometry.coordinates.push([]);
                     nodes.forEach(function(n) {
                         feature.geometry.coordinates[0].push(context.graph().hasEntity(n).loc);
                     });
-                } else if (obj.classList.value.includes("line")) {
+                } else if (classList.includes("line")) {
                     feature.geometry.type = 'LineString';
                     nodes = obj.__data__.nodes;
                     nodes.forEach(function(n) {
                         feature.geometry.coordinates.push(context.graph().hasEntity(n).loc);
                     });
-                } else if (obj.classList.value.includes("point") || obj.classList.value.includes("vertex")) {
+                } else if (/point|vertex/.test(classList)) {
                     if (!obj.__data__.loc) return;
                     feature.geometry.type = 'Point';
                     feature.geometry.coordinates = obj.__data__.loc
@@ -390,7 +391,9 @@ export function uiMapInMap(context) {
         function getSelectedElements() {
             var query_selector = utilEntityOrMemberSelector(context.selectedIDs(), context.graph())
                                     .split(",")
-                                    .map(s => '#map ' + s)
+                                    .map(function(s) {
+                                        return '#map ' + s;
+                                    })
                                     .join(', ');
 
             selected = Array.from(d3_selectAll(query_selector)._groups[0]);
@@ -402,7 +405,9 @@ export function uiMapInMap(context) {
                 }
             }
 
-            return selected.filter(s => s !== null);
+            return selected.filter(function(s) {
+                return s !== null;
+            });
         }
 
 

--- a/modules/ui/map_in_map.js
+++ b/modules/ui/map_in_map.js
@@ -289,13 +289,9 @@ export function uiMapInMap(context) {
                 .merge(path)
                 .attr('d', getPath)
                 .classed('map-in-map-selection', true)
-                .style('fill', function(d) {
-                    return (d.geometry.type === 'Point' || d.geometry.type === 'Polygon') ? '#f90' : 'none';
-                })
-                .style('stroke-width', function(d) {
-                    return (d.geometry.type === 'LineString') ? 5 : 3;
-                })
-                .style('stroke', '#f60');
+                .classed('line', function(d) {
+                    return (d.geometry.type === 'LineString') ? true : false;
+                });
 
             path
                 .exit()


### PR DESCRIPTION
This is a work in progress for #5415 

It simply copies any selected features from the main map and replicates them on the minimap. The styles etc are all maintained (which will require some editing most likely as it can look a bit cumbersome, but that can all be fixed)

Multiple features can be selected and they'll all be replicated on the minimap without an issue.

Todo:
 - Modify styles so they are less intrusive
 - Add breathing (i.e. red pulsing on selected features) to minimap features (?)
 - Improve styling of Point markers (currently a plain red dot - maybe better if its a small black dot with breathe effect)
 - Improve relation/area selections (either a big red blob or a thin line atm)

Note that this doesn't fix the selection dropping when the selection is dragged off the screen. I'm looking into sorting that, but its not too easy!

![image](https://user-images.githubusercontent.com/4670502/47615747-4d8ab980-daab-11e8-922c-a60369ec7f9c.png)
