### PR TITLE
Add preset aliases property [WIP, Feedback required]

### DIFF
--- a/data/presets/README.md
+++ b/data/presets/README.md
@@ -88,6 +88,18 @@ A features can only match one preset even if its tags and geometry could technic
 
 This property is required. There is no default.
 
+##### `aliases`
+
+A list of aliases beside the name for this preset. Optional.
+
+Aliases, like names, use [title case](https://en.wikipedia.org/wiki/Letter_case#Title_case). 
+
+This may be displayed alongside `name` in the result list when searching for presets.
+
+##### `terms`
+
+A list of related terms beside the name and aliases with which the preset should be found. Optional.
+
 ##### `addTags`
 
 The tags that are added to the feature when selecting this preset. Defaults to `tags`. If needed, this property will typically be a superset of `tags`.

--- a/data/presets/schema/preset.json
+++ b/data/presets/schema/preset.json
@@ -63,8 +63,15 @@
             "description": "The URL of a remote image that is more specific than 'icon'",
             "type": "string"
         },
+        "aliases": {
+            "description": "English aliases / synonyms",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
         "terms": {
-            "description": "English synonyms or related terms",
+            "description": "English related terms / keywords",
             "type": "array",
             "items": {
                 "type": "string"

--- a/data/update_locales.js
+++ b/data/update_locales.js
@@ -92,17 +92,26 @@ function getResource(resource, callback) {
 
                 } else {
                     if (resource === 'presets') {
-                        // remove terms that were not really translated
+                        // remove terms that were not really translated, transform names back to name+aliases
                         var presets = (result.presets && result.presets.presets) || {};
                         for (const key of Object.keys(presets)) {
                             var preset = presets[key];
-                            if (!preset.terms) continue;
-                            preset.terms = preset.terms.replace(/<.*>/, '').trim();
-                            if (!preset.terms) {
-                                delete preset.terms;
-                                if (!Object.keys(preset).length) {
-                                    delete presets[key];
+                            if (preset.terms) {
+                                preset.terms = preset.terms.replace(/<.*>/, '').trim();
+                                if (!preset.terms) {
+                                    delete preset.terms;
                                 }
+                            }
+                            if (preset.name) {
+                                var names = preset.name.trim().split(/\s*,+\s*/);
+                                preset.name = names[0];
+                                if(names.length > 1) {
+                                    preset.aliases = names.slice(1);
+                                }
+                            }
+
+                            if (!Object.keys(preset).length) {
+                                delete presets[key];
                             }
                         }
                     }

--- a/modules/presets/preset.js
+++ b/modules/presets/preset.js
@@ -140,7 +140,6 @@ export function presetPreset(id, preset, fields, visible, rawPresets) {
 
     preset.originalName = preset.name || '';
 
-
     preset.name = function() {
         if (preset.suggestion) {
             var path = id.split('/');
@@ -154,11 +153,15 @@ export function presetPreset(id, preset, fields, visible, rawPresets) {
 
     preset.originalTerms = (preset.terms || []).join();
 
-
     preset.terms = function() {
         return preset.t('terms', { 'default': preset.originalTerms }).toLowerCase().trim().split(/\s*,+\s*/);
     };
 
+    preset.originalAliases = (preset.aliases || []);
+
+    preset.aliases = function() {
+        return preset.t('aliases', { 'default': preset.originalAliases });
+    };
 
     preset.isFallback = function() {
         var tagCount = Object.keys(preset.tags).length;

--- a/modules/util/array.js
+++ b/modules/util/array.js
@@ -137,3 +137,16 @@ export function utilArrayUniqBy(a, key) {
     }, []);
 }
 
+// like Array.prototype.map(fn), only that null elements and elements for
+// which the function returns something are filtered out.
+// utilArrayMapTruthy([1,2,null,3,4,5], a => a%2 ? a*2 : null) == [2,6,10]
+export function utilArrayMapTruthy(a, fn) {
+    var result = [];
+    for (var i = 0; i < a.length; i++) {
+        if (a[i] != null) {
+            var r = fn.call(null, a[i], i, a);
+            if (r != null) result.push(r);
+        }
+    }
+    return result;
+}

--- a/modules/util/index.js
+++ b/modules/util/index.js
@@ -6,6 +6,8 @@ export { utilArrayIntersection } from './array';
 export { utilArrayUnion } from './array';
 export { utilArrayUniq } from './array';
 export { utilArrayUniqBy } from './array';
+export { utilArrayMapTruthy } from './array';
+
 
 export { utilAsyncMap } from './util';
 export { utilCallWhenIdle } from './idle';

--- a/test/spec/presets/collection.js
+++ b/test/spec/presets/collection.js
@@ -18,8 +18,7 @@ describe('iD.presetCollection', function() {
         grill: iD.presetPreset('__test/amenity/bbq', {
             name: 'Grill',
             tags: { amenity: 'bbq' },
-            geometry: ['point'],
-            terms: []
+            geometry: ['point']
         }),
         sandpit: iD.presetPreset('__test/amenity/grit_bin', {
             name: 'Sandpit',
@@ -30,27 +29,23 @@ describe('iD.presetCollection', function() {
         residential: iD.presetPreset('__test/highway/residential', {
             name: 'Residential Area',
             tags: { highway: 'residential' },
-            geometry: ['point', 'area'],
-            terms: []
+            geometry: ['point', 'area']
         }),
         grass1: iD.presetPreset('__test/landuse/grass1', {
             name: 'Grass',
             tags: { landuse: 'grass' },
-            geometry: ['point', 'area'],
-            terms: []
+            geometry: ['point', 'area']
         }),
         grass2: iD.presetPreset('__test/landuse/grass2', {
             name: 'Ğṝȁß',
             tags: { landuse: 'ğṝȁß' },
-            geometry: ['point', 'area'],
-            terms: []
+            geometry: ['point', 'area']
         }),
         park: iD.presetPreset('__test/leisure/park', {
             name: 'Park',
             tags: { leisure: 'park' },
             geometry: ['point', 'area'],
-            terms: [ 'grass' ],
-            matchScore: 0.5
+            terms: [ 'grass' ]
         }),
         parking: iD.presetPreset('__test/amenity/parking', {
             name: 'Parking',

--- a/test/spec/util/array.js
+++ b/test/spec/util/array.js
@@ -120,4 +120,17 @@ describe('iD.utilArray', function() {
         });
     });
 
+    describe('utilArrayMapTruthy', function() {
+
+        it('ignores nulls in input array', function() {
+            expect(iD.utilArrayMapTruthy([0,1,null,2,null], function(a) { return a; } ))
+                .to.eql([0,1,2]);
+        });
+
+        it('maps truthy values', function() {
+            expect(iD.utilArrayMapTruthy([1,2,3,4,5], function(a) { if (a%2) return a*2; } ))
+                .to.eql([2,6,10]);
+        });
+    });
+
 });


### PR DESCRIPTION
Implementation for #6139

Work in progress. Basically done except for the UI.

There are a few basic questions that need to be cleared before I can continue with the implementation:
1. extending Transifex `name` key with extended descriptions for translators okay? @1ec5 had some comments on that
2. refactor of `presetCollection.search` to return a list of matches instead of simply the presets okay? This has some more implications for the UI code because the UI that works with the results of this function needs to be refactored to be able to display these (alongside "raw" presets, recents, categories, ...). Advice how to do that is very welcome.
3. reconsider #6298 in the frame of this PR? It is now a bit inconsistent that `aliases` are a string array while `terms` is a comma separated string.

More detailed comments in the code.