### PR TITLE
Add preset for natural=rock

### DIFF
--- a/data/presets/presets/natural/rock.json
+++ b/data/presets/presets/natural/rock.json
@@ -1,0 +1,15 @@
+{
+    "fields": [
+        "name"
+    ],
+    "geometry": [
+        "point"
+    ],
+    "tags": {
+        "natural": "rock"
+    },
+    "terms": [
+        "Rock"
+    ],
+    "name": "Boulder"
+}

--- a/data/presets/presets/natural/rock.json
+++ b/data/presets/presets/natural/rock.json
@@ -3,7 +3,8 @@
         "name"
     ],
     "geometry": [
-        "point"
+        "point",
+        "area"
     ],
     "tags": {
         "natural": "rock"


### PR DESCRIPTION
... which is actually more precisely a free-standing (large) [boulder](https://en.wikipedia.org/wiki/Boulder). Already **used a whopping 156+k  times** and [documented in the wiki](https://wiki.openstreetmap.org/wiki/Tag:natural%3Drock).

<img src="https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/Balanced_Rock.jpg/320px-Balanced_Rock.jpg"/>

Useful for orientation and interesting for climbers.

### `natural=stone`

There is also `natural=stone`, used 14+k times, also [documented in the wiki](https://wiki.openstreetmap.org/wiki/Tag:natural%3Dstone), but not included in this pull request. It is documented to be a type of boulder, **one which is not attached to the underlying bedrock**. These often arrived at their current place through glaciation. In English, this type of boulder is called a [glacial erratic](https://en.wikipedia.org/wiki/Glacial_erratic).

<img src="https://wiki.openstreetmap.org/w/images/thumb/1/1d/Big_rock_at_saynatsalo.jpg/320px-Big_rock_at_saynatsalo.jpg"/>

#### German translation
If you wonder why there are these two tags at all, this is because in German, only boulders attached to the underlying bedrock are called **_Fels_**(block), while one that isn't is called **_Findling_**. One quote from the [German Wikipedia on this topic](https://de.wikipedia.org/wiki/Felsblock#Zur_Bezeichnung):
> Allgemein wird ein loser Steinblock geowissenschaftlich nicht als Felsen (gewachsen), sondern Stein bezeichnet.

**Translation**:
> In general, a loose stone block is geoscientifically not called a rock (grown), but a stone.

And there you have the origin of `natural=rock` and `natural=stone`. A distinction like this is not mentioned in the English Wikipedia articles about boulders, stones and rocks.

It is for this reason why I left out `natural=stone` aka _glacial erratic_ from this PR, because the distinction between these types of boulders are not part of common knowledge in English.

If you do not see a problem, I can change this to include also the stone.