### PR TITLE
Updated readme urls to https to avoid redirect [v2]

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@
 if you're looking for something to do.
 * [Translate!](https://github.com/openstreetmap/iD/blob/master/CONTRIBUTING.md#translating)
 * Test a prerelease version of iD:
-  * Stable mirror of `release` branch:  http://preview.ideditor.com/release
-  * Development mirror of `master` branch + latest translations:  http://preview.ideditor.com/master
+  * Stable mirror of `release` branch:  https://preview.ideditor.com/release
+  * Development mirror of `master` branch + latest translations:  https://preview.ideditor.com/master
 
 Come on in, the water's lovely. More help? Ping `bhousel` or `quincylvania` on:
 * [OpenStreetMap US Slack](https://slack.openstreetmap.us/)


### PR DESCRIPTION
Changed the urls linking to the preview branch from http to https to avoid an automatic redirect to the https version.

Sorry for my mistake earlier!

(Redid https://github.com/openstreetmap/iD/pull/6983#event-2748966721 on the correct branch)