### PR TITLE
Fix street imagery hover and selection behaviour

### DIFF
--- a/css/60_photos.css
+++ b/css/60_photos.css
@@ -101,7 +101,7 @@
     cursor: pointer;
 }
 
-.viewfield-group.selected * {
+.viewfield-group.currentView * {
     fill: #ffee00 !important;
 }
 .viewfield-group.hovered * {
@@ -125,7 +125,7 @@
     stroke-opacity: 0.9;
     fill-opacity: 0.9;
 }
-.viewfield-group.highlighted.selected circle {
+.viewfield-group.highlighted.currentView circle {
     stroke: #222;
     stroke-width: 2;
     stroke-opacity: 1;
@@ -145,12 +145,12 @@
     stroke-width: 1;
     fill-opacity: 0.8;
 }
-.viewfield-group.highlighted.selected .viewfield {
+.viewfield-group.highlighted.currentView .viewfield {
     stroke-width: 1;
     fill-opacity: 0.9;
 }
 
-.viewfield-group.selected .viewfield-scale {
+.viewfield-group.currentView .viewfield-scale {
     transform: scale(2,2);
 }
 
@@ -160,7 +160,7 @@
     stroke-opacity: 0.4;
 }
 .sequence.highlighted,
-.sequence.selected {
+.sequence.currentView {
     stroke-width: 4;
     stroke-opacity: 1;
 }
@@ -204,7 +204,7 @@
     outline: 5px solid #eebb00;
     background-color: #eebb00;
 }
-.layer-mapillary-signs .icon-sign.selected {
+.layer-mapillary-signs .icon-sign.currentView {
     outline: 5px solid #ffee00;
     background-color: #ffee00;
 }

--- a/modules/services/mapillary.js
+++ b/modules/services/mapillary.js
@@ -556,6 +556,9 @@ export default {
     },
 
 
+    // Updates the currently highlighted sequence and selected bubble.
+    // Reset is only necessary when interacting with the viewport because
+    // this implicitly changes the currently selected bubble/sequence
     setStyles: function(hovered, reset) {
         if (reset) {  // reset all layers
             d3_selectAll('.viewfield-group')

--- a/modules/services/mapillary.js
+++ b/modules/services/mapillary.js
@@ -410,7 +410,7 @@ export default {
             .classed('hide', true);
 
         d3_selectAll('.viewfield-group, .sequence, .icon-sign')
-            .classed('selected', false);
+            .classed('currentView', false);
 
         return this.setStyles(null, true);
     },
@@ -531,7 +531,7 @@ export default {
 
         // if signs signs are shown, highlight the ones that appear in this image
         d3_selectAll('.layer-mapillary-signs .icon-sign')
-            .classed('selected', function(d) {
+            .classed('currentView', function(d) {
                 return _some(d.detections, function(detection) {
                     return detection.image_key === imageKey;
                 });
@@ -564,11 +564,11 @@ export default {
             d3_selectAll('.viewfield-group')
                 .classed('highlighted', false)
                 .classed('hovered', false)
-                .classed('selected', false);
+                .classed('currentView', false);
 
             d3_selectAll('.sequence')
                 .classed('highlighted', false)
-                .classed('selected', false);
+                .classed('currentView', false);
         }
 
         var hoveredImageKey = hovered && hovered.key;
@@ -589,11 +589,11 @@ export default {
         d3_selectAll('.layer-mapillary-images .viewfield-group')
             .classed('highlighted', function(d) { return highlightedImageKeys.indexOf(d.key) !== -1; })
             .classed('hovered', function(d) { return d.key === hoveredImageKey; })
-            .classed('selected', function(d) { return d.key === selectedImageKey; });
+            .classed('currentView', function(d) { return d.key === selectedImageKey; });
 
         d3_selectAll('.layer-mapillary-images .sequence')
             .classed('highlighted', function(d) { return d.properties.key === hoveredSequenceKey; })
-            .classed('selected', function(d) { return d.properties.key === selectedSequenceKey; });
+            .classed('currentView', function(d) { return d.properties.key === selectedSequenceKey; });
 
         // update viewfields if needed
         d3_selectAll('.viewfield-group .viewfield')

--- a/modules/services/openstreetcam.js
+++ b/modules/services/openstreetcam.js
@@ -403,7 +403,7 @@ export default {
             .classed('hide', true);
 
         d3_selectAll('.viewfield-group, .sequence, .icon-sign')
-            .classed('selected', false);
+            .classed('currentView', false);
 
         return this.setStyles(null, true);
     },
@@ -476,7 +476,7 @@ export default {
         this.setStyles(null, true);
 
         d3_selectAll('.icon-sign')
-            .classed('selected', false);
+            .classed('currentView', false);
 
         return this;
     },
@@ -500,11 +500,11 @@ export default {
             d3_selectAll('.viewfield-group')
                 .classed('highlighted', false)
                 .classed('hovered', false)
-                .classed('selected', false);
+                .classed('currentView', false);
 
             d3_selectAll('.sequence')
                 .classed('highlighted', false)
-                .classed('selected', false);
+                .classed('currentView', false);
         }
 
         var hoveredImageKey = hovered && hovered.key;
@@ -525,11 +525,11 @@ export default {
         d3_selectAll('.layer-openstreetcam-images .viewfield-group')
             .classed('highlighted', function(d) { return highlightedImageKeys.indexOf(d.key) !== -1; })
             .classed('hovered', function(d) { return d.key === hoveredImageKey; })
-            .classed('selected', function(d) { return d.key === selectedImageKey; });
+            .classed('currentView', function(d) { return d.key === selectedImageKey; });
 
         d3_selectAll('.layer-openstreetcam-images .sequence')
             .classed('highlighted', function(d) { return d.properties.key === hoveredSequenceKey; })
-            .classed('selected', function(d) { return d.properties.key === selectedSequenceKey; });
+            .classed('currentView', function(d) { return d.properties.key === selectedSequenceKey; });
 
         // update viewfields if needed
         d3_selectAll('.viewfield-group .viewfield')

--- a/modules/services/openstreetcam.js
+++ b/modules/services/openstreetcam.js
@@ -492,6 +492,9 @@ export default {
     },
 
 
+    // Updates the currently highlighted sequence and selected bubble.
+    // Reset is only necessary when interacting with the viewport because
+    // this implicitly changes the currently selected bubble/sequence
     setStyles: function(hovered, reset) {
         if (reset) {  // reset all layers
             d3_selectAll('.viewfield-group')

--- a/modules/services/streetside.js
+++ b/modules/services/streetside.js
@@ -750,7 +750,7 @@ export default {
             .classed('hide', true);
 
         d3_selectAll('.viewfield-group, .sequence, .icon-sign')
-            .classed('selected', false);
+            .classed('currentView', false);
 
         return this.setStyles(null, true);
     },
@@ -933,11 +933,11 @@ export default {
             d3_selectAll('.viewfield-group')
                 .classed('highlighted', false)
                 .classed('hovered', false)
-                .classed('selected', false);
+                .classed('currentView', false);
 
             d3_selectAll('.sequence')
                 .classed('highlighted', false)
-                .classed('selected', false);
+                .classed('currentView', false);
         }
 
         var hoveredBubbleKey = hovered && hovered.key;
@@ -958,11 +958,11 @@ export default {
         d3_selectAll('.layer-streetside-images .viewfield-group')
             .classed('highlighted', function (d) { return highlightedBubbleKeys.indexOf(d.key) !== -1; })
             .classed('hovered', function (d) { return d.key === hoveredBubbleKey; })
-            .classed('selected', function (d) { return d.key === selectedBubbleKey; });
+            .classed('currentView', function (d) { return d.key === selectedBubbleKey; });
 
         d3_selectAll('.layer-streetside-images .sequence')
             .classed('highlighted', function (d) { return d.properties.key === hoveredSequenceKey; })
-            .classed('selected', function (d) { return d.properties.key === selectedSequenceKey; });
+            .classed('currentView', function (d) { return d.properties.key === selectedSequenceKey; });
 
         // update viewfields if needed
         d3_selectAll('.viewfield-group .viewfield')

--- a/modules/services/streetside.js
+++ b/modules/services/streetside.js
@@ -925,9 +925,9 @@ export default {
     },
 
 
-    /**
-     * setStyles().
-     */
+    // Updates the currently highlighted sequence and selected bubble.
+    // Reset is only necessary when interacting with the viewport because
+    // this implicitly changes the currently selected bubble/sequence
     setStyles: function (hovered, reset) {
         if (reset) {  // reset all layers
             d3_selectAll('.viewfield-group')

--- a/modules/svg/mapillary_images.js
+++ b/modules/svg/mapillary_images.js
@@ -164,8 +164,8 @@ export function svgMapillaryImages(projection, context, dispatch) {
         var groupsEnter = groups.enter()
             .append('g')
             .attr('class', 'viewfield-group')
-            .on('mouseover', mouseover)
-            .on('mouseout', mouseout)
+            .on('mouseenter', mouseover)
+            .on('mouseleave', mouseout)
             .on('click', click);
 
         groupsEnter

--- a/modules/svg/mapillary_images.js
+++ b/modules/svg/mapillary_images.js
@@ -205,6 +205,7 @@ export function svgMapillaryImages(projection, context, dispatch) {
             .attr('transform', 'scale(1.5,1.5),translate(-8, -13)')
             .attr('d', viewfieldPath);
 
+
         function viewfieldPath() {
             var d = this.parentNode.__data__;
             if (d.pano) {

--- a/modules/svg/mapillary_images.js
+++ b/modules/svg/mapillary_images.js
@@ -33,7 +33,7 @@ export function svgMapillaryImages(projection, context, dispatch) {
                 // e.g. during drags or easing.
                 if (context.map().isTransformed()) return;
 
-                layer.selectAll('.viewfield-group.selected')
+                layer.selectAll('.viewfield-group.currentView')
                     .filter(function(d) {
                         return d.pano;
                     })
@@ -204,7 +204,6 @@ export function svgMapillaryImages(projection, context, dispatch) {
             .classed('pano', function() { return this.parentNode.__data__.pano; })
             .attr('transform', 'scale(1.5,1.5),translate(-8, -13)')
             .attr('d', viewfieldPath);
-
 
         function viewfieldPath() {
             var d = this.parentNode.__data__;

--- a/modules/svg/mapillary_signs.js
+++ b/modules/svg/mapillary_signs.js
@@ -105,7 +105,7 @@ export function svgMapillarySigns(projection, context, dispatch) {
             .attr('x', '-12px')
             .attr('y', '-12px')
             .attr('xlink:href', function(d) { return '#' + d.value; })
-            .classed('selected', function(d) {
+            .classed('currentView', function(d) {
                 return _some(d.detections, function(detection) {
                     return detection.image_key === selectedImageKey;
                 });

--- a/modules/svg/openstreetcam_images.js
+++ b/modules/svg/openstreetcam_images.js
@@ -147,8 +147,8 @@ export function svgOpenstreetcamImages(projection, context, dispatch) {
         var groupsEnter = groups.enter()
             .append('g')
             .attr('class', 'viewfield-group')
-            .on('mouseover', mouseover)
-            .on('mouseout', mouseout)
+            .on('mouseenter', mouseover)
+            .on('mouseleave', mouseout)
             .on('click', click);
 
         groupsEnter

--- a/modules/svg/streetside.js
+++ b/modules/svg/streetside.js
@@ -122,7 +122,7 @@ export function svgStreetside(projection, context, dispatch) {
     function mouseover(d) {
         var service = getService();
         _hoveredBubble = d;
-        if (service) service.setStyles(d, true);
+        if (service) service.setStyles(d);
     }
 
     /**
@@ -131,7 +131,7 @@ export function svgStreetside(projection, context, dispatch) {
     function mouseout() {
         var service = getService();
         _hoveredBubble = null;
-        if (service) service.setStyles(null, true);
+        if (service) service.setStyles(null);
     }
 
     /**
@@ -253,7 +253,7 @@ export function svgStreetside(projection, context, dispatch) {
 
 
         if (service) {
-            service.setStyles(_hoveredBubble, true);
+            service.setStyles(_hoveredBubble);
         }
 
 

--- a/modules/svg/streetside.js
+++ b/modules/svg/streetside.js
@@ -209,8 +209,8 @@ export function svgStreetside(projection, context, dispatch) {
         var groupsEnter = groups.enter()
             .append('g')
             .attr('class', 'viewfield-group')
-            .on('mouseover', mouseover)
-            .on('mouseout', mouseout)
+            .on('mouseenter', mouseover)
+            .on('mouseleave', mouseout)
             .on('click', click);
 
         groupsEnter

--- a/modules/svg/streetside.js
+++ b/modules/svg/streetside.js
@@ -12,7 +12,6 @@ export function svgStreetside(projection, context, dispatch) {
     var layer = d3_select(null);
     var _viewerYaw = 0;
     var _selectedSequence = null;
-    var _hoveredBubble = null;
     var _streetside;
 
     /**
@@ -121,7 +120,6 @@ export function svgStreetside(projection, context, dispatch) {
      */
     function mouseover(d) {
         var service = getService();
-        _hoveredBubble = d;
         if (service) service.setStyles(d);
     }
 
@@ -130,7 +128,6 @@ export function svgStreetside(projection, context, dispatch) {
      */
     function mouseout() {
         var service = getService();
-        _hoveredBubble = null;
         if (service) service.setStyles(null);
     }
 
@@ -161,7 +158,7 @@ export function svgStreetside(projection, context, dispatch) {
         // e.g. during drags or easing.
         if (context.map().isTransformed()) return;
 
-        layer.selectAll('.viewfield-group.selected')
+        layer.selectAll('.viewfield-group.currentView')
             .attr('transform', transform);
     }
 
@@ -250,12 +247,6 @@ export function svgStreetside(projection, context, dispatch) {
             .attr('class', 'viewfield')
             .attr('transform', 'scale(1.5,1.5),translate(-8, -13)')
             .attr('d', viewfieldPath);
-
-
-        if (service) {
-            service.setStyles(_hoveredBubble);
-        }
-
 
         function viewfieldPath() {
             var d = this.parentNode.__data__;


### PR DESCRIPTION
Closes #5494 

~~So the cause of that issue was that whenever the svg layer `update()` method was triggered the "selected" and "highlighted" classes which get added by method `setStyles()` in the service are not being retained. The simple fix here is to just re-apply `setStyles()` with every update (there's likely a nicer way to just preserve them in the first place).~~

Since found to be false. See my comments below.

In testing, further issue with the interaction between multiple active street imagery layers was discovered. This turned out to be because the `reset` parameter of `setStyles()` was being used for style updates due to svg layer events (as far as I can see it is only needed for style updates due to interaction with the viewport - where the selected bubble/sequence is changed indirectly).

Beyond that I also changed the `mouseover` and `mouseout` events to `mouseenter` and `mouseleave` respectively. This is because the former fire for each child element of the svg group individually which is unnecessary.

There's still the issue of disabling any street imagery layer deselecting the current bubble which isn't part of that layer. However, I will open a separate issue for that (and PR if nobody beats me to it).