### PR TITLE
Add bust, graffiti and installation artwork type preset

### DIFF
--- a/data/presets/presets/tourism/artwork/bust.json
+++ b/data/presets/presets/tourism/artwork/bust.json
@@ -1,0 +1,22 @@
+{
+    "icon": "maki-art-gallery",
+    "fields": [
+        "name",
+        "artist",
+        "material"
+    ],
+    "geometry": [
+        "point", "vertex"
+    ],
+    "tags": {
+        "tourism": "artwork",
+        "artwork_type": "bust"
+    },
+    "reference": {
+        "key": "artwork_type"
+    },
+    "terms": [
+        "figure"
+    ],
+    "name": "Bust"
+}

--- a/data/presets/presets/tourism/artwork/graffiti.json
+++ b/data/presets/presets/tourism/artwork/graffiti.json
@@ -18,9 +18,9 @@
         "key": "artwork_type"
     },
     "terms": [
-        "graffiti",
         "Street Artwork",
-        "Guerilla Artwork"
+        "Guerilla Artwork",
+        "Graffiti Artwork"
     ],
-    "name": "Graffiti Artwork"
+    "name": "Graffiti"
 }

--- a/data/presets/presets/tourism/artwork/graffiti.json
+++ b/data/presets/presets/tourism/artwork/graffiti.json
@@ -1,0 +1,26 @@
+{
+    "icon": "maki-art-gallery",
+    "fields": [
+        "name",
+        "artist"
+    ],
+    "geometry": [
+        "point",
+        "vertex",
+        "line",
+        "area"
+    ],
+    "tags": {
+        "tourism": "artwork",
+        "artwork_type": "graffiti"
+    },
+    "reference": {
+        "key": "artwork_type"
+    },
+    "terms": [
+        "graffiti",
+        "Street Artwork",
+        "Guerilla Artwork"
+    ],
+    "name": "Graffiti Artwork"
+}

--- a/data/presets/presets/tourism/artwork/installation.json
+++ b/data/presets/presets/tourism/artwork/installation.json
@@ -1,0 +1,26 @@
+{
+    "icon": "maki-art-gallery",
+    "fields": [
+        "name",
+        "artist"
+    ],
+    "geometry": [
+        "point",
+        "vertex",
+        "line",
+        "area"
+    ],
+    "tags": {
+        "tourism": "artwork",
+        "artwork_type": "installation"
+    },
+    "reference": {
+        "key": "artwork_type"
+    },
+    "terms": [
+        "interactive art",
+        "intervention art",
+        "modern art"
+    ],
+    "name": "Installation Artwork"
+}

--- a/data/presets/presets/tourism/artwork/installation.json
+++ b/data/presets/presets/tourism/artwork/installation.json
@@ -22,5 +22,5 @@
         "intervention art",
         "modern art"
     ],
-    "name": "Installation Artwork"
+    "name": "Art Installation"
 }


### PR DESCRIPTION
Added the next three most used (according to taginfo) artwork types: Graffiti, Installation and Bust.

I think it is important to
* have bust if statue exists as a preset
* have graffiti if mural exists as a preset
* and have installation if sculpture exists as a preset

to avoid mistaggings, e.g. people searching for "graffiti wall" and finding only the "mural" preset would probably tag it (incorrectly) as a mural. Same with the others