### PR TITLE
add castle-related presets

### DIFF
--- a/data/presets/presets/barrier/sally_port.json
+++ b/data/presets/presets/barrier/sally_port.json
@@ -1,0 +1,14 @@
+{
+    "icon": "fas-dungeon",
+    "geometry": [
+        "vertex"
+    ],
+    "tags": {
+        "barrier": "sally_port"
+    },
+    "terms": [
+        "Postern",
+        "castle side gate"
+    ],
+    "name": "Sally Port"
+}

--- a/data/presets/presets/historic/castle/fortress.json
+++ b/data/presets/presets/historic/castle/fortress.json
@@ -1,0 +1,26 @@
+{
+    "icon": "maki-castle",
+    "fields": [
+        "name",
+        "building_area",
+        "access_simple",
+        "start_date"
+    ],
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "reference": {
+        "key": "castle_type",
+        "value": "fortress"
+    },
+    "tags": {
+        "historic": "castle",
+        "castle_type": "fortress"
+    },
+    "terms": [
+        "citadel",
+        "military"
+    ],
+    "name": "Historic Fortress"
+}

--- a/data/presets/presets/historic/castle/palace.json
+++ b/data/presets/presets/historic/castle/palace.json
@@ -1,0 +1,28 @@
+{
+    "icon": "fas-crown",
+    "fields": [
+        "name",
+        "building_area",
+        "access_simple",
+        "start_date"
+    ],
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "reference": {
+        "key": "castle_type",
+        "value": "palace"
+    },
+    "tags": {
+        "historic": "castle",
+        "castle_type": "palace"
+    },
+    "terms": [
+        "Royal Residence",
+        "royal",
+        "king",
+        "queen"
+    ],
+    "name": "Palace"
+}

--- a/data/presets/presets/historic/castle/stately.json
+++ b/data/presets/presets/historic/castle/stately.json
@@ -1,0 +1,29 @@
+{
+    "icon": "fas-crown",
+    "fields": [
+        "name",
+        "building_area",
+        "access_simple",
+        "start_date"
+    ],
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "reference": {
+        "key": "castle_type",
+        "value": "stately"
+    },
+    "tags": {
+        "historic": "castle",
+        "castle_type": "stately"
+    },
+    "terms": [
+        "Historic Country House",
+        "Stately Home",
+        "nobility",
+        "gentry",
+        "representative"
+    ],
+    "name": "Château"
+}

--- a/data/presets/presets/historic/city_gate.json
+++ b/data/presets/presets/historic/city_gate.json
@@ -2,10 +2,8 @@
     "icon": "maki-castle",
     "fields": [
         "name",
-        "castle_type",
         "building_area",
         "historic/civilization",
-        "access_simple",
         "start_date"
     ],
     "geometry": [
@@ -13,7 +11,10 @@
         "area"
     ],
     "tags": {
-        "historic": "castle"
+        "historic": "city_gate"
     },
-    "name": "Castle"
+    "terms": [
+        "Town Gate"
+    ],
+    "name": "City Gate"
 }

--- a/data/presets/presets/historic/fort.json
+++ b/data/presets/presets/historic/fort.json
@@ -2,9 +2,7 @@
     "icon": "maki-castle",
     "fields": [
         "name",
-        "castle_type",
         "building_area",
-        "historic/civilization",
         "access_simple",
         "start_date"
     ],
@@ -13,7 +11,10 @@
         "area"
     ],
     "tags": {
-        "historic": "castle"
+        "historic": "fort"
     },
-    "name": "Castle"
+    "terms": [
+        "military"
+    ],
+    "name": "Historic Fort"
 }

--- a/data/presets/presets/historic/manor.json
+++ b/data/presets/presets/historic/manor.json
@@ -2,9 +2,7 @@
     "icon": "maki-castle",
     "fields": [
         "name",
-        "castle_type",
         "building_area",
-        "historic/civilization",
         "access_simple",
         "start_date"
     ],
@@ -13,7 +11,13 @@
         "area"
     ],
     "tags": {
-        "historic": "castle"
+        "historic": "manor"
     },
-    "name": "Castle"
+    "terms": [
+        "Mansion",
+        "gentry",
+        "nobility",
+        "estate"
+    ],
+    "name": "Manor House"
 }

--- a/data/presets/presets/man_made/cross.json
+++ b/data/presets/presets/man_made/cross.json
@@ -1,0 +1,19 @@
+{
+    "icon": "maki-religious-christian",
+    "fields": [
+        "name",
+        "material",
+        "height",
+        "ele",
+        "inscription",
+        "direction"
+    ],
+    "geometry": [
+        "point",
+        "vertex"
+    ],
+    "tags": {
+        "man_made": "cross"
+    },
+    "name": "Summit cross"
+}

--- a/data/presets/presets/natural/water/moat.json
+++ b/data/presets/presets/natural/water/moat.json
@@ -1,0 +1,15 @@
+{
+    "icon": "maki-water",
+    "fields": [
+        "{natural/water}",
+        "salt"
+    ],
+    "geometry": [
+        "area"
+    ],
+    "tags": {
+        "natural": "water",
+        "water": "moat"
+    },
+    "name": "Moat"
+}


### PR DESCRIPTION
- [`man_made=cross`](https://wiki.openstreetmap.org/wiki/Tag%3Aman_made%3Dcross), documented since 2011, used 4600+ times. This is a "cross of no religious or historic importance", so, usually a **summit cross**.
- [`water=moat`](https://wiki.openstreetmap.org/wiki/Key:water), documented since 2013, used 400+ times
- [`historic=city_gate`](https://wiki.openstreetmap.org/wiki/Tag%3Ahistoric%3Dcity_gate), documented since 2010, used 3000+ times
- [`barrier=sally_port`](https://wiki.openstreetmap.org/wiki/Tag:barrier%3Dsally_port), documented since 2012/2016, used 4000+ times, approved. A side gate or **postern** in castles, e.g. for sorties.
- [`historic=fort`](https://wiki.openstreetmap.org/wiki/Tag%3Ahistoric%3Dfort), documented since 2012/2016, used 3500 times
- [`castle_type=fortress`](https://wiki.openstreetmap.org/wiki/Tag%3Acastle_type%3Dfortress), documented since 2014 in German wiki and in English wiki since 2015, used 1400+ times. Heavily fortified castle for military use.
- [`castle_type=palace`](https://wiki.openstreetmap.org/wiki/Tag%3Acastle_type%3Dpalace), documented since 2014 in German wiki and in English wiki since 2015, used 1300+ times. A royal residence.
There is also `historic=palace`, but it is used only 380+ times and was never documented.
- [`castle_type=stately`](https://wiki.openstreetmap.org/wiki/Tag%3Acastle_type%3Dstately), documented since 2014 in German wiki only, translated to English wiki in 2017, used 4000 times. A residence of the nobility.
- [`historic=manor`](https://wiki.openstreetmap.org/wiki/Tag%3Ahistoric%3Dmanor), documented since 2011, used 5000+ times. Or mansion. A residence on an estate.
There is also `castle_type=manor`, but it is used much less often (2300 times) and was documented later (2015). There is no discussion in the wiki whether `historic=manor` should be replaced by that `castle_type=manor` tagging.

How exactly some of the castle types presented here differ from another, for example manor vs stately, is I think not so important because in the end, what counts is the denomination used on the plaques / tourist guides / info booklets / wikipedia article. So, the mapper mapping with iD will likely input the denomination on this info material there and expect to get the correct preset for that.

By the way, "castle" may be used rather as a generic term for most of the above, that is why I did not add the `castle_type=defensive` - this would be the typical medieval castle.