### PR TITLE
Add cairn preset

### DIFF
--- a/data/presets.yaml
+++ b/data/presets.yaml
@@ -5429,6 +5429,11 @@ en:
         name: Bunker Silo
         # 'terms: Silage,Storage'
         terms: '<translate with synonyms or related terms for ''Bunker Silo'', separated by commas>'
+      man_made/cairn:
+        # man_made=cairn
+        name: Cairn
+        # 'terms: rock pile,stone stack,stone pile,càrn'
+        terms: '<translate with synonyms or related terms for ''Cairn'', separated by commas>'
       man_made/chimney:
         # man_made=chimney
         name: Chimney

--- a/data/presets/presets.json
+++ b/data/presets/presets.json
@@ -688,6 +688,7 @@
     "man_made/breakwater": {"fields": ["material", "seamark/type"], "geometry": ["line", "area"], "tags": {"man_made": "breakwater"}, "name": "Breakwater"},
     "man_made/bridge": {"icon": "maki-bridge", "fields": ["name", "bridge", "layer", "maxweight"], "moreFields": ["manufacturer", "material", "seamark/type"], "geometry": ["area"], "tags": {"man_made": "bridge"}, "addTags": {"man_made": "bridge", "layer": "1"}, "removeTags": {"man_made": "bridge", "layer": "*"}, "reference": {"key": "man_made", "value": "bridge"}, "name": "Bridge", "matchScore": 0.85},
     "man_made/bunker_silo": {"icon": "temaki-silo", "fields": ["content"], "geometry": ["point", "area"], "terms": ["Silage", "Storage"], "tags": {"man_made": "bunker_silo"}, "name": "Bunker Silo"},
+    "man_made/cairn": {"icon": "maki-triangle", "geometry": ["point", "area"], "terms": ["rock pile", "stone stack", "stone pile", "càrn"], "tags": {"man_made": "cairn"}, "name": "Cairn"},
     "man_made/chimney": {"icon": "temaki-chimney", "fields": ["operator", "material", "height"], "geometry": ["point", "area"], "tags": {"man_made": "chimney"}, "name": "Chimney"},
     "man_made/clearcut": {"icon": "maki-logging", "geometry": ["area"], "tags": {"man_made": "clearcut"}, "terms": ["cut", "forest", "lumber", "tree", "wood"], "name": "Clearcut Forest"},
     "man_made/crane": {"icon": "temaki-crane", "fields": ["operator", "manufacturer", "height", "crane/type"], "geometry": ["point", "line", "vertex", "area"], "tags": {"man_made": "crane"}, "name": "Crane"},

--- a/data/presets/presets/man_made/cairn.json
+++ b/data/presets/presets/man_made/cairn.json
@@ -1,0 +1,17 @@
+{
+    "icon": "maki-triangle",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "terms": [
+        "rock pile",
+        "stone stack",
+        "stone pile",
+        "càrn"
+    ],
+    "tags": {
+        "man_made": "cairn"
+    },
+    "name": "Cairn"
+}


### PR DESCRIPTION
Have been mapping a lot of these recently (common hiking feature here in Scotland). Seems like this is the generally accepted tagging with [much more usage](https://taginfo.openstreetmap.org/tags/man_made=cairn) than [`landmark=cairn`](https://taginfo.openstreetmap.org/tags/landmark=cairn).