### PR TITLE
Update Clearcut preset

### DIFF
--- a/data/presets/presets/man_made/clearcut.json
+++ b/data/presets/presets/man_made/clearcut.json
@@ -4,7 +4,8 @@
         "area"
     ],
     "tags": {
-        "man_made": "clearcut"
+        "man_made": "clearcut",
+        "natural": "scrub"
     },
     "terms": [
         "cut",


### PR DESCRIPTION
This change adds `natural=scrub` to the `man_made=clearcut` preset. As suggested [on the wiki](https://wiki.openstreetmap.org/wiki/Tag:man_made%3Dclearcut#Rendering), this will make clearcuts render on the map while providing accurate tagging.

There is still a discussion going on on the [Talk page](https://wiki.openstreetmap.org/wiki/Talk:Tag:man_made%3Dclearcut) as to whether this tag should actually be used in conjunction with `man_made=clearcut`, or whether `man_made=clearcut` should exist at all. However I think that for iD this change should be fine. Open to discussion though!