### PR TITLE
Expanded undo messages for node-dragging scenarios

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -118,10 +118,18 @@ en:
       annotation: Removed a member from a relation.
     connect:
       annotation:
-        point: Connected a way to a point.
-        vertex: Connected a way to another.
-        line: Connected a way to a line.
-        area: Connected a way to an area.
+        from_vertex:
+          to_point: Connected a way to a point.
+          to_vertex: Connected a way to another.
+          to_line: Connected a way to a line.
+          to_area: Connected a way to an area.
+          to_adjacent_vertex: Merged adjacent points in a way.
+          to_sibling_vertex: Connected a way to itself.
+        from_point:
+          to_point: Merged a point with another.
+          to_vertex: Merged a point with a point in a way.
+          to_line: Moved a point to a line.
+          to_area: Moved a point to an area.
       relation: These features can't be connected because they have conflicting relation roles.
       restriction: "These features can't be connected because it would damage a \"{relation}\" relation."
     disconnect:

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -154,10 +154,20 @@
             },
             "connect": {
                 "annotation": {
-                    "point": "Connected a way to a point.",
-                    "vertex": "Connected a way to another.",
-                    "line": "Connected a way to a line.",
-                    "area": "Connected a way to an area."
+                    "from_vertex": {
+                        "to_point": "Connected a way to a point.",
+                        "to_vertex": "Connected a way to another.",
+                        "to_line": "Connected a way to a line.",
+                        "to_area": "Connected a way to an area.",
+                        "to_adjacent_vertex": "Merged adjacent points in a way.",
+                        "to_sibling_vertex": "Connected a way to itself."
+                    },
+                    "from_point": {
+                        "to_point": "Merged a point with another.",
+                        "to_vertex": "Merged a point with a point in a way.",
+                        "to_line": "Moved a point to a line.",
+                        "to_area": "Moved a point to an area."
+                    }
                 },
                 "relation": "These features can't be connected because they have conflicting relation roles.",
                 "restriction": "These features can't be connected because it would damage a \"{relation}\" relation."


### PR DESCRIPTION
Adds undo messages for connecting:
- Points to points, vertices, lines, and areas
- Vertices to sibling and adjacent vertices (nodes with the same parent way)

Closes #1252.