### PR TITLE
Add email and website format validation

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1443,10 +1443,12 @@ en:
       title: Invalid Formatting
       tip: Find features tagged with invalid value formatting
       email:
-        message: '{feature} is tagged with an invalid email address'
+        message: '{feature} has an invalid email address: {email}'
+        message_multi: '{feature} has multiple invalid email addresses: {email}'
         reference: 'Email addresses must be of the form "local-part@domain".'
       website:
-        message: '{feature} is tagged with an invalid website'
+        message: '{feature} has a website with no scheme: {site}'
+        message_multi: '{feature} has multiple websites with no scheme: {site}'
         reference: 'Websites should start with a "http" or "https" scheme.'
     missing_role:
       title: Missing Roles

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1439,6 +1439,15 @@ en:
         feature:
           message: '{feature} lists Google as a data source'
         reference: "Google products are proprietary and must not be used as references."
+    invalid_format:
+      title: Invalid Formatting
+      tip: Find features tagged with invalid value formatting
+      email:
+        message: '{feature} is tagged with an invalid email address'
+        reference: 'Email addresses must be of the form "local-part@domain".'
+      website:
+        message: '{feature} is tagged with an invalid website'
+        reference: 'Websites should start with a "http" or "https" scheme.'
     missing_role:
       title: Missing Roles
       message: "{member} has no role within {relation}"

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -1782,6 +1782,18 @@
                     "reference": "Google products are proprietary and must not be used as references."
                 }
             },
+            "invalid_format": {
+                "title": "Invalid Formatting",
+                "tip": "Find features tagged with invalid value formatting",
+                "email": {
+                    "message": "{feature} is tagged with an invalid email address",
+                    "reference": "Email addresses must be of the form \"local-part@domain\"."
+                },
+                "website": {
+                    "message": "{feature} is tagged with an invalid website",
+                    "reference": "Websites should start with a \"http\" or \"https\" scheme."
+                }
+            },
             "missing_role": {
                 "title": "Missing Roles",
                 "message": "{member} has no role within {relation}",

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -1786,11 +1786,13 @@
                 "title": "Invalid Formatting",
                 "tip": "Find features tagged with invalid value formatting",
                 "email": {
-                    "message": "{feature} is tagged with an invalid email address",
+                    "message": "{feature} has an invalid email address: {email}",
+                    "message_multi": "{feature} has multiple invalid email addresses: {email}",
                     "reference": "Email addresses must be of the form \"local-part@domain\"."
                 },
                 "website": {
-                    "message": "{feature} is tagged with an invalid website",
+                    "message": "{feature} has a website with no scheme: {site}",
+                    "message_multi": "{feature} has multiple websites with no scheme: {site}",
                     "reference": "Websites should start with a \"http\" or \"https\" scheme."
                 }
             },

--- a/modules/validations/index.js
+++ b/modules/validations/index.js
@@ -6,6 +6,7 @@ export { validationFixmeTag } from './fixme_tag';
 export { validationGenericName } from './generic_name';
 export { validationImpossibleOneway } from './impossible_oneway';
 export { validationIncompatibleSource } from './incompatible_source';
+export { validationFormatting } from './invalid_format';
 export { validationMaprules } from './maprules';
 export { validationMissingRole } from './missing_role';
 export { validationMissingTag } from './missing_tag';

--- a/modules/validations/invalid_format.js
+++ b/modules/validations/invalid_format.js
@@ -7,59 +7,79 @@ export function validationFormatting() {
 
     var validation = function(entity, context) {
         var issues = [];
-        if (entity.tags.website) {
-            var valid_scheme = /^https?:\/\//i;
 
-            if (!valid_scheme.test(entity.tags.website)) {
+        function isInvalidEmail(email) {
+            // Same regex as used by HTML5 "email" inputs
+            // Emails in OSM are going to be official so they should be pretty simple
+            var valid_email = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
+            return !valid_email.test(email);
+        }
+
+        function isSchemeMissing(url) {
+            var valid_scheme = /^https?:\/\//i;
+            return !valid_scheme.test(url);
+        }
+
+
+        if (entity.tags.website) {
+            // Multiple websites are possible
+            var websites = entity.tags.website.split(';').filter(isSchemeMissing);
+
+            if (websites.length) {
+                var multi = (websites.length > 1) ? '_multi' : '';
+
                 issues.push(new validationIssue({
                     type: type,
                     subtype: 'website',
                     severity: 'warning',
                     message: function() {
                         var entity = context.hasEntity(this.entityIds[0]);
-                        return entity ? t('issues.invalid_format.website.message', { feature: utilDisplayLabel(entity, context) }) : '';
+                        return entity ? t('issues.invalid_format.website.message' + multi, { feature: utilDisplayLabel(entity, context), site: websites.join(', ') }) : '';
                     },
                     reference: showReferenceWebsite,
-                    entityIds: [entity.id]
+                    entityIds: [entity.id],
+                    hash: websites.join()
                 }));
+            }
 
-                function showReferenceWebsite(selection) {
-                    selection.selectAll('.issue-reference')
-                        .data([0])
-                        .enter()
-                        .append('div')
-                        .attr('class', 'issue-reference')
-                        .text(t('issues.invalid_format.website.reference'));
-                }
+            function showReferenceWebsite(selection) {
+                selection.selectAll('.issue-reference')
+                    .data([0])
+                    .enter()
+                    .append('div')
+                    .attr('class', 'issue-reference')
+                    .text(t('issues.invalid_format.website.reference'));
             }
         }
 
         if (entity.tags.email) {
-            // Same regex as used by HTML5 "email" inputs
-            // Emails in OSM are going to be official so they should be pretty simple
-            var valid_email = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
+            // Multiple emails are possible
+            var emails = entity.tags.email.split(';').filter(isInvalidEmail);
 
-            if (!valid_email.test(entity.tags.email)) {
+            if (emails.length) {
+                var multi = (emails.length > 1) ? '_multi' : '';
+
                 issues.push(new validationIssue({
                     type: type,
                     subtype: 'email',
                     severity: 'warning',
                     message: function() {
                         var entity = context.hasEntity(this.entityIds[0]);
-                        return entity ? t('issues.invalid_format.email.message', { feature: utilDisplayLabel(entity, context) }) : '';
+                        return entity ? t('issues.invalid_format.email.message' + multi, { feature: utilDisplayLabel(entity, context), email: emails.join(', ') }) : '';
                     },
                     reference: showReferenceEmail,
-                    entityIds: [entity.id]
+                    entityIds: [entity.id],
+                    hash: emails.join()
                 }));
+            }
 
-                function showReferenceEmail(selection) {
-                    selection.selectAll('.issue-reference')
-                        .data([0])
-                        .enter()
-                        .append('div')
-                        .attr('class', 'issue-reference')
-                        .text(t('issues.invalid_format.email.reference'));
-                }
+            function showReferenceEmail(selection) {
+                selection.selectAll('.issue-reference')
+                    .data([0])
+                    .enter()
+                    .append('div')
+                    .attr('class', 'issue-reference')
+                    .text(t('issues.invalid_format.email.reference'));
             }
         }
 

--- a/modules/validations/invalid_format.js
+++ b/modules/validations/invalid_format.js
@@ -20,35 +20,43 @@ export function validationFormatting() {
             return !valid_scheme.test(url);
         }
 
+        function showReferenceEmail(selection) {
+            selection.selectAll('.issue-reference')
+                .data([0])
+                .enter()
+                .append('div')
+                .attr('class', 'issue-reference')
+                .text(t('issues.invalid_format.email.reference'));
+        }
+
+        function showReferenceWebsite(selection) {
+            selection.selectAll('.issue-reference')
+                .data([0])
+                .enter()
+                .append('div')
+                .attr('class', 'issue-reference')
+                .text(t('issues.invalid_format.website.reference'));
+        }
 
         if (entity.tags.website) {
             // Multiple websites are possible
             var websites = entity.tags.website.split(';').filter(isSchemeMissing);
 
             if (websites.length) {
-                var multi = (websites.length > 1) ? '_multi' : '';
-
                 issues.push(new validationIssue({
                     type: type,
                     subtype: 'website',
                     severity: 'warning',
                     message: function() {
                         var entity = context.hasEntity(this.entityIds[0]);
-                        return entity ? t('issues.invalid_format.website.message' + multi, { feature: utilDisplayLabel(entity, context), site: websites.join(', ') }) : '';
+                        return entity ? t('issues.invalid_format.website.message' + this.data,
+                            { feature: utilDisplayLabel(entity, context), site: websites.join(', ') }) : '';
                     },
                     reference: showReferenceWebsite,
                     entityIds: [entity.id],
-                    hash: websites.join()
+                    hash: websites.join(),
+                    data: (websites.length > 1) ? '_multi' : ''
                 }));
-            }
-
-            function showReferenceWebsite(selection) {
-                selection.selectAll('.issue-reference')
-                    .data([0])
-                    .enter()
-                    .append('div')
-                    .attr('class', 'issue-reference')
-                    .text(t('issues.invalid_format.website.reference'));
             }
         }
 
@@ -57,29 +65,20 @@ export function validationFormatting() {
             var emails = entity.tags.email.split(';').filter(isInvalidEmail);
 
             if (emails.length) {
-                var multi = (emails.length > 1) ? '_multi' : '';
-
                 issues.push(new validationIssue({
                     type: type,
                     subtype: 'email',
                     severity: 'warning',
                     message: function() {
                         var entity = context.hasEntity(this.entityIds[0]);
-                        return entity ? t('issues.invalid_format.email.message' + multi, { feature: utilDisplayLabel(entity, context), email: emails.join(', ') }) : '';
+                        return entity ? t('issues.invalid_format.email.message' + this.data,
+                            { feature: utilDisplayLabel(entity, context), email: emails.join(', ') }) : '';
                     },
                     reference: showReferenceEmail,
                     entityIds: [entity.id],
-                    hash: emails.join()
+                    hash: emails.join(),
+                    data: (emails.length > 1) ? '_multi' : ''
                 }));
-            }
-
-            function showReferenceEmail(selection) {
-                selection.selectAll('.issue-reference')
-                    .data([0])
-                    .enter()
-                    .append('div')
-                    .attr('class', 'issue-reference')
-                    .text(t('issues.invalid_format.email.reference'));
             }
         }
 

--- a/modules/validations/invalid_format.js
+++ b/modules/validations/invalid_format.js
@@ -8,16 +8,18 @@ export function validationFormatting() {
     var validation = function(entity, context) {
         var issues = [];
 
-        function isInvalidEmail(email) {
+        function isValidEmail(email) {
             // Same regex as used by HTML5 "email" inputs
             // Emails in OSM are going to be official so they should be pretty simple
             var valid_email = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
-            return !valid_email.test(email);
+
+            // An empty value is also acceptable
+            return (!email || valid_email.test(email));
         }
 
-        function isSchemeMissing(url) {
+        function isSchemePresent(url) {
             var valid_scheme = /^https?:\/\//i;
-            return !valid_scheme.test(url);
+            return (!url || valid_scheme.test(url));
         }
 
         function showReferenceEmail(selection) {
@@ -40,7 +42,8 @@ export function validationFormatting() {
 
         if (entity.tags.website) {
             // Multiple websites are possible
-            var websites = entity.tags.website.split(';').filter(isSchemeMissing);
+            // If ever we support ES6, arrow functions make this nicer
+            var websites = entity.tags.website.split(';').filter(function(x) { return !isSchemePresent(x); });
 
             if (websites.length) {
                 issues.push(new validationIssue({
@@ -62,7 +65,7 @@ export function validationFormatting() {
 
         if (entity.tags.email) {
             // Multiple emails are possible
-            var emails = entity.tags.email.split(';').filter(isInvalidEmail);
+            var emails = entity.tags.email.split(';').filter(function(x) { return !isValidEmail(x); });
 
             if (emails.length) {
                 issues.push(new validationIssue({

--- a/modules/validations/invalid_format.js
+++ b/modules/validations/invalid_format.js
@@ -1,0 +1,72 @@
+import { t } from '../util/locale';
+import { utilDisplayLabel } from '../util';
+import { validationIssue } from '../core/validation';
+
+export function validationFormatting() {
+    var type = 'invalid_format';
+
+    var validation = function(entity, context) {
+        var issues = [];
+        if (entity.tags.website) {
+            var valid_scheme = /^https?:\/\//i;
+
+            if (!valid_scheme.test(entity.tags.website)) {
+                issues.push(new validationIssue({
+                    type: type,
+                    subtype: 'website',
+                    severity: 'warning',
+                    message: function() {
+                        var entity = context.hasEntity(this.entityIds[0]);
+                        return entity ? t('issues.invalid_format.website.message', { feature: utilDisplayLabel(entity, context) }) : '';
+                    },
+                    reference: showReferenceWebsite,
+                    entityIds: [entity.id]
+                }));
+
+                function showReferenceWebsite(selection) {
+                    selection.selectAll('.issue-reference')
+                        .data([0])
+                        .enter()
+                        .append('div')
+                        .attr('class', 'issue-reference')
+                        .text(t('issues.invalid_format.website.reference'));
+                }
+            }
+        }
+
+        if (entity.tags.email) {
+            // Same regex as used by HTML5 "email" inputs
+            // Emails in OSM are going to be official so they should be pretty simple
+            var valid_email = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
+
+            if (!valid_email.test(entity.tags.email)) {
+                issues.push(new validationIssue({
+                    type: type,
+                    subtype: 'email',
+                    severity: 'warning',
+                    message: function() {
+                        var entity = context.hasEntity(this.entityIds[0]);
+                        return entity ? t('issues.invalid_format.email.message', { feature: utilDisplayLabel(entity, context) }) : '';
+                    },
+                    reference: showReferenceEmail,
+                    entityIds: [entity.id]
+                }));
+
+                function showReferenceEmail(selection) {
+                    selection.selectAll('.issue-reference')
+                        .data([0])
+                        .enter()
+                        .append('div')
+                        .attr('class', 'issue-reference')
+                        .text(t('issues.invalid_format.email.reference'));
+                }
+            }
+        }
+
+        return issues;
+    };
+
+    validation.type = type;
+
+    return validation;
+}


### PR DESCRIPTION
Closes #5866

Simple validation following the HTML5 standard for emails as we don't expect POIs to have convoluted email addresses (so there should be minimal false positives). For websites I'm only checking that the scheme is present currently. 

Only checks the `website` and `email` tags as these are what iD currently supports with fields.

I was unsure how best to handle the `reference` property for the `validationIssue` objects because both issues can be present at once on the same entity (so using one function and changing the text via variable isn't viable). Just defined two functions for now since it works, can be refactored as desired.

The main thing to get right here are the translated strings. I think the website one should probably be reworded as it can flag instances where the user sees a seemingly valid site (e.g. `www.example.com`).