### PR TITLE
add barrier=chain preset

### DIFF
--- a/data/presets/presets/barrier/chain.json
+++ b/data/presets/presets/barrier/chain.json
@@ -1,0 +1,14 @@
+{
+    "icon": "maki-barrier",
+    "fields": [
+        "access"
+    ],
+    "geometry": [
+        "vertex",
+        "line"
+    ],
+    "tags": {
+        "barrier": "chain"
+    },
+    "name": "Chain"
+}


### PR DESCRIPTION
**Used 11000+ times** and documented since 2009 (on own page since 2011)

See https://wiki.openstreetmap.org/wiki/Tag:barrier%3Dchain

The problem maybe is that the name "chain" is perhaps too broad so it might be mistaken for something else? Suggestion: "Chain Barrier"?