### PR TITLE
add joiner, floorer, agricultural engine mechanic and parquet layer crafts

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -213,6 +213,14 @@
       "replace": {"craft": "glaziery"}
     },
     {
+      "old": {"craft": "catering"},
+      "replace": {"craft": "caterer"}
+    },
+    {
+      "old": {"craft": "sculpter"},
+      "replace": {"craft": "sculptor"}
+    },
+    {
       "old": {"crossing": "zebra"},
       "replace": {"crossing": "marked"}
     },

--- a/data/presets/presets/craft/agricultural_engines.json
+++ b/data/presets/presets/craft/agricultural_engines.json
@@ -7,5 +7,5 @@
     "tags": {
         "craft": "agricultural_engines"
     },
-    "name": "Argricultural Engines mechanic"
+    "name": "Argricultural Engines Mechanic"
 }

--- a/data/presets/presets/craft/agricultural_engines.json
+++ b/data/presets/presets/craft/agricultural_engines.json
@@ -1,0 +1,11 @@
+{
+    "icon": "temaki-tools",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "craft": "agricultural_engines"
+    },
+    "name": "Argricultural Engines mechanic"
+}

--- a/data/presets/presets/craft/floorer.json
+++ b/data/presets/presets/craft/floorer.json
@@ -1,0 +1,11 @@
+{
+    "icon": "temaki-tools",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "craft": "floorer"
+    },
+    "name": "Floorer"
+}

--- a/data/presets/presets/craft/joiner.json
+++ b/data/presets/presets/craft/joiner.json
@@ -1,0 +1,14 @@
+{
+    "icon": "temaki-tools",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "craft": "joiner"
+    },
+    "terms": [
+        "furniture"
+    ],
+    "name": "Joiner"
+}

--- a/data/presets/presets/craft/parquet_layer.json
+++ b/data/presets/presets/craft/parquet_layer.json
@@ -1,0 +1,11 @@
+{
+    "icon": "temaki-tools",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "craft": "parquet_layer"
+    },
+    "name": "Parquet Layer"
+}


### PR DESCRIPTION
Add a few craft presets:
- [**joiner**](https://wiki.openstreetmap.org/wiki/Tag%3Acraft%3Djoiner), documented since 2014, 600+ usages. A joiner is someone who builds furniture. There is also [`craft=cabinet_maker`](https://wiki.openstreetmap.org/wiki/Tag%3Acraft%3Dcabinet_maker) (200 usages) but I did not include that in this PR because it is not clear what is the difference to a joiner.
- [**agricultural engines mechanic**](https://wiki.openstreetmap.org/wiki/Tag%3Acraft%3Dagricultural_engines), documented since 2011, 500+ usages. I am not sure if this is the right word in English, in German it is [Landmaschinenmechaniker](https://de.wikipedia.org/wiki/Landmaschinenmechaniker)
- [**parquet layer**](https://wiki.openstreetmap.org/wiki/Tag:craft%3Dparquet_layer), documented since 2011, ~80 usages
- [**floorer**](https://wiki.openstreetmap.org/wiki/Tag:craft%3Dfloorer), documented since 2014, ~200 usages. So, a craftsman/company, that does general different floorer jobs, all of parquet laying, tile laying, floor laying etc.

Additionally, added deprecations catering -> caterer and sculpter -> sculptor