### PR TITLE
[usability] add suggestion text below search bar

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -875,6 +875,13 @@ a.hide-toggle {
 .feature-list  {
     width: 100%;
 }
+
+.search-hints {
+    padding: 20px;
+    font-size: 14px;
+    text-align: left;
+}
+
 .no-results-item,
 .geocode-item,
 .feature-list-item {

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -415,6 +415,11 @@ en:
     search: Search worldwide...
     no_results_visible: No results in visible map area
     no_results_worldwide: No results found
+    search_hints: >
+      You can search for features by name (like California, Manhattan, or White House)
+      or by type (like cafe or restaurant). You can search by lat/lng coordinates
+      (e.g. 39.12, -75.99), or plus codes. You can also enter ids of OSM elements
+      (e.g. n1234567 for a node, w9876543 for a way/area, r13579864 for a relation).
   geolocate:
     title: Show My Location
     locating: "Locating, please wait..."

--- a/modules/ui/feature_list.js
+++ b/modules/ui/feature_list.js
@@ -59,6 +59,11 @@ export function uiFeatureList(context) {
             .append('div')
             .attr('class', 'feature-list cf');
 
+        list
+            .append('p')
+            .attr('class', 'search-hints')
+            .text(t('geocoder.search_hints'));
+
         context
             .on('exit.feature-list', clearSearch);
         context.map()
@@ -229,6 +234,9 @@ export function uiFeatureList(context) {
 
             resultsIndicator.append('span')
                 .attr('class', 'entity-name');
+
+            list.selectAll('.search-hints')
+                .style('display', value.length ? 'none' : 'block');
 
             list.selectAll('.no-results-item .entity-name')
                 .text(noResultsWorldwide ? t('geocoder.no_results_worldwide') : t('geocoder.no_results_visible'));


### PR DESCRIPTION
Adds some suggestions below the search bar to help users get started. Uses [this copy](https://github.com/openstreetmap/iD/issues/5214#issuecomment-412212612) written by @manfredbrandl 

Question: is searching by plus code actually supported?

Fixes #5214 

<img width="1072" alt="screen shot 2019-03-03 at 10 00 38 am" src="https://user-images.githubusercontent.com/5483332/53699597-f0777b00-3d9e-11e9-94ee-227a2ce1af0f.png">
