### PR TITLE
Persist forced visible entities on move/rotate

### DIFF
--- a/modules/modes/move.js
+++ b/modules/modes/move.js
@@ -125,9 +125,9 @@ export function modeMove(context, entityIDs, baseGraph) {
         _prevGraph = null;
         _cache = {};
 
-        behaviors.forEach(function(behavior) {
-            context.install(behavior);
-        });
+        context.features().forceVisible(entityIDs);
+
+        behaviors.forEach(context.install);
 
         context.surface()
             .on('mousemove.move', move)
@@ -161,6 +161,8 @@ export function modeMove(context, entityIDs, baseGraph) {
 
         d3_select(document)
             .call(keybinding.unbind);
+
+        context.features().forceVisible([]);
     };
 
 

--- a/modules/modes/rotate.js
+++ b/modules/modes/rotate.js
@@ -114,6 +114,8 @@ export function modeRotate(context, entityIDs) {
 
 
     mode.enter = function() {
+        context.features().forceVisible(entityIDs);
+
         behaviors.forEach(context.install);
 
         context.surface()
@@ -144,6 +146,8 @@ export function modeRotate(context, entityIDs) {
 
         d3_select(document)
             .call(keybinding.unbind);
+
+        context.features().forceVisible([]);
     };
 
 


### PR DESCRIPTION
Allows these operations to be performed on entities that are forced visible without them disappearing during the move/rotation.