### PR TITLE
Change cliff direction marker to dark grey to match the line

### DIFF
--- a/css/20_map.css
+++ b/css/20_map.css
@@ -5,7 +5,7 @@
 
 /* IE/Edge needs these overrides for markers to show up */
 .layer-osm path.oneway-marker-path          { fill: #000; }
-.layer-osm path.sided-marker-natural-path   { fill: rgb(140, 208, 95); }
+.layer-osm path.sided-marker-natural-path   { fill: rgb(170, 170, 170); }
 .layer-osm path.sided-marker-coastline-path { fill: #77dede; }
 .layer-osm path.sided-marker-barrier-path   { fill: #ddd; }
 .layer-osm path.sided-marker-man_made-path  { fill: #fff; }

--- a/modules/svg/defs.js
+++ b/modules/svg/defs.js
@@ -53,7 +53,7 @@ export function svgDefs(context) {
                 .attr('stroke', 'none')
                 .attr('fill', color);
         }
-        addSidedMarker('natural', 'rgb(140, 208, 95)', 0);
+        addSidedMarker('natural', 'rgb(170, 170, 170)', 0);
         // for a coastline, the arrows are (somewhat unintuitively) on
         // the water side, so let's color them blue (with a gap) to
         // give a stronger indication


### PR DESCRIPTION
Cliffs had their colour changed in 5f9bea67d, but the directional
arrow remained green.

<img width="181" alt="image" src="https://user-images.githubusercontent.com/1203825/66268834-11500380-e88d-11e9-8579-35e5c112c66f.png">


Fixes #6918