### PR TITLE
Added "Shared Path" localisation to en-AU

### DIFF
--- a/dist/locales/en-AU.json
+++ b/dist/locales/en-AU.json
@@ -76,6 +76,9 @@
                 "healthcare/blood_donation": {
                     "name": "Blood Donor Centre"
                 },
+                "highway/cycleway/bicycle_foot": {
+                    "name": "Shared Path"
+                },
                 "highway/crossing/marked": {
                     "name": "Marked Crossing"
                 },


### PR DESCRIPTION
Shared path is the official and legal term in Australia for a path where cyclists and pedestrians can both legally travel on the same path together