### PR TITLE
Filter out generic tools in recents

### DIFF
--- a/modules/ui/tools/quick_presets_recent.js
+++ b/modules/ui/tools/quick_presets_recent.js
@@ -16,11 +16,18 @@ export function uiToolAddRecent(context) {
         var precedingCount = context.storage('tool.add_generic.toggledOn') === 'true' ? 3 : 0;
 
         var favorites = context.presets().getFavorites().slice(0, maxShown);
+        var generics = context.presets().getGenericRibbonItems();
         precedingCount += favorites.length;
 
         function isAFavorite(recent) {
             return favorites.some(function(favorite) {
                 return favorite.matches(recent.preset);
+            });
+        }
+
+        function isGeneric(recent) {
+            return generics.some(function(generic) {
+                return generic.matches(recent.preset);
             });
         }
 
@@ -32,11 +39,15 @@ export function uiToolAddRecent(context) {
             });
             for (var i in recents) {
                 var recent = recents[i];
-                if (!isAFavorite(recent)) {
-                    items.push(recent);
-                    if (items.length === maxRecents) {
-                        break;
-                    }
+                if (isAFavorite(recent)) {
+                    continue;
+                }
+                if (isGeneric(recent) && context.storage('tool.add_generic.toggledOn') === 'true') {
+                    continue;
+                }
+                items.push(recent);
+                if (items.length === maxRecents) {
+                    break;
                 }
             }
         }


### PR DESCRIPTION
Closes #6888.

When Geometries is toggled off they are visible in Recents.
<img width="952" alt="Screenshot 2019-10-02 at 13 26 00" src="https://user-images.githubusercontent.com/5765413/66040633-49b3b280-e518-11e9-9cd4-84897041d430.png">

When Geometries is toggled on they are filtered out of Recents.
<img width="953" alt="Screenshot 2019-10-02 at 13 26 13" src="https://user-images.githubusercontent.com/5765413/66040638-4c160c80-e518-11e9-80f6-b2c4f016f559.png">
