### PR TITLE
Revert "Deprecate amenity=dancing_school"

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -33,10 +33,6 @@
       "replace": {"amenity": "community_centre"}
     },
     {
-      "old": {"amenity": "dancing_school"},
-      "replace": {"leisure": "dance", "dance:teaching": "yes" }
-    },
-    {
       "old": {"amenity": "dog_bin"},
       "replace": {"amenity": "waste_basket", "waste": "dog_excrement"}
     },


### PR DESCRIPTION
Reverts openstreetmap/iD#6251

The wiki is/was misleading here. Apparently, the `amenity=dancing_school` is just the school, while `leisure=dance` is generally a venue where people can dance.