### PR TITLE
fix: pin sinon to 7.2.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "rollup-plugin-node-resolve": "^4.0.0",
     "shelljs": "^0.8.0",
     "shx": "^0.3.0",
-    "sinon": "^7.2.6",
+    "sinon": "7.2.7",
     "sinon-chai": "^3.1.0",
     "smash": "0.0",
     "svg-sprite": "1.5.0",


### PR DESCRIPTION
Don't feel like tracking down whatever `getOwnPropertySymbols` thing is breaking PhantomJS right now.