### PR TITLE
Remove crazyegg from the preview-index.html

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -28,12 +28,6 @@
               var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
             })();
 
-            // crazyegg
-            setTimeout(function(){var a=document.createElement('script');
-            var b=document.getElementsByTagName('script')[0];
-            a.src=document.location.protocol+'//dnn506yrbagrg.cloudfront.net/pages/scripts/0013/6714.js?'+Math.floor(new Date().getTime()/3600000);
-            a.async=true;a.type='text/javascript';b.parentNode.insertBefore(a,b)}, 1);
-
             if (typeof iD == 'undefined' || !iD.Detect().support) {
                 document.getElementById('id-container').innerHTML = 'Sorry, your browser is not currently supported. Please use Potlatch 2 to edit the map.';
                 document.getElementById('id-container').className = 'unsupported';


### PR DESCRIPTION
It looks like it is more than 6 years old https://github.com/openstreetmap/iD/blame/372bb7d892048d67415087f474688f85391bab2a/dist/index.html#L28 and the linked URL seems to be broken:
> $ curl http://dnn506yrbagrg.cloudfront.net/pages/scripts/0013/6714.js
> "undefined"==typeof CE2&&(CE2={}),CE2.uid=136714,CE2.status="no data available";

So to me it looks like it is save to remove it(?)