### PR TITLE
Adds a Wikidata field

### DIFF
--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -2025,6 +2025,9 @@ en:
       width:
         # width=*
         label: Width (Meters)
+      wikidata:
+        # wikidata=*
+        label: Wikidata
       wikipedia:
         # 'wikipedia=*, wikidata=*'
         label: Wikipedia

--- a/data/presets/fields.json
+++ b/data/presets/fields.json
@@ -342,6 +342,7 @@
     "wheelchair": {"key": "wheelchair", "type": "radio", "options": ["yes", "limited", "no"], "icon": "maki-wheelchair", "universal": true, "label": "Wheelchair Access"},
     "wholesale": {"key": "wholesale", "type": "typeCombo", "label": "Wholesale"},
     "width": {"key": "width", "type": "number", "minValue": 0, "label": "Width (Meters)"},
+    "wikidata": {"key": "wikidata", "type": "wikidata", "icon": "wikipedia", "universal": true, "label": "Wikidata"},
     "wikipedia": {"key": "wikipedia", "keys": ["wikipedia", "wikidata"], "type": "wikipedia", "icon": "wikipedia", "universal": true, "label": "Wikipedia"},
     "windings": {"key": "windings", "type": "number", "minValue": 1, "label": "Windings", "placeholder": "1, 2, 3..."},
     "windings/configuration": {"key": "windings:configuration", "type": "combo", "label": "Windings Configuration", "strings": {"options": {"star": "Star / Wye", "delta": "Delta", "open-delta": "Open Delta", "zigzag": "Zig Zag", "open": "Open", "scott": "Scott", "leblanc": "Leblanc"}}}

--- a/data/presets/fields/wikidata.json
+++ b/data/presets/fields/wikidata.json
@@ -1,0 +1,7 @@
+{
+    "key": "wikidata",
+    "type": "wikidata",
+    "icon": "wikipedia",
+    "universal": true,
+    "label": "Wikidata"
+}

--- a/data/presets/schema/field.json
+++ b/data/presets/schema/field.json
@@ -71,6 +71,7 @@
                 "text",
                 "typeCombo",
                 "url",
+                "wikidata",
                 "wikipedia"
             ],
             "required": true

--- a/data/taginfo.json
+++ b/data/taginfo.json
@@ -7863,8 +7863,8 @@
     {"key": "wheelchair", "description": "Wheelchair Access"},
     {"key": "wholesale", "description": "Wholesale"},
     {"key": "width", "description": "Width (Meters)"},
+    {"key": "wikidata", "description": "Wikidata, Wikipedia"},
     {"key": "wikipedia", "description": "Wikipedia"},
-    {"key": "wikidata", "description": "Wikipedia"},
     {"key": "windings", "description": "Windings"},
     {
       "key": "windings:configuration",

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -3155,6 +3155,9 @@
                 "width": {
                     "label": "Width (Meters)"
                 },
+                "wikidata": {
+                    "label": "Wikidata"
+                },
                 "wikipedia": {
                     "label": "Wikipedia"
                 },

--- a/modules/presets/index.js
+++ b/modules/presets/index.js
@@ -139,6 +139,10 @@ export function presetIndex() {
             });
         }
 
+        // move the wikidata field to directly follow the wikipedia field
+        _universal.splice(_universal.indexOf(_fields.wikidata), 1);
+        _universal.splice(_universal.indexOf(_fields.wikipedia)+1, 0, _fields.wikidata);
+
         if (d.presets) {
             _forEach(d.presets, function(d, id) {
                 all.collection.push(presetPreset(id, d, _fields));

--- a/modules/ui/fields/index.js
+++ b/modules/ui/fields/index.js
@@ -10,6 +10,7 @@ export * from './maxspeed';
 export * from './radio';
 export * from './restrictions';
 export * from './textarea';
+export * from './wikidata';
 export * from './wikipedia';
 
 import {
@@ -47,6 +48,7 @@ import { uiFieldLocalized } from './localized';
 import { uiFieldMaxspeed } from './maxspeed';
 import { uiFieldRestrictions } from './restrictions';
 import { uiFieldTextarea } from './textarea';
+import { uiFieldWikidata } from './wikidata';
 import { uiFieldWikipedia } from './wikipedia';
 
 export var uiFields = {
@@ -73,5 +75,6 @@ export var uiFields = {
     textarea: uiFieldTextarea,
     typeCombo: uiFieldTypeCombo,
     url: uiFieldUrl,
+    wikidata: uiFieldWikidata,
     wikipedia: uiFieldWikipedia
 };

--- a/modules/ui/fields/wikidata.js
+++ b/modules/ui/fields/wikidata.js
@@ -1,0 +1,106 @@
+import { dispatch as d3_dispatch } from 'd3-dispatch';
+
+import {
+    select as d3_select,
+    event as d3_event
+} from 'd3-selection';
+
+import { svgIcon } from '../../svg/index';
+import {
+    utilGetSetValue,
+    utilNoAuto,
+    utilRebind
+} from '../../util';
+
+
+export function uiFieldWikidata(field) {
+    var dispatch = d3_dispatch('change'),
+        link = d3_select(null),
+        title = d3_select(null),
+        wikiURL = '',
+        entity;
+
+
+    function wiki(selection) {
+
+        title = selection.selectAll('input.wiki-title')
+            .data([0]);
+
+        title = title.enter()
+            .append('input')
+            .attr('type', 'text')
+            .attr('class', 'wiki-title')
+            .attr('id', 'preset-input-' + field.safeid)
+            .call(utilNoAuto)
+            .merge(title);
+
+        title
+            .on('blur', blur)
+            .on('change', change);
+
+
+        link = selection.selectAll('.wiki-link')
+            .data([0]);
+
+        link = link.enter()
+            .append('button')
+            .attr('class', 'button-input-action wiki-link minor')
+            .attr('tabindex', -1)
+            .call(svgIcon('#iD-icon-out-link'))
+            .merge(link);
+
+        link
+            .on('click', function() {
+                d3_event.preventDefault();
+                if (wikiURL) window.open(wikiURL, '_blank');
+            });
+    }
+
+
+    function blur() {
+        change();
+    }
+
+
+    function change() {
+        var syncTags = {
+            wikidata: utilGetSetValue(title)
+        };
+        dispatch.call('change', this, syncTags);
+    }
+
+
+    wiki.tags = function(tags) {
+        var value = tags[field.key] || '',
+            matches = value.match(/^Q[0-9]*$/);
+
+        utilGetSetValue(title, value);
+
+        // value in correct format
+        if (matches) {
+            wikiURL = 'https://wikidata.org/wiki/' + value;
+        // unrecognized value format
+        } else {
+            if (value && value !== '') {
+                wikiURL = 'https://wikidata.org/wiki/Special:Search?search=' + value;
+            } else {
+                wikiURL = '';
+            }
+        }
+    };
+
+
+    wiki.entity = function(_) {
+        if (!arguments.length) return entity;
+        entity = _;
+        return wiki;
+    };
+
+
+    wiki.focus = function() {
+        title.node().focus();
+    };
+
+
+    return utilRebind(wiki, dispatch, 'on');
+}


### PR DESCRIPTION
This is a first step toward #4382, though it doesn't fulfill that issue's specific task. It adds a field for editing the `wikidata` tag and includes a button linking to the item's page on https://wikidata.org.

While casual mappers are unlikely to add Wikidata IDs separate from Wikipedia pages, this field is useful since it shows users if a value is present and lets them quickly open the Wikidata page. Having this as a separate field makes for a simpler interface, especially should more functionality be added to either field in the future (such as loading Wikidata values right in iD).

To maintain a sensible order, the Wikidata field is made to directly follow the Wikipedia field if both are present.

<img width="369" alt="screen shot 2018-11-18 at 7 31 44 pm" src="https://user-images.githubusercontent.com/2046746/48680437-9513db00-eb69-11e8-999d-895f9a51dc3a.png">