### PR TITLE
Nicify grid for save area of notes and keepright.

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -2561,7 +2561,9 @@ input.key-trap {
 }
 
 .note-save,
-.keepRight-save,
+.keepRight-save {
+    padding-top: 20px;
+}
 .kr_error-details,
 .kr_error-comment-container {
     padding: 10px;


### PR DESCRIPTION
([A place with note and keepright nearby to test it](http://preview.ideditor.com/master/#background=DigitalGlobe-Premium&disable_features=boundaries&locale=en-US&map=18.02/52.50705/13.43147).)

For keepright I feel like the grid is off.
For notes its the same but less visible due to the comments area.

IMO the save are should be part of the outer "box", so no padding left and right, to fit in the information hierarchy.

keepright before
<img width="405" alt="keepright-before" src="https://user-images.githubusercontent.com/111561/51031006-82cb8180-159b-11e9-8cbb-6f451ff00ccf.png">

keepright after 
<img width="406" alt="keepright-after" src="https://user-images.githubusercontent.com/111561/51031013-86f79f00-159b-11e9-928b-20ee9c41fb0e.png">

note before
<img width="403" alt="notes-before" src="https://user-images.githubusercontent.com/111561/51030995-76dfbf80-159b-11e9-9c74-f421c25cba4f.png">

notes after
<img width="403" alt="notes-after" src="https://user-images.githubusercontent.com/111561/51031001-7cd5a080-159b-11e9-905b-fe9da151b702.png">

ps: I did not run this locally, just edited the one file in github, so probably some steps to take …