### PR TITLE
Fix pressing Escape with only one active node in area

### DIFF
--- a/modules/behavior/draw_way.js
+++ b/modules/behavior/draw_way.js
@@ -125,6 +125,8 @@ export function behaviorDrawWay(context, wayID, index, mode, startGraph, baselin
 
             if (origWay.isClosed()) { // Check if Area
                 if (finishDraw) {
+                    if (nodes.length < 3) return false;
+
                     nodes.splice(-2, 1);
                     entity = nodes[nodes.length-2];
                 } else {


### PR DESCRIPTION
Fixes #5941 