### PR TITLE
Validate against duplicate name/address tags

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1344,6 +1344,10 @@ en:
       title: Unknown Roads
       message: "{feature} has no classification"
       tip: "Roads without a specific type may not appear in maps or routing."
+    duplicate_tags:
+      title: Duplicate Tags
+      message: 'An entity with {tag_type}: "{tag_value}" already exists in this part of the map'
+      tip: "{tag_type} tags are typically unique in a given geographical area."
     fix:
       connect_almost_junction:
         annotation: Connected very close features.
@@ -1375,6 +1379,9 @@ en:
       remove_tag:
         title: Remove the tag
         annotation: Removed tag.
+      remove_duplicated_tag:
+        title: Remove duplicated tag
+        annotation: Removed duplicated tag.
       remove_tags:
         title: Remove the tags
       reposition_features:

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -1656,6 +1656,11 @@
                 "message": "{feature} has no classification",
                 "tip": "Roads without a specific type may not appear in maps or routing."
             },
+            "duplicate_tags": {
+                "title": "Duplicate Tags",
+                "message": "An entity with {tag_type}: \"{tag_value}\" already exists in this part of the map",
+                "tip": "{tag_type} tags are typically unique in a given geographical area."
+            },
             "fix": {
                 "connect_almost_junction": {
                     "annotation": "Connected very close features."
@@ -1699,6 +1704,10 @@
                 "remove_tag": {
                     "title": "Remove the tag",
                     "annotation": "Removed tag."
+                },
+                "remove_duplicated_tag": {
+                    "title": "Remove duplicated tag",
+                    "annotation": "Removed duplicated tag."
                 },
                 "remove_tags": {
                     "title": "Remove the tags"
@@ -8553,24 +8562,6 @@
             }
         },
         "imagery": {
-            "AGIV": {
-                "attribution": {
-                    "text": "Orthophoto Flanders most recent © AGIV"
-                },
-                "name": "AGIV Flanders most recent aerial imagery"
-            },
-            "AGIV10cm": {
-                "attribution": {
-                    "text": "Orthophoto Flanders © AGIV"
-                },
-                "name": "AGIV Flanders 2013-2015 aerial imagery 10cm"
-            },
-            "AGIVFlandersGRB": {
-                "attribution": {
-                    "text": "GRB Flanders © AGIV"
-                },
-                "name": "AGIV Flanders GRB"
-            },
             "Bing": {
                 "description": "Satellite and aerial imagery.",
                 "name": "Bing aerial imagery"
@@ -8579,28 +8570,28 @@
                 "attribution": {
                     "text": "Terms & Feedback"
                 },
-                "description": "DigitalGlobe-Premium is a mosaic composed of DigitalGlobe basemap with select regions filled with +Vivid or custom area of interest imagery, 50cm resolution or better, and refreshed more frequently with ongoing updates.",
+                "description": "Premium DigitalGlobe satellite imagery.",
                 "name": "DigitalGlobe Premium Imagery"
             },
             "DigitalGlobe-Premium-vintage": {
                 "attribution": {
                     "text": "Terms & Feedback"
                 },
-                "description": "Imagery boundaries and capture dates. Labels appear at zoom level 13 and higher.",
+                "description": "Imagery boundaries and capture dates. Labels appear at zoom level 14 and higher.",
                 "name": "DigitalGlobe Premium Imagery Vintage"
             },
             "DigitalGlobe-Standard": {
                 "attribution": {
                     "text": "Terms & Feedback"
                 },
-                "description": "DigitalGlobe-Standard is a curated set of imagery covering 86% of the earth’s landmass, with 30-60cm resolution where available, backfilled by Landsat. Average age is 2.31 years, with some areas updated 2x per year.",
+                "description": "Standard DigitalGlobe satellite imagery.",
                 "name": "DigitalGlobe Standard Imagery"
             },
             "DigitalGlobe-Standard-vintage": {
                 "attribution": {
                     "text": "Terms & Feedback"
                 },
-                "description": "Imagery boundaries and capture dates. Labels appear at zoom level 13 and higher.",
+                "description": "Imagery boundaries and capture dates. Labels appear at zoom level 14 and higher.",
                 "name": "DigitalGlobe Standard Imagery Vintage"
             },
             "EsriWorldImagery": {
@@ -8673,11 +8664,8 @@
                 },
                 "name": "OSM Inspector: Tagging"
             },
-            "SPW_ORTHO_LAST": {
-                "name": "SPW(allonie) most recent aerial imagery"
-            },
-            "SPW_PICC": {
-                "name": "SPW(allonie) PICC numerical imagery"
+            "US-TIGER-Roads-2012": {
+                "name": "TIGER Roads 2012"
             },
             "US-TIGER-Roads-2014": {
                 "description": "At zoom level 16+, public domain map data from the US Census. At lower zooms, only changes since 2006 minus changes already incorporated into OpenStreetMap",
@@ -8686,44 +8674,6 @@
             "US-TIGER-Roads-2017": {
                 "description": "Yellow = Public domain map data from the US Census. Red = Data not found in OpenStreetMap",
                 "name": "TIGER Roads 2017"
-            },
-            "US-TIGER-Roads-2018": {
-                "description": "Yellow = Public domain map data from the US Census. Red = Data not found in OpenStreetMap",
-                "name": "TIGER Roads 2018"
-            },
-            "US_Forest_Service_roads_overlay": {
-                "description": "Highway: Green casing = unclassified. Brown casing = track. Surface: gravel = light brown fill, Asphalt = black, paved = gray, ground =white, concrete = blue, grass = green. Seasonal = white bars",
-                "name": "U.S. Forest Roads Overlay"
-            },
-            "UrbISOrtho2016": {
-                "attribution": {
-                    "text": "Realized by means of Brussels UrbIS®© - Distribution & Copyright CIRB"
-                },
-                "name": "UrbIS-Ortho 2016"
-            },
-            "UrbISOrtho2017": {
-                "attribution": {
-                    "text": "Realized by means of Brussels UrbIS®© - Distribution & Copyright CIRB"
-                },
-                "name": "UrbIS-Ortho 2017"
-            },
-            "UrbISOrtho2018": {
-                "attribution": {
-                    "text": "Realized by means of Brussels UrbIS®© - Distribution & Copyright CIRB"
-                },
-                "name": "UrbIS-Ortho 2018"
-            },
-            "UrbisAdmFR": {
-                "attribution": {
-                    "text": "Realized by means of Brussels UrbIS®© - Distribution & Copyright CIRB"
-                },
-                "name": "UrbisAdm FR"
-            },
-            "UrbisAdmNL": {
-                "attribution": {
-                    "text": "Realized by means of Brussels UrbIS®© - Distribution & Copyright CIRB"
-                },
-                "name": "UrbisAdm NL"
             },
             "Waymarked_Trails-Cycling": {
                 "attribution": {
@@ -8759,7 +8709,7 @@
                 "attribution": {
                     "text": "basemap.at"
                 },
-                "description": "Basemap of Austria, based on government data.",
+                "description": "Basemap of Austria, based on goverment data.",
                 "name": "basemap.at"
             },
             "basemap.at-orthofoto": {
@@ -8769,110 +8719,11 @@
                 "description": "Orthofoto layer provided by basemap.at. \"Successor\" of geoimage.at imagery.",
                 "name": "basemap.at Orthofoto"
             },
-            "eufar-balaton": {
+            "hike_n_bike": {
                 "attribution": {
-                    "text": "EUFAR Balaton ortofotó 2010"
+                    "text": "© OpenStreetMap contributors"
                 },
-                "description": "1940 geo-tagged photography from Balaton Limnological Institute.",
-                "name": "EUFAR Balaton orthophotos"
-            },
-            "finds.jp_KBN_2500": {
-                "attribution": {
-                    "text": "GSI KIBAN 2500"
-                },
-                "description": "GSI Kiban 2500 via finds.jp. Good for tracing, but a bit older.",
-                "name": "Japan GSI KIBAN 2500"
-            },
-            "gsi.go.jp": {
-                "attribution": {
-                    "text": "GSI Japan"
-                },
-                "description": "Japan GSI ortho Imagery. Usually better than bing, but a bit older.",
-                "name": "Japan GSI ortho Imagery"
-            },
-            "gsi.go.jp_airphoto": {
-                "attribution": {
-                    "text": "GSI Japan"
-                },
-                "description": "Japan GSI airphoto Imagery. Not fully orthorectified, but a bit newer and/or differently covered than GSI ortho Imagery.",
-                "name": "Japan GSI airphoto Imagery"
-            },
-            "gsi.go.jp_seamlessphoto": {
-                "attribution": {
-                    "text": "GSI Japan seamless photo"
-                },
-                "description": "Japan GSI seamlessphoto Imagery. The collection of latest imageries of GSI ortho, airphoto, post disaster and others.",
-                "name": "Japan GSI seamlessphoto Imagery"
-            },
-            "gsi.go.jp_std_map": {
-                "attribution": {
-                    "text": "GSI Japan"
-                },
-                "description": "Japan GSI Standard Map. Widely covered.",
-                "name": "Japan GSI Standard Map"
-            },
-            "helsingborg-orto": {
-                "attribution": {
-                    "text": "© Helsingborg municipality"
-                },
-                "description": "Orthophotos from the municipality of Helsingborg 2016, public domain",
-                "name": "Helsingborg Orthophoto"
-            },
-            "kalmar-orto-2014": {
-                "attribution": {
-                    "text": "© Kalmar municipality"
-                },
-                "description": "Orthophotos for the north coast of the municipality of Kalmar 2014",
-                "name": "Kalmar North Orthophoto 2014"
-            },
-            "kalmar-orto-2016": {
-                "attribution": {
-                    "text": "© Kalmar municipality"
-                },
-                "description": "Orthophotos for the south coast of the municipality of Kalmar 2016",
-                "name": "Kalmar South Orthophoto 2016"
-            },
-            "kalmar-orto-2018": {
-                "attribution": {
-                    "text": "© Kalmar municipality"
-                },
-                "description": "Orthophotos for urban areas of the municipality of Kalmar 2018",
-                "name": "Kalmar Urban Orthophoto 2018"
-            },
-            "kelkkareitit": {
-                "attribution": {
-                    "text": "© Kelkkareitit.fi"
-                },
-                "description": "Kelkkareitit.fi snowmobile trails from OSM (Nordic coverage)",
-                "name": "Nordic snowmobile overlay"
-            },
-            "lantmateriet-orto1960": {
-                "attribution": {
-                    "text": "© Lantmäteriet, CC0"
-                },
-                "description": "Mosaic of Swedish orthophotos from the period 1955–1965. Older and younger pictures may occur.",
-                "name": "Lantmäteriet Historic Orthophoto 1960"
-            },
-            "lantmateriet-orto1975": {
-                "attribution": {
-                    "text": "© Lantmäteriet, CC0"
-                },
-                "description": "Mosaic of Swedish orthophotos from the period 1970–1980. Is under construction.",
-                "name": "Lantmäteriet Historic Orthophoto 1975"
-            },
-            "lantmateriet-topowebb": {
-                "attribution": {
-                    "text": "© Lantmäteriet, CC0"
-                },
-                "description": "Topographic map of Sweden 1:50 000",
-                "name": "Lantmäteriet Topographic Map"
-            },
-            "linkoping-orto": {
-                "attribution": {
-                    "text": "© Linköping municipality"
-                },
-                "description": "Orthophotos from the municipality of Linköping 2010, open data",
-                "name": "Linköping Orthophoto"
+                "name": "Hike & Bike"
             },
             "mapbox_locator_overlay": {
                 "attribution": {
@@ -8906,13 +8757,6 @@
                 },
                 "name": "OpenStreetMap (German Style)"
             },
-            "osmse-ekonomiska": {
-                "attribution": {
-                    "text": "© Lantmäteriet"
-                },
-                "description": "Scan of \"Economic maps\" ca. 1950–1980",
-                "name": "Lantmäteriet Economic Map 1950–1980"
-            },
             "qa_no_address": {
                 "attribution": {
                     "text": "Simon Poole, Data ©OpenStreetMap contributors"
@@ -8925,25 +8769,11 @@
                 },
                 "name": "skobbler"
             },
-            "skoterleder": {
-                "attribution": {
-                    "text": "© Skoterleder.org"
-                },
-                "description": "Snowmobile trails",
-                "name": "Snowmobile map Sweden"
-            },
             "stamen-terrain-background": {
                 "attribution": {
-                    "text": "Map tiles by Stamen Design, under CC BY 3.0. Data by OpenStreetMap, under ODbL"
+                    "text": "Map tiles by Stamen Design, under CC BY 3.0"
                 },
                 "name": "Stamen Terrain"
-            },
-            "stockholm-orto": {
-                "attribution": {
-                    "text": "© Stockholm municipality, CC0"
-                },
-                "description": "Orthophotos from the municipality of Stockholm 2015, CC0 license",
-                "name": "Stockholm Orthophoto"
             },
             "tf-cycle": {
                 "attribution": {
@@ -8956,48 +8786,6 @@
                     "text": "Maps © Thunderforest, Data © OpenStreetMap contributors"
                 },
                 "name": "Thunderforest Landscape"
-            },
-            "trafikverket-baninfo": {
-                "attribution": {
-                    "text": "© Trafikverket, CC0"
-                },
-                "description": "Swedish railway network, including sidings",
-                "name": "Trafikverket Railway Network"
-            },
-            "trafikverket-baninfo-option": {
-                "attribution": {
-                    "text": "© Trafikverket, CC0"
-                },
-                "description": "Swedish railway network with several options for map layers",
-                "name": "Trafikverket Railway Network options"
-            },
-            "trafikverket-vagnat": {
-                "attribution": {
-                    "text": "© Trafikverket, CC0"
-                },
-                "description": "Swedish NVDB road network",
-                "name": "Trafikverket Road Network"
-            },
-            "trafikverket-vagnat-extra": {
-                "attribution": {
-                    "text": "© Trafikverket, CC0"
-                },
-                "description": "Swedish NVDB extra details: Highway reference, traffic calming, rest area, bus stop, bridge, tunnel, speed camera",
-                "name": "Trafikverket Road Network extra"
-            },
-            "trafikverket-vagnat-navn": {
-                "attribution": {
-                    "text": "© Trafikverket, CC0"
-                },
-                "description": "Swedish NVDB street names",
-                "name": "Trafikverket Street Names"
-            },
-            "trafikverket-vagnat-option": {
-                "attribution": {
-                    "text": "© Trafikverket, CC0"
-                },
-                "description": "Swedish NVDB road network with several options for map layers",
-                "name": "Trafikverket Road Network options"
             }
         },
         "community": {

--- a/modules/validations/duplicate_tags.js
+++ b/modules/validations/duplicate_tags.js
@@ -31,7 +31,7 @@ export function validationDuplicateTags() {
                                     return entity.tags[t];
                                 }).join(',');
 
-            if (!entityTagValue.match(/^,+$/) && existingTagValues.indexOf(entityTagValue.toLowerCase()) !== -1) {
+            if (!entityTagValue.match(/^,*$/) && existingTagValues.indexOf(entityTagValue.toLowerCase()) !== -1) {
                 issues.push(new validationIssue({
                             type: type,
                             severity: 'warning',

--- a/modules/validations/duplicate_tags.js
+++ b/modules/validations/duplicate_tags.js
@@ -7,7 +7,7 @@ export function validationDuplicateTags() {
     var type = 'duplicate_tags';
     var tagsToCheck = [
                         ['Name', ['name']],
-                        ['Address', ['addr:housenumber', 'addr:street']],
+                        ['Address', ['addr:unit', 'addr:housenumber', 'addr:street']],
                         // Add more tags to check here
                       ];
 
@@ -31,7 +31,7 @@ export function validationDuplicateTags() {
                                     return entity.tags[t];
                                 }).join(',');
 
-            if (entity.tags[tag[1][0]] !== undefined && existingTagValues.indexOf(entityTagValue.toLowerCase()) !== -1) {
+            if (!entityTagValue.match(/^,+$/) && existingTagValues.indexOf(entityTagValue.toLowerCase()) !== -1) {
                 issues.push(new validationIssue({
                             type: type,
                             severity: 'warning',

--- a/modules/validations/duplicate_tags.js
+++ b/modules/validations/duplicate_tags.js
@@ -19,7 +19,7 @@ export function validationDuplicateTags() {
         tagsToCheck.forEach(function(tag) {
             var existingTagValues = Object.keys(context.graph().entities)
                                     .filter(function(n) {
-                                        return n !== entity.id;
+                                        return n !== entity.id && context.hasEntity(n);
                                     })
                                     .map(function(n) {
                                         return tag[1].map(function(t) {

--- a/modules/validations/duplicate_tags.js
+++ b/modules/validations/duplicate_tags.js
@@ -1,0 +1,77 @@
+import { actionChangeTags } from '../actions/index';
+import { t } from '../util/locale';
+import { validationIssue, validationIssueFix } from '../core/validator';
+
+
+export function validationDuplicateTags() {
+    var type = 'duplicate_tags';
+    var tagsToCheck = [
+                        ['Name', ['name']],
+                        ['Address', ['addr:housenumber', 'addr:street']],
+                        // Add more tags to check here
+                      ];
+
+    var validation = function(entity, context) {
+
+        var issues = [];
+        var fixes = [];
+
+        tagsToCheck.forEach(function(tag) {
+            var existingTagValues = Object.keys(context.graph().entities)
+                                    .filter(function(n) {
+                                        return n !== entity.id;
+                                    })
+                                    .map(function(n) {
+                                        return tag[1].map(function(t) {
+                                            return context.hasEntity(n).tags[t];
+                                        }).join(',').toLowerCase();
+                                    });
+
+            var entityTagValue = tag[1].map(function(t) {
+                                    return entity.tags[t];
+                                }).join(',');
+
+            if (entity.tags[tag[1][0]] !== undefined && existingTagValues.indexOf(entityTagValue.toLowerCase()) !== -1) {
+                issues.push(new validationIssue({
+                            type: type,
+                            severity: 'warning',
+                            message: t('issues.duplicate_tags.message', {
+                                tag_type: tag[0],
+                                tag_value: entityTagValue
+                            }),
+                            tooltip: t('issues.duplicate_tags.tip', {
+                                tag_type: tag[0]
+                            }),
+                            entities: [entity],
+                            fixes: fixes
+                        }));
+
+                fixes.push(
+                    new validationIssueFix({
+                        icon: 'iD-operation-delete',
+                        title: t('issues.fix.remove_duplicated_tag.title'),
+                        onClick: function() {
+                            var updatedTags = entity.tags;
+
+                            tag[1].forEach(function(t) {
+                                delete updatedTags[t];
+                            });
+                            context.perform(
+                                actionChangeTags(entity.id, updatedTags),
+                                t('operations.change_tags.annotation')
+                            );
+                            
+                            context.map().pan([0,0]); //force redraw
+                        }
+                    })
+                );
+            }
+        });
+
+        return issues;
+    };
+
+    validation.type = type;
+
+    return validation;
+}

--- a/modules/validations/index.js
+++ b/modules/validations/index.js
@@ -1,6 +1,7 @@
 export { validationAlmostJunction } from './almost_junction';
 export { validationCrossingWays } from './crossing_ways';
 export { validationDisconnectedWay } from './disconnected_way';
+export { validationDuplicateTags } from './duplicate_tags';
 export { validationGenericName } from './generic_name';
 export { validationIncompatibleSource } from './incompatible_source';
 export { validationManyDeletions } from './many_deletions';

--- a/test/index.html
+++ b/test/index.html
@@ -154,6 +154,7 @@
     <script src='spec/validations/almost_junction.js'></script>
     <script src='spec/validations/crossing_ways.js'></script>
     <script src='spec/validations/disconnected_way.js'></script>
+    <script src='spec/validations/duplicate_tags.js'></script>
     <script src='spec/validations/generic_name.js'></script>
     <script src='spec/validations/incompatible_source.js'></script>
     <script src='spec/validations/missing_role.js'></script>

--- a/test/spec/validations/duplicate_tags.js
+++ b/test/spec/validations/duplicate_tags.js
@@ -76,9 +76,9 @@ describe('iD.validations.duplicate_tags', function () {
         expect(issues).to.have.lengthOf(0);
     });
 
-    it('flags both ways having same start of address', function() {
+    it('flags both ways having same start of address (without unit)', function() {
         createWays({ 'addr:housenumber': '23', 'addr:street': 'Park Street' },
-                  { 'addr:housenumber': '23', 'addr:street': 'Park Street' });
+                   { 'addr:housenumber': '23', 'addr:street': 'Park Street' });
         var issues = validate();
         expect(issues).to.have.lengthOf(2);
 
@@ -91,9 +91,39 @@ describe('iD.validations.duplicate_tags', function () {
         expect(issues[1].entities[0].id).to.eql('w-2');
     });
 
-    it('flags both ways having same start of address (case-insensitive)', function() {
+    it('flags both ways having same start of address (without unit) (case-insensitive)', function() {
         createWays({ 'addr:housenumber': '23', 'addr:street': 'Park Street' },
-                  { 'addr:housenumber': '23', 'addr:street': 'park street' });
+                   { 'addr:housenumber': '23', 'addr:street': 'park street' });
+        var issues = validate();
+        expect(issues).to.have.lengthOf(2);
+
+        expect(issues[0].type).to.eql('duplicate_tags');
+        expect(issues[0].entities).to.have.lengthOf(1);
+        expect(issues[0].entities[0].id).to.eql('w-1');
+
+        expect(issues[1].type).to.eql('duplicate_tags');
+        expect(issues[1].entities).to.have.lengthOf(1);
+        expect(issues[1].entities[0].id).to.eql('w-2');
+    });
+
+    it('flags both ways having same start of address (with unit)', function() {
+        createWays({ 'addr:unit': '6', 'addr:housenumber': '23', 'addr:street': 'Park Street' },
+                   { 'addr:unit': '6', 'addr:housenumber': '23', 'addr:street': 'Park Street' });
+        var issues = validate();
+        expect(issues).to.have.lengthOf(2);
+
+        expect(issues[0].type).to.eql('duplicate_tags');
+        expect(issues[0].entities).to.have.lengthOf(1);
+        expect(issues[0].entities[0].id).to.eql('w-1');
+
+        expect(issues[1].type).to.eql('duplicate_tags');
+        expect(issues[1].entities).to.have.lengthOf(1);
+        expect(issues[1].entities[0].id).to.eql('w-2');
+    });
+
+    it('flags both ways having same start of address (with unit) (case-insensitive)', function() {
+        createWays({ 'addr:unit': '6B', 'addr:housenumber': '23', 'addr:street': 'Park Street' },
+                   { 'addr:unit': '6b', 'addr:housenumber': '23', 'addr:street': 'park street' });
         var issues = validate();
         expect(issues).to.have.lengthOf(2);
 
@@ -108,14 +138,21 @@ describe('iD.validations.duplicate_tags', function () {
 
     it('ignores ways having different house number, same street', function() {
         createWays({ 'addr:housenumber': '22', 'addr:street': 'Park Street' },
-                  { 'addr:housenumber': '23', 'addr:street': 'Park Street' });
+                   { 'addr:housenumber': '23', 'addr:street': 'Park Street' });
         var issues = validate();
         expect(issues).to.have.lengthOf(0);
     });
 
     it('ignores ways having same house number, different street', function() {
         createWays({ 'addr:housenumber': '22', 'addr:street': 'Park Street' },
-                  { 'addr:housenumber': '22', 'addr:street': 'Tree Street' });
+                   { 'addr:housenumber': '22', 'addr:street': 'Tree Street' });
+        var issues = validate();
+        expect(issues).to.have.lengthOf(0);
+    });
+
+    it('ignores ways having different unit, same house number, same street', function() {
+        createWays({ 'addr:unit': '6', 'addr:housenumber': '22', 'addr:street': 'Park Street' },
+                   { 'addr:unit': '7', 'addr:housenumber': '22', 'addr:street': 'Tree Street' });
         var issues = validate();
         expect(issues).to.have.lengthOf(0);
     });

--- a/test/spec/validations/duplicate_tags.js
+++ b/test/spec/validations/duplicate_tags.js
@@ -1,0 +1,124 @@
+describe('iD.validations.duplicate_tags', function () {
+    var context;
+
+    beforeEach(function() {
+        context = iD.coreContext();
+    });
+
+    function createWays(tags1, tags2) {
+        var n1 = iD.osmNode({id: 'n-1', loc: [4,4]});
+        var n2 = iD.osmNode({id: 'n-2', loc: [4,5]});
+        var n3 = iD.osmNode({id: 'n-3', loc: [3,4]});
+        var n4 = iD.osmNode({id: 'n-4', loc: [3,5]});
+        
+        var w1 = iD.osmWay({id: 'w-1', nodes: ['n-1', 'n-2'], tags: tags1});
+        var w2 = iD.osmWay({id: 'w-2', nodes: ['n-3', 'n-4'], tags: tags2});
+
+        context.perform(
+            iD.actionAddEntity(n1),
+            iD.actionAddEntity(n2),
+            iD.actionAddEntity(n3),
+            iD.actionAddEntity(n4),
+            iD.actionAddEntity(w1),
+            iD.actionAddEntity(w2)
+        );
+    }
+
+    function validate() {
+        var validator = iD.validationDuplicateTags();
+        var changes = context.history().changes();
+        var entities = changes.modified.concat(changes.created);
+        var issues = [];
+        
+        entities.forEach(function(entity) {
+            issues = issues.concat(validator(entity, context));
+        });
+        
+        return issues;
+    }
+
+    it('has no errors on init', function() {
+        var issues = validate();
+        expect(issues).to.have.lengthOf(0);
+    });
+
+    it('flags both ways having the same name', function() {
+        createWays({ name: 'Park Street' }, { name: 'Park Street' });
+        var issues = validate();
+        expect(issues).to.have.lengthOf(2);
+
+        expect(issues[0].type).to.eql('duplicate_tags');
+        expect(issues[0].entities).to.have.lengthOf(1);
+        expect(issues[0].entities[0].id).to.eql('w-1');
+
+        expect(issues[1].type).to.eql('duplicate_tags');
+        expect(issues[1].entities).to.have.lengthOf(1);
+        expect(issues[1].entities[0].id).to.eql('w-2');
+    });
+
+    it('flags both ways having the same name (case insensitive)', function() {
+        createWays({ name: 'Park Street' }, { name: 'park street' });
+        var issues = validate();
+        expect(issues).to.have.lengthOf(2);
+
+        expect(issues[0].type).to.eql('duplicate_tags');
+        expect(issues[0].entities).to.have.lengthOf(1);
+        expect(issues[0].entities[0].id).to.eql('w-1');
+
+        expect(issues[1].type).to.eql('duplicate_tags');
+        expect(issues[1].entities).to.have.lengthOf(1);
+        expect(issues[1].entities[0].id).to.eql('w-2');
+    });
+
+    it('ignores ways having different name', function() {
+        createWays({ name: 'Tree Street' }, { name: 'Park Street' });
+        var issues = validate();
+        expect(issues).to.have.lengthOf(0);
+    });
+
+    it('flags both ways having same start of address', function() {
+        createWays({ 'addr:housenumber': '23', 'addr:street': 'Park Street' },
+                  { 'addr:housenumber': '23', 'addr:street': 'Park Street' });
+        var issues = validate();
+        expect(issues).to.have.lengthOf(2);
+
+        expect(issues[0].type).to.eql('duplicate_tags');
+        expect(issues[0].entities).to.have.lengthOf(1);
+        expect(issues[0].entities[0].id).to.eql('w-1');
+
+        expect(issues[1].type).to.eql('duplicate_tags');
+        expect(issues[1].entities).to.have.lengthOf(1);
+        expect(issues[1].entities[0].id).to.eql('w-2');
+    });
+
+    it('flags both ways having same start of address (case-insensitive)', function() {
+        createWays({ 'addr:housenumber': '23', 'addr:street': 'Park Street' },
+                  { 'addr:housenumber': '23', 'addr:street': 'park street' });
+        var issues = validate();
+        expect(issues).to.have.lengthOf(2);
+
+        expect(issues[0].type).to.eql('duplicate_tags');
+        expect(issues[0].entities).to.have.lengthOf(1);
+        expect(issues[0].entities[0].id).to.eql('w-1');
+
+        expect(issues[1].type).to.eql('duplicate_tags');
+        expect(issues[1].entities).to.have.lengthOf(1);
+        expect(issues[1].entities[0].id).to.eql('w-2');
+    });
+
+    it('ignores ways having different house number, same street', function() {
+        createWays({ 'addr:housenumber': '22', 'addr:street': 'Park Street' },
+                  { 'addr:housenumber': '23', 'addr:street': 'Park Street' });
+        var issues = validate();
+        expect(issues).to.have.lengthOf(0);
+    });
+
+    it('ignores ways having same house number, different street', function() {
+        createWays({ 'addr:housenumber': '22', 'addr:street': 'Park Street' },
+                  { 'addr:housenumber': '22', 'addr:street': 'Tree Street' });
+        var issues = validate();
+        expect(issues).to.have.lengthOf(0);
+    });
+
+
+});

--- a/test/spec/validations/duplicate_tags.js
+++ b/test/spec/validations/duplicate_tags.js
@@ -157,5 +157,9 @@ describe('iD.validations.duplicate_tags', function () {
         expect(issues).to.have.lengthOf(0);
     });
 
-
+    it('ignores ways having no tags', function() {
+        createWays({ }, { });
+        var issues = validate();
+        expect(issues).to.have.lengthOf(0);
+    });
 });


### PR DESCRIPTION
Implements some of #6177 

This is a bit of a work in progress as I don't know if it would be better to combine it with a more thorough validation process (although it works as is), but it checks whether there are duplicates in the current graph of various tags (at the moment just _name_ and both _addr:housenumber_ and _addr:street_ together.)

Includes tests

![validate_road_name](https://user-images.githubusercontent.com/4670502/56171538-98f33e80-5fdd-11e9-820b-8e3a4fda2d29.gif)

![validate_duplicate_address](https://user-images.githubusercontent.com/4670502/56171487-62b5bf00-5fdd-11e9-88b8-373170ecb426.gif)