### PR TITLE
Add an empty favicon for preview.ideditor.com

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -4,7 +4,7 @@
         <meta charset='utf-8'>
         <title>iD</title>
         <link rel='stylesheet' href='iD.css'>
-        <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgo=">
+        <link rel='icon' type='image/png' href='data:image/png;base64,iVBORw0KGgo='>
 
         <!-- mobile devices -->
         <meta name='viewport' content='initial-scale=1.0 maximum-scale=1.0'>

--- a/dist/index.html
+++ b/dist/index.html
@@ -4,6 +4,7 @@
         <meta charset='utf-8'>
         <title>iD</title>
         <link rel='stylesheet' href='iD.css'>
+        <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgo=">
 
         <!-- mobile devices -->
         <meta name='viewport' content='initial-scale=1.0 maximum-scale=1.0'>


### PR DESCRIPTION
There are multiple calls to the favicon on the preview.ideditor.com system in one session:
 > GET http://preview.ideditor.com/favicon.ico 403 (Forbidden)

According to https://stackoverflow.com/questions/1321878/how-to-prevent-favicon-ico-requests#comment50777781_13416784 this should show an empty favicon which will prevent the browser to try loading the missing icon.

- Is this the right index.html file that is used for the preview build?
- Is this the smart way to solve this? – Please just close it otherwise :).
