### PR TITLE
Add validation for nordic pistes

### DIFF
--- a/data/presets/presets/piste/nordic.json
+++ b/data/presets/presets/piste/nordic.json
@@ -22,5 +22,10 @@
     "tags": {
         "piste:type": "nordic"
     },
+    "addTags": {
+        "piste:type":"nordic",
+        "piste:difficulty":"",
+        "piste:grooming":""
+    },
     "name": "Nordic or Crosscountry Piste/Ski Trail"
 }


### PR DESCRIPTION
While piste:difficulty is more than just useful for the data user, piste:grooming for cross-country skiing appears to defaults to quite different practices across the world.