### PR TITLE
Custom WMS imagery

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -755,7 +755,10 @@ en:
       header: Custom Background Settings
       instructions: "Enter a tile URL template. Valid tokens are:\n   {zoom} or {z}, {x}, {y} for Z/X/Y tile scheme\n   {-y} or {ty} for flipped TMS-style Y coordinates\n   {u} for quadtile scheme\n   {switch:a,b,c} for DNS server multiplexing\n\nExample:\n{example}"
       template:
-        placeholder: Enter a url template
+        placeholder: Enter a URL template
+      generate_from_wms: WMS
+      wms:
+        instructions: "Enter a WMS server GetCapabilities URL, for example:\n\nhttps://www.example.org/geoserver/gwc/service/wms?SERVICE=WMS&VERSION=1.1.1&REQUEST=getcapabilities&TILED=true\n\nhttps://www.example.com/arcgis/services/Orthophotography/ImageServer/WMSServer?request=GetCapabilities&service=WMS"
     custom_data:
       tooltip: Edit custom data layer
       header: Custom Map Data Settings

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -948,7 +948,11 @@
                 "header": "Custom Background Settings",
                 "instructions": "Enter a tile URL template. Valid tokens are:\n   {zoom} or {z}, {x}, {y} for Z/X/Y tile scheme\n   {-y} or {ty} for flipped TMS-style Y coordinates\n   {u} for quadtile scheme\n   {switch:a,b,c} for DNS server multiplexing\n\nExample:\n{example}",
                 "template": {
-                    "placeholder": "Enter a url template"
+                    "placeholder": "Enter a URL template"
+                },
+                "generate_from_wms": "WMS",
+                "wms": {
+                    "instructions": "Enter a WMS server GetCapabilities URL, for example:\n\nhttps://www.example.org/geoserver/gwc/service/wms?SERVICE=WMS&VERSION=1.1.1&REQUEST=getcapabilities&TILED=true\n\nhttps://www.example.com/arcgis/services/Orthophotography/ImageServer/WMSServer?request=GetCapabilities&service=WMS"
                 }
             },
             "custom_data": {

--- a/modules/renderer/background_source.js
+++ b/modules/renderer/background_source.js
@@ -36,6 +36,7 @@ export function rendererBackgroundSource(data) {
     var template = source.template;
 
     source.tileSize = data.tileSize || 256;
+    source.projection = data.projection || 'EPSG:3857';
     source.zoomExtent = data.zoomExtent || [0, 22];
     source.overzoom = data.overzoom !== false;
 
@@ -90,7 +91,8 @@ export function rendererBackgroundSource(data) {
 
 
     source.url = function(coord) {
-        if (this.type === 'wms') {
+        var url = template;
+        if (this.type === 'wms' || source.id === 'custom') {
             var tileToProjectedCoords = (function(x, y, z) {
                 //polyfill for IE11, PhantomJS
                 var sinh = Math.sinh || function(x) {
@@ -117,11 +119,11 @@ export function rendererBackgroundSource(data) {
                 }
             }).bind(this);
 
-            var tileSize = this.tileSize;
+            var tileSize = this.tileSize || 256;
             var projection = this.projection;
             var minXmaxY = tileToProjectedCoords(coord[0], coord[1], coord[2]);
             var maxXminY = tileToProjectedCoords(coord[0]+1, coord[1]+1, coord[2]);
-            return template.replace(/\{(\w+)\}/g, function (token, key) {
+            url = url.replace(/\{(\w+)\}/g, function (token, key) {
               switch (key) {
                 case 'width':
                 case 'height':
@@ -145,7 +147,7 @@ export function rendererBackgroundSource(data) {
               }
             });
         }
-        return template
+        return url
             .replace('{x}', coord[0])
             .replace('{y}', coord[1])
             // TMS-flipped y coordinate

--- a/modules/ui/settings/custom_background.js
+++ b/modules/ui/settings/custom_background.js
@@ -7,7 +7,7 @@ import { utilNoAuto, utilRebind } from '../../util';
 
 function wmsTemplateFromCapabilities(capabilitiesURL, capabilities) {
     var formats = [];
-    capabilities.querySelectorAll("Format").forEach(function (format) {
+    capabilities.querySelectorAll('Format').forEach(function (format) {
         formats.push(format.textContent);
     });
     var preferredFormats = [
@@ -23,7 +23,7 @@ function wmsTemplateFromCapabilities(capabilitiesURL, capabilities) {
     });
     var format = preferredFormats[formatIndex === -1 ? formatIndex : 0];
 
-    var layer = capabilities.querySelector("Layer > Name").textContent;
+    var layer = capabilities.querySelector('Layer > Name').textContent;
 
     capabilitiesURL.search = '';
     capabilitiesURL.searchParams.set('FORMAT', format);
@@ -110,8 +110,11 @@ export function uiSettingsCustomBackground(context) {
                     .then(function (capabilities) {
                         var wmsTemplate = wmsTemplateFromCapabilities(capabilitiesURL, capabilities);
                         textSection.select('.field-template').property('value', wmsTemplate);
+                    }).catch(function (err) {
+                        alert(err);
                     });
             } catch (err) {
+                alert(err);
             }
         }
 


### PR DESCRIPTION
A custom background imagery URL template can now include WMS tokens like `{bbox}`. A new button in the Custom Background Settings dialog generates a URL template from a WMS GetCapabilities URL.

<img src="https://user-images.githubusercontent.com/1231218/66259457-1d8d7100-e766-11e9-92ac-34bdd097a291.png" width="300" alt="before">
<img width="301" alt="wms" src="https://user-images.githubusercontent.com/1231218/66259464-2b42f680-e766-11e9-8cae-845e2a34de97.png">
<img src="https://user-images.githubusercontent.com/1231218/66259467-33029b00-e766-11e9-96a5-6a7def895f07.png" width="300" alt="after">

The WMS GetCapabilities UI and the logic for converting the GetCapabilities document into a URL template are rather crude for now, and I’m also not wedded to the idea of a separate dialog. Should the Custom Background Settings dialog just accept the GetCapabilities URL in its main text field and asynchronously fetch the GetCapabilities XML when clicking OK? Should that dialog have a separate tab for WMS, to keep the instructions from getting unwieldy? Whatever the case, the JavaScript `prompt()` will need to be replaced by a proper custom dialog, since some WMS servers require the user to choose from among multiple named layers.

Fixes #4977.