### PR TITLE
Update for playground equipment presets

### DIFF
--- a/data/presets/fields/playground/baby.json
+++ b/data/presets/fields/playground/baby.json
@@ -1,5 +1,5 @@
 {
     "key": "baby",
     "type": "check",
-    "label": "Baby Seat"
+    "label": "Primarily designed for babies"
 }

--- a/data/presets/fields/playground/blind.json
+++ b/data/presets/fields/playground/blind.json
@@ -1,0 +1,6 @@
+{
+    "key": "blind",
+    "type": "combo",
+    "label": "Can be used by blind people",
+    "options": ["yes", "no", "limited"]
+}

--- a/data/presets/fields/playground/blind.json
+++ b/data/presets/fields/playground/blind.json
@@ -1,6 +1,10 @@
 {
     "key": "blind",
-    "type": "combo",
-    "label": "Can be used by blind people",
-    "options": ["yes", "no", "limited"]
+    "type": "radio",
+    "options": [
+        "yes",
+        "no",
+        "limited"
+    ],
+    "label": "Can be used by blind people"
 }

--- a/data/presets/fields/playground/sitting_disability.json
+++ b/data/presets/fields/playground/sitting_disability.json
@@ -1,0 +1,6 @@
+{
+    "key": "sitting_disability",
+    "type": "combo",
+    "label": "Can be used by those who cannot sit",
+    "options": ["yes", "no", "limited"]
+}

--- a/data/presets/fields/playground/sitting_disability.json
+++ b/data/presets/fields/playground/sitting_disability.json
@@ -1,6 +1,10 @@
 {
     "key": "sitting_disability",
     "type": "combo",
-    "label": "Can be used by those who cannot sit",
-    "options": ["yes", "no", "limited"]
+    "options": [
+        "yes",
+        "no",
+        "limited"
+    ],
+    "label": "Can be used by those who cannot sit"
 }

--- a/data/presets/fields/playground/theme.json
+++ b/data/presets/fields/playground/theme.json
@@ -1,0 +1,10 @@
+{
+    "key": "playground:theme",
+    "type": "radio",
+    "options": [
+        "yes",
+        "no",
+        "limited"
+    ],
+    "label": "If it is themed in some way"
+}

--- a/data/presets/fields/playground/theme.json
+++ b/data/presets/fields/playground/theme.json
@@ -1,10 +1,5 @@
 {
     "key": "playground:theme",
-    "type": "radio",
-    "options": [
-        "yes",
-        "no",
-        "limited"
-    ],
+    "type": "semiCombo",
     "label": "If it is themed in some way"
 }

--- a/data/presets/fields/playground/walking_disability.json
+++ b/data/presets/fields/playground/walking_disability.json
@@ -1,6 +1,10 @@
 {
     "key": "walking_disability",
     "type": "combo",
-    "label": "Can be used by those who cannot walk",
-    "options": ["yes", "no", "limited"]
+    "options": [
+        "yes",
+        "no",
+        "limited"
+    ],
+    "label": "Can be used by those who cannot walk"
 }

--- a/data/presets/fields/playground/walking_disability.json
+++ b/data/presets/fields/playground/walking_disability.json
@@ -1,0 +1,6 @@
+{
+    "key": "walking_disability",
+    "type": "combo",
+    "label": "Can be used by those who cannot walk",
+    "options": ["yes", "no", "limited"]
+}

--- a/data/presets/presets/playground/activitypanel.json
+++ b/data/presets/presets/playground/activitypanel.json
@@ -1,5 +1,19 @@
 {
     "icon": "maki-playground",
+    "fields": [
+        "playground/theme",
+        "playground/min_age",
+        "playground/max_age",
+        "playground/baby",
+        "wheelchair"
+    ],
+    "moreFields": [
+        "name",
+        "playground/blind",
+        "playground/walking_disability",
+        "playground/sitting_disability",
+        "material"
+    ],
     "geometry": [
         "point"
     ],

--- a/data/presets/presets/playground/activitypanel.json
+++ b/data/presets/presets/playground/activitypanel.json
@@ -1,0 +1,10 @@
+{
+    "icon": "maki-playground",
+    "geometry": [
+        "point"
+    ],
+    "tags": {
+        "playground": "acrivitypanel"
+    },
+    "name": "Playground Activity Panel"
+}

--- a/data/presets/presets/playground/aerial_rotator.json
+++ b/data/presets/presets/playground/aerial_rotator.json
@@ -1,0 +1,10 @@
+{
+    "icon": "maki-playground",
+    "geometry": [
+        "point"
+    ],
+    "tags": {
+        "playground": "aerialrotator"
+    },
+    "name": "Playground Overhead Rotator"
+}

--- a/data/presets/presets/playground/aerial_rotator.json
+++ b/data/presets/presets/playground/aerial_rotator.json
@@ -1,5 +1,17 @@
 {
     "icon": "maki-playground",
+    "fields": [
+        "playground/theme",
+        "playground/min_age",
+        "playground/max_age"
+    ],
+    "moreFields": [
+        "name",
+        "playground/blind",
+        "playground/walking_disability",
+        "playground/sitting_disability",
+        "material"
+    ],
     "geometry": [
         "point"
     ],

--- a/data/presets/presets/playground/balance_beam.json
+++ b/data/presets/presets/playground/balance_beam.json
@@ -1,5 +1,17 @@
 {
     "icon": "maki-playground",
+     "fields": [
+        "playground/theme",
+        "playground/min_age",
+        "playground/max_age",
+        "playground/baby"
+    ],
+    "moreFields": [
+        "name",
+        "playground/blind",
+        "playground/sitting_disability",
+        "material"
+    ],
     "geometry": [
         "point",
         "line"

--- a/data/presets/presets/playground/basket_spinner.json
+++ b/data/presets/presets/playground/basket_spinner.json
@@ -1,5 +1,18 @@
 {
     "icon": "maki-playground",
+     "fields": [
+        "playground/theme",
+        "playground/min_age",
+        "playground/max_age",
+        "playground/baby"
+    ],
+    "moreFields": [
+        "name",
+        "playground/blind",
+        "playground/walking_disability",
+        "playground/sitting_disability",
+        "material"
+    ],
     "geometry": [
         "point"
     ],

--- a/data/presets/presets/playground/basket_swing.json
+++ b/data/presets/presets/playground/basket_swing.json
@@ -1,5 +1,18 @@
 {
     "icon": "maki-playground",
+     "fields": [
+        "playground/theme",
+        "playground/min_age",
+        "playground/max_age",
+        "playground/baby"
+    ],
+    "moreFields": [
+        "name",
+        "playground/blind",
+        "playground/walking_disability",
+        "playground/sitting_disability",
+        "material"
+    ],
     "geometry": [
         "point"
     ],

--- a/data/presets/presets/playground/climbing_frame.json
+++ b/data/presets/presets/playground/climbing_frame.json
@@ -1,5 +1,17 @@
 {
     "icon": "maki-playground",
+    "fields": [
+        "playground/theme",
+        "playground/min_age",
+        "playground/max_age",
+        "playground/baby"
+    ],
+    "moreFields": [
+        "name",
+        "playground/blind",
+        "playground/sitting_disability",
+        "material"
+    ],
     "geometry": [
         "point",
         "area"

--- a/data/presets/presets/playground/climbing_wall.json
+++ b/data/presets/presets/playground/climbing_wall.json
@@ -1,0 +1,12 @@
+{
+    "icon": "maki-playground",
+    "geometry": [
+        "point",
+        "line",
+        "area"
+    ],
+    "tags": {
+        "playground": "climbingwall"
+    },
+    "name": "Play Climbing Wall"
+}

--- a/data/presets/presets/playground/climbing_wall.json
+++ b/data/presets/presets/playground/climbing_wall.json
@@ -1,5 +1,15 @@
 {
     "icon": "maki-playground",
+    "fields": [
+        "playground/theme",
+        "playground/min_age",
+        "playground/max_age"
+    ],
+    "moreFields": [
+        "name",
+        "playground/blind",
+        "material"
+    ],
     "geometry": [
         "point",
         "line",

--- a/data/presets/presets/playground/cushion.json
+++ b/data/presets/presets/playground/cushion.json
@@ -1,5 +1,17 @@
 {
     "icon": "maki-playground",
+    "fields": [
+        "playground/theme",
+        "playground/min_age",
+        "playground/max_age",
+        "playground/baby"
+    ],
+    "moreFields": [
+        "name",
+        "playground/blind",
+        "playground/sitting_disability",
+        "material"
+    ],
     "geometry": [
         "point",
         "area"

--- a/data/presets/presets/playground/exercise.json
+++ b/data/presets/presets/playground/exercise.json
@@ -1,5 +1,18 @@
 {
     "icon": "maki-playground",
+    "fields": [
+        "playground/theme",
+        "playground/min_age",
+        "playground/max_age",
+        "wheelchair"
+    ],
+    "moreFields": [
+        "name",
+        "playground/blind",
+        "playground/walking_disability",
+        "playground/sitting_disability",
+        "material"
+    ],
     "geometry": [
         "point"
     ],

--- a/data/presets/presets/playground/exercise.json
+++ b/data/presets/presets/playground/exercise.json
@@ -1,0 +1,10 @@
+{
+    "icon": "maki-playground",
+    "geometry": [
+        "point"
+    ],
+    "tags": {
+        "playground": "exercise"
+    },
+    "name": "Playground Exercise Equipment"
+}

--- a/data/presets/presets/playground/hopscotch.json
+++ b/data/presets/presets/playground/hopscotch.json
@@ -1,0 +1,12 @@
+{
+    "icon": "maki-playground",
+    "geometry": [
+        "point",
+        "line",
+        "area"
+    ],
+    "tags": {
+        "playground": "hopscotch"
+    },
+    "name": "Play Hopscotch"
+}

--- a/data/presets/presets/playground/horizontal_bar.json
+++ b/data/presets/presets/playground/horizontal_bar.json
@@ -1,7 +1,11 @@
 {
     "icon": "maki-pitch",
     "fields": [
-        "height"
+        "height",
+        "playground/theme"
+    ],
+    "moreFields": [
+        "material"
     ],
     "geometry": [
         "point"

--- a/data/presets/presets/playground/playhouse.json
+++ b/data/presets/presets/playground/playhouse.json
@@ -1,0 +1,11 @@
+{
+    "icon": "maki-playground",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "playground": "playhouse"
+    },
+    "name": "Playhouse"
+}

--- a/data/presets/presets/playground/playhouse.json
+++ b/data/presets/presets/playground/playhouse.json
@@ -1,5 +1,19 @@
 {
     "icon": "maki-playground",
+    "fields": [
+        "playground/theme",
+        "playground/min_age",
+        "playground/max_age",
+        "playground/baby",
+        "wheelchair"
+    ],
+    "moreFields": [
+        "name",
+        "playground/blind",
+        "playground/walking_disability",
+        "playground/sitting_disability",
+        "material"
+    ],
     "geometry": [
         "point",
         "area"

--- a/data/presets/presets/playground/rocker.json
+++ b/data/presets/presets/playground/rocker.json
@@ -1,5 +1,17 @@
 {
     "icon": "maki-playground",
+    "fields": [
+        "playground/theme",
+        "playground/min_age",
+        "playground/max_age",
+        "playground/baby"
+    ],
+    "moreFields": [
+        "name",
+        "playground/blind",
+        "playground/walking_disability",
+        "material"
+    ],
     "geometry": [
         "point"
     ],

--- a/data/presets/presets/playground/roundabout.json
+++ b/data/presets/presets/playground/roundabout.json
@@ -1,6 +1,20 @@
 {
     "icon": "maki-stadium",
     "fields": [
+        "playground/theme",
+        "playground/min_age",
+        "playground/max_age",
+        "playground/baby",
+        "wheelchair"
+    ],
+    "moreFields": [
+        "name",
+        "playground/blind",
+        "playground/walking_disability",
+        "playground/sitting_disability",
+        "material"
+    ],
+    "fields": [
         "bench"
     ],
     "geometry": [

--- a/data/presets/presets/playground/sandpit.json
+++ b/data/presets/presets/playground/sandpit.json
@@ -1,5 +1,19 @@
 {
     "icon": "maki-playground",
+    "fields": [
+        "playground/theme",
+        "playground/min_age",
+        "playground/max_age",
+        "playground/baby",
+        "wheelchair"
+    ],
+    "moreFields": [
+        "name",
+        "playground/blind",
+        "playground/walking_disability",
+        "playground/sitting_disability",
+        "material"
+    ],
     "geometry": [
         "point",
         "area"

--- a/data/presets/presets/playground/seesaw.json
+++ b/data/presets/presets/playground/seesaw.json
@@ -1,5 +1,19 @@
 {
     "icon": "maki-playground",
+    "fields": [
+        "playground/theme",
+        "playground/min_age",
+        "playground/max_age",
+        "playground/baby",
+        "wheelchair"
+    ],
+    "moreFields": [
+        "name",
+        "playground/blind",
+        "playground/walking_disability",
+        "playground/sitting_disability",
+        "material"
+    ],
     "geometry": [
         "point"
     ],

--- a/data/presets/presets/playground/sledding.json
+++ b/data/presets/presets/playground/sledding.json
@@ -1,0 +1,12 @@
+{
+    "icon": "maki-playground",
+    "geometry": [
+        "point",
+        "line",
+        "area"
+    ],
+    "tags": {
+        "playground": "sledding"
+    },
+    "name": "Play Sledding"
+}

--- a/data/presets/presets/playground/sledding.json
+++ b/data/presets/presets/playground/sledding.json
@@ -1,5 +1,19 @@
 {
     "icon": "maki-playground",
+    "fields": [
+        "playground/theme",
+        "playground/min_age",
+        "playground/max_age",
+        "playground/baby",
+        "wheelchair"
+    ],
+    "moreFields": [
+        "name",
+        "playground/blind",
+        "playground/walking_disability",
+        "playground/sitting_disability",
+        "material"
+    ],
     "geometry": [
         "point",
         "line",

--- a/data/presets/presets/playground/slide.json
+++ b/data/presets/presets/playground/slide.json
@@ -1,5 +1,19 @@
 {
     "icon": "maki-playground",
+    "fields": [
+        "playground/theme",
+        "playground/min_age",
+        "playground/max_age",
+        "playground/baby",
+        "wheelchair"
+    ],
+    "moreFields": [
+        "name",
+        "playground/blind",
+        "playground/walking_disability",
+        "playground/sitting_disability",
+        "material"
+    ],
     "geometry": [
         "point",
         "line"

--- a/data/presets/presets/playground/splash_pad.json
+++ b/data/presets/presets/playground/splash_pad.json
@@ -1,5 +1,19 @@
 {
     "icon": "maki-playground",
+    "fields": [
+        "playground/theme",
+        "playground/min_age",
+        "playground/max_age",
+        "playground/baby",
+        "wheelchair"
+    ],
+    "moreFields": [
+        "name",
+        "playground/blind",
+        "playground/walking_disability",
+        "playground/sitting_disability",
+        "material"
+    ],
     "geometry": [
         "point",
         "area"

--- a/data/presets/presets/playground/splash_pad.json
+++ b/data/presets/presets/playground/splash_pad.json
@@ -1,0 +1,11 @@
+{
+    "icon": "maki-playground",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "playground": "splash_pad"
+    },
+    "name": "Playground Splash Pad"
+}

--- a/data/presets/presets/playground/structure.json
+++ b/data/presets/presets/playground/structure.json
@@ -1,5 +1,19 @@
 {
     "icon": "maki-pitch",
+    "fields": [
+        "playground/theme",
+        "playground/min_age",
+        "playground/max_age",
+        "playground/baby",
+        "wheelchair"
+    ],
+    "moreFields": [
+        "name",
+        "playground/blind",
+        "playground/walking_disability",
+        "playground/sitting_disability",
+        "material"
+    ],
     "geometry": [
         "point",
         "area"

--- a/data/presets/presets/playground/swing.json
+++ b/data/presets/presets/playground/swing.json
@@ -1,6 +1,20 @@
 {
     "icon": "maki-playground",
     "fields": [
+        "playground/theme",
+        "playground/min_age",
+        "playground/max_age",
+        "playground/baby",
+        "wheelchair"
+    ],
+    "moreFields": [
+        "name",
+        "playground/blind",
+        "playground/walking_disability",
+        "playground/sitting_disability",
+        "material"
+    ],
+    "fields": [
         "capacity",
         "playground/baby",
         "wheelchair"

--- a/data/presets/presets/playground/teen_shelter.json
+++ b/data/presets/presets/playground/teen_shelter.json
@@ -1,5 +1,16 @@
 {
     "icon": "maki-playground",
+    "fields": [
+        "playground/theme",
+        "wheelchair"
+    ],
+    "moreFields": [
+        "name",
+        "playground/blind",
+        "playground/walking_disability",
+        "playground/sitting_disability",
+        "material"
+    ],
     "geometry": [
         "point",
         "area"

--- a/data/presets/presets/playground/teen_shelter.json
+++ b/data/presets/presets/playground/teen_shelter.json
@@ -1,0 +1,11 @@
+{
+    "icon": "maki-playground",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "playground": "teenshelter"
+    },
+    "name": "Playground Teen Shelter"
+}

--- a/data/presets/presets/playground/trampoline.json
+++ b/data/presets/presets/playground/trampoline.json
@@ -1,0 +1,11 @@
+{
+    "icon": "maki-playground",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "playground": "trampoline"
+    },
+    "name": "Play Trampoline"
+}

--- a/data/presets/presets/playground/trampoline.json
+++ b/data/presets/presets/playground/trampoline.json
@@ -1,5 +1,19 @@
 {
     "icon": "maki-playground",
+    "fields": [
+        "playground/theme",
+        "playground/min_age",
+        "playground/max_age",
+        "playground/baby",
+        "wheelchair"
+    ],
+    "moreFields": [
+        "name",
+        "playground/blind",
+        "playground/walking_disability",
+        "playground/sitting_disability",
+        "material"
+    ],
     "geometry": [
         "point",
         "area"

--- a/data/presets/presets/playground/water.json
+++ b/data/presets/presets/playground/water.json
@@ -1,0 +1,11 @@
+{
+    "icon": "maki-playground",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "playground": "water"
+    },
+    "name": "Playground Water Pump"
+}

--- a/data/presets/presets/playground/water.json
+++ b/data/presets/presets/playground/water.json
@@ -1,5 +1,19 @@
 {
     "icon": "maki-playground",
+    "fields": [
+        "playground/theme",
+        "playground/min_age",
+        "playground/max_age",
+        "playground/baby",
+        "wheelchair"
+    ],
+    "moreFields": [
+        "name",
+        "playground/blind",
+        "playground/walking_disability",
+        "playground/sitting_disability",
+        "material"
+    ],
     "geometry": [
         "point",
         "area"

--- a/data/presets/presets/playground/zipwire.json
+++ b/data/presets/presets/playground/zipwire.json
@@ -1,5 +1,17 @@
 {
     "icon": "maki-playground",
+    "fields": [
+        "playground/theme",
+        "playground/min_age",
+        "playground/max_age"
+    ],
+    "moreFields": [
+        "name",
+        "playground/blind",
+        "playground/walking_disability",
+        "material",
+        "wheelchair"
+    ],
     "geometry": [
         "point",
         "line"


### PR DESCRIPTION
Additional equipment types according to wiki:

- activity panel
- aerial rotator
- climbing wall
- excersise
- hopscotch
- playhouse
- sledding
- splash pad
- teen shelter
- trampoline
- water

Additional description fields for playground equipment:

- blind
- sitting_disability
- walking_disability
- min_age
- max_age
- theme