### PR TITLE
Added laundromat preset and self_service field

### DIFF
--- a/data/presets/fields/self_service.json
+++ b/data/presets/fields/self_service.json
@@ -1,5 +1,5 @@
 {
     "key": "self_service",
     "type": "check",
-    "label": "Self-service"
+    "label": "Self-Service"
 }

--- a/data/presets/fields/self_service.json
+++ b/data/presets/fields/self_service.json
@@ -1,0 +1,5 @@
+{
+    "key": "self_service",
+    "type": "check",
+    "label": "Self-service"
+}

--- a/data/presets/presets/amenity/car_wash.json
+++ b/data/presets/presets/amenity/car_wash.json
@@ -6,7 +6,8 @@
         "address",
         "building_area",
         "opening_hours",
-        "payment_multi"
+        "payment_multi",
+        "self_service"
     ],
     "moreFields": [
         "website",

--- a/data/presets/presets/amenity/fuel.json
+++ b/data/presets/presets/amenity/fuel.json
@@ -5,7 +5,8 @@
         "brand",
         "operator",
         "address",
-        "fuel_multi"
+        "fuel_multi",
+        "self_service"
     ],
     "moreFields": [
         "opening_hours",

--- a/data/presets/presets/shop/laundry.json
+++ b/data/presets/presets/shop/laundry.json
@@ -1,5 +1,9 @@
 {
     "icon": "maki-laundry",
+    "fields": [
+        "{shop}",
+        "self_service"
+    ],
     "geometry": [
         "point",
         "area"

--- a/data/presets/presets/shop/laundry/self_service_laundry.json
+++ b/data/presets/presets/shop/laundry/self_service_laundry.json
@@ -1,0 +1,19 @@
+{
+    "icon": "maki-laundry",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "shop": "laundry",
+        "self_service": "yes"
+    },
+    "terms": [
+        "coin laundry",
+        "laundromat",
+        "coin wash",
+        "launderette",
+        "washateria"
+    ],
+    "name": "Self-service laundry"
+}

--- a/data/presets/presets/shop/laundry/self_service_laundry.json
+++ b/data/presets/presets/shop/laundry/self_service_laundry.json
@@ -9,11 +9,11 @@
         "self_service": "yes"
     },
     "terms": [
-        "coin laundry",
-        "laundromat",
-        "coin wash",
-        "launderette",
-        "washateria"
+        "Coin Laundry",
+        "Laundromat",
+        "Coin Wash",
+        "Launderette",
+        "Washateria"
     ],
-    "name": "Self-service laundry"
+    "name": "Self-service Laundry"
 }


### PR DESCRIPTION
Added the laundromat preset because it often has quite a different name in languages (including English) than a generic (staff-operated) laundry. See https://en.wikipedia.org/wiki/Self-service_laundry

Also, added the `self_service` field https://wiki.openstreetmap.org/wiki/Key%3Aself_service , used 7k+ times and added this field to the presets that often have self-service: fuel stations, car washes and laundries. Not sure if it should be in `fields` or `moreFields`.