### PR TITLE
Presets: Add alias of "real estate" for estate agent

### DIFF
--- a/data/presets/presets/office/estate_agent.json
+++ b/data/presets/presets/office/estate_agent.json
@@ -7,6 +7,6 @@
     "tags": {
         "office": "estate_agent"
     },
-    "terms": [],
+    "terms": ["real estate"],
     "name": "Real Estate Office"
 }


### PR DESCRIPTION
Current behaviour:
![image](https://user-images.githubusercontent.com/365751/51296677-18b84e00-1a6d-11e9-9c5a-214ad55215cd.png)
