### PR TITLE
Add osmarender:nameDirection to discarded tags

### DIFF
--- a/data/discarded.json
+++ b/data/discarded.json
@@ -13,6 +13,8 @@
     "geobase:datasetName": true,
     "geobase:uuid": true,
 
+    "osmarender:nameDirection": true,
+
     "sub_sea:type": true,
 
     "KSJ2:ADS": true,


### PR DESCRIPTION
There is currently ongoing discussion on talk mailing list about my proposed automatic edit that proposed to remove it.

It seems to be that there is a consensus to eliminate this tag (as unwanted rendering instruction for no longer existing renderer), but not everybody is happy about using bot edits. It was proposed to silently discard it during editing like created_by tag.

JOSM added this tag to list of automatically discarded ones - see https://josm.openstreetmap.de/changeset/14916/josm

See https://wiki.openstreetmap.org/wiki/Key:osmarender:nameDirection (note, I recently changed it), https://wiki.openstreetmap.org/wiki/Mechanical_Edits/Mateusz_Konieczny_-_bot_account/elimination_of_osmarender:nameDirection and https://lists.openstreetmap.org/pipermail/talk/2019-March/082280.html thread

Tag is described as

> By default Osmarender will draw street names left-to-right along ways. It uses the longitude (horizontal position) of the start and end points of the way to determine the direction.

> In some cases, for example, very winding roads, the automatically chosen name direction is not ideal. In this case the way can be tagged with osmarender:nameDirection=-1 or osmarender:nameDirection=1 as a hint to tell Osmarender which way to draw the name. 

Note that Osmarender is not existing anymore and any real renderer has better name display for roads.