### PR TITLE
add preset for water=wastewater

### DIFF
--- a/data/presets/presets/natural/water/wastewater.json
+++ b/data/presets/presets/natural/water/wastewater.json
@@ -1,0 +1,23 @@
+{
+    "icon": "maki-water",
+    "geometry": [
+        "area"
+    ],
+    "tags": {
+        "natural": "water",
+        "water": "wastewater"
+    },
+    "reference": {
+        "key": "water",
+        "value": "wastewater"
+    },
+    "terms": [
+        "excrement",
+        "shit",
+        "sewage",
+        "wastewater",
+        "Settling Basin",
+        "Clarifier Basin"
+    ],
+    "name": "Wastewater Basin"
+}


### PR DESCRIPTION
A settling or clarifying basin for wastewater. Used 17+k times and [documented in the wiki](https://wiki.openstreetmap.org/wiki/Tag:water%3Dwastewater).

Usually found in a wastewater plant, but on the countryside, it may also look like an innocent pond (if there are no signs).

I am not sure if I hit the correct English name here, I did not find a wikipedia article that is only about the basin, not the whole wastewater plant.