### PR TITLE
add some zoo types presets

### DIFF
--- a/data/presets/presets/tourism/zoo/petting.json
+++ b/data/presets/presets/tourism/zoo/petting.json
@@ -1,0 +1,22 @@
+{
+    "icon": "temaki-zoo",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "tourism": "zoo",
+        "zoo": "petting_zoo"
+    },
+    "reference": {
+        "key": "zoo",
+        "value": "petting_zoo"
+    },
+    "terms": [
+        "Children's Zoo",
+        "Children's Farm",
+        "Petting Farm",
+        "farm animals"
+    ],
+    "name": "Petting Zoo"
+}

--- a/data/presets/presets/tourism/zoo/safari.json
+++ b/data/presets/presets/tourism/zoo/safari.json
@@ -1,0 +1,20 @@
+{
+    "icon": "temaki-zoo",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "tourism": "zoo",
+        "zoo": "safari_park"
+    },
+    "reference": {
+        "key": "zoo",
+        "value": "safari_park"
+    },
+    "terms": [
+        "Drive-Through Zoo",
+        "Drive-In Zoo"
+    ],
+    "name": "Safari Park"
+}

--- a/data/presets/presets/tourism/zoo/wildlife.json
+++ b/data/presets/presets/tourism/zoo/wildlife.json
@@ -1,0 +1,19 @@
+{
+    "icon": "temaki-zoo",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "tourism": "zoo",
+        "zoo": "wildlife_park"
+    },
+    "reference": {
+        "key": "zoo",
+        "value": "wildlife_park"
+    },
+    "terms": [
+        "indigenous animals"
+    ],
+    "name": "Wildlife Park"
+}


### PR DESCRIPTION
- add [**petting zoo**](https://wiki.openstreetmap.org/wiki/Tag:zoo%3Dpetting_zoo) preset, documented since 2009, used ~600 times. A children's zoo with farm animals.
- add [**wildlife_park**](https://wiki.openstreetmap.org/wiki/Tag:zoo%3Dwildlife_park) preset, documented since 2017, used ~180 times. A zoo with indigenous animals in natural environment.
- add [**safari_park**](https://wiki.openstreetmap.org/wiki/Tag:zoo%3Dsafari_park) preset, documented since 2017, used only ~24 times. A drive-through zoo with exotic animals.

The wildlife park seems to be mostly unknown in the USA / United Kingdom, but it is a thing in Germany, Austria, Switzerland ([**Wildpark**](https://de.wikipedia.org/wiki/Wildpark)), France (**Parc de vision**), Netherlands (**Wildpark**), Israel (**חי-בר**) maybe other countries.

So, it is difficult to find a name in English that does not collide with the Safari Park. This is the reason why I added the Safari Park preset as well, even though it is used only a few times so far - so that in English-speaking countries, Safari parks will not be incorrectly added as Wildlife parks because iD only would only know the latter.