### PR TITLE
Fix email validation for Unicode characters

### DIFF
--- a/modules/validations/invalid_format.js
+++ b/modules/validations/invalid_format.js
@@ -9,9 +9,9 @@ export function validationFormatting() {
         var issues = [];
 
         function isValidEmail(email) {
-            // Same regex as used by HTML5 "email" inputs
             // Emails in OSM are going to be official so they should be pretty simple
-            var valid_email = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
+            // Using negated lists to better support all possible unicode characters (#6494)
+            var valid_email = /^[^\(\)\\,":;<>@\[\]]+@[^\(\)\\,":;<>@\[\]\.]+(?:\.[a-z0-9-]+)*$/i;
 
             // An empty value is also acceptable
             return (!email || valid_email.test(email));
@@ -43,7 +43,10 @@ export function validationFormatting() {
         if (entity.tags.website) {
             // Multiple websites are possible
             // If ever we support ES6, arrow functions make this nicer
-            var websites = entity.tags.website.split(';').filter(function(x) { return !isSchemePresent(x); });
+            var websites = entity.tags.website
+                .split(';')
+                .map(function(s) { return s.trim(); })
+                .filter(function(x) { return !isSchemePresent(x); });
 
             if (websites.length) {
                 issues.push(new validationIssue({
@@ -65,7 +68,10 @@ export function validationFormatting() {
 
         if (entity.tags.email) {
             // Multiple emails are possible
-            var emails = entity.tags.email.split(';').filter(function(x) { return !isValidEmail(x); });
+            var emails = entity.tags.email
+                .split(';')
+                .map(function(s) { return s.trim(); })
+                .filter(function(x) { return !isValidEmail(x); });
 
             if (emails.length) {
                 issues.push(new validationIssue({


### PR DESCRIPTION
Issue raised by https://github.com/openstreetmap/iD/pull/6494#issuecomment-499620002.

I just modified the regex to instead use negated lists for characters which can only appear inside a quoted string email address (the likelihood of a POI - or anyone - using such an email is minuscule). The other option would have been to put Unicode character ranges inside the square brackets, but this way means we don't accidentally exclude any more valid characters.

Also fixes handling for list values with excess whitespace by stripping it out.