### PR TITLE
fix(de-hotkeys): Remove duplicate G keybinding

### DIFF
--- a/dist/locales/de.json
+++ b/dist/locales/de.json
@@ -857,7 +857,7 @@
             "wireframe": {
                 "description": "Keine Füllung (Gittermodus)",
                 "tooltip": "Der Gittermodus verbessert die Sichtbarkeit des Hintergrund-Bildmaterials",
-                "key": "G"
+                "key": "W"
             },
             "partial": {
                 "description": "Teilweise Füllung",


### PR DESCRIPTION
Remove duplicate G keybinding in German locale, falling back to W key, the same as in the EN locale.

Having two keybindings on the same key resulted in the last keybinding for the G key taking effect over any prior ones.

W now toggles wireframe, G toggles unsaved edits, as expected.

Fixes #6972