### PR TITLE
Add aerialway=j-bar to presets

### DIFF
--- a/data/presets/presets/aerialway/j-bar.json
+++ b/data/presets/presets/aerialway/j-bar.json
@@ -1,0 +1,17 @@
+{
+    "geometry": [
+        "line"
+    ],
+    "fields": [
+        "name",
+        "aerialway/capacity",
+        "aerialway/duration"
+    ],
+    "terms": [
+        "jbar"
+    ],
+    "tags": {
+        "aerialway": "j-bar"
+    },
+    "name": "J-bar Lift"
+}


### PR DESCRIPTION
I noticed that from the `aerialway` presets, `j-bar`, described in the wiki as a type of `aerialway=drag_lift` seems to be missing. T-bar already exists in the presets.

https://wiki.openstreetmap.org/wiki/Tag:aerialway%3Dj-bar