### PR TITLE
Update .gitattributes to use lf eol for .js files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 * text=auto
 *.bat eol=crlf
+*.js eol=lf


### PR DESCRIPTION
Running "npm test" currently spews out many eol errors if you don't have git configured not to convert line endings to crlf.

As I understand it this change should override that (see: https://help.github.com/articles/dealing-with-line-endings/).