### PR TITLE
add presets for types of wetland [Require Feedback]

### DIFF
--- a/data/presets/presets/natural/wetland.json
+++ b/data/presets/presets/natural/wetland.json
@@ -5,27 +5,15 @@
         "salt",
         "tidal"
     ],
-    "geometry": [
-        "point",
-        "area"
-    ],
+    "geometry": [ "area" ],
     "tags": {
         "natural": "wetland"
     },
     "terms": [
-        "bog",
-        "fen",
-        "marsh",
         "mire",
         "moor",
         "muskeg",
-        "peatland",
-        "quagmire",
-        "reedbed",
-        "saltmarsh",
-        "swamp",
-        "tidalflat",
-        "wet meadow"
+        "quagmire"
     ],
     "name": "Wetland"
 }

--- a/data/presets/presets/natural/wetland/bog.json
+++ b/data/presets/presets/natural/wetland/bog.json
@@ -1,0 +1,20 @@
+{
+    "icon": "maki-wetland",
+    "geometry": [ "area" ],
+    "tags": {
+        "natural": "wetland",
+        "wetland": "bog"
+    },
+    "reference": {
+        "key": "wetland",
+        "value": "bog"
+    },
+    "terms": [
+        "Bogland",
+        "Peatland",
+        "peat",
+        "acidic",
+        "rain-fed"
+    ],
+    "name": "Bog"
+}

--- a/data/presets/presets/natural/wetland/fen.json
+++ b/data/presets/presets/natural/wetland/fen.json
@@ -1,0 +1,18 @@
+{
+    "icon": "maki-wetland",
+    "geometry": [ "area" ],
+    "tags": {
+        "natural": "wetland",
+        "wetland": "fen"
+    },
+    "reference": {
+        "key": "wetland",
+        "value": "fen"
+    },
+    "terms": [
+        "Peatland",
+        "peat",
+        "groundwater-fed"
+    ],
+    "name": "Fen"
+}

--- a/data/presets/presets/natural/wetland/mangrove.json
+++ b/data/presets/presets/natural/wetland/mangrove.json
@@ -1,0 +1,18 @@
+{
+    "icon": "maki-wetland",
+    "geometry": [ "area" ],
+    "tags": {
+        "natural": "wetland",
+        "wetland": "mangrove"
+    },
+    "reference": {
+        "key": "wetland",
+        "value": "mangrove"
+    },
+    "terms": [
+        "Mangrove Forest",
+        "Mangal",
+        "mangroves"
+    ],
+    "name": "Mangrove Swamp"
+}

--- a/data/presets/presets/natural/wetland/marsh.json
+++ b/data/presets/presets/natural/wetland/marsh.json
@@ -1,0 +1,17 @@
+{
+    "icon": "maki-wetland",
+    "geometry": [ "area" ],
+    "tags": {
+        "natural": "wetland",
+        "wetland": "marsh"
+    },
+    "reference": {
+        "key": "wetland",
+        "value": "marsh"
+    },
+    "terms": [
+        "grass",
+        "wet grass"
+    ],
+    "name": "Marsh"
+}

--- a/data/presets/presets/natural/wetland/reedbed.json
+++ b/data/presets/presets/natural/wetland/reedbed.json
@@ -1,0 +1,17 @@
+{
+    "icon": "maki-wetland",
+    "geometry": [ "area" ],
+    "tags": {
+        "natural": "wetland",
+        "wetland": "reedbed"
+    },
+    "reference": {
+        "key": "wetland",
+        "value": "reedbed"
+    },
+    "terms": [
+        "reeds",
+        "bulrushes"
+    ],
+    "name": "Reedbed"
+}

--- a/data/presets/presets/natural/wetland/saltmarsh.json
+++ b/data/presets/presets/natural/wetland/saltmarsh.json
@@ -1,0 +1,18 @@
+{
+    "icon": "maki-wetland",
+    "geometry": [ "area" ],
+    "tags": {
+        "natural": "wetland",
+        "wetland": "saltmarsh"
+    },
+    "reference": {
+        "key": "wetland",
+        "value": "saltmarsh"
+    },
+    "terms": [
+        "Salt Marsh",
+        "Tidal Marsh",
+        "cordgrass"
+    ],
+    "name": "Saltmarsh"
+}

--- a/data/presets/presets/natural/wetland/swamp.json
+++ b/data/presets/presets/natural/wetland/swamp.json
@@ -1,0 +1,18 @@
+{
+    "icon": "maki-wetland",
+    "geometry": [ "area" ],
+    "tags": {
+        "natural": "wetland",
+        "wetland": "swamp"
+    },
+    "reference": {
+        "key": "wetland",
+        "value": "swamp"
+    },
+    "terms": [
+        "Swamp Forest",
+        "Shrub Swamp",
+        "forest"
+    ],
+    "name": "Swamp"
+}

--- a/data/presets/presets/natural/wetland/tidalflat.json
+++ b/data/presets/presets/natural/wetland/tidalflat.json
@@ -1,0 +1,18 @@
+{
+    "icon": "maki-wetland",
+    "geometry": [ "area" ],
+    "tags": {
+        "natural": "wetland",
+        "wetland": "wet_meadow"
+    },
+    "reference": {
+        "key": "wetland",
+        "value": "wet_meadow"
+    },
+    "terms": [
+        "Mud Flat",
+        "Mudflat",
+        "mud"
+    ],
+    "name": "Tidal Flat"
+}

--- a/data/presets/presets/natural/wetland/wet_meadow.json
+++ b/data/presets/presets/natural/wetland/wet_meadow.json
@@ -1,0 +1,19 @@
+{
+    "icon": "maki-wetland",
+    "geometry": [ "area" ],
+    "tags": {
+        "natural": "wetland",
+        "wetland": "wet_meadow"
+    },
+    "reference": {
+        "key": "wetland",
+        "value": "wet_meadow"
+    },
+    "terms": [
+        "Flood-Meadow",
+        "grass",
+        "wet grass",
+        "intermittent"
+    ],
+    "name": "Wet Meadow"
+}


### PR DESCRIPTION
Added the different types of wetland as presets. Also, corrected the geometry - should only be used on areas.

The `natural=wetland` preset contains the fields `salt` and `tidal`. I am not sure how to proceed with the sub-presets because some wetland types are `salt=yes` or `no` by definition, same with tidal.

**Should for example `salt=yes` automatically be added for `saltmarsh` and `mangrove` or the field be left away in cases where it is clear from the tag?**

Overview:
<table>
<tr><th></th><th>salt</th><th>tidal</th><th>intermittent</th></tr>
<tr><th colspan="4">Woody</th></tr>
<tr><td>swamp</td><td>well, there is <tt>mangrove</tt></td><td></td><td> </td></tr>
<tr><td>mangrove</td><td>always</td><td>always</td><td> </td></tr>
<tr><th colspan="4">Boggy</th></tr>
<tr><td>bog</td><td>never</td><td></td><td> </td></tr>
<tr><td>fen</td><td>never</td><td></td><td> </td></tr>
<tr><th colspan="4">Grassy</th></tr>
<tr><td>marsh</td><td>well, there is <tt>saltmarsh</tt></td><td> </td><td> </td></tr>
<tr><td>wet_meadow</td><td>well, there is <tt>saltmarsh</tt></td><td> </td><td>always</td></tr>
<tr><td>saltmarsh</td><td>always</td><td>always</td><td> </td></tr>
<tr><td>reedbed</td><td>well, there is <tt>saltmarsh</tt></td><td> </td><td> </td></tr>
<tr><th colspan="4">Muddy</th></tr>
<tr><td>tidalflat</td><td></td><td>always</td><td> </td></tr>
</table>