### PR TITLE
add preset for fire hose

### DIFF
--- a/data/presets/presets/emergency/fire_hose.json
+++ b/data/presets/presets/emergency/fire_hose.json
@@ -1,0 +1,16 @@
+{
+    "icon": "fas-fire-extinguisher",
+    "fields": [
+        "indoor",
+        "ref",
+        "operator"
+    ],
+    "geometry": [
+        "point",
+        "vertex"
+    ],
+    "tags": {
+        "emergency": "fire_hose"
+    },
+    "name": "Fire Hose"
+}


### PR DESCRIPTION
[Documented in the wiki](https://wiki.openstreetmap.org/wiki/Tag%3Aemergency%3Dfire_hose) since 2010, used 0.9k times.