### PR TITLE
Deprecate leisure/tanning_salon

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -460,6 +460,10 @@
       "replace": {"club": "*"}
     },
     {
+      "old": {"leisure": "tanning_salon"},
+      "replace": {"shop": "beauty", "beauty": "tanning"}
+    },
+    {
       "old": {"leisure": "video_arcade"},
       "replace": {"leisure": "amusement_arcade"}
     },


### PR DESCRIPTION
The correct way to tag a tanning salon is a beauty shop that offers
tanning as a service.

Signed-off-by: Tim Smith <tsmith@chef.io>