### PR TITLE
Redraw restrictions panel when dragging sidebar

### DIFF
--- a/modules/ui/fields/restrictions.js
+++ b/modules/ui/fields/restrictions.js
@@ -66,6 +66,8 @@ export function uiFieldRestrictions(field, context) {
     var _intersection;
     var _fromWayID;
 
+    var _redrawHandler;
+
 
     function restrictions(selection) {
         _parent = selection;
@@ -301,6 +303,14 @@ export function uiFieldRestrictions(field, context) {
                 });
         }
 
+        if (!_redrawHandler) {
+            _redrawHandler = setInterval(function() {
+                if (d3_select('#sidebar-resizer').classed('dragging')) {
+                    utilSetDimensions(_container, null);
+                    redraw();
+                }
+            }, 50);
+        }
 
         // This can happen if we've lowered the detail while a FROM way
         // is selected, and that way is no longer part of the intersection.
@@ -661,6 +671,8 @@ export function uiFieldRestrictions(field, context) {
 
         d3_select(window)
             .on('resize.restrictions', null);
+
+        clearInterval(_redrawHandler);
     };
 
 

--- a/modules/ui/fields/restrictions.js
+++ b/modules/ui/fields/restrictions.js
@@ -295,21 +295,6 @@ export function uiFieldRestrictions(field, context) {
 
             surface
                 .call(breathe);
-
-            d3_select(window)
-                .on('resize.restrictions', function() {
-                    utilSetDimensions(_container, null);
-                    redraw();
-                });
-        }
-
-        if (!_redrawHandler) {
-            _redrawHandler = setInterval(function() {
-                if (d3_select('#sidebar-resizer').classed('dragging')) {
-                    utilSetDimensions(_container, null);
-                    redraw();
-                }
-            }, 50);
         }
 
         // This can happen if we've lowered the detail while a FROM way
@@ -344,6 +329,11 @@ export function uiFieldRestrictions(field, context) {
                 .classed('selected', true)
                 .classed('related', true);
         }
+
+        document.addEventListener('resizeWindow', function (e) {
+            utilSetDimensions(_container, null);
+            redraw();
+        }, false);
 
         updateHints(null);
 

--- a/modules/ui/fields/restrictions.js
+++ b/modules/ui/fields/restrictions.js
@@ -332,7 +332,7 @@ export function uiFieldRestrictions(field, context) {
 
         document.addEventListener('resizeWindow', function () {
             utilSetDimensions(_container, null);
-            redraw(2);
+            redraw(1);
         }, false);
 
         updateHints(null);

--- a/modules/ui/fields/restrictions.js
+++ b/modules/ui/fields/restrictions.js
@@ -332,7 +332,7 @@ export function uiFieldRestrictions(field, context) {
 
         document.addEventListener('resizeWindow', function () {
             utilSetDimensions(_container, null);
-            redraw(10);
+            redraw(2);
         }, false);
 
         updateHints(null);

--- a/modules/ui/fields/restrictions.js
+++ b/modules/ui/fields/restrictions.js
@@ -66,7 +66,7 @@ export function uiFieldRestrictions(field, context) {
     var _intersection;
     var _fromWayID;
 
-    var _redrawHandler;
+    var _lastXPos;
 
 
     function restrictions(selection) {
@@ -330,9 +330,9 @@ export function uiFieldRestrictions(field, context) {
                 .classed('related', true);
         }
 
-        document.addEventListener('resizeWindow', function (e) {
+        document.addEventListener('resizeWindow', function () {
             utilSetDimensions(_container, null);
-            redraw();
+            redraw(10);
         }, false);
 
         updateHints(null);
@@ -435,10 +435,20 @@ export function uiFieldRestrictions(field, context) {
             updateHints(datum);
         }
 
+        _lastXPos = _lastXPos || sdims[0];
 
-        function redraw() {
-            if (context.hasEntity(_vertexID)) {
-                _container.call(renderViewer);
+        function redraw(minChange) {
+            var xPos = -1;
+
+            if (minChange) {
+                xPos = utilGetDimensions(d3_select('#sidebar'))[0];
+            }
+
+            if (!minChange || (minChange && Math.abs(xPos - _lastXPos) >= minChange)) {
+                if (context.hasEntity(_vertexID)) {
+                    _lastXPos = xPos;
+                    _container.call(renderViewer);
+                }
             }
         }
 
@@ -661,8 +671,6 @@ export function uiFieldRestrictions(field, context) {
 
         d3_select(window)
             .on('resize.restrictions', null);
-
-        clearInterval(_redrawHandler);
     };
 
 

--- a/modules/ui/init.js
+++ b/modules/ui/init.js
@@ -411,6 +411,13 @@ export function uiInit(context) {
         // check if header or footer have overflowed
         ui.checkOverflow('#bar');
         ui.checkOverflow('#footer');
+
+        // Use older code so it works on Explorer
+        var resizeWindowEvent = document.createEvent('Event');
+
+        resizeWindowEvent.initEvent('resizeWindow', true, true);
+
+        document.dispatchEvent(resizeWindowEvent);
     };
 
 

--- a/modules/ui/init.js
+++ b/modules/ui/init.js
@@ -412,7 +412,7 @@ export function uiInit(context) {
         ui.checkOverflow('#bar');
         ui.checkOverflow('#footer');
 
-        // Use older code so it works on Explorer
+        // Use outdated code so it works on Explorer
         var resizeWindowEvent = document.createEvent('Event');
 
         resizeWindowEvent.initEvent('resizeWindow', true, true);

--- a/modules/ui/sidebar.js
+++ b/modules/ui/sidebar.js
@@ -62,6 +62,8 @@ export function uiSidebar(context) {
                 selection
                     .style('width', widthPct + '%')    // lock in current width
                     .style('max-width', '85%');        // but allow larger widths
+
+                resizer.classed('dragging', true);
             })
             .on('drag', function() {
                 var isRTL = (textDirection === 'rtl');
@@ -96,6 +98,9 @@ export function uiSidebar(context) {
                         context.ui().onResize([-d3_event.dx, 0]);
                     }
                 }
+            })
+            .on('end', function() {
+                resizer.classed('dragging', false);
             })
         );
 


### PR DESCRIPTION
Fixes #5474 

I've put together a bit of a hacky fix for the restrictions editor not scaling properly with the sidebar being dragged.

Ideally, I'd call the `redraw()` method direction from the sidebar's drag handler, but can't figure out a way to get access to it efficiently, so instead I just add a `dragging` class when the drag starts and remove it when it stops.

The restrictions.js file then just sets a `setInterval` that checks whether the `dragged` class is present or not, and then redraws the panel every 50ms if it is.

The redraw interval can be changed easily enough (is 50ms too frequent?), but when dragging, the street graphics are chopped off so close to the border of the svg, that when dragging, the chopped-off street edge is still visible for a few ms until the panel redraws.

The only way I can think of getting around that is to render the junction so that the streets are initially drawn much further out past the svg border, meaning when the svg resizes, there is much more 'buffer' space before the street-end is reached. (if that makes sense?)