### PR TITLE
fix for first part of #5687

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -847,6 +847,10 @@ a.hide-toggle {
     border-radius: 2px;
 }
 
+[dir='rtl'] .geocode-item {
+    left: -25%;
+}
+
 .geocode-item:hover {
     background-color: #aaa;
 }


### PR DESCRIPTION
This will center `.geocode-item` in rtl mode.