### PR TITLE
Fix generic name validation for known brands

### DIFF
--- a/modules/validations/generic_name.js
+++ b/modules/validations/generic_name.js
@@ -19,6 +19,8 @@ export function validationGenericName() {
     function isGenericName(entity) {
         var name = entity.tags.name;
         if (!name) return false;
+        // a generic name is okay if it's a known brand or entity
+        if (entity.hasWikidata()) return false;
         name = name.toLowerCase();
 
         var i, key, val;


### PR DESCRIPTION
Currently a generic name warning can be given for a known brand (see http://preview.ideditor.com/master/#background=Bing&id=n6573433998) and this fixes that.

I figure it makes sense for an entity with a regular wikidata tag too which is why I've used `hasWikidata`.