### PR TITLE
add houseboat preset

### DIFF
--- a/data/presets/presets/building/houseboat.json
+++ b/data/presets/presets/building/houseboat.json
@@ -1,0 +1,17 @@
+{
+    "icon": "maki-home",
+    "geometry": [
+        "area"
+    ],
+    "tags": {
+        "building": "houseboat"
+    },
+    "terms": [
+        "home",
+        "family",
+        "residence",
+        "dwelling"
+    ],
+    "matchScore": 0.5,
+    "name": "Houseboat"
+}


### PR DESCRIPTION
[Documented since 2014](https://wiki.openstreetmap.org/wiki/Tag%3Abuilding%3Dhouseboat), used 14k+ times.

<img src="https://amsterdam.citymundo.com/wp-content/uploads/L1101802-1024x683.jpg"/>