### PR TITLE
Allow for multiple invalid sources

### DIFF
--- a/modules/validations/incompatible_source.js
+++ b/modules/validations/incompatible_source.js
@@ -6,7 +6,7 @@ import { validationIssue, validationIssueFix } from '../core/validator';
 export function validationIncompatibleSource() {
     var type = 'incompatible_source';
 
-    var invalidSources = [{id:"google", regex:"google"}];
+    var invalidSources = [{id:'google', regex:'google'}];
 
     var validation = function(entity, context) {
         var issues = [];
@@ -14,7 +14,7 @@ export function validationIncompatibleSource() {
         if (entity.tags && entity.tags.source) {
             
             invalidSources.forEach(function(invalidSource) {
-                var pattern = new RegExp(invalidSource.regex, "i");
+                var pattern = new RegExp(invalidSource.regex, 'i');
 
                 if (entity.tags.source.match(pattern)) {
                     issues.push(new validationIssue({

--- a/modules/validations/incompatible_source.js
+++ b/modules/validations/incompatible_source.js
@@ -6,25 +6,35 @@ import { validationIssue, validationIssueFix } from '../core/validator';
 export function validationIncompatibleSource() {
     var type = 'incompatible_source';
 
-    var validation = function(entity, context) {
+    var invalidSources = [{id:"google", regex:"google"}];
 
-        if (entity.tags && entity.tags.source && entity.tags.source.toLowerCase().match(/google/)) {
-            return [new validationIssue({
-                type: type,
-                severity: 'warning',
-                message: t('issues.incompatible_source.google.feature.message', {
-                    feature: utilDisplayLabel(entity, context),
-                }),
-                tooltip: t('issues.incompatible_source.google.tip'),
-                entities: [entity],
-                fixes: [
-                    new validationIssueFix({
-                        title: t('issues.fix.remove_proprietary_data.title')
-                    })
-                ]
-            })];
+    var validation = function(entity, context) {
+        var issues = [];
+
+        if (entity.tags && entity.tags.source) {
+            
+            invalidSources.forEach(function(invalidSource) {
+                var pattern = new RegExp(invalidSource.regex, "i");
+
+                if (entity.tags.source.match(pattern)) {
+                    issues.push(new validationIssue({
+                        type: type,
+                        severity: 'warning',
+                        message: t('issues.incompatible_source.' + invalidSource.id + '.feature.message', {
+                            feature: utilDisplayLabel(entity, context),
+                        }),
+                        tooltip: t('issues.incompatible_source.' + invalidSource.id + '.tip'),
+                        entities: [entity],
+                        fixes: [
+                            new validationIssueFix({
+                                title: t('issues.fix.remove_proprietary_data.title')
+                            })
+                        ]
+                    }));
+                }
+            });
         }
-        return [];
+        return issues;
     };
 
     validation.type = type;


### PR DESCRIPTION
Updates the fix for #6135 and just adds a loop that loops through a list of invalid sources