### PR TITLE
Add vending=bottle_return preset

### DIFF
--- a/data/presets/presets/amenity/vending_machine/bottle_return.json
+++ b/data/presets/presets/amenity/vending_machine/bottle_return.json
@@ -1,0 +1,22 @@
+{
+    "icon": "temaki-vending_machine",
+    "fields": [
+        "vending",
+        "operator"
+    ],
+    "geometry": [
+        "point"
+    ],
+    "terms": [
+        "bottle return"
+    ],
+    "tags": {
+        "amenity": "vending_machine",
+        "vending": "bottle_return"
+    },
+    "reference": {
+        "key": "vending",
+        "value": "bottle_return"
+    },
+    "name": "Bottle Return Machine"
+}


### PR DESCRIPTION
This might be useful as a preset, as, at least in Germany, every store that sells bottles also has to provide a machine to return those bottles. (There is even a law for that 😄: https://www.gesetze-im-internet.de/verpackg/__15.html)
The current usage in OpenStreetMap is actually rather low (below 100), but maybe this increases when there is a preset for this machine...