### PR TITLE
Deprecate amenity=dancing_school

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -29,6 +29,10 @@
       "replace": {"amenity": "community_centre"}
     },
     {
+      "old": {"amenity": "dancing_school"},
+      "replace": {"leisure": "dance", "dance:teaching": "yes" }
+    },
+    {
       "old": {"amenity": "dog_bin"},
       "replace": {"amenity": "waste_basket", "waste": "dog_excrement"}
     },


### PR DESCRIPTION
Also deprecated in the wiki and a replacement is available, see https://wiki.openstreetmap.org/wiki/Tag%3Aamenity%3Ddancing_school