### PR TITLE
Fix issue #6617

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1652,8 +1652,9 @@ en:
       upgrade_tags:
         title: Upgrade the tags
         annotation: Upgraded old tags.
-      use_bridge_or_tunnel:
-        title: Use a bridge or tunnel
+      use_bridge:
+        title: Use a bridge
+        annotation: Created bridge
       use_different_layers:
         title: Use different layers
       use_different_layers_or_levels:
@@ -1662,6 +1663,7 @@ en:
         title: Use different levels
       use_tunnel:
         title: Use a tunnel
+        annotation: Created tunnel
   intro:
     done: done
     ok: OK


### PR DESCRIPTION
This concerns issue [#6617](https://github.com/openstreetmap/iD/issues/6617) . When user clicks on "Use a bridge"/"Use a tunnel" it splits edge if is long and creates bridge/tunnel. Later user may correct bridge/tunnel location by manually shifting nodes.  