### PR TITLE
Flexbox buttons in top bar

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -569,15 +569,17 @@ button.secondary-action:hover {
     display: flex;
     flex: 0 1 auto;
     flex-flow: row nowrap;
+    width: 100%;
 }
 .tool-group.leading-area {
+    flex-shrink: 2;
     justify-content: flex-start;
 }
 .tool-group.center-area {
     justify-content: center;
 }
 .tool-group.trailing-area {
-    justify-content: flex-end;
+    justify-content: flex-start;
 }
 
 .tool-group > div {

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -16,7 +16,6 @@ body {
         sans-serif;
     margin: 0;
     padding: 0;
-    min-width: 768px;
     color: #333;
     overflow: hidden;
     -ms-user-select: none;
@@ -32,7 +31,6 @@ body {
 .id-container {
     height: 100%;
     width: 100%;
-    min-width: 768px;
 }
 
 #content {
@@ -606,6 +604,19 @@ button.add-note svg.icon {
     transform: scaleX(-1);
     filter: FlipH;
     -ms-filter: "FlipH";
+}
+
+
+#bar.narrow .tool-group {
+    width: unset;
+}
+#bar.narrow .spinner,
+#bar.narrow button .label {
+    display: none;
+}
+#bar.narrow button .count {
+    border-left-width: 0;
+    border-right-width: 0;
 }
 
 

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -4585,19 +4585,6 @@ li.hide + li.version .badge .tooltip .tooltip-arrow {
 }
 
 
-/* Media Queries
-------------------------------------------------------- */
-@media screen and (max-width: 1200px) {
-    .user-list { display: none !important; }
-}
-@media screen and (max-width: 1000px) {
-    #userLink { display: none !important; }
-}
-@media screen and (max-width: 900px) {
-    #scale-block { display: none !important; }
-}
-
-
 /* Scrollbars
  ----------------------------------------------------- */
 ::-webkit-scrollbar {

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -61,6 +61,7 @@ body {
     #content > #bar {
         width: 100vw;
     }
+/*
     #content.inactive > #bar > .spacer.col4 {
         width: 0px;
     }
@@ -69,6 +70,7 @@ body {
         transition-duration: 200ms;
         transition-timing-function: step-end;
     }
+*/
 }
 
 #defs {
@@ -92,12 +94,9 @@ body {
     height: 40px;
     width: 40px;
     border-radius: 4px;
-    margin-right: 10px;
     background: black;
 }
 [dir='rtl'] .spinner img {
-    margin-left: 10px;
-    margin-right: auto;
     -moz-transform: scaleX(-1);
     -o-transform: scaleX(-1);
     -webkit-transform: scaleX(-1);
@@ -278,18 +277,8 @@ table.tags, table.tags td, table.tags th {
 
 /* Grid
 ------------------------------------------------------- */
-.col0    { float: left; width: 04.1666%; }
-.col1    { float: left; width: 08.3333%; }
-.col2    { float: left; width: 16.6666%; }
-.col3    { float: left; width: 25.0000%; max-width: 300px; }
-.col4    { float: left; width: 33.3333%; max-width: 400px; }
-.col5    { float: left; width: 41.6666%; max-width: 500px; }
 .col6    { float: left; width: 50.0000%; max-width: 600px; }
-.col7    { float: left; width: 58.3333%; }
 .col8    { float: left; width: 66.6666%; }
-.col9    { float: left; width: 75.0000%; }
-.col10   { float: left; width: 83.3333%; }
-.col11   { float: left; width: 91.6666%; }
 .col12   { float: left; width: 100.0000%; }
 
 /* UI Lists
@@ -326,7 +315,7 @@ ul li { list-style: none;}
 }
 
 .toggle-list > label.active {
-    background: #E8EBFF;
+    background: #e8ebff;
 }
 
 
@@ -433,7 +422,7 @@ button.minor:hover {
     background-color: #f1f1f1;
 }
 
-.button-wrap {
+/*.button-wrap {
     display: inline-block;
     padding-right: 10px;
     margin: 0;
@@ -455,7 +444,7 @@ button.minor:hover {
 }
 [dir='rtl'] .button-wrap:last-of-type {
     padding-left: 0;
-}
+}*/
 
 .joined button {
     border-radius: 0;
@@ -489,18 +478,15 @@ button.action {
     background: #7092ff;
     color: #fff;
 }
-
 button[disabled].action,
 button[disabled].action:hover {
     background: #cccccc;
     color: #888;
 }
-
 button.action:focus,
 button.action:hover {
-    background: #597BE7;
+    background: #597be7;
 }
-
 button.secondary-action {
     background: #ececec;
 }
@@ -508,61 +494,6 @@ button.secondary-action {
 button.secondary-action:focus,
 button.secondary-action:hover {
     background: #cccccc;
-}
-.button-wrap.sidebar-collapse,
-.button-wrap.save-wrap {
-    min-width: 33.3333%;
-}
-.button-wrap.modes {
-    width: 100%;
-}
-
-button.undo-button,
-button.redo-button {
-    width: 44px;
-}
-button.save {
-    padding: 0;
-    display: flex;
-}
-button.save .save-inner-wrap {
-    flex: 1;
-}
-button.save .count {
-    display: none;
-}
-button.save.has-count .count {
-    display: inline-block;
-    color: #333;
-    border: 0px solid rgba(51, 51, 51, 0.2);
-    border-left-width: 1px;
-    padding: 0px 12px;
-}
-[dir='rtl'] button.save.has-count .count {
-    border-left-width: 0px;
-    border-right-width: 1px;
-}
-
-.help-wrap svg.icon.pre-text.add-note,
-button.add-note svg.icon {
-    height: 15px;
-    width: 15px;
-    color: rgba(0,0,0,0.25);
-    stroke: #333;
-    stroke-width: 60px;
-    margin-top: 3px;
-}
-button.add-note svg.icon {
-    margin-left: unset;
-    margin-right: 7px;
-}
-[dir='rtl'] button.add-note svg.icon {
-    margin-left: 7px;
-    margin-right: unset;
-}
-.help-wrap svg.icon.pre-text.add-note {
-    margin-left: 3px;
-    margin-right: 3px;
 }
 
 
@@ -622,6 +553,9 @@ button.add-note svg.icon {
 /* Toolbar / Persistent UI Elements
 ------------------------------------------------------- */
 #bar {
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: space-between;
     position: absolute;
     padding: 10px;
     left: 0;
@@ -629,51 +563,103 @@ button.add-note svg.icon {
     right: 0;
     height: 60px;
     z-index: 9;
-    min-width: 600px;
 }
 
-[dir='rtl'] #bar .button-wrap button {
-    float: right;
+.tool-group {
+    display: flex;
+    flex: 0 1 auto;
+    flex-flow: row nowrap;
 }
-#bar .center-area,
-#bar .trailing-area {
-    min-width: 50%;
+.tool-group.leading-area {
+    justify-content: flex-start;
 }
-.sidebar-collapsed #bar .leading-area,
-.sidebar-collapsed #bar .center-area,
-.sidebar-collapsed #bar .trailing-area {
-    min-width: 33.3333%;
+.tool-group.center-area {
+    justify-content: center;
 }
-#bar .center-area {
-    float: left;
+.tool-group.trailing-area {
+    justify-content: flex-end;
 }
-[dir='rtl'] #bar .center-area {
-    float: right;
+
+.tool-group > div {
+    display: flex;
+    margin: 0 5px;
 }
-.sidebar-collapsed #bar .center-area {
-    position: absolute;
-    left: 50%;
-    transform: translateX(-50%);
-    float: none;
+
+.tool-group button {
+    display: flex;
+    flex: 1 1 auto;
+    flex-flow: row nowrap;
+    padding: 0 10px;
+    min-width: 30px;
 }
-#bar .leading-area {
-    float: left;
-    display: none;
+
+.tool-group button .icon {
+    flex: 0 0 20px;
 }
-[dir='rtl'] #bar .leading-area {
-    float: right;
+.tool-group button .label {
+    flex: 0 1 auto;
+    padding: 0 5px;
 }
-.sidebar-collapsed #bar .leading-area {
+
+
+button.save .count {
+    visibility: hidden;
     display: inline-block;
+    border: 0px solid #ccc;
+    border-left-width: 1px;
+    padding: 0px 8px;
+    min-width: 32px;
+    text-align: center;
 }
-#bar .trailing-area {
-    float: right;
-    text-align: right;
+[dir='rtl'] button.save .count {
+    border-left-width: 0px;
+    border-right-width: 1px;
 }
-[dir='rtl'] #bar .trailing-area {
-    float: left;
-    text-align: left;
+button.save.has-count .count {
+    visibility: visible;
 }
+
+/* if no count, shift label over where the count would be, preserving width */
+button.save .label {
+    margin-right: -12px;
+    margin-left: 15px;
+}
+[dir='rtl'] button.save .label {
+    margin-left: -12px;
+    margin-right: 15px;
+}
+button.save.has-count .label {
+    margin-right: 3px;
+    margin-left: 0;
+}
+[dir='rtl'] button.save.has-count .label {
+    margin-left: 3px;
+    margin-right: 0;
+}
+
+
+.help-wrap svg.icon.pre-text.add-note,
+button.add-note svg.icon {
+    height: 15px;
+    width: 15px;
+    color: rgba(0,0,0,0.25);
+    stroke: #333;
+    stroke-width: 60px;
+    margin-top: 3px;
+}
+button.add-note svg.icon {
+    margin-left: unset;
+    margin-right: 4px;
+}
+[dir='rtl'] button.add-note svg.icon {
+    margin-left: 4px;
+    margin-right: unset;
+}
+.help-wrap svg.icon.pre-text.add-note {
+    margin-left: 3px;
+    margin-right: 3px;
+}
+
 
 
 /* Header for modals / panes
@@ -771,14 +757,6 @@ button.add-note svg.icon {
     justify-content: center;
 }
 
-.sidebar-component .body {
-    width: 100%;
-    overflow: auto;
-    top: 60px;
-    bottom: 0;
-    position: absolute;
-}
-
 
 /* Hide/Toggle collapsable sections (aka Disclosure)
 ------------------------------------------------------- */
@@ -799,6 +777,25 @@ a.hide-toggle {
     font-size: 14px;
     font-weight: bold;
     padding-bottom: 5px;
+}
+
+
+/* Sidebar / Inspector
+------------------------------------------------------- */
+#sidebar {
+    position: relative;
+    float: left;
+    height: 100%;
+    z-index: 10;
+    background: #f6f6f6;
+    -ms-user-select: element;
+    border: 0px solid #ccc;
+    border-right-width: 1px;
+}
+[dir='rtl'] #sidebar {
+    float: right;
+    border-right-width: 0px;
+    border-left-width: 1px;
 }
 
 #sidebar-resizer {
@@ -822,23 +819,6 @@ a.hide-toggle {
     left: -10px;
 }
 
-/* Sidebar / Inspector
-------------------------------------------------------- */
-#sidebar {
-    position: relative;
-    float: left;
-    height: 100%;
-    z-index: 10;
-    background: #f6f6f6;
-    -ms-user-select: element;
-    border: 0px solid #ccc;
-    border-right-width: 1px;
-}
-[dir='rtl'] #sidebar {
-    float: right;
-    border-right-width: 0px;
-    border-left-width: 1px;
-}
 
 .sidebar-component {
     position: absolute;
@@ -846,6 +826,14 @@ a.hide-toggle {
     left: 0;
     bottom: 0;
     right: 0;
+}
+
+.sidebar-component .body {
+    width: 100%;
+    overflow: auto;
+    top: 60px;
+    bottom: 0;
+    position: absolute;
 }
 
 .panewrap {
@@ -933,6 +921,7 @@ a.hide-toggle {
     font-size: 18px;
     font-weight: bold;
 }
+
 
 
 /* Feature List / Search Results
@@ -3019,6 +3008,8 @@ div.full-screen > button:hover {
     top: 60px;
     bottom: 30px;
     right: 0;
+    width: 33.3333%;
+    max-width: 400px;
     padding-bottom: 50px;
     overflow: hidden;
     z-index: -1;
@@ -3026,6 +3017,11 @@ div.full-screen > button:hover {
 [dir='rtl'] .map-pane {
     left: 0;
     right: auto !important;
+}
+
+.map-pane.help-wrap {
+    width: 50.0000%;
+    max-width: 600px;
 }
 
 .pane-heading {
@@ -3826,6 +3822,10 @@ img.tile-debug {
     text-align: center;
 }
 
+.modal-section.buttons button {
+    min-width: 130px;
+}
+
 .modal-section.buttons .action {
     display: inline-block;
     margin: 0 10px;
@@ -4102,9 +4102,6 @@ svg.mouseclick use.right {
 ------------------------------------------------------- */
 .settings-modal textarea {
     height: 70px;
-}
-.settings-modal .buttons .button.col3 {
-    float: none;   /* undo float left */
 }
 
 .settings-custom-background .instructions-template {
@@ -4508,12 +4505,12 @@ svg.mouseclick use.right {
 }
 
 /* Move over tooltips that are near the edge of screen */
-.add-point .tooltip .tooltip-arrow {
-    left: 60px;
+button.sidebar-toggle .tooltip .tooltip-arrow {
+    left: 32px;
 }
-[dir='rtl'] .add-point .tooltip .tooltip-arrow {
+[dir='rtl'] button.sidebar-toggle .tooltip .tooltip-arrow {
     left: auto;
-    right: 60px;
+    right: 32px;
 }
 
 li:first-of-type .badge .tooltip,

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -57,20 +57,11 @@ body {
 
 /* Firefox has its own ideas about fixed positioning when a css filter is active - #4348 */
 /* https://stackoverflow.com/questions/37949942/firefox-position-bug-by-parent-with-filter */
+/* TODO: check whether this is necessary now with flexbox */
 @-moz-document url-prefix() {
     #content > #bar {
         width: 100vw;
     }
-/*
-    #content.inactive > #bar > .spacer.col4 {
-        width: 0px;
-    }
-    #content.active > #bar > .spacer.col4 {
-        width: 33.3333%;
-        transition-duration: 200ms;
-        transition-timing-function: step-end;
-    }
-*/
 }
 
 #defs {
@@ -79,32 +70,6 @@ body {
     width: 0;
     height: 0;
 }
-
-.spacer {
-    height: 40px;
-    margin-right: 10px;
-}
-
-.spinner {
-    opacity: .5;
-    display: inline-block;
-}
-
-.spinner img {
-    height: 40px;
-    width: 40px;
-    border-radius: 4px;
-    background: black;
-}
-[dir='rtl'] .spinner img {
-    -moz-transform: scaleX(-1);
-    -o-transform: scaleX(-1);
-    -webkit-transform: scaleX(-1);
-    transform: scaleX(-1);
-    filter: FlipH;
-    -ms-filter: "FlipH";
-}
-
 
 div, textarea, label, input, form, span, ul, li, ol, a, button, h1, h2, h3, h4, h5, p, img {
     -moz-box-sizing: border-box;
@@ -141,7 +106,6 @@ h3 {
     font-weight: bold;
     margin-bottom: 10px;
 }
-
 h4, h5 {
     font-size: 12px;
     font-weight: bold;
@@ -169,23 +133,18 @@ p {
     margin: 0;
     padding: 0;
 }
-
 p:last-child {
     padding-bottom: 0;
 }
-
 em {
     font-style: italic;
 }
-
 strong {
     font-weight: bold;
 }
-
 a:visited, a {
     color: #7092ff;
 }
-
 a:hover {
     color: #597be7;
 }
@@ -277,9 +236,9 @@ table.tags, table.tags td, table.tags th {
 
 /* Grid
 ------------------------------------------------------- */
-.col6    { float: left; width: 50.0000%; max-width: 600px; }
-.col8    { float: left; width: 66.6666%; }
-.col12   { float: left; width: 100.0000%; }
+.col6  { float: left; width: 50.0000%; max-width: 600px; }
+.col8  { float: left; width: 66.6666%; }
+.col12 { float: left; width: 100.0000%; }
 
 /* UI Lists
 ------------------------------------------------------- */
@@ -417,34 +376,9 @@ button.minor {
 button.minor .icon {
     opacity: .5;
 }
-
 button.minor:hover {
     background-color: #f1f1f1;
 }
-
-/*.button-wrap {
-    display: inline-block;
-    padding-right: 10px;
-    margin: 0;
-}
-[dir='rtl'] .button-wrap {
-    padding-left: 10px;
-}
-.button-wrap button {
-    white-space: nowrap;
-    padding: 0px 8px;
-}
-
-.button-wrap button:only-child {
-    width: 100%;
-}
-
-.button-wrap:last-of-type {
-    padding-right: 0;
-}
-[dir='rtl'] .button-wrap:last-of-type {
-    padding-left: 0;
-}*/
 
 .joined button {
     border-radius: 0;
@@ -458,14 +392,12 @@ button.minor:hover {
 .fillL .joined button {
     border-right: 1px solid #fff;
 }
-
 .joined button:first-child {
     border-radius: 4px 0 0 4px;
 }
 [dir='rtl'] .joined button:first-child {
     border-radius: 0 4px 4px 0;
 }
-
 .joined button:last-child {
     border-right-width: 0;
     border-radius: 0 4px 4px 0;
@@ -528,15 +460,12 @@ button.secondary-action:hover {
 .icon.light {
     color: #fff;
 }
-
 .icon.created {
     color: #00ca07;
 }
-
 .icon.modified {
     color: #666;
 }
-
 .icon.deleted {
     color: #ea0000;
 }
@@ -586,7 +515,6 @@ button.secondary-action:hover {
     display: flex;
     margin: 0 5px;
 }
-
 .tool-group button {
     display: flex;
     flex: 1 1 auto;
@@ -594,7 +522,6 @@ button.secondary-action:hover {
     padding: 0 10px;
     min-width: 30px;
 }
-
 .tool-group button .icon {
     flex: 0 0 20px;
 }
@@ -602,7 +529,6 @@ button.secondary-action:hover {
     flex: 0 1 auto;
     padding: 0 5px;
 }
-
 
 button.save .count {
     visibility: hidden;
@@ -639,7 +565,6 @@ button.save.has-count .label {
     margin-right: 0;
 }
 
-
 .help-wrap svg.icon.pre-text.add-note,
 button.add-note svg.icon {
     height: 15px;
@@ -662,6 +587,26 @@ button.add-note svg.icon {
     margin-right: 3px;
 }
 
+.spinner {
+    opacity: .5;
+    display: flex;
+    flex-shrink: 2;
+    justify-content: flex-end;
+}
+.spinner img {
+    height: 40px;
+    width: 40px;
+    border-radius: 4px;
+    background: black;
+}
+[dir='rtl'] .spinner img {
+    -moz-transform: scaleX(-1);
+    -o-transform: scaleX(-1);
+    -webkit-transform: scaleX(-1);
+    transform: scaleX(-1);
+    filter: FlipH;
+    -ms-filter: "FlipH";
+}
 
 
 /* Header for modals / panes

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -755,19 +755,19 @@ a.hide-toggle {
     width: 6px;
     cursor: col-resize;
 }
-.sidebar-collapsed #sidebar-resizer {
-    /* make target wider to avoid the user accidentally resizing window */
-    width: 10px;
-    right: -10px;
-}
 [dir='rtl'] #sidebar-resizer {
     right: auto;
     left: -6px;
 }
-.sidebar-collapsed[dir='rtl'] #sidebar-resizer {
+
+#sidebar.collapsed #sidebar-resizer {
+    /* make target wider to avoid the user accidentally resizing window */
+    width: 10px;
+    right: -10px;
+}
+[dir='rtl'] #sidebar.collapsed #sidebar-resizer {
     left: -10px;
 }
-
 
 .sidebar-component {
     position: absolute;

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -53,15 +53,6 @@ body {
     transition-duration: 200ms;
 }
 
-/* Firefox has its own ideas about fixed positioning when a css filter is active - #4348 */
-/* https://stackoverflow.com/questions/37949942/firefox-position-bug-by-parent-with-filter */
-/* TODO: check whether this is necessary now with flexbox */
-@-moz-document url-prefix() {
-    #content > #bar {
-        width: 100vw;
-    }
-}
-
 #defs {
     /* Can't be display: none or the clippaths are ignored. */
     position: absolute;

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -296,7 +296,7 @@ en:
   help_translate: Help translate
   sidebar_button:
     title: Sidebar
-    tooltip: Open the sidebar.
+    tooltip: Toggle the sidebar.
   feature_info:
     hidden_warning: "{count} hidden features"
     hidden_details: "These features are currently hidden: {details}"

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -294,8 +294,8 @@ en:
   loading_auth: "Connecting to OpenStreetMap..."
   report_a_bug: Report a bug
   help_translate: Help translate
-  sidebar_button:
-    title: Sidebar
+  sidebar:
+    key: '`'
     tooltip: Toggle the sidebar.
   feature_info:
     hidden_warning: "{count} hidden features"
@@ -1151,6 +1151,7 @@ en:
         background_switch: "Switch back to last background"
         map_data: "Show map data options"
         fullscreen: "Enter full screen mode"
+        sidebar: "Toggle sidebar"
         wireframe: "Toggle wireframe mode"
         minimap: "Toggle minimap"
       selecting:

--- a/data/shortcuts.json
+++ b/data/shortcuts.json
@@ -67,6 +67,10 @@
               "text": "shortcuts.browsing.display_options.fullscreen"
             },
             {
+              "shortcuts": ["sidebar.key"],
+              "text": "shortcuts.browsing.display_options.sidebar"
+            },
+            {
               "shortcuts": ["area_fill.wireframe.key"],
               "text": "shortcuts.browsing.display_options.wireframe"
             },

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -375,7 +375,7 @@
         "help_translate": "Help translate",
         "sidebar_button": {
             "title": "Sidebar",
-            "tooltip": "Open the sidebar."
+            "tooltip": "Toggle the sidebar."
         },
         "feature_info": {
             "hidden_warning": "{count} hidden features",

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -373,8 +373,8 @@
         "loading_auth": "Connecting to OpenStreetMap...",
         "report_a_bug": "Report a bug",
         "help_translate": "Help translate",
-        "sidebar_button": {
-            "title": "Sidebar",
+        "sidebar": {
+            "key": "`",
             "tooltip": "Toggle the sidebar."
         },
         "feature_info": {
@@ -1329,6 +1329,7 @@
                     "background_switch": "Switch back to last background",
                     "map_data": "Show map data options",
                     "fullscreen": "Enter full screen mode",
+                    "sidebar": "Toggle sidebar",
                     "wireframe": "Toggle wireframe mode",
                     "minimap": "Toggle minimap"
                 },

--- a/modules/geo/extent.js
+++ b/modules/geo/extent.js
@@ -20,7 +20,6 @@ export function geoExtent(min, max) {
     }
 }
 
-// $FlowFixMe
 geoExtent.prototype = new Array(2);
 
 _extend(geoExtent.prototype, {

--- a/modules/modes/select_data.js
+++ b/modules/modes/select_data.js
@@ -1,3 +1,6 @@
+
+import { geoBounds as d3_geoBounds } from 'd3-geo';
+
 import {
     event as d3_event,
     select as d3_select
@@ -12,11 +15,8 @@ import {
     behaviorSelect
 } from '../behavior';
 
-import {
-    modeDragNode,
-    modeDragNote
-} from '../modes';
-
+import { geoExtent } from '../geo';
+import { modeDragNode, modeDragNote } from '../modes';
 import { modeBrowse } from './browse';
 import { uiDataEditor } from '../ui';
 
@@ -69,8 +69,12 @@ export function modeSelectData(context, selectedDatum) {
 
         selectData();
 
-        context.ui().sidebar
-            .show(dataEditor.datum(selectedDatum));
+        var sidebar = context.ui().sidebar;
+        sidebar.show(dataEditor.datum(selectedDatum));
+
+        // expand the sidebar, avoid obscuring the data if needed
+        var extent = geoExtent(d3_geoBounds(selectedDatum));
+        sidebar.expand(sidebar.intersects(extent));
 
         context.map()
             .on('drawn.select-data', selectData);

--- a/modules/modes/select_note.js
+++ b/modules/modes/select_note.js
@@ -105,8 +105,11 @@ export function modeSelectNote(context, selectedNoteID) {
 
         selectNote();
 
-        context.ui().sidebar
-            .show(noteEditor.note(note));
+        var sidebar = context.ui().sidebar;
+        sidebar.show(noteEditor.note(note));
+
+        // expand the sidebar, avoid obscuring the note if needed
+        sidebar.expand(sidebar.intersects(note.extent()));
 
         context.map()
             .on('drawn.select', selectNote);

--- a/modules/renderer/map.js
+++ b/modules/renderer/map.js
@@ -662,13 +662,11 @@ export function rendererMap(context) {
 
     map.dimensions = function(_) {
         if (!arguments.length) return dimensions;
-        var center = map.center();
         dimensions = _;
         drawLayers.dimensions(dimensions);
         context.background().dimensions(dimensions);
         projection.clipExtent([[0, 0], dimensions]);
         mouse = utilFastMouse(supersurface.node());
-        setCenter(center);
 
         scheduleRedraw();
         return map;

--- a/modules/services/mapillary.js
+++ b/modules/services/mapillary.js
@@ -372,7 +372,7 @@ export default {
         defs.call(svgDefs(context).addSprites, ['mapillary-sprite']);
 
         // Register viewer resize handler
-        context.ui().on('photoviewerResize', function() {
+        context.ui().photoviewer.on('resize', function() {
             if (_mlyViewer) {
                 _mlyViewer.resize();
             }

--- a/modules/services/openstreetcam.js
+++ b/modules/services/openstreetcam.js
@@ -327,7 +327,7 @@ export default {
 
 
         // Register viewer resize handler
-        context.ui().on('photoviewerResize', function(dimensions) {
+        context.ui().photoviewer.on('resize', function(dimensions) {
             imgZoom = d3_zoom()
                 .extent([[0, 0], dimensions])
                 .translateExtent([[0, 0], dimensions])

--- a/modules/services/streetside.js
+++ b/modules/services/streetside.js
@@ -626,7 +626,7 @@ export default {
 
 
         // Register viewer resize handler
-        context.ui().on('photoviewerResize', function() {
+        context.ui().photoviewer.on('resize', function() {
             if (_pannellumViewer) {
                 _pannellumViewer.resize();
             }

--- a/modules/ui/background.js
+++ b/modules/ui/background.js
@@ -340,7 +340,7 @@ export function uiBackground(context) {
 
         var pane = selection
             .append('div')
-            .attr('class', 'fillL map-pane col4 hide');
+            .attr('class', 'fillL map-pane hide');
 
         var paneTooltip = tooltip()
             .placement((textDirection === 'rtl') ? 'right' : 'left')

--- a/modules/ui/confirm.js
+++ b/modules/ui/confirm.js
@@ -23,7 +23,7 @@ export function uiConfirm(selection) {
     modalSelection.okButton = function() {
         buttons
             .append('button')
-            .attr('class', 'button ok-button action col4')
+            .attr('class', 'button ok-button action')
             .on('click.confirm', function() {
                 modalSelection.remove();
             })

--- a/modules/ui/help.js
+++ b/modules/ui/help.js
@@ -384,7 +384,7 @@ export function uiHelp(context) {
 
 
         var pane = selection.append('div')
-            .attr('class', 'help-wrap map-pane fillL col6 hide');
+            .attr('class', 'help-wrap map-pane fillL hide');
 
         var tooltipBehavior = tooltip()
             .placement((textDirection === 'rtl') ? 'right' : 'left')

--- a/modules/ui/init.js
+++ b/modules/ui/init.js
@@ -45,7 +45,14 @@ import { uiCmd } from './cmd';
 
 
 export function uiInit(context) {
-    var uiInitCounter = 0;
+    // Selectors for elements that can be collapsed if they overflow
+    // (can't use a media query for this because it depends on sidebar width, not screen width)
+    var headerCollapsable = 'button > span.label';
+    var footerCollapsable = '';
+
+    var _initCounter = 0;
+    var _initCallback;
+
 
     function render(container) {
         container
@@ -92,7 +99,7 @@ export function uiInit(context) {
             .call(uiInfo(context))
             .call(uiNotice(context));
 
-        // Leading area button group (sidebar toggle)
+        // Leading area button group (Sidebar toggle)
         var leadingArea = bar
             .append('div')
             .attr('class', 'tool-group leading-area');
@@ -119,7 +126,7 @@ export function uiInit(context) {
             .call(uiFullScreen(context));
 
 
-        // Center area button group (mode buttons)
+        // Center area button group (Point/Line/Area/Note mode buttons)
         bar
             .append('div')
             .attr('class', 'tool-group center-area')
@@ -128,7 +135,7 @@ export function uiInit(context) {
             .call(uiModes(context), bar);
 
 
-        // Center area button group (undo/redo save buttons)
+        // Trailing area button group (Undo/Redo save buttons)
         var trailingArea = bar
             .append('div')
             .attr('class', 'tool-group trailing-area');
@@ -143,13 +150,15 @@ export function uiInit(context) {
             .attr('class', 'save-wrap')
             .call(uiSave(context));
 
-        trailingArea
+
+        // For now, just put spinner at the end
+        bar
             .append('div')
             .attr('class', 'spinner')
             .call(uiSpinner(context));
 
 
-        // Map controls
+        // Map controls (appended to #bar, but absolutely positioned)
         var controls = bar
             .append('div')
             .attr('class', 'map-controls');
@@ -305,7 +314,7 @@ export function uiInit(context) {
 
         context.enter(modeBrowse(context));
 
-        if (!uiInitCounter++) {
+        if (!_initCounter++) {
             if (!hash.startWalkthrough) {
                 context.container()
                     .call(uiSplash(context))
@@ -330,7 +339,7 @@ export function uiInit(context) {
                 });
         }
 
-        uiInitCounter++;
+        _initCounter++;
 
         if (hash.startWalkthrough) {
             hash.startWalkthrough = false;
@@ -347,10 +356,8 @@ export function uiInit(context) {
     }
 
 
-    var renderCallback;
-
     function ui(node, callback) {
-        renderCallback = callback;
+        _initCallback = callback;
         var container = d3_select(node);
         context.container(container);
         context.loadLocale(function(err) {
@@ -370,7 +377,7 @@ export function uiInit(context) {
             if (!err) {
                 context.container().selectAll('*').remove();
                 render(context.container());
-                if (renderCallback) renderCallback();
+                if (_initCallback) _initCallback();
             }
         });
     };

--- a/modules/ui/init.js
+++ b/modules/ui/init.js
@@ -105,9 +105,7 @@ export function uiInit(context) {
             .call(tooltip()
                 .placement('bottom')
                 .html(true)
-                .title(function(mode) {
-                    return uiTooltipHtml(t('sidebar.tooltip'), t('sidebar.key'));
-                })
+                .title(uiTooltipHtml(t('sidebar.tooltip'), t('sidebar.key')))
             );
 
         var iconSuffix = textDirection === 'rtl' ? 'right' : 'left';
@@ -381,10 +379,17 @@ export function uiInit(context) {
 
     ui.photoviewer = uiPhotoviewer(context);
 
-    ui.onResize = function() {
+    ui.onResize = function(withPan) {
+        var map = context.map();
         var content = d3_select('#content');
         var mapDimensions = utilGetDimensions(content, true);
-        context.map().dimensions(mapDimensions);
+
+        if (withPan !== undefined) {
+            map.redrawEnable(false);
+            map.pan(withPan);
+            map.redrawEnable(true);
+        }
+        map.dimensions(mapDimensions);
 
         ui.photoviewer.onMapResize();
     };

--- a/modules/ui/init.js
+++ b/modules/ui/init.js
@@ -37,6 +37,7 @@ import { uiSidebar } from './sidebar';
 import { uiSpinner } from './spinner';
 import { uiSplash } from './splash';
 import { uiStatus } from './status';
+import { uiTooltipHtml } from './tooltipHtml';
 import { uiUndoRedo } from './undo_redo';
 import { uiVersion } from './version';
 import { uiZoom } from './zoom';
@@ -101,14 +102,17 @@ export function uiInit(context) {
             .attr('class', 'sidebar-toggle')
             .attr('tabindex', -1)
             .on('click', ui.sidebar.toggleCollapse)
-            .call(tooltip().title(t('sidebar_button.tooltip')).placement('bottom'));
+            .call(tooltip()
+                .placement('bottom')
+                .html(true)
+                .title(function(mode) {
+                    return uiTooltipHtml(t('sidebar.tooltip'), t('sidebar.key'));
+                })
+            );
 
         var iconSuffix = textDirection === 'rtl' ? 'right' : 'left';
         sidebarButton
             .call(svgIcon('#iD-icon-sidebar-' + iconSuffix));
-            // .append('span')
-            // .attr('class', 'label')
-            // .text(t('sidebar_button.title'));
 
         leadingArea
             .append('div')
@@ -287,6 +291,7 @@ export function uiInit(context) {
         var pa = 80;  // pan amount
         var keybinding = d3_keybinding('main')
             .on('⌫', function() { d3_event.preventDefault(); })
+            .on(t('sidebar.key'), ui.sidebar.toggleCollapse)
             .on('←', pan([pa, 0]))
             .on('↑', pan([0, pa]))
             .on('→', pan([-pa, 0]))

--- a/modules/ui/init.js
+++ b/modules/ui/init.js
@@ -74,6 +74,7 @@ export function uiInit(context) {
             .attr('id', 'content')
             .attr('class', 'active');
 
+        // Top toolbar
         var bar = content
             .append('div')
             .attr('id', 'bar')
@@ -90,56 +91,62 @@ export function uiInit(context) {
             .call(uiInfo(context))
             .call(uiNotice(context));
 
+        // Leading area button group (sidebar toggle)
         var leadingArea = bar
             .append('div')
-            .attr('class', 'leading-area');
+            .attr('class', 'tool-group leading-area');
 
         var sidebarButton = leadingArea
-            .append('div')
-            .attr('class', 'button-wrap sidebar-collapse')
             .append('button')
-            .attr('class', 'col12')
+            .attr('class', 'sidebar-toggle')
             .attr('tabindex', -1)
             .on('click', ui.sidebar.toggleCollapse)
             .call(tooltip().title(t('sidebar_button.tooltip')).placement('bottom'));
+
         var iconSuffix = textDirection === 'rtl' ? 'right' : 'left';
         sidebarButton
-            .call(svgIcon('#iD-icon-sidebar-'+iconSuffix, 'pre-text'))
-            .append('span')
-            .attr('class', 'label')
-            .text(t('sidebar_button.title'));
+            .call(svgIcon('#iD-icon-sidebar-' + iconSuffix));
+            // .append('span')
+            // .attr('class', 'label')
+            // .text(t('sidebar_button.title'));
 
+        leadingArea
+            .append('div')
+            .attr('class', 'full-screen bar-group')
+            .call(uiFullScreen(context));
+
+
+        // Center area button group (mode buttons)
         bar
             .append('div')
-            .attr('class', 'center-area')
+            .attr('class', 'tool-group center-area')
             .append('div')
-            .attr('class', 'modes button-wrap joined')
+            .attr('class', 'modes joined')
             .call(uiModes(context), bar);
 
+
+        // Center area button group (undo/redo save buttons)
         var trailingArea = bar
             .append('div')
-            .attr('class', 'trailing-area');
+            .attr('class', 'tool-group trailing-area');
 
         trailingArea
             .append('div')
-            .attr('class', 'full-screen')
-            .call(uiFullScreen(context));
+            .attr('class', 'joined')
+            .call(uiUndoRedo(context));
+
+        trailingArea
+            .append('div')
+            .attr('class', 'save-wrap')
+            .call(uiSave(context));
 
         trailingArea
             .append('div')
             .attr('class', 'spinner')
             .call(uiSpinner(context));
 
-        trailingArea
-            .append('div')
-            .attr('class', 'button-wrap joined')
-            .call(uiUndoRedo(context));
 
-        trailingArea
-            .append('div')
-            .attr('class', 'button-wrap save-wrap')
-            .call(uiSave(context));
-
+        // Map controls
         var controls = bar
             .append('div')
             .attr('class', 'map-controls');

--- a/modules/ui/init.js
+++ b/modules/ui/init.js
@@ -105,7 +105,7 @@ export function uiInit(context) {
             .append('button')
             .attr('class', 'sidebar-toggle')
             .attr('tabindex', -1)
-            .on('click', ui.sidebar.toggleCollapse)
+            .on('click', ui.sidebar.toggle)
             .call(tooltip()
                 .placement('bottom')
                 .html(true)
@@ -295,7 +295,7 @@ export function uiInit(context) {
         var pa = 80;  // pan amount
         var keybinding = d3_keybinding('main')
             .on('⌫', function() { d3_event.preventDefault(); })
-            .on(t('sidebar.key'), ui.sidebar.toggleCollapse)
+            .on(t('sidebar.key'), ui.sidebar.toggle)
             .on('←', pan([pa, 0]))
             .on('↑', pan([0, pa]))
             .on('→', pan([-pa, 0]))

--- a/modules/ui/init.js
+++ b/modules/ui/init.js
@@ -45,13 +45,9 @@ import { uiCmd } from './cmd';
 
 
 export function uiInit(context) {
-    // Selectors for elements that can be collapsed if they overflow
-    // (can't use a media query for this because it depends on sidebar width, not screen width)
-    var headerCollapsable = 'button > span.label';
-    var footerCollapsable = '';
-
     var _initCounter = 0;
     var _initCallback;
+    var _needWidth = {};
 
 
     function render(container) {
@@ -400,7 +396,35 @@ export function uiInit(context) {
         map.dimensions(mapDimensions);
 
         ui.photoviewer.onMapResize();
+
+        // check if header or footer have overflowed
+        ui.checkOverflow('#bar');
+        ui.checkOverflow('#footer');
     };
+
+
+    // Call checkOverflow when resizing or whenever the contents change.
+    ui.checkOverflow = function(selector, reset) {
+        if (reset) {
+            delete _needWidth[selector];
+        }
+
+        var element = d3_select(selector);
+        var scrollWidth = element.property('scrollWidth');
+        var clientWidth = element.property('clientWidth');
+        var needed = _needWidth[selector] || scrollWidth;
+
+        if (scrollWidth > clientWidth) {    // overflow happening
+            element.classed('narrow', true);
+            if (!_needWidth[selector]) {
+                _needWidth[selector] = scrollWidth;
+            }
+
+        } else if (scrollWidth >= needed) {
+            element.classed('narrow', false);
+        }
+    };
+
 
     return ui;
 }

--- a/modules/ui/init.js
+++ b/modules/ui/init.js
@@ -98,6 +98,7 @@ export function uiInit(context) {
             .attr('class', 'tool-group leading-area');
 
         var sidebarButton = leadingArea
+            .append('div')
             .append('button')
             .attr('class', 'sidebar-toggle')
             .attr('tabindex', -1)

--- a/modules/ui/map_data.js
+++ b/modules/ui/map_data.js
@@ -578,7 +578,7 @@ export function uiMapData(context) {
 
         var pane = selection
             .append('div')
-            .attr('class', 'fillL map-pane col4 hide');
+            .attr('class', 'fillL map-pane hide');
 
         var paneTooltip = tooltip()
             .placement((textDirection === 'rtl') ? 'right' : 'left')

--- a/modules/ui/modes.js
+++ b/modules/ui/modes.js
@@ -125,7 +125,7 @@ export function uiModes(context) {
             buttonsEnter
                 .each(function(d) {
                     d3_select(this)
-                        .call(svgIcon('#iD-icon-' + d.button, 'pre-text'));
+                        .call(svgIcon('#iD-icon-' + d.button));
                 });
 
             buttonsEnter
@@ -136,8 +136,6 @@ export function uiModes(context) {
             // update
             buttons = buttons
                 .merge(buttonsEnter)
-                .classed('col3', showNotes)    // 25%
-                .classed('col4', !showNotes)   // 33%
                 .property('disabled', function(d) {
                     return d.id === 'add-note' ? !notesEditable() : !editable();
                 });

--- a/modules/ui/modes.js
+++ b/modules/ui/modes.js
@@ -133,6 +133,11 @@ export function uiModes(context) {
                 .attr('class', 'label')
                 .text(function(mode) { return mode.title; });
 
+            // if we are adding/removing the buttons, check if toolbar has overflowed
+            if (buttons.enter().size() || buttons.exit().size()) {
+                context.ui().checkOverflow('#bar', true);
+            }
+
             // update
             buttons = buttons
                 .merge(buttonsEnter)

--- a/modules/ui/photoviewer.js
+++ b/modules/ui/photoviewer.js
@@ -11,7 +11,7 @@ import { services } from '../services';
 
 export function uiPhotoviewer(context) {
 
-    var dispatch = d3_dispatch('photoviewerResize');
+    var dispatch = d3_dispatch('resize');
 
     function photoviewer(selection) {
         selection
@@ -30,7 +30,7 @@ export function uiPhotoviewer(context) {
             .attr('class', 'resize-handle-xy')
             .on(
                 'mousedown',
-                buildResizeListener(selection, 'photoviewerResize', dispatch, { resizeOnX: true, resizeOnY: true })
+                buildResizeListener(selection, 'resize', dispatch, { resizeOnX: true, resizeOnY: true })
             );
 
         selection
@@ -38,7 +38,7 @@ export function uiPhotoviewer(context) {
             .attr('class', 'resize-handle-x')
             .on(
                 'mousedown',
-                buildResizeListener(selection, 'photoviewerResize', dispatch, { resizeOnX: true })
+                buildResizeListener(selection, 'resize', dispatch, { resizeOnX: true })
             );
 
         selection
@@ -46,7 +46,7 @@ export function uiPhotoviewer(context) {
             .attr('class', 'resize-handle-y')
             .on(
                 'mousedown',
-                buildResizeListener(selection, 'photoviewerResize', dispatch, { resizeOnY: true })
+                buildResizeListener(selection, 'resize', dispatch, { resizeOnY: true })
             );
 
 
@@ -117,7 +117,7 @@ export function uiPhotoviewer(context) {
                 .style('width', setPhotoDimensions[0] + 'px')
                 .style('height', setPhotoDimensions[1] + 'px');
 
-            dispatch.call('photoviewerResize', photoviewer, setPhotoDimensions);
+            dispatch.call('resize', photoviewer, setPhotoDimensions);
         }
     };
 

--- a/modules/ui/save.js
+++ b/modules/ui/save.js
@@ -80,15 +80,15 @@ export function uiSave(context) {
 
         var button = selection
             .append('button')
-            .attr('class', 'save col12 disabled')
+            .attr('class', 'save disabled')
             .attr('tabindex', -1)
             .on('click', save)
             .call(tooltipBehavior);
 
         button
-            .append('div')
-            .attr('class', 'save-inner-wrap')
-            .call(svgIcon('#iD-icon-save', 'pre-text'))
+            .call(svgIcon('#iD-icon-save'));
+
+        button
             .append('span')
             .attr('class', 'label')
             .text(t('save.title'));

--- a/modules/ui/settings/custom_background.js
+++ b/modules/ui/settings/custom_background.js
@@ -41,12 +41,12 @@ export function uiSettingsCustomBackground(context) {
             .property('value', _currSettings.template);
 
 
-        // insert a cancel button, and adjust the button widths
+        // insert a cancel button
         var buttonSection = modal.select('.modal-section.buttons');
 
         buttonSection
             .insert('button', '.ok-button')
-            .attr('class', 'button col3 cancel-button secondary-action')
+            .attr('class', 'button cancel-button secondary-action')
             .text(t('confirm.cancel'));
 
 
@@ -54,8 +54,6 @@ export function uiSettingsCustomBackground(context) {
             .on('click.cancel', clickCancel);
 
         buttonSection.select('.ok-button')
-            .classed('col3', true)
-            .classed('col4', false)
             .attr('disabled', isSaveDisabled)
             .on('click.save', clickSave);
 

--- a/modules/ui/settings/custom_data.js
+++ b/modules/ui/settings/custom_data.js
@@ -70,12 +70,12 @@ export function uiSettingsCustomData(context) {
             .property('value', _currSettings.url);
 
 
-        // insert a cancel button, and adjust the button widths
+        // insert a cancel button
         var buttonSection = modal.select('.modal-section.buttons');
 
         buttonSection
             .insert('button', '.ok-button')
-            .attr('class', 'button col3 cancel-button secondary-action')
+            .attr('class', 'button cancel-button secondary-action')
             .text(t('confirm.cancel'));
 
 
@@ -83,8 +83,6 @@ export function uiSettingsCustomData(context) {
             .on('click.cancel', clickCancel);
 
         buttonSection.select('.ok-button')
-            .classed('col3', true)
-            .classed('col4', false)
             .attr('disabled', isSaveDisabled)
             .on('click.save', clickSave);
 

--- a/modules/ui/sidebar.js
+++ b/modules/ui/sidebar.js
@@ -165,10 +165,23 @@ export function uiSidebar(context) {
         sidebar.hover = _throttle(hover, 200);
 
 
+        sidebar.intersects = function(extent) {
+            var rect = selection.node().getBoundingClientRect();
+            return extent.intersects([
+                context.projection.invert([0, rect.height]),
+                context.projection.invert([rect.width, 0])
+            ]);
+        };
+
+
         sidebar.select = function(id, newFeature) {
             if (!_current && id) {
-                // uncollapse the sidebar to show the editor
-                sidebar.expand(true);
+                // uncollapse the sidebar
+                if (selection.classed('collapsed')) {
+                    var entity = context.entity(id);
+                    var extent = entity.extent(context.graph());
+                    sidebar.expand(sidebar.intersects(extent));
+                }
 
                 featureListWrap
                     .classed('inspector-hidden', true);
@@ -294,6 +307,7 @@ export function uiSidebar(context) {
 
     sidebar.hover = function() {};
     sidebar.hover.cancel = function() {};
+    sidebar.intersects = function() {};
     sidebar.select = function() {};
     sidebar.show = function() {};
     sidebar.hide = function() {};

--- a/modules/ui/sidebar.js
+++ b/modules/ui/sidebar.js
@@ -168,7 +168,7 @@ export function uiSidebar(context) {
         sidebar.select = function(id, newFeature) {
             if (!_current && id) {
                 // uncollapse the sidebar to show the editor
-                sidebar.expand();
+                sidebar.expand(true);
 
                 featureListWrap
                     .classed('inspector-hidden', true);
@@ -223,23 +223,23 @@ export function uiSidebar(context) {
         };
 
 
-        sidebar.expand = function() {
+        sidebar.expand = function(moveMap) {
             if (selection.classed('collapsed')) {
-                sidebar.toggle();
+                sidebar.toggle(moveMap);
             }
         };
 
 
-        sidebar.collapse = function() {
+        sidebar.collapse = function(moveMap) {
             if (!selection.classed('collapsed')) {
-                sidebar.toggle();
+                sidebar.toggle(moveMap);
             }
         };
 
 
-        sidebar.toggle = function() {
+        sidebar.toggle = function(moveMap) {
             var e = d3_event;
-            if (e.sourceEvent) {
+            if (e && e.sourceEvent) {
                 e.sourceEvent.preventDefault();
             } else if (e) {
                 e.preventDefault();
@@ -270,7 +270,7 @@ export function uiSidebar(context) {
                     return function(t) {
                         var dx = lastMargin - Math.round(i(t));
                         lastMargin = lastMargin - dx;
-                        context.ui().onResize([dx, 0]);
+                        context.ui().onResize(moveMap ? undefined : [dx, 0]);
                     };
                 })
                 .on('end', function() {

--- a/modules/ui/sidebar.js
+++ b/modules/ui/sidebar.js
@@ -223,8 +223,11 @@ export function uiSidebar(context) {
 
 
         sidebar.toggleCollapse = function(shouldCollapse) {
-            if (d3_event) {
-                d3_event.preventDefault();
+            var e = d3_event;
+            if (e.sourceEvent) {
+                e.sourceEvent.preventDefault();
+            } else if (e) {
+                e.preventDefault();
             }
 
             var container = d3_select('#id-container');

--- a/modules/ui/undo_redo.js
+++ b/modules/ui/undo_redo.js
@@ -48,7 +48,7 @@ export function uiUndoRedo(context) {
             .data(commands)
             .enter()
             .append('button')
-            .attr('class', function(d) { return 'col6 disabled ' + d.id + '-button'; })
+            .attr('class', function(d) { return 'disabled ' + d.id + '-button'; })
             .on('click', function(d) { return d.action(); })
             .call(tooltipBehavior);
 


### PR DESCRIPTION
closes #4356

- Makes the "Sidebar" toggle button permanent but removes the label
- Did some things to the "Save" button to make it the same width whether there
  is a count or not (prevents the buttons from jumping when pressing undo/redo)
- Removes a lot of the floated col rules that aren't used much anymore

![flexbox buttons](https://user-images.githubusercontent.com/38784/47892923-b1f1a400-de30-11e8-86a0-e0a706eba02c.gif)

I'd like to figure out collapsing away the labels and leaving only icons on very narrow screens.  
(I know I can use a media query for this)