### PR TITLE
Adds a preset for Flush Curb

### DIFF
--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -3118,6 +3118,11 @@ en:
         # barrier=kerb
         name: Curb
         terms: '<translate with synonyms or related terms for ''Curb'', separated by commas>'
+      barrier/kerb/flush:
+        # 'barrier=kerb, kerb=flush'
+        name: Flush Curb
+        # 'terms: even curb,level curb,tactile curb'
+        terms: '<translate with synonyms or related terms for ''Flush Curb'', separated by commas>'
       barrier/kerb/lowered:
         # 'barrier=kerb, kerb=lowered'
         name: Lowered Curb

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -239,6 +239,7 @@
     "barrier/guard_rail": {"icon": "maki-barrier", "geometry": ["line"], "tags": {"barrier": "guard_rail"}, "name": "Guard Rail", "terms": ["guardrail", "traffic barrier", "crash barrier", "median barrier", "roadside barrier", "Armco barrier"], "matchScore": 0.75},
     "barrier/hedge": {"fields": ["height"], "geometry": ["line", "area"], "tags": {"barrier": "hedge"}, "name": "Hedge", "matchScore": 0.25},
     "barrier/kerb": {"icon": "maki-wheelchair", "fields": ["kerb", "tactile_paving"], "geometry": ["vertex", "line"], "tags": {"barrier": "kerb"}, "name": "Curb"},
+    "barrier/kerb/flush": {"icon": "maki-wheelchair", "fields": ["kerb", "tactile_paving"], "geometry": ["vertex", "line"], "tags": {"barrier": "kerb", "kerb": "flush"}, "reference": {"key": "kerb", "value": "flush"}, "terms": ["even curb", "level curb", "tactile curb"], "name": "Flush Curb"},
     "barrier/kerb/lowered": {"icon": "maki-wheelchair", "fields": ["kerb", "tactile_paving"], "geometry": ["vertex", "line"], "tags": {"barrier": "kerb", "kerb": "lowered"}, "reference": {"key": "kerb", "value": "lowered"}, "terms": ["curb cut", "curb ramp", "kerb ramp", "dropped kerb", "pram ramp"], "name": "Lowered Curb"},
     "barrier/kissing_gate": {"icon": "maki-barrier", "fields": ["access"], "geometry": ["vertex"], "tags": {"barrier": "kissing_gate"}, "name": "Kissing Gate"},
     "barrier/lift_gate": {"icon": "maki-roadblock", "fields": ["access"], "geometry": ["vertex", "line"], "tags": {"barrier": "lift_gate"}, "name": "Lift Gate"},

--- a/data/presets/presets/barrier/kerb/flush.json
+++ b/data/presets/presets/barrier/kerb/flush.json
@@ -1,0 +1,25 @@
+{
+    "icon": "maki-wheelchair",
+    "fields": [
+        "kerb",
+        "tactile_paving"
+    ],
+    "geometry": [
+        "vertex",
+        "line"
+    ],
+    "tags": {
+        "barrier": "kerb",
+        "kerb": "flush"
+    },
+    "reference": {
+        "key": "kerb",
+        "value": "flush"
+    },
+    "terms": [
+        "even curb",
+        "level curb",
+        "tactile curb"
+    ],
+    "name": "Flush Curb"
+}

--- a/data/taginfo.json
+++ b/data/taginfo.json
@@ -1626,6 +1626,13 @@
     },
     {
       "key": "kerb",
+      "value": "flush",
+      "description": "Flush Curb",
+      "object_types": ["node", "way"],
+      "icon_url": "https://raw.githubusercontent.com/mapbox/maki/master/icons/wheelchair-15.svg?sanitize=true"
+    },
+    {
+      "key": "kerb",
       "value": "lowered",
       "description": "Lowered Curb",
       "object_types": ["node", "way"],

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -4135,6 +4135,10 @@
                     "name": "Curb",
                     "terms": ""
                 },
+                "barrier/kerb/flush": {
+                    "name": "Flush Curb",
+                    "terms": "even curb,level curb,tactile curb"
+                },
                 "barrier/kerb/lowered": {
                     "name": "Lowered Curb",
                     "terms": "curb cut,curb ramp,kerb ramp,dropped kerb,pram ramp"


### PR DESCRIPTION
Matches features with `barrier=kerb` and `kerb=flush`. This complements the Lowered Curb preset and will make accessible footway mapping faster. See https://wiki.openstreetmap.org/wiki/Key:kerb