### PR TITLE
Do not suggest amenity=public_building -> building=public

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -37,10 +37,6 @@
       "replace": {"landuse": "garages"}
     },
     {
-      "old": {"amenity": "public_building"},
-      "replace": {"building": "public"}
-    },
-    {
       "old": {"amenity": "real_estate"},
       "replace": {"office": "estate_agent"}
     },


### PR DESCRIPTION
Note that building tag is for what building was constructed.

For example something constructed as a church now used as, for example, townhall should be still tagged .

Therefore assuming that all  should be converted to  is a poor idea.

This change reverts part of https://github.com/openstreetmap/iD/commit/e5e547ff530f435c6556c195256f72e142fb2efc

Fixes #5951