### PR TITLE
convert terms back to array on transifex import [Suggestion]

### DIFF
--- a/data/update_locales.js
+++ b/data/update_locales.js
@@ -92,12 +92,12 @@ function getResource(resource, callback) {
 
                 } else {
                     if (resource === 'presets') {
-                        // remove terms that were not really translated
+                        // remove terms that were not really translated and convert back to string array
                         var presets = (result.presets && result.presets.presets) || {};
                         for (const key of Object.keys(presets)) {
                             var preset = presets[key];
                             if (!preset.terms) continue;
-                            preset.terms = preset.terms.replace(/<.*>/, '').trim();
+                            preset.terms = preset.terms.replace(/<.*>/, '').trim().toLowerCase().split(/\s*,+\s*/);
                             if (!preset.terms) {
                                 delete preset.terms;
                                 if (!Object.keys(preset).length) {

--- a/modules/presets/preset.js
+++ b/modules/presets/preset.js
@@ -152,11 +152,11 @@ export function presetPreset(id, preset, fields, visible, rawPresets) {
     };
 
 
-    preset.originalTerms = (preset.terms || []).join();
+    preset.originalTerms = preset.terms || [];
 
 
     preset.terms = function() {
-        return preset.t('terms', { 'default': preset.originalTerms }).toLowerCase().trim().split(/\s*,+\s*/);
+        return preset.t('terms', { 'default': preset.originalTerms });
     };
 
 


### PR DESCRIPTION
I think it would be a slight improvement from a data structure point of view to convert the `terms` back from a comma separated string to an array already during the import from transifex.
So, the actual iD code does not convert it back but it is already in the right form to consume. Also, it is more consistent to have the `terms` as an array in the localization files because it is also an array in the `presets.json`. (Was confused about this)

What do you think?

The localizations need to be re-generated if this is merged.