### PR TITLE
Add rendering for attraction=water_slide

### DIFF
--- a/css/50_misc.css
+++ b/css/50_misc.css
@@ -373,3 +373,27 @@ path.stroke.tag-attraction-summer_toboggan {
 path.casing.tag-attraction-summer_toboggan {
     stroke: #666;
 }
+path.shadow.tag-attraction-water_slide {
+	stroke-width: 16;
+}
+path.casing.tag-attraction-water_slide {
+	stroke-width: 7;
+}
+path.stroke.tag-attraction-water_slide {
+	stroke-width: 5;
+}
+.low-zoom path.shadow.tag-attraction-water_slide {
+    stroke-width: 12;
+}
+.low-zoom path.casing.tag-attraction-water_slide {
+    stroke-width: 5;
+}
+.low-zoom path.stroke.tag-attraction-water_slide {
+	stroke-width: 3;
+}
+path.stroke.tag-attraction-water_slide {
+    stroke: #aae0cb;
+}
+path.casing.tag-attraction-water_slide {
+    stroke: #3d6c71;
+}

--- a/css/50_misc.css
+++ b/css/50_misc.css
@@ -349,22 +349,28 @@ path.stroke.tag-crossing.tag-crossing-zebra {
 }
 
 /* Attractions */
-path.shadow.tag-attraction-summer_toboggan {
+path.shadow.tag-attraction-summer_toboggan,
+path.shadow.tag-attraction-water_slide {
 	stroke-width: 16;
 }
-path.casing.tag-attraction-summer_toboggan {
+path.casing.tag-attraction-summer_toboggan,
+path.casing.tag-attraction-water_slide {
 	stroke-width: 7;
 }
-path.stroke.tag-attraction-summer_toboggan {
+path.stroke.tag-attraction-summer_toboggan,
+path.stroke.tag-attraction-water_slide {
 	stroke-width: 5;
 }
-.low-zoom path.shadow.tag-attraction-summer_toboggan {
+.low-zoom path.shadow.tag-attraction-summer_toboggan,
+.low-zoom path.shadow.tag-attraction-water_slide {
     stroke-width: 12;
 }
-.low-zoom path.casing.tag-attraction-summer_toboggan {
+.low-zoom path.casing.tag-attraction-summer_toboggan,
+.low-zoom path.casing.tag-attraction-water_slide {
     stroke-width: 5;
 }
-.low-zoom path.stroke.tag-attraction-summer_toboggan {
+.low-zoom path.stroke.tag-attraction-summer_toboggan,
+.low-zoom path.stroke.tag-attraction-water_slide {
 	stroke-width: 3;
 }
 path.stroke.tag-attraction-summer_toboggan {
@@ -373,24 +379,7 @@ path.stroke.tag-attraction-summer_toboggan {
 path.casing.tag-attraction-summer_toboggan {
     stroke: #666;
 }
-path.shadow.tag-attraction-water_slide {
-	stroke-width: 16;
-}
-path.casing.tag-attraction-water_slide {
-	stroke-width: 7;
-}
-path.stroke.tag-attraction-water_slide {
-	stroke-width: 5;
-}
-.low-zoom path.shadow.tag-attraction-water_slide {
-    stroke-width: 12;
-}
-.low-zoom path.casing.tag-attraction-water_slide {
-    stroke-width: 5;
-}
-.low-zoom path.stroke.tag-attraction-water_slide {
-	stroke-width: 3;
-}
+
 path.stroke.tag-attraction-water_slide {
     stroke: #aae0cb;
 }


### PR DESCRIPTION
This PR adds special rendering for attraction=water_slide. I've used the color for the water slide stroke from OpenStreetMap Carto and it looks like this:
![water slide rendering](https://user-images.githubusercontent.com/31667811/48970497-2624ff00-f00d-11e8-83b5-0bbaf177b6df.png)