### PR TITLE
Capitalize first letter of KeepRight error detail

### DIFF
--- a/modules/ui/keepRight_details.js
+++ b/modules/ui/keepRight_details.js
@@ -18,13 +18,15 @@ export function uiKeepRightDetails(context) {
         var et = dataEn.QA.keepRight.errorTypes[errorType];
         var pt = dataEn.QA.keepRight.errorTypes[parentErrorType];
 
+        var detail;
         if (et && et.description) {
-            return t('QA.keepRight.errorTypes.' + errorType + '.description', d.replacements);
+            detail = t('QA.keepRight.errorTypes.' + errorType + '.description', d.replacements);
         } else if (pt && pt.description) {
-            return t('QA.keepRight.errorTypes.' + parentErrorType + '.description', d.replacements);
+            detail = t('QA.keepRight.errorTypes.' + parentErrorType + '.description', d.replacements);
         } else {
-            return unknown;
+            detail = unknown;
         }
+        return detail.substr(0, 1).toUpperCase() + detail.substr(1);
     }
 
 


### PR DESCRIPTION
Capitalize the first letter of the KeepRight error detail, specifically for detail strings that could begin with a placeholder string. For example, in Vietnamese, the following strings begin with a placeholder string denoting a type of element:

* `QA.keepRight.errorTypes.<60>.description`
* `QA.keepRight.errorTypes.<70>.description`
* `QA.keepRight.errorTypes.<74>.description`
* `QA.keepRight.errorTypes.<75>.description`
* `QA.keepRight.errorTypes.<100>.description`
* `QA.keepRight.errorTypes.<190>.description`
* `QA.keepRight.errorTypes.<200>.description`
* `QA.keepRight.errorTypes.<220>.description`
* `QA.keepRight.errorTypes.<221>.description`
* `QA.keepRight.errorTypes.<232>.description`

But the same placeholder string can be inserted mid-sentence into `QA.keepRight.errorTypes.<360>.description`. It’s conceivable that other languages may need this capitalization for different strings, perhaps `QA.keepRight.errorTypes.<283>.description` and the like.

Capitalizing the first word of the sentence should be safe from a localization standpoint and can be considered a good practice when cobbling together a sentence from multiple strings. I’m only aware of lojban as a language that would insist on beginning the sentence with a lowercase Latin letter. Note that `QA.keepRight.errorTypes.<170>.description` is the raw value of `FIXME`, which would generally look more polished with a capitalized first letter anyways.