### PR TITLE
Add preset for building=hangar

### DIFF
--- a/data/presets/presets/aeroway/hangar.json
+++ b/data/presets/presets/aeroway/hangar.json
@@ -9,5 +9,13 @@
     "tags": {
         "aeroway": "hangar"
     },
+    "addTags": {
+        "building": "hangar",
+        "aeroway": "hangar"
+    },
+    "removeTags": {
+        "building": "hangar",
+        "aeroway": "hangar"
+    },
     "name": "Hangar"
 }

--- a/data/presets/presets/building/hangar.json
+++ b/data/presets/presets/building/hangar.json
@@ -1,0 +1,13 @@
+{
+    "fields": [
+        "name"
+    ],
+    "geometry": [
+        "area"
+    ],
+    "tags": {
+        "building": "hangar"
+    },
+    "matchScore": 0.5,
+    "name": "Hangar building"
+}

--- a/data/presets/presets/building/hangar.json
+++ b/data/presets/presets/building/hangar.json
@@ -9,5 +9,5 @@
         "building": "hangar"
     },
     "matchScore": 0.5,
-    "name": "Hangar building"
+    "name": "Hangar Building"
 }


### PR DESCRIPTION
Also, make the hangar building preset have a lower matchScore so that first the` aeroway=hangar` is found. Add `building=hangar` to the aeroway preset.

See https://wiki.openstreetmap.org/wiki/Tag:building%3Dhangar