### PR TITLE
Allow "layer" tags alone to resolve building crossing issues

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1334,9 +1334,9 @@ en:
       building-building:
         reference: "Buildings should not intersect except on different layers."
       building-highway:
-        reference: "Highways crossing buildings should use bridges, tunnels, coverings, or entrances."
+        reference: "Highways crossing buildings should use bridges, tunnels, or different layers."
       building-railway:
-        reference: "Railways crossing buildings should use bridges or tunnels."
+        reference: "Railways crossing buildings should use bridges, tunnels, or different layers."
       building-waterway:
         reference: "Waterways crossing buildings should use tunnels or different layers."
       highway-highway:

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -1637,10 +1637,10 @@
                     "reference": "Buildings should not intersect except on different layers."
                 },
                 "building-highway": {
-                    "reference": "Highways crossing buildings should use bridges, tunnels, coverings, or entrances."
+                    "reference": "Highways crossing buildings should use bridges, tunnels, or different layers."
                 },
                 "building-railway": {
-                    "reference": "Railways crossing buildings should use bridges or tunnels."
+                    "reference": "Railways crossing buildings should use bridges, tunnels, or different layers."
                 },
                 "building-waterway": {
                     "reference": "Waterways crossing buildings should use tunnels or different layers."

--- a/modules/ui/fields/radio.js
+++ b/modules/ui/fields/radio.js
@@ -75,10 +75,10 @@ export function uiFieldRadio(field, context) {
 
 
     function structureExtras(selection, tags) {
-        var selected = selectedKey();
+        var selected = selectedKey() || tags.layer !== undefined;
         var type = context.presets().field(selected);
         var layer = context.presets().field('layer');
-        var showLayer = (selected === 'bridge' || selected === 'tunnel');
+        var showLayer = (selected === 'bridge' || selected === 'tunnel' || tags.layer !== undefined);
 
 
         var extrasWrap = selection.selectAll('.structure-extras-wrap')

--- a/modules/validations/crossing_ways.js
+++ b/modules/validations/crossing_ways.js
@@ -49,17 +49,11 @@ export function validationCrossingWays() {
         return hasTag(tags, 'level') || tags.highway === 'corridor';
     }
 
-    function allowsStructures(featureType) {
-        return allowsBridge(featureType) || allowsTunnel(featureType);
-    }
     function allowsBridge(featureType) {
         return featureType === 'highway' || featureType === 'railway' || featureType === 'waterway';
     }
     function allowsTunnel(featureType) {
         return featureType === 'highway' || featureType === 'railway' || featureType === 'waterway';
-    }
-    function canCover(featureType) {
-        return featureType === 'building';
     }
 
 
@@ -121,20 +115,12 @@ export function validationCrossingWays() {
         } else if (allowsTunnel(featureType1) && hasTag(tags1, 'tunnel')) return true;
         else if (allowsTunnel(featureType2) && hasTag(tags2, 'tunnel')) return true;
 
-        if (canCover(featureType1) && canCover(featureType2)) {
-            if (hasTag(tags1, 'covered') && !hasTag(tags2, 'covered')) return true;
-            if (!hasTag(tags1, 'covered') && hasTag(tags2, 'covered')) return true;
-            // crossing covered features that can themselves cover must use different layers
-            if (hasTag(tags1, 'covered') && hasTag(tags2, 'covered') && layer1 !== layer2) return true;
-        } else if (canCover(featureType1) && hasTag(tags2, 'covered')) return true;
-        else if (canCover(featureType2) && hasTag(tags1, 'covered')) return true;
-
         // don't flag crossing waterways and pier/highways
         if (featureType1 === 'waterway' && featureType2 === 'highway' && tags2.man_made === 'pier') return true;
         if (featureType2 === 'waterway' && featureType1 === 'highway' && tags1.man_made === 'pier') return true;
 
-        if (!allowsStructures(featureType1) && !allowsStructures(featureType2)) {
-            // if no structures are applicable, the layers must be different
+        if (featureType1 === 'building' || featureType2 === 'building') {
+            // for building crossings, different layers are enough
             if (layer1 !== layer2) return true;
         }
         return false;
@@ -428,10 +414,13 @@ export function validationCrossingWays() {
         } else {
             useFixID = 'use_different_layers';
         }
-        if (useFixID === 'use_different_layers') {
+        if (useFixID === 'use_different_layers' ||
+            featureType1 === 'building' ||
+            featureType2 === 'building') {
             fixes.push(makeChangeLayerFix('higher', context));
             fixes.push(makeChangeLayerFix('lower', context));
-        } else {
+        }
+        if (useFixID !== 'use_different_layers') {
             fixes.push(new validationIssueFix({
                 icon: useFixIcon,
                 title: t('issues.fix.' + useFixID + '.title')

--- a/test/spec/validations/crossing_ways.js
+++ b/test/spec/validations/crossing_ways.js
@@ -99,7 +99,7 @@ describe('iD.validations.crossing_ways', function () {
     });
 
     it('legit crossing between highway and building', function() {
-        createWaysWithOneCrossingPoint({ highway: 'residential', covered: 'yes' }, { building: 'yes' });
+        createWaysWithOneCrossingPoint({ highway: 'residential', layer: '-1' }, { building: 'yes' });
         var issues = validate();
         expect(issues).to.have.lengthOf(0);
     });
@@ -123,7 +123,7 @@ describe('iD.validations.crossing_ways', function () {
     });
 
     it('legit crossing between railway and building', function() {
-        createWaysWithOneCrossingPoint({ railway: 'rail', covered: 'yes' }, { building: 'yes' });
+        createWaysWithOneCrossingPoint({ railway: 'rail', layer: '-1' }, { building: 'yes' });
         var issues = validate();
         expect(issues).to.have.lengthOf(0);
     });
@@ -135,13 +135,13 @@ describe('iD.validations.crossing_ways', function () {
     });
 
     it('legit crossing between waterway and building', function() {
-        createWaysWithOneCrossingPoint({ waterway: 'river', covered: 'yes' }, { building: 'yes' });
+        createWaysWithOneCrossingPoint({ waterway: 'river', layer: '-1' }, { building: 'yes' });
         var issues = validate();
         expect(issues).to.have.lengthOf(0);
     });
 
     it('legit crossing between building and building', function() {
-        createWaysWithOneCrossingPoint({ building: 'yes' }, { building: 'yes', covered: 'yes' });
+        createWaysWithOneCrossingPoint({ building: 'yes' }, { building: 'yes', layer: '1' });
         var issues = validate();
         expect(issues).to.have.lengthOf(0);
     });


### PR DESCRIPTION
Closes #5924.

This lets instances of buildings crossing highway/railways/waterways to be disambiguated by simply setting different `layer` tags. The `covered` tag is ignored altogether.

Leaving this as a draft since I'm still not 100% sure this is the desired behavior. 

![Screen Shot 2019-05-15 at 12 13 05 PM](https://user-images.githubusercontent.com/2046746/57799233-9ee35900-771c-11e9-8018-58b4b2f59a58.png)

This also makes makes the Layer editor visible in the Structure field even without a structure tag if a "layer" tag is present