### PR TITLE
Stop penalising forums and mailing lists

### DIFF
--- a/modules/ui/success.js
+++ b/modules/ui/success.js
@@ -12,16 +12,17 @@ import { utilRebind } from '../util/rebind';
 export function uiSuccess(context) {
     var MAXEVENTS = 2;
 
-    // All else being equal, rank more "social" communities higher
+    // All else being equal, rank communities higher when
+    // OSM has more influence on who's there
     // (anything not in this list receives no adjustment)
     var COMMUNITYRANK = {
         'meetup': +5,
-        'slack': +4,
-        'facebook': +3,
-        'reddit': +2,
-        'forum': -2,
-        'mailinglist': -3,
-        'irc': -4
+        'slack': -1,
+        'facebook': -3,
+        'reddit': -2,
+        'forum': +3,
+        'mailinglist': +2,
+        'irc': +1
     };
 
     var detected = utilDetect();


### PR DESCRIPTION
Until now, Facebook, Slack, and Reddit were always listed above forums, mailinglists, and IRC for a same-sized area. This fails to give a true picture of the OSM community in all but a small number of countries. Furthermore,
* Facebook, Slack, and Reddit are closed, proprietary platforms where you can only participate by giving up some of your privacy and we should not over-eagerly promote them;
* Facebook and Reddit are proven to harbour the most obnoxious people on the planet, and we have no control over these platforms to exclude people we don't like (whereas we have, and do exert, this control on the forums and mailing lists).

It is ok to list Facebook/Reddit/Slack if the community in a country has chosen to use them, but it is not ok to make the knee-jerk assumption that as soon as there's any Facebook/Reddit/Slack channel in one country, it should automatically be recommended above a forum or mailing list.