### PR TITLE
building:color -> building:colour deprecation

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -93,6 +93,10 @@
       "replace": {"entrance": "*"}
     },
     {
+      "old": {"building:color": "*"},
+      "replace": {"building:colour": "$1"}
+    },
+    {
       "old": {"building:roof:colour": "*"},
       "replace": {"roof:colour": "$1"}
     },


### PR DESCRIPTION
https://taginfo.openstreetmap.org/keys/building%3Acolor

inspired by https://josm.openstreetmap.de/browser/josm/trunk/data/validator/deprecated.mapcss#L569
