### PR TITLE
Add shop=general for general store

### DIFF
--- a/data/presets/presets/shop/general.json
+++ b/data/presets/presets/shop/general.json
@@ -1,0 +1,12 @@
+{
+    "icon": "maki-shop",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "shop": "general"
+    },
+    "terms": ["village shop"],
+    "name": "General store"
+}

--- a/data/presets/presets/shop/general.json
+++ b/data/presets/presets/shop/general.json
@@ -7,6 +7,6 @@
     "tags": {
         "shop": "general"
     },
-    "terms": ["village shop"],
+    "terms": ["Village Shop"],
     "name": "General Store"
 }

--- a/data/presets/presets/shop/general.json
+++ b/data/presets/presets/shop/general.json
@@ -8,5 +8,5 @@
         "shop": "general"
     },
     "terms": ["village shop"],
-    "name": "General store"
+    "name": "General Store"
 }


### PR DESCRIPTION
The tag is used 2800+ times and following a recent discussion on the tagging mailing list, the tag is pretty well documented now and also what is the difference to `shop=convenience`, `shop=variety_store`, `shop=department_store`, `shop=hardware` and `shop=doityourself` and so on.

See https://wiki.openstreetmap.org/wiki/Tag:shop%3Dgeneral

Also, there is a good wikipedia article about it: https://en.wikipedia.org/wiki/General_store