### PR TITLE
Replace wkid/w/s/n/e in WMS URL templates

### DIFF
--- a/modules/renderer/background_source.js
+++ b/modules/renderer/background_source.js
@@ -124,13 +124,33 @@ export function rendererBackgroundSource(data) {
                 }
             }).bind(this);
 
+            var tileSize = this.tileSize;
+            var projection = this.projection;
             var minXmaxY = tileToProjectedCoords(coord[0], coord[1], coord[2]);
             var maxXminY = tileToProjectedCoords(coord[0]+1, coord[1]+1, coord[2]);
-            return template
-                .replace('{width}', this.tileSize)
-                .replace('{height}', this.tileSize)
-                .replace('{proj}', this.projection)
-                .replace('{bbox}', minXmaxY.x + ',' + maxXminY.y + ',' + maxXminY.x + ',' + minXmaxY.y);
+            return template.replace(/\{(\w+)\}/g, function (token, key) {
+              switch (key) {
+                case 'width':
+                case 'height':
+                  return tileSize;
+                case 'proj':
+                  return projection;
+                case 'wkid':
+                  return projection.replace(/^EPSG:/, '');
+                case 'bbox':
+                  return minXmaxY.x + ',' + maxXminY.y + ',' + maxXminY.x + ',' + minXmaxY.y;
+                case 'w':
+                  return minXmaxY.x;
+                case 's':
+                  return maxXminY.y;
+                case 'n':
+                  return maxXminY.x;
+                case 'e':
+                  return minXmaxY.y;
+                default:
+                  return token;
+              }
+            });
         }
         return template
             .replace('{x}', coord[0])

--- a/test/spec/renderer/background_source.js
+++ b/test/spec/renderer/background_source.js
@@ -16,11 +16,13 @@ describe('iD.rendererBackgroundSource', function() {
         var source = iD.rendererBackgroundSource({
             type: 'wms',
             projection: 'EPSG:3857',
-            template: 'SRS={proj}&FORMAT=image/jpeg&WIDTH={width}&HEIGHT={height}&BBOX={bbox}'
+            template: 'SRS={proj}&imageSR={wkid}&bboxSR={wkid}&FORMAT=image/jpeg&WIDTH={width}&HEIGHT={height}&BBOX={bbox}'
         });
 
         var result = iD.utilStringQs(source.url([0,1,2]));
         expect(result.SRS).to.equal('EPSG:3857');
+        expect(result.imageSR).to.equal('3857');
+        expect(result.bboxSR).to.equal('3857');
         expect(result.FORMAT).to.equal('image/jpeg');
         expect(result.WIDTH).to.equal('256');
         expect(result.HEIGHT).to.equal('256');


### PR DESCRIPTION
Added support for `{wkid}`, `{w}`, `{s}`, `{n}`, and `{e}` tokens in WMS-style background imagery templates, as described in [this JOSM documentation](https://josm.openstreetmap.de/wiki/Maps#WebMapServicesWMS).

The `{wkid}` token is particularly handy for `exportImage` endpoints in ArcGIS ImageServer services. (In fact, it appears multiple times, whereas the previous code only replaced each token once.) Currently, osmlab/editor-layer-index#611 works around the lack of this token by hard-coding a projection, but JOSM can use the `projection` property correctly: https://github.com/osmlab/editor-layer-index/commit/95680b2a3b9f468748365deb37943c7f1f871955#r31964799. Once this PR lands, we can modify the editor layer index’s tests to accept `{wkid}` as an alternative to `{proj}`.

Thanks to @don-vip for making me aware of these additional tokens.