### PR TITLE
Allow locale and language being set via URL param

### DIFF
--- a/modules/util/detect.js
+++ b/modules/util/detect.js
@@ -59,24 +59,31 @@ export function utilDetect(force) {
     // Added due to incomplete svg style support. See #715
     detected.opera = (detected.browser.toLowerCase() === 'opera' && parseFloat(detected.version) < 15 );
 
-    detected.locale = (navigator.language || navigator.userLanguage || 'en-US');
-    detected.language = detected.locale.split('-')[0];
+    // Set locale based on url param (format 'en-US') or browser lang (default)
+    var q = utilStringQs(window.location.hash.substring(1));
+    if (q.hasOwnProperty('locale')) {
+        detected.locale = q.locale;
+        detected.language = q.locale.split('-')[0];
+    } else {
+        detected.locale = (navigator.language || navigator.userLanguage || 'en-US');
+        detected.language = detected.locale.split('-')[0];
 
-    // Search `navigator.languages` for a better locale.. Prefer the first language,
-    // unless the second language is a culture-specific version of the first one, see #3842
-    if (navigator.languages && navigator.languages.length > 0) {
-        var code0 = navigator.languages[0],
-            parts0 = code0.split('-');
+        // Search `navigator.languages` for a better locale. Prefer the first language,
+        // unless the second language is a culture-specific version of the first one, see #3842
+        if (navigator.languages && navigator.languages.length > 0) {
+            var code0 = navigator.languages[0],
+                parts0 = code0.split('-');
 
-        detected.locale = code0;
-        detected.language = parts0[0];
+            detected.locale = code0;
+            detected.language = parts0[0];
 
-        if (navigator.languages.length > 1 && parts0.length === 1) {
-            var code1 = navigator.languages[1],
-                parts1 = code1.split('-');
+            if (navigator.languages.length > 1 && parts0.length === 1) {
+                var code1 = navigator.languages[1],
+                    parts1 = code1.split('-');
 
-            if (parts1[0] === parts0[0]) {
-                detected.locale = code1;
+                if (parts1[0] === parts0[0]) {
+                    detected.locale = code1;
+                }
             }
         }
     }

--- a/modules/util/detect.js
+++ b/modules/util/detect.js
@@ -9,7 +9,8 @@ export function utilDetect(force) {
     detected = {};
 
     var ua = navigator.userAgent,
-        m = null;
+        m = null,
+        q = utilStringQs(window.location.hash.substring(1));
 
     m = ua.match(/(edge)\/?\s*(\.?\d+(\.\d+)*)/i);   // Edge
     if (m !== null) {
@@ -60,7 +61,6 @@ export function utilDetect(force) {
     detected.opera = (detected.browser.toLowerCase() === 'opera' && parseFloat(detected.version) < 15 );
 
     // Set locale based on url param (format 'en-US') or browser lang (default)
-    var q = utilStringQs(window.location.hash.substring(1));
     if (q.hasOwnProperty('locale')) {
         detected.locale = q.locale;
         detected.language = q.locale.split('-')[0];
@@ -97,7 +97,6 @@ export function utilDetect(force) {
     }
 
     // detect text direction
-    var q = utilStringQs(window.location.hash.substring(1));
     var lang = dataLocales[detected.locale];
     if ((lang && lang.rtl) || (q.rtl === 'true')) {
         detected.textDirection = 'rtl';


### PR DESCRIPTION
With the hash-url `locale=en-US` or `locale=de-DE` one can force a locale and language regardless of the given language from the osm-website-settings.

This is to solve https://github.com/openstreetmap/iD/issues/5644.

However, while looking into this I understood that the interface language is in fact pulled from the OSM-website-profile-language (not the browser language). So there is a way to change the language, by editing the preferred languages in the profile.

So while this PR makes changing the language a bit easier and quicker, I am not sure if it is worth the added complexity.

In case this should be continued, those thinks are todo IMO:
- [x] This line https://github.com/openstreetmap/iD/blob/master/modules/util/detect.js#L93 is duplicated now, should it be removed?
- [x] Should there be specs for this? If so, I don't know enough about specs to write good ones.
