### PR TITLE
Rejoin way if structure choice is reverted

### DIFF
--- a/modules/ui/tools/structure.js
+++ b/modules/ui/tools/structure.js
@@ -15,8 +15,6 @@ import { actionJoin } from '../../actions/join';
 import { modeDrawLine } from '../../modes/draw_line';
 import { osmWay } from '../../osm/way';
 
-import { utilArrayIntersection } from '../../util';
-
 export function uiToolStructure(context) {
 
     var key = t('toolbar.structure.key');
@@ -142,10 +140,7 @@ export function uiToolStructure(context) {
                 // Reload way with updated tags
                 way = context.hasEntity(wayID);
 
-                if (
-                    prevWay &&
-                    utilArrayIntersection(way.nodes, prevWay.nodes).length > 0 &&
-                    JSON.stringify(prevWay.tags) === JSON.stringify(way.tags)) {
+                if (prevWay && JSON.stringify(prevWay.tags) === JSON.stringify(way.tags)) {
 
                     var action = actionJoin([prevWay.id, way.id]);
 

--- a/modules/ui/tools/structure.js
+++ b/modules/ui/tools/structure.js
@@ -147,12 +147,15 @@ export function uiToolStructure(context) {
                     utilArrayIntersection(way.nodes, prevWay.nodes).length > 0 &&
                     JSON.stringify(prevWay.tags) === JSON.stringify(way.tags)) {
 
-                    context.perform(
-                        actionJoin([prevWay.id, way.id])
-                    );
-                    context.enter(
-                        modeDrawLine(context, prevWay.id, context.graph(), context.graph(), mode.button, false, mode.addMode)
-                    );
+                    var action = actionJoin([prevWay.id, way.id]);
+
+                    if (!action.disabled(context.graph())) {
+                        context.perform(action);
+
+                        context.enter(
+                            modeDrawLine(context, prevWay.id, context.graph(), context.graph(), mode.button, false, mode.addMode)
+                        );
+                    }
                 }
             } else {
                 var isLast = mode.activeID() === way.last();


### PR DESCRIPTION
Fixes #6559 
Way is rejoined back to a single way if structure change is reverted

![rejoin_structure_revert](https://user-images.githubusercontent.com/4670502/59918532-e5635c00-941c-11e9-84ee-7831625ecff9.gif)
