### PR TITLE
Improve validation for disconnected highways #5869

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1353,7 +1353,9 @@ en:
       tip: "Find unconnected highways and paths"
       highway:
         message: "{highway} is disconnected from other roads and paths"
+        message_new_road: "New {highway} is disconnected from existing road network"
         reference: "Highways should connect to other highways or building entrances."
+        reference_new_road: "New roads should connect to existing road network or building entrances."
     fixme_tag:
       title: '"Fix Me" Requests'
       message: '{feature} has a "Fix Me" request'

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -1669,7 +1669,9 @@
                 "tip": "Find unconnected highways and paths",
                 "highway": {
                     "message": "{highway} is disconnected from other roads and paths",
-                    "reference": "Highways should connect to other highways or building entrances."
+                    "message_new_road": "New {highway} is disconnected from existing road network",
+                    "reference": "Highways should connect to other highways or building entrances.",
+                    "reference_new_road": "New roads should connect to existing road network or building entrances."
                 }
             },
             "fixme_tag": {

--- a/test/spec/validations/disconnected_way.js
+++ b/test/spec/validations/disconnected_way.js
@@ -33,6 +33,22 @@ describe('iD.validations.disconnected_way', function () {
         );
     }
 
+    function createWayAtEndOfExistingOne(tags1, tags2) {
+        var n1 = iD.osmNode({id: 'n1', loc: [4,4]});
+        var n2 = iD.osmNode({id: 'n2', loc: [4,5]});
+        var n3 = iD.osmNode({id: 'n-3', loc: [5,5]});
+        var w = iD.osmWay({id: 'w1', nodes: ['n1', 'n2'], tags: tags1});
+        var w2 = iD.osmWay({id: 'w-2', nodes: ['n1', 'n-3'], tags: tags2});
+
+        context.perform(
+            iD.actionAddEntity(n1),
+            iD.actionAddEntity(n2),
+            iD.actionAddEntity(n3),
+            iD.actionAddEntity(w),
+            iD.actionAddEntity(w2)
+        );
+    }
+
     function validate() {
         var validator = iD.validationDisconnectedWay();
         var changes = context.history().changes();
@@ -91,8 +107,9 @@ describe('iD.validations.disconnected_way', function () {
         expect(issue.entities[0].id).to.eql('w-1');
     });
 
-    it('ignores highways that are connected', function() {
-        createConnectingWays({'highway': 'unclassified'}, {'highway': 'unclassified'});
+    it('ignores highways that are connected to existing highways', function() {
+        createWayAtEndOfExistingOne({'highway': 'secondary'}, {'highway': 'secondary'});
+
         var issues = validate();
         expect(issues).to.have.lengthOf(0);
     });


### PR DESCRIPTION
This addresses issue #5869. 

(This code was originally by @gaoxm- Thanks Ming!) 

Old behavior: mappers could create new highways that didn't attach to any existing highways. If the new highways were all connected to each other, no warning flag would present itself. 

New behavior: mappers will receive a warning if they create any new highways that aren't ultimately connected to existing ones. 


Validation catching two new connected primary (orange) highways that are otherwise disconnected from the rest of the highways: 
![image](https://user-images.githubusercontent.com/1887955/57044844-e86e7700-6c39-11e9-8158-17f606d9bd3d.png)

Issue is no longer flagged when the two new highways are connected: 
![image](https://user-images.githubusercontent.com/1887955/57044959-32eff380-6c3a-11e9-9aae-a9b001f740d7.png)
