### PR TITLE
fix autocomplete combobox bug

### DIFF
--- a/modules/ui/combobox.js
+++ b/modules/ui/combobox.js
@@ -341,7 +341,7 @@ export function uiCombobox(context, klass) {
         // Dispatches an 'accept' event if an option has been chosen.
         // Then hides the combobox.
         function accept(d) {
-            d = d || _choice;
+            d = d || _choice || value();
             if (d) {
                 utilGetSetValue(input, d.value);
                 utilTriggerEvent(input, 'change');


### PR DESCRIPTION
closes #5618

I reproduced by adding a part, and in raw tag editor and `ca` as value for key `natural`.
Now, it should accept that input rather than setting it to `cave_entrance` or removing the input entirely...