### PR TITLE
Fixes an issue where the walkthrough would not display and cause an error

### DIFF
--- a/modules/ui/intro/intro.js
+++ b/modules/ui/intro/intro.js
@@ -98,7 +98,10 @@ export function uiIntro(context) {
         // Setup data layers (only OSM)
         var layers = context.layers();
         layers.all().forEach(function(item) {
-            item.layer.enabled(item.id === 'osm');
+            // if the layer has the function `enabled`
+            if (typeof item.layer.enabled == 'function') {
+                item.layer.enabled(item.id === 'osm');
+            }
         });
 
         // Mock geocoder

--- a/modules/ui/intro/intro.js
+++ b/modules/ui/intro/intro.js
@@ -99,7 +99,7 @@ export function uiIntro(context) {
         var layers = context.layers();
         layers.all().forEach(function(item) {
             // if the layer has the function `enabled`
-            if (typeof item.layer.enabled == 'function') {
+            if (typeof item.layer.enabled === 'function') {
                 item.layer.enabled(item.id === 'osm');
             }
         });


### PR DESCRIPTION
Fixes #5553.

The crash was due to the `touch` layer not having an `enabled` function. Since we always want the touch layer enabled, I just added a check to make sure the `enabled` function exists before calling it.