### PR TITLE
Make incompatible Google source data more generic

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1297,10 +1297,10 @@ en:
       tip: "Names should be the actual, on-the-ground names of features."
     incompatible_source:
       title: Incompatible Data Sources
-      google:
+      source:
         feature:
-          message: '{feature} lists Google as a data source'
-        tip: "Google products are proprietary and must not be used as references."
+          message: '{feature} lists {source} as a data source'
+        tip: "{source} products are proprietary and must not be used as references."
       tip: "Source data must be licensed in a manner compatible with OpenStreetMap."
     many_deletions:
       title: Many Deletions

--- a/modules/validations/incompatible_source.js
+++ b/modules/validations/incompatible_source.js
@@ -6,7 +6,7 @@ import { validationIssue, validationIssueFix } from '../core/validator';
 export function validationIncompatibleSource() {
     var type = 'incompatible_source';
 
-    var invalidSources = [{id:'google', regex:'google'}];
+    var invalidSources = [{id:'google', name: 'Google', regex:'google'}];
 
     var validation = function(entity, context) {
         var issues = [];
@@ -20,10 +20,13 @@ export function validationIncompatibleSource() {
                     issues.push(new validationIssue({
                         type: type,
                         severity: 'warning',
-                        message: t('issues.incompatible_source.' + invalidSource.id + '.feature.message', {
+                        message: t('issues.incompatible_source.source.feature.message', {
                             feature: utilDisplayLabel(entity, context),
+                            source: invalidSource.name
                         }),
-                        tooltip: t('issues.incompatible_source.' + invalidSource.id + '.tip'),
+                        tooltip: t('issues.incompatible_source.source.tip', {
+                            source: invalidSource.name
+                        }),
                         entities: [entity],
                         fixes: [
                             new validationIssueFix({


### PR DESCRIPTION
Change incompatible_source locale translation lookup to pass in 'Google' as an argument, rather than having it hardcoded into the text