### PR TITLE
Add landuse=industrial to scrap_yard's tags.

### DIFF
--- a/data/presets/presets/landuse/industrial/scrap_yard.json
+++ b/data/presets/presets/landuse/industrial/scrap_yard.json
@@ -11,6 +11,7 @@
         "area"
     ],
     "tags": {
+        "landuse": "industrial",
         "industrial": "scrap_yard"
     },
     "addTags": {


### PR DESCRIPTION
If I understand correctly, any preset `iD/data/presets/presets/foo/bar/baz.json` should have `foo=bar` in its tags, along with a test on `baz`.

If this is so, then `iD/data/presets/presets/landuse/industrial/scrap_yard.json` is missing `landuse=industrial`, which `slaughterhouse.json` in the same directory has.

This PR adds `landuse=industrial` to `scrap_yard.json`.