### PR TITLE
Typo fix

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -51,7 +51,7 @@ en:
       # "Good Night" isn't a greeting in English but it can be in some languages
       night: Good Evening
     welcome:
-      first_time: "You’re editing <b>OpenStreetMap</b>: the free, collborative world map.<br/>If this is your first time here, consider taking the <a>quick-start tutorial</a>.<br/>Thanks for contributing. Have fun!"
+      first_time: "You’re editing <b>OpenStreetMap</b>: the free, collaborative world map.<br/>If this is your first time here, consider taking the <a>quick-start tutorial</a>.<br/>Thanks for contributing. Have fun!"
       return: "Welcome back. Ready to make the map even better?"
       start_mapping: Start Mapping
     restore:


### PR DESCRIPTION
collborative -> collaborative, thanks to @ignaciolep on transifex.