### PR TITLE
Leave way as closed when disconnecting

### DIFF
--- a/modules/actions/disconnect.js
+++ b/modules/actions/disconnect.js
@@ -59,7 +59,7 @@ export function actionDisconnect(nodeId, newNodeId) {
             } else {
                 way.nodes.forEach(function(waynode, index) {
                     if (waynode === nodeId) {
-                        if (way.isClosed() && parentWays.length > 1 && wayIds && wayIds.includes(way.id) && index === way.nodes.length-1) {
+                        if (way.isClosed() && parentWays.length > 1 && wayIds && wayIds.indexOf(way.id) !== -1 && index === way.nodes.length-1) {
                             return;
                         }
                         candidates.push({ wayID: way.id, index: index });

--- a/modules/actions/disconnect.js
+++ b/modules/actions/disconnect.js
@@ -22,7 +22,7 @@ export function actionDisconnect(nodeId, newNodeId) {
     var action = function(graph) {
         var node = graph.entity(nodeId);
         var connections = action.connections(graph);
-        
+
         connections.forEach(function(connection) {
             var way = graph.entity(connection.wayID);
             var newNode = osmNode({id: newNodeId, loc: node.loc, tags: node.tags});

--- a/modules/actions/disconnect.js
+++ b/modules/actions/disconnect.js
@@ -22,7 +22,7 @@ export function actionDisconnect(nodeId, newNodeId) {
     var action = function(graph) {
         var node = graph.entity(nodeId);
         var connections = action.connections(graph);
-
+        
         connections.forEach(function(connection) {
             var way = graph.entity(connection.wayID);
             var newNode = osmNode({id: newNodeId, loc: node.loc, tags: node.tags});
@@ -59,6 +59,9 @@ export function actionDisconnect(nodeId, newNodeId) {
             } else {
                 way.nodes.forEach(function(waynode, index) {
                     if (waynode === nodeId) {
+                        if (way.isClosed() && parentWays.length > 1 && wayIds && wayIds.includes(way.id) && index === way.nodes.length-1) {
+                            return;
+                        }
                         candidates.push({ wayID: way.id, index: index });
                     }
                 });
@@ -71,7 +74,7 @@ export function actionDisconnect(nodeId, newNodeId) {
 
     action.disabled = function(graph) {
         var connections = action.connections(graph);
-        if (connections.length === 0 || (wayIds && wayIds.length !== connections.length))
+        if (connections.length === 0)
             return 'not_connected';
 
         var parentWays = graph.parentWays(graph.entity(nodeId));

--- a/modules/operations/disconnect.js
+++ b/modules/operations/disconnect.js
@@ -8,7 +8,11 @@ export function operationDisconnect(selectedIDs, context) {
         ways = [];
 
     selectedIDs.forEach(function(id) {
-        context.geometry(id) === 'vertex' ? vertices.push(id) : ways.push(id);
+        if (context.geometry(id) === 'vertex') {
+            vertices.push(id);
+        } else {
+            ways.push(id);
+        }
     });
 
     var entityID = vertices[0];

--- a/modules/operations/disconnect.js
+++ b/modules/operations/disconnect.js
@@ -8,6 +8,10 @@ export function operationDisconnect(selectedIDs, context) {
         return context.geometry(id) === 'vertex';
     });
 
+    var ways = selectedIDs.filter(function(id) {
+        return context.geometry(id) !== 'vertex';
+    });
+
     var entityID = vertices[0];
     var action = actionDisconnect(entityID);
 
@@ -23,7 +27,7 @@ export function operationDisconnect(selectedIDs, context) {
 
 
     operation.available = function() {
-        return vertices.length === 1;
+        return vertices.length === 1 && ways.every(function(way) { return context.graph().entity(way).nodes.includes(vertices[0]); });
     };
 
 

--- a/modules/operations/disconnect.js
+++ b/modules/operations/disconnect.js
@@ -4,12 +4,11 @@ import { behaviorOperation } from '../behavior/index';
 
 
 export function operationDisconnect(selectedIDs, context) {
-    var vertices = selectedIDs.filter(function(id) {
-        return context.geometry(id) === 'vertex';
-    });
+    var vertices = [],
+        ways = [];
 
-    var ways = selectedIDs.filter(function(id) {
-        return context.geometry(id) !== 'vertex';
+    selectedIDs.forEach(function(id) {
+        context.geometry(id) === 'vertex' ? vertices.push(id) : ways.push(id);
     });
 
     var entityID = vertices[0];

--- a/test/index.html
+++ b/test/index.html
@@ -88,7 +88,6 @@
 
     <script src='spec/operations/detach_node.js'></script>
     <script src='spec/operations/straighten.js'></script>
-    <script src='spec/operations/disconnect.js'></script>
 
     <script src='spec/osm/changeset.js'></script>
     <script src='spec/osm/entity.js'></script>

--- a/test/index.html
+++ b/test/index.html
@@ -88,6 +88,7 @@
 
     <script src='spec/operations/detach_node.js'></script>
     <script src='spec/operations/straighten.js'></script>
+    <script src='spec/operations/disconnect.js'></script>
 
     <script src='spec/osm/changeset.js'></script>
     <script src='spec/osm/entity.js'></script>

--- a/test/spec/actions/disconnect.js
+++ b/test/spec/actions/disconnect.js
@@ -180,6 +180,35 @@ describe('iD.actionDisconnect', function () {
         expect(graph.entity('|').nodes).to.eql(['d', 'b']);
     });
 
+    it('preserves the closed way when part of a larger disconnect operation', function () {
+        // Situation:
+        //    a ---- bb === c
+        //           =   ==
+        //           = ==
+        //           d
+        // Disconnect - at b (whilst == is selected).
+        //
+        // Expected result:
+        //    a ---- b   ee === c
+        //               =   ==
+        //               = ==
+        //               d
+        //
+        var graph = iD.coreGraph([
+                iD.osmNode({id: 'a'}),
+                iD.osmNode({id: 'b'}),
+                iD.osmNode({id: 'c'}),
+                iD.osmNode({id: 'd'}),
+                iD.osmWay({id: '-', nodes: ['a', 'b']}),
+                iD.osmWay({id: '=', nodes: ['e', 'c', 'd', 'e']})
+            ]);
+
+        graph = iD.actionDisconnect('b', 'e').limitWays(['='])(graph);
+
+        expect(graph.entity('-').nodes).to.eql(['a', 'b']);
+        expect(graph.entity('=').nodes).to.eql(['e', 'c', 'd', 'e']);
+    });
+
     it('replaces later occurrences in a self-intersecting way', function() {
         // Situtation:
         //  a --- b

--- a/test/spec/actions/disconnect.js
+++ b/test/spec/actions/disconnect.js
@@ -200,7 +200,7 @@ describe('iD.actionDisconnect', function () {
                 iD.osmNode({id: 'c'}),
                 iD.osmNode({id: 'd'}),
                 iD.osmWay({id: '-', nodes: ['a', 'b']}),
-                iD.osmWay({id: '=', nodes: ['e', 'c', 'd', 'e']})
+                iD.osmWay({id: '=', nodes: ['b', 'c', 'd', 'b']})
             ]);
 
         graph = iD.actionDisconnect('b', 'e').limitWays(['='])(graph);


### PR DESCRIPTION
This adds to the fix in #6149 and makes it so that when a closed way is selected as well as the node to disconnect, the closed way gets disconnected from anything it is connected to, but remains closed.

I think this stay truer to the existing functionality where when a way is selected, the way is disconnected independently and every other connection remains as it was. Chances are that the user just wants to disconnect the closed way from the junction node, rather than opening up the way as well (which they can just do after if that was actually their intention)

If they _do_ want to disconnect everything at the junction node, they can just right click the node without selecting any connected ways, and everything will be disconnected as usual.

![disconnect_closed_way2](https://user-images.githubusercontent.com/4670502/55733434-bd677d80-5a15-11e9-8dd0-98edc48f5f76.gif)

![disconnect_closed_way1](https://user-images.githubusercontent.com/4670502/55733551-eb4cc200-5a15-11e9-83a8-c5d5d38dded0.gif)

I've also added a fix so that the option to disconnect doesn't even appear unless all selected ways are connected to the selected node, to save confusion on what actually will be disconnected, which is closer to how it was before #6149 was fixed.

![disconnect_closed_way3](https://user-images.githubusercontent.com/4670502/55734128-e9cfc980-5a16-11e9-8726-90d7b455dd3b.gif)
