### PR TITLE
add man_made=beacon preset

### DIFF
--- a/data/presets/presets/man_made/beacon.json
+++ b/data/presets/presets/man_made/beacon.json
@@ -1,0 +1,18 @@
+{
+    "fields": [
+        "name",
+        "height"
+    ],
+    "moreFields": [
+        "seamark/type"
+    ],
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "man_made": "beacon"
+    },
+    "name": "Beacon",
+    "matchScore": 0.5
+}


### PR DESCRIPTION
Used about 8k times. Documentation defines this a little wide:
https://wiki.openstreetmap.org/wiki/Tag:man_made%3Dbeacon

In other words, could be any kind of beacon, a [daybeacon](https://en.wikipedia.org/wiki/Day_beacon), a [light (beacon)](https://en.wikipedia.org/wiki/Leading_lights), even an aeronautical beacon. This is why I put `matchScore: 0.5`, so that a match does not possibly shadow the more exact presets with the various `seamark:type`s.