### PR TITLE
deprecate shop=jewellery

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -610,6 +610,10 @@
       "replace": {"shop": "art"}
     },
     {
+      "old": {"shop": "jewellery"},
+      "replace": {"shop": "jewelry"}
+    },
+    {
       "old": {"shop": "lingerie"},
       "replace": {"shop": "clothes", "clothes": "underwear"}
     },


### PR DESCRIPTION
Jewellery is the British English name for a jewelry. Usually in OSM, we use British English for tag names, but in this case the American English name established itself. Jewellery is now marked as deprecated in the wiki. See
https://wiki.openstreetmap.org/wiki/Tag%3Ashop%3Djewellery and
https://wiki.openstreetmap.org/wiki/Tag%3Ashop%3Djewelry

There are now a few hundred places left which are tagged with jewellery. A deprecation in iD helps to reduce this and accidental mistaggings as `jewellery` in the future by people who simply input the British English name as we usually do.