### PR TITLE
Minor CSS fix

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -1934,6 +1934,7 @@ button.preset-favorite-button.active .icon {
 }
 [dir='rtl'] .form-field-input-wrap > button:last-of-type {
     border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 0;
 }
 
 


### PR DESCRIPTION
I was testing out OSM iD V3 (awesome, by the way! 😎) and I noticed that the trash button has a border-radius on both left and right sides in right-to-left language layout.  Quick fix

![Screen Shot 2019-07-24 at 3 00 44 PM](https://user-images.githubusercontent.com/643918/61769514-7dda6b00-ae25-11e9-81eb-92a778630b86.png)
