### PR TITLE
fix issue #7090

### DIFF
--- a/modules/ui/entity_editor.js
+++ b/modules/ui/entity_editor.js
@@ -252,7 +252,8 @@ export function uiEntityEditor(context) {
                     difference.didChange.deletion;
             if (!significant) return;
 
-            if (!_entityIDs.every(context.hasEntity)) return;
+            _entityIDs = _entityIDs.filter(context.hasEntity);
+            if (!_entityIDs.length) return;
 
             loadActivePreset();
 


### PR DESCRIPTION
An easier way to recreate the issue is by creating two ways of different type then select both and undo one of the lines. This patch removes the removed selected ids from the editor by manipulating _entityIDs in historyChange().