### PR TITLE
Handle multiple tags when splitting up in tag editor

### DIFF
--- a/modules/ui/raw_tag_editor.js
+++ b/modules/ui/raw_tag_editor.js
@@ -329,13 +329,13 @@ export function uiRawTagEditor(context) {
             }
 
             // if the key looks like "key=value key2=value2", split them up - #5024
-            var keys = (kNew.match(/[\w_]+=/g) || []).map(function (key) { return key.slice(0, -1)});
+            var keys = (kNew.match(/[\w_]+=/g) || []).map(function (key) { return key.slice(0, -1); });
             var vals = keys.length === 0
                     ? []
                     : kNew
-                        .split(new RegExp(keys.map(function (key) { return key.replace('_', '\\_') }).join('|')))
+                        .split(new RegExp(keys.map(function (key) { return key.replace('_', '\\_'); }).join('|')))
                         .splice(1)
-                        .map(function (val) { return val.slice(1).trim() });
+                        .map(function (val) { return val.slice(1).trim(); });
 
             if (keys.length > 0) {
                 kNew = keys[0];

--- a/modules/ui/raw_tag_editor.js
+++ b/modules/ui/raw_tag_editor.js
@@ -329,19 +329,19 @@ export function uiRawTagEditor(context) {
             }
 
             // if the key looks like "key=value key2=value2", split them up - #5024
-            var keys = (kNew.match(/[\w_]+=/g) || []).map(key => key.slice(0, -1));
+            var keys = (kNew.match(/[\w_]+=/g) || []).map(function (key) { return key.slice(0, -1)});
             var vals = keys.length === 0
                     ? []
                     : kNew
-                        .split(new RegExp(keys.map(key => key.replace('_', '\\_')).join('|')))
+                        .split(new RegExp(keys.map(function (key) { return key.replace('_', '\\_') }).join('|')))
                         .splice(1)
-                        .map(val => val.slice(1).trim());
+                        .map(function (val) { return val.slice(1).trim() });
 
             if (keys.length > 0) {
                 kNew = keys[0];
                 vNew = vals[0];
 
-                keys.forEach((key, i) => {
+                keys.forEach(function (key, i) {
                     _pendingChange[key] = vals[i];
                 });
             } else {


### PR DESCRIPTION
As requested by @tordans in #5070 and #6185:

When pasting multiple tags like "amenity=restaurant name=The Restaurant", they shall be split up and added separately. My implementation assumes that there will never be spaces in keys, so it also handles cases like "name=The Restaurant amenity=restaurant" correctly, and splits it up at the last space before the key.