### PR TITLE
Raw tag editor for multiple select features (2.x)

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -1245,16 +1245,10 @@ a.hide-toggle {
     display: flex;
     flex-flow: row wrap;
     justify-content: flex-end;
-    padding: 0 20px;
+    padding: 5px 0 0 0;
 }
 .quick-link {
     margin: 0 5px;
-}
-
-.data-editor .quick-links,
-.error-editor .quick-links,
-.note-editor .quick-links {
-    padding: 5px 0 0 0;
 }
 
 

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -565,7 +565,6 @@ en:
     back_tooltip: Change feature
     remove: Remove
     search: Search
-    multiselect: Selected features
     unknown: Unknown
     incomplete: <not downloaded>
     feature_list: Search features

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -557,6 +557,7 @@ en:
     edit_reference: "edit/translate"
     wiki_reference: View documentation
     wiki_en_reference: View documentation in English
+    key_value: "key=value"
     multiple_values: Multiple Values
     hidden_preset:
       manual: "{features} are hidden. Enable them in the Map Data pane."

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -555,6 +555,7 @@ en:
     edit_reference: "edit/translate"
     wiki_reference: View documentation
     wiki_en_reference: View documentation in English
+    multiple_values: Multiple Values
     hidden_preset:
       manual: "{features} are hidden. Enable them in the Map Data pane."
       zoom: "{features} are hidden. Zoom in to enable them."
@@ -566,6 +567,7 @@ en:
     incomplete: <not downloaded>
     feature_list: Search features
     edit: Edit feature
+    edit_features: Edit features
     check:
       "yes": "Yes"
       "no": "No"

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -8,6 +8,8 @@ en:
     copy: copy
     view_on: view on {domain}
     favorite: favorite
+    list: list
+    text: text
   toolbar:
     inspect: Inspect
     undo_redo: Undo / Redo

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -709,7 +709,6 @@
             "back_tooltip": "Change feature",
             "remove": "Remove",
             "search": "Search",
-            "multiselect": "Selected features",
             "unknown": "Unknown",
             "incomplete": "<not downloaded>",
             "feature_list": "Search features",

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -698,6 +698,7 @@
             "edit_reference": "edit/translate",
             "wiki_reference": "View documentation",
             "wiki_en_reference": "View documentation in English",
+            "multiple_values": "Multiple Values",
             "hidden_preset": {
                 "manual": "{features} are hidden. Enable them in the Map Data pane.",
                 "zoom": "{features} are hidden. Zoom in to enable them."
@@ -710,6 +711,7 @@
             "incomplete": "<not downloaded>",
             "feature_list": "Search features",
             "edit": "Edit feature",
+            "edit_features": "Edit features",
             "check": {
                 "yes": "Yes",
                 "no": "No",

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -8,7 +8,9 @@
             "zoom_to": "zoom to",
             "copy": "copy",
             "view_on": "view on {domain}",
-            "favorite": "favorite"
+            "favorite": "favorite",
+            "list": "list",
+            "text": "text"
         },
         "toolbar": {
             "inspect": "Inspect",
@@ -698,6 +700,7 @@
             "edit_reference": "edit/translate",
             "wiki_reference": "View documentation",
             "wiki_en_reference": "View documentation in English",
+            "key_value": "key=value",
             "multiple_values": "Multiple Values",
             "hidden_preset": {
                 "manual": "{features} are hidden. Enable them in the Map Data pane.",

--- a/modules/modes/select.js
+++ b/modules/modes/select.js
@@ -19,7 +19,6 @@ import { modeDragNote } from './drag_note';
 import { osmNode, osmWay } from '../osm';
 import * as Operations from '../operations/index';
 import { uiEditMenu } from '../ui/edit_menu';
-import { uiSelectionList } from '../ui/selection_list';
 import { uiCmd } from '../ui/cmd';
 import {
     utilArrayIntersection, utilDeepMemberSelector, utilEntityOrDeepMemberSelector,
@@ -307,7 +306,7 @@ export function modeSelect(context, selectedIDs) {
             .call(keybinding);
 
         context.ui().sidebar
-            .select(singular() ? singular().id : null, _newFeature);
+            .select(selectedIDs, _newFeature);
 
         context.history()
             .on('change.select', function() {
@@ -331,11 +330,6 @@ export function modeSelect(context, selectedIDs) {
 
 
         selectElements();
-
-        if (selectedIDs.length > 1) {
-            var entities = uiSelectionList(context, selectedIDs);
-            context.ui().sidebar.show(entities);
-        }
 
         if (_follow) {
             var extent = geoExtent();

--- a/modules/ui/entity_editor.js
+++ b/modules/ui/entity_editor.js
@@ -100,7 +100,7 @@ export function uiEntityEditor(context) {
                 update: function(section) {
                     section
                         .call(selectionList
-                            .setSelectedIDs(_entityIDs)
+                            .selectedIDs(_entityIDs)
                         );
                 }
             },

--- a/modules/ui/entity_editor.js
+++ b/modules/ui/entity_editor.js
@@ -1,5 +1,5 @@
 import { dispatch as d3_dispatch } from 'd3-dispatch';
-import {event as d3_event, selectAll as d3_selectAll } from 'd3-selection';
+import { event as d3_event, selectAll as d3_selectAll, select as d3_select } from 'd3-selection';
 import deepEqual from 'fast-deep-equal';
 
 import { t, textDirection } from '../util/locale';
@@ -15,6 +15,7 @@ import { uiRawTagEditor } from './raw_tag_editor';
 import { uiTagReference } from './tag_reference';
 import { uiPresetEditor } from './preset_editor';
 import { uiEntityIssues } from './entity_issues';
+import { uiSelectionList } from './selection_list';
 import { uiTooltipHtml } from './tooltipHtml';
 import { utilCleanTags, utilRebind } from '../util';
 
@@ -24,12 +25,13 @@ export function uiEntityEditor(context) {
     var _state = 'select';
     var _coalesceChanges = false;
     var _modified = false;
-    var _scrolled = false;
     var _base;
-    var _entityID;
+    var _entityIDs;
     var _activePreset;
     var _tagReference;
+    var _newFeature;
 
+    var selectionList = uiSelectionList(context);
     var entityIssues = uiEntityIssues(context);
     var quickLinks = uiQuickLinks();
     var presetEditor = uiPresetEditor(context).on('change', changeTags);
@@ -38,8 +40,9 @@ export function uiEntityEditor(context) {
     var rawMembershipEditor = uiRawMembershipEditor(context);
 
     function entityEditor(selection) {
-        var entity = context.entity(_entityID);
-        var tags = Object.assign({}, entity.tags);  // shallow copy
+        var entityID = singularEntityID();
+        var entity = entityID && context.entity(entityID);
+        var tags = entity && Object.assign({}, entity.tags);  // shallow copy
 
         // Header
         var header = selection.selectAll('.header')
@@ -62,18 +65,20 @@ export function uiEntityEditor(context) {
             .call(svgIcon(_modified ? '#iD-icon-apply' : '#iD-icon-close'));
 
         headerEnter
-            .append('h3')
-            .text(t('inspector.edit'));
+            .append('h3');
 
         // Update
         header = header
             .merge(headerEnter);
 
+        header.selectAll('h3')
+            .text(entityID ? t('inspector.edit') : t('inspector.edit_features'));
+
         header.selectAll('.preset-reset')
+            .style('display', entityID ? null : 'none')
             .on('click', function() {
                 dispatch.call('choose', this, _activePreset);
             });
-
 
         // Body
         var body = selection.selectAll('.inspector-body')
@@ -82,159 +87,215 @@ export function uiEntityEditor(context) {
         // Enter
         var bodyEnter = body.enter()
             .append('div')
-            .attr('class', 'inspector-body')
-            .on('scroll.entity-editor', function() { _scrolled = true; });
-
-        bodyEnter
-            .append('div')
-            .attr('class', 'preset-list-item inspector-inner')
-            .append('div')
-            .attr('class', 'preset-list-button-wrap')
-            .append('button')
-            .attr('class', 'preset-list-button preset-reset')
-            .call(tooltip().title(t('inspector.back_tooltip')).placement('bottom'))
-            .append('div')
-            .attr('class', 'label')
-            .append('div')
-            .attr('class', 'label-inner');
-
-        bodyEnter
-            .append('div')
-            .attr('class', 'preset-quick-links');
-
-        bodyEnter
-            .append('div')
-            .attr('class', 'entity-issues');
-
-        bodyEnter
-            .append('div')
-            .attr('class', 'preset-editor');
-
-        bodyEnter
-            .append('div')
-            .attr('class', 'raw-tag-editor inspector-inner');
-
-        bodyEnter
-            .append('div')
-            .attr('class', 'raw-member-editor inspector-inner');
-
-        bodyEnter
-            .append('div')
-            .attr('class', 'raw-membership-editor inspector-inner');
-
-        bodyEnter
-            .append('input')
-            .attr('type', 'text')
-            .attr('class', 'key-trap');
-
+            .attr('class', 'entity-editor inspector-body sep-top');
 
         // Update
         body = body
             .merge(bodyEnter);
 
-        // update header
-        if (_tagReference) {
-            body.selectAll('.preset-list-button-wrap')
-                .call(_tagReference.button);
-
-            body.selectAll('.preset-list-item')
-                .call(_tagReference.body);
-        }
-
-        body.selectAll('.preset-reset')
-            .on('click', function() {
-                dispatch.call('choose', this, _activePreset);
-            });
-
-        body.select('.preset-list-item button')
-            .call(uiPresetIcon(context)
-                .geometry(context.geometry(_entityID))
-                .preset(_activePreset)
-            );
-
-        // NOTE: split on en-dash, not a hypen (to avoid conflict with hyphenated names)
-        var label = body.select('.label-inner');
-        var nameparts = label.selectAll('.namepart')
-            .data(_activePreset.name().split(' – '), function(d) { return d; });
-
-        nameparts.exit()
-            .remove();
-
-        nameparts
-            .enter()
-            .append('div')
-            .attr('class', 'namepart')
-            .text(function(d) { return d; });
-
-        // update quick links
-        var choices = [{
-            id: 'zoom_to',
-            label: 'inspector.zoom_to.title',
-            tooltip: function() {
-                return uiTooltipHtml(t('inspector.zoom_to.tooltip_feature'), t('inspector.zoom_to.key'));
-            },
-            click: function zoomTo() {
-                context.mode().zoomToSelected();
-            }
-        }];
-
-        body.select('.preset-quick-links')
-            .call(quickLinks.choices(choices));
-
-
-        // update editor sections
-        body.select('.entity-issues')
-            .call(entityIssues
-                .entityID(_entityID)
-            );
-
-        body.select('.preset-editor')
-            .call(presetEditor
-                .preset(_activePreset)
-                .entityID(_entityID)
-                .tags(tags)
-                .state(_state)
-            );
-
-        body.select('.raw-tag-editor')
-            .call(rawTagEditor
-                .preset(_activePreset)
-                .entityID(_entityID)
-                .tags(tags)
-                .state(_state)
-            );
-
-        if (entity.type === 'relation') {
-            body.select('.raw-member-editor')
-                .style('display', 'block')
-                .call(rawMemberEditor
-                    .entityID(_entityID)
-                );
-        } else {
-            body.select('.raw-member-editor')
-                .style('display', 'none');
-        }
-
-        body.select('.raw-membership-editor')
-            .call(rawMembershipEditor
-                .entityID(_entityID)
-            );
-
-        body.select('.key-trap')
-            .on('keydown.key-trap', function() {
-                // On tabbing, send focus back to the first field on the inspector-body
-                // (probably the `name` field) #4159
-                if (d3_event.keyCode === 9 && !d3_event.shiftKey) {
-                    d3_event.preventDefault();
-                    body.select('input').node().focus();
+        var sectionInfos = [
+            {
+                klass: 'selection-list',
+                shouldHave: _entityIDs.length > 1,
+                update: function(section) {
+                    section
+                        .call(selectionList
+                            .setSelectedIDs(_entityIDs)
+                        );
                 }
+            },
+            {
+                klass: 'preset-list-item inspector-inner',
+                shouldHave: entityID,
+                create: function(sectionEnter) {
+
+                    var presetButtonWrap = sectionEnter
+                        .append('div')
+                        .attr('class', 'preset-list-button-wrap');
+
+                    var presetButton = presetButtonWrap.append('button')
+                        .attr('class', 'preset-list-button preset-reset')
+                        .call(tooltip().title(t('inspector.back_tooltip')).placement('bottom'));
+
+                    presetButton
+                        .append('div')
+                        .attr('class', 'label')
+                        .append('div')
+                        .attr('class', 'label-inner');
+
+                    presetButtonWrap.append('div')
+                        .attr('class', 'accessory-buttons');
+
+                    // update quick links
+                    var choices = [{
+                        id: 'zoom_to',
+                        label: 'inspector.zoom_to.title',
+                        tooltip: function() {
+                            return uiTooltipHtml(t('inspector.zoom_to.tooltip_feature'), t('inspector.zoom_to.key'));
+                        },
+                        click: function zoomTo() {
+                            context.mode().zoomToSelected();
+                        }
+                    }];
+
+                    sectionEnter
+                        .append('div')
+                        .attr('class', 'preset-quick-links')
+                        .call(quickLinks.choices(choices));
+                },
+                update: function(section) {
+
+                    // update header
+                    if (_tagReference) {
+                        section.selectAll('.preset-list-button-wrap .accessory-buttons')
+                            .call(_tagReference.button);
+
+                        section.selectAll('.preset-list-item')
+                            .call(_tagReference.body);
+                    }
+
+                    section.selectAll('.preset-reset')
+                        .on('click', function() {
+                             dispatch.call('choose', this, _activePreset);
+                        })
+                        .on('mousedown', function() {
+                            d3_event.preventDefault();
+                            d3_event.stopPropagation();
+                        })
+                        .on('mouseup', function() {
+                            d3_event.preventDefault();
+                            d3_event.stopPropagation();
+                        });
+
+                    section.select('.preset-list-item button')
+                        .call(uiPresetIcon(context)
+                            .geometry(context.geometry(entityID))
+                            .preset(_activePreset)
+                        );
+
+                    // NOTE: split on en-dash, not a hypen (to avoid conflict with hyphenated names)
+                    var label = section.select('.label-inner');
+                    var nameparts = label.selectAll('.namepart')
+                        .data(_activePreset.name().split(' – '), function(d) { return d; });
+
+                    nameparts.exit()
+                        .remove();
+
+                    nameparts
+                        .enter()
+                        .append('div')
+                        .attr('class', 'namepart')
+                        .text(function(d) { return d; });
+
+                }
+            }, {
+                klass: 'entity-issues',
+                shouldHave: entityID,
+                update: function(section) {
+                    section
+                        .call(entityIssues
+                            .entityID(entityID)
+                        );
+                }
+            }, {
+                klass: 'preset-editor',
+                shouldHave: entityID,
+                update: function(section) {
+                    section
+                        .call(presetEditor
+                            .preset(_activePreset)
+                            .entityID(entityID)
+                            .tags(tags)
+                            .state(_state)
+                        );
+                }
+            }, {
+                klass: 'raw-tag-editor inspector-inner',
+                shouldHave: true,
+                update: function(section) {
+                    section
+                        .call(rawTagEditor
+                            .preset(_activePreset)
+                            .entityIDs(_entityIDs)
+                            .state(_state)
+                        );
+                }
+            }, {
+                klass: 'raw-member-editor inspector-inner',
+                shouldHave: entity && entity.type === 'relation',
+                update: function(section) {
+                    section
+                        .call(rawMemberEditor
+                            .entityID(entityID)
+                        );
+                }
+            }, {
+                klass: 'raw-membership-editor inspector-inner',
+                shouldHave: entityID,
+                update: function(section) {
+                    section
+                        .call(rawMembershipEditor
+                            .entityID(entityID)
+                        );
+                }
+            }, {
+                klass: 'key-trap-wrap',
+                shouldHave: true,
+                create: function(sectionEnter) {
+                    sectionEnter
+                        .append('input')
+                        .attr('type', 'text')
+                        .attr('class', 'key-trap');
+                },
+                update: function(section) {
+                    section.select('key-trap')
+                        .on('keydown.key-trap', function() {
+                        // On tabbing, send focus back to the first field on the inspector-body
+                        // (probably the `name` field) #4159
+                        if (d3_event.keyCode === 9 && !d3_event.shiftKey) {
+                            d3_event.preventDefault();
+                            body.select('input').node().focus();
+                        }
+                    });
+                }
+            }
+        ];
+
+        sectionInfos = sectionInfos.filter(function(info) {
+            return info.shouldHave;
+        });
+
+        var sections = body.selectAll('.section')
+            .data(sectionInfos, function(d) { return d.klass; });
+
+        sections.exit().remove();
+
+        var sectionsEnter = sections.enter()
+            .append('div')
+            .attr('class', function(d) {
+                return 'section ' + d.klass;
             });
+
+        sectionsEnter.each(function(d) {
+            if (d.create) {
+                d.create(d3_select(this));
+            }
+        });
+
+        sections = sectionsEnter
+            .merge(sections);
+
+        sections.each(function(d) {
+            if (d.update) {
+                d.update(d3_select(this));
+            }
+        });
 
         context.history()
             .on('change.entity-editor', historyChanged);
 
-
         function historyChanged(difference) {
+            if (selection.selectAll('.entity-editor').empty()) return;
             if (_state === 'hide') return;
             var significant = !difference ||
                     difference.didChange.properties ||
@@ -242,30 +303,12 @@ export function uiEntityEditor(context) {
                     difference.didChange.deletion;
             if (!significant) return;
 
-            var entity = context.hasEntity(_entityID);
+            _entityIDs = _entityIDs.filter(context.hasEntity);
+            if (!_entityIDs.length) return;
+
+            loadActivePreset();
+
             var graph = context.graph();
-            if (!entity) return;
-
-            var match = context.presets().match(entity, graph);
-            var activePreset = entityEditor.preset();
-            var weakPreset = activePreset &&
-                Object.keys(activePreset.addTags || {}).length === 0;
-
-            // A "weak" preset doesn't set any tags. (e.g. "Address")
-            // Don't replace a weak preset with a fallback preset (e.g. "Point")
-            if (!(weakPreset && match.isFallback())) {
-                entityEditor.preset(match);
-
-                if (match.id !== activePreset.id) {
-                    // flash the button to indicate the preset changed
-                    selection
-                        .selectAll('button.preset-reset .label')
-                        .style('background-color', '#fff')
-                        .transition()
-                        .duration(500)
-                        .style('background-color', null);
-                }
-            }
             entityEditor.modified(_base !== graph);
             entityEditor(selection);
         }
@@ -275,27 +318,45 @@ export function uiEntityEditor(context) {
     // Tag changes that fire on input can all get coalesced into a single
     // history operation when the user leaves the field.  #2342
     function changeTags(changed, onInput) {
-        var entity = context.entity(_entityID);
-        var annotation = t('operations.change_tags.annotation');
-        var tags = Object.assign({}, entity.tags);   // shallow copy
 
-        for (var k in changed) {
-            if (!k) continue;
-            var v = changed[k];
-            if (v !== undefined || tags.hasOwnProperty(k)) {
-                tags[k] = v;
+        var actions = [];
+        for (var i in _entityIDs) {
+            var entityID = _entityIDs[i];
+            var entity = context.entity(entityID);
+
+            var tags = Object.assign({}, entity.tags);   // shallow copy
+
+            for (var k in changed) {
+                if (!k) continue;
+                var v = changed[k];
+                if (v !== undefined || tags.hasOwnProperty(k)) {
+                    tags[k] = v;
+                }
+            }
+
+            if (!onInput) {
+                tags = utilCleanTags(tags);
+            }
+
+            if (!deepEqual(entity.tags, tags)) {
+                actions.push(actionChangeTags(entityID, tags));
             }
         }
 
-        if (!onInput) {
-            tags = utilCleanTags(tags);
-        }
+        if (actions.length) {
+            var combinedAction = function(graph) {
+                actions.forEach(function(action) {
+                    graph = action(graph);
+                });
+                return graph;
+            };
 
-        if (!deepEqual(entity.tags, tags)) {
+            var annotation = t('operations.change_tags.annotation');
+
             if (_coalesceChanges) {
-                context.overwrite(actionChangeTags(_entityID, tags), annotation);
+                context.overwrite(combinedAction, annotation);
             } else {
-                context.perform(actionChangeTags(_entityID, tags), annotation);
+                context.perform(combinedAction, annotation);
                 _coalesceChanges = !!onInput;
             }
         }
@@ -310,8 +371,6 @@ export function uiEntityEditor(context) {
     entityEditor.modified = function(val) {
         if (!arguments.length) return _modified;
         _modified = val;
-        d3_selectAll('button.preset-close use')
-            .attr('xlink:href', (_modified ? '#iD-icon-apply' : '#iD-icon-close'));
         return entityEditor;
     };
 
@@ -323,39 +382,74 @@ export function uiEntityEditor(context) {
     };
 
 
-    entityEditor.entityID = function(val) {
-        if (!arguments.length) return _entityID;
-        if (_entityID === val) return entityEditor;  // exit early if no change
+    entityEditor.entityIDs = function(val) {
+        if (!arguments.length) return _entityIDs;
+        if (_entityIDs === val) return entityEditor;  // exit early if no change
 
-        _entityID = val;
+        _entityIDs = val;
         _base = context.graph();
         _coalesceChanges = false;
 
-        // reset the scroll to the top of the inspector (warning: triggers reflow)
-        if (_scrolled) {
-            window.requestIdleCallback(function() {
-                var body = d3_selectAll('.entity-editor-pane .inspector-body');
-                if (!body.empty()) {
-                    _scrolled = false;
-                    body.node().scrollTop = 0;
-                }
-            });
-        }
-
-        var presetMatch = context.presets().match(context.entity(_entityID), _base);
+        loadActivePreset();
 
         return entityEditor
-            .preset(presetMatch)
             .modified(false);
     };
 
+
+    entityEditor.newFeature = function(val) {
+        if (!arguments.length) return _newFeature;
+        _newFeature = val;
+        return entityEditor;
+    };
+
+
+    function singularEntityID() {
+        if (_entityIDs.length === 1) {
+            return _entityIDs[0];
+        }
+        return null;
+    }
+
+
+    function loadActivePreset() {
+        var entityID = singularEntityID();
+        var entity = entityID && context.hasEntity(entityID);
+        if (!entity) return;
+
+        var graph = context.graph();
+        var match = context.presets().match(entity, graph);
+
+        // A "weak" preset doesn't set any tags. (e.g. "Address")
+        var weakPreset = _activePreset &&
+            Object.keys(_activePreset.addTags || {}).length === 0;
+
+        // Don't replace a weak preset with a fallback preset (e.g. "Point")
+        if ((weakPreset && match.isFallback()) ||
+            // don't reload for same preset
+            match === _activePreset) return;
+
+        if (_activePreset && match.id !== _activePreset.id) {
+            // flash the button to indicate the preset changed
+            d3_selectAll('.entity-editor button.preset-reset .label')
+                .style('background-color', '#fff')
+                .transition()
+                .duration(500)
+                .style('background-color', null);
+        }
+
+        entityEditor.preset(match);
+    }
 
     entityEditor.preset = function(val) {
         if (!arguments.length) return _activePreset;
         if (val !== _activePreset) {
             _activePreset = val;
-            _tagReference = uiTagReference(_activePreset.reference(context.geometry(_entityID)), context)
-                .showing(false);
+            var entityID = singularEntityID();
+            if (entityID) {
+                _tagReference = uiTagReference(_activePreset.reference(context.geometry(entityID)), context)
+                    .showing(false);
+            }
         }
         return entityEditor;
     };

--- a/modules/ui/inspector.js
+++ b/modules/ui/inspector.js
@@ -101,7 +101,10 @@ export function uiInspector(context) {
         if (!preset) {
             if (_entityIDs.length !== 1) return;
 
-            preset = context.presets().match(_entityIDs[0], context.graph());
+            var entity = context.hasEntity(_entityIDs[0]);
+            if (!entity) return;
+
+            preset = context.presets().match(entity, context.graph());
         }
 
         wrap.transition()

--- a/modules/ui/preset_list.js
+++ b/modules/ui/preset_list.js
@@ -25,6 +25,11 @@ export function uiPresetList(context) {
 
 
     function presetList(selection) {
+        if (!_entityID) {
+            //selection.html('');
+            return;
+        }
+
         var entity = context.entity(_entityID);
         var geometry = context.geometry(_entityID);
 
@@ -461,7 +466,9 @@ export function uiPresetList(context) {
     presetList.entityID = function(val) {
         if (!arguments.length) return _entityID;
         _entityID = val;
-        presetList.preset(context.presets().match(context.entity(_entityID), context.graph()));
+        if (_entityID) {
+            presetList.preset(context.presets().match(context.entity(_entityID), context.graph()));
+        }
         return presetList;
     };
 

--- a/modules/ui/raw_tag_editor.js
+++ b/modules/ui/raw_tag_editor.js
@@ -139,6 +139,7 @@ export function uiRawTagEditor(context) {
             .append('textarea')
             .attr('class', 'tag-text' + (_tagView !== 'text' ? ' hide' : ''))
             .call(utilNoAuto)
+            .attr('placeholder', t('inspector.key_value'))
             .attr('spellcheck', 'false')
             .merge(textarea);
 

--- a/modules/ui/raw_tag_editor.js
+++ b/modules/ui/raw_tag_editor.js
@@ -7,7 +7,8 @@ import { svgIcon } from '../svg/icon';
 import { uiCombobox } from './combobox';
 import { uiDisclosure } from './disclosure';
 import { uiTagReference } from './tag_reference';
-import { utilArrayDifference, utilGetSetValue, utilNoAuto, utilRebind, utilTagDiff } from '../util';
+import { utilArrayDifference, utilArrayIdentical } from '../util/array';
+import { utilGetSetValue, utilNoAuto, utilRebind, utilTagDiff } from '../util';
 
 
 export function uiRawTagEditor(context) {
@@ -609,7 +610,7 @@ export function uiRawTagEditor(context) {
 
     rawTagEditor.entityIDs = function(val) {
         if (!arguments.length) return _entityIDs;
-        if (_entityIDs !== val) {
+        if (!_entityIDs || !val || !utilArrayIdentical(_entityIDs, val)) {
             _entityIDs = val;
             _orderedKeys = [];
         }

--- a/modules/ui/raw_tag_editor.js
+++ b/modules/ui/raw_tag_editor.js
@@ -109,7 +109,7 @@ export function uiRawTagEditor(context) {
             .attr('class', function(d) {
                 return 'raw-tag-option raw-tag-option-' + d.id + (_tagView === d.id ? ' selected' : '');
             })
-            .attr('title', function(d) { return d.id; })
+            .attr('title', function(d) { return t('icons.' + d.id); })
             .on('click', function(d) {
                 _tagView = d.id;
                 context.storage('raw-tag-editor-view', d.id);

--- a/modules/ui/selection_list.js
+++ b/modules/ui/selection_list.js
@@ -8,7 +8,7 @@ import { utilDisplayName, utilHighlightEntities } from '../util';
 
 export function uiSelectionList(context) {
 
-    var selectedIDs = [];
+    var _selectedIDs = [];
 
 
     function selectEntity(entity) {
@@ -18,21 +18,25 @@ export function uiSelectionList(context) {
 
     function deselectEntity(entity) {
         d3_event.stopPropagation();
+
+        var selectedIDs = _selectedIDs.slice();
         var index = selectedIDs.indexOf(entity.id);
         if (index > -1) {
             selectedIDs.splice(index, 1);
+            context.enter(modeSelect(context, selectedIDs));
         }
-        context.enter(modeSelect(context, selectedIDs));
     }
 
 
     function selectionList(selection) {
 
         var list = selection.selectAll('.feature-list')
-            .data([0])
-            .enter()
+            .data([0]);
+
+        list = list.enter()
             .append('div')
-            .attr('class', 'feature-list');
+            .attr('class', 'feature-list')
+            .merge(list);
 
         context.history()
             .on('change.selectionList', function(difference) {
@@ -41,11 +45,10 @@ export function uiSelectionList(context) {
 
         drawList();
 
-
         function drawList() {
-            var entities = selectedIDs
+            var entities = _selectedIDs
                 .map(function(id) { return context.hasEntity(id); })
-                .filter(function(entity) { return entity; });
+                .filter(Boolean);
 
             var items = list.selectAll('.feature-list-item')
                 .data(entities, osmEntity.key);
@@ -109,10 +112,13 @@ export function uiSelectionList(context) {
         }
     }
 
-    selectionList.setSelectedIDs = function(val) {
-        selectedIDs = val;
+
+    selectionList.selectedIDs = function(val) {
+        if (!arguments.length) return _selectedIDs;
+        _selectedIDs = val;
         return selectionList;
     };
+
 
     return selectionList;
 }

--- a/modules/ui/selection_list.js
+++ b/modules/ui/selection_list.js
@@ -1,13 +1,15 @@
 import { event as d3_event, select as d3_select } from 'd3-selection';
 
-import { t } from '../util/locale';
 import { modeSelect } from '../modes/select';
 import { osmEntity } from '../osm';
 import { svgIcon } from '../svg/icon';
 import { utilDisplayName, utilHighlightEntities } from '../util';
 
 
-export function uiSelectionList(context, selectedIDs) {
+export function uiSelectionList(context) {
+
+    var selectedIDs = [];
+
 
     function selectEntity(entity) {
         context.enter(modeSelect(context, [entity.id]));
@@ -25,24 +27,12 @@ export function uiSelectionList(context, selectedIDs) {
 
 
     function selectionList(selection) {
-        selection.classed('selection-list-pane', true);
 
-        var header = selection
+        var list = selection.selectAll('.feature-list')
+            .data([0])
+            .enter()
             .append('div')
-            .attr('class', 'header fillL cf');
-
-        header
-            .append('h3')
-            .text(t('inspector.multiselect'));
-
-        var listWrap = selection
-            .append('div')
-            .attr('class', 'inspector-body');
-
-        var list = listWrap
-            .append('div')
-            .attr('class', 'feature-list cf');
-
+            .attr('class', 'feature-list');
 
         context.history()
             .on('change.selectionList', function(difference) {
@@ -118,6 +108,11 @@ export function uiSelectionList(context, selectedIDs) {
                 .text(function(entity) { return utilDisplayName(entity); });
         }
     }
+
+    selectionList.setSelectedIDs = function(val) {
+        selectedIDs = val;
+        return selectionList;
+    };
 
     return selectionList;
 }

--- a/modules/ui/sidebar.js
+++ b/modules/ui/sidebar.js
@@ -167,10 +167,10 @@ export function uiSidebar(context) {
                     .classed('inspector-hidden', false)
                     .classed('inspector-hover', true);
 
-                if (inspector.entityID() !== datum.id || inspector.state() !== 'hover') {
+                if (inspector.entityIDs() !== [datum.id] || inspector.state() !== 'hover') {
                     inspector
                         .state('hover')
-                        .entityID(datum.id);
+                        .entityIDs([datum.id]);
 
                     inspectorWrap
                         .call(inspector);
@@ -206,17 +206,16 @@ export function uiSidebar(context) {
         };
 
 
-        sidebar.select = function(id, newFeature) {
+        sidebar.select = function(ids, newFeature) {
             sidebar.hide();
 
-            if (id) {
-                var entity = context.entity(id);
-                // uncollapse the sidebar
-                if (selection.classed('collapsed')) {
-                    if (newFeature) {
-                        var extent = entity.extent(context.graph());
-                        sidebar.expand(sidebar.intersects(extent));
-                    }
+            if (ids && ids.length) {
+
+                var entity = ids.length === 1 && context.entity(ids[0]);
+                if (entity && newFeature && selection.classed('collapsed')) {
+                    // uncollapse the sidebar
+                    var extent = entity.extent(context.graph());
+                    sidebar.expand(sidebar.intersects(extent));
                 }
 
                 featureListWrap
@@ -226,24 +225,25 @@ export function uiSidebar(context) {
                     .classed('inspector-hidden', false)
                     .classed('inspector-hover', false);
 
-                if (inspector.entityID() !== id || inspector.state() !== 'select') {
+                if (inspector.entityIDs() !== ids || inspector.state() !== 'select') {
                     inspector
                         .state('select')
-                        .entityID(id)
+                        .entityIDs(ids)
                         .newFeature(newFeature);
 
                     inspectorWrap
                         .call(inspector, newFeature);
                 }
 
-                sidebar.showPresetList = function() {
-                    inspector.showList(context.presets().match(entity, context.graph()));
-                };
-
             } else {
                 inspector
                     .state('hide');
             }
+        };
+
+
+        sidebar.showPresetList = function() {
+            inspector.showList();
         };
 
 

--- a/modules/ui/sidebar.js
+++ b/modules/ui/sidebar.js
@@ -8,7 +8,7 @@ import {
     event as d3_event,
     selectAll as d3_selectAll
 } from 'd3-selection';
-
+import { utilArrayIdentical } from '../util/array';
 import { osmEntity, osmNote, qaError } from '../osm';
 import { services } from '../services';
 import { uiDataEditor } from './data_editor';
@@ -167,7 +167,7 @@ export function uiSidebar(context) {
                     .classed('inspector-hidden', false)
                     .classed('inspector-hover', true);
 
-                if (inspector.entityIDs() !== [datum.id] || inspector.state() !== 'hover') {
+                if (!inspector.entityIDs() || !utilArrayIdentical(inspector.entityIDs(), [datum.id]) || inspector.state() !== 'hover') {
                     inspector
                         .state('hover')
                         .entityIDs([datum.id]);
@@ -225,7 +225,7 @@ export function uiSidebar(context) {
                     .classed('inspector-hidden', false)
                     .classed('inspector-hover', false);
 
-                if (inspector.entityIDs() !== ids || inspector.state() !== 'select') {
+                if (!inspector.entityIDs() || !utilArrayIdentical(inspector.entityIDs(), ids) || inspector.state() !== 'select') {
                     inspector
                         .state('select')
                         .entityIDs(ids)

--- a/modules/util/array.js
+++ b/modules/util/array.js
@@ -1,6 +1,9 @@
 
 // Returns true if a and b have the same elements at the same indices.
 export function utilArrayIdentical(a, b) {
+    // an array is always identical to itself
+    if (a === b) return true;
+
     var i = a.length;
     if (i !== b.length) return false;
     while (i--) {
@@ -146,4 +149,3 @@ export function utilArrayUniqBy(a, key) {
         return acc;
     }, []);
 }
-

--- a/modules/util/array.js
+++ b/modules/util/array.js
@@ -1,4 +1,14 @@
 
+// Returns true if a and b have the same elements at the same indices.
+export function utilArrayIdentical(a, b) {
+    var i = a.length;
+    if (i !== b.length) return false;
+    while (i--) {
+        if (a[i] !== b[i]) return false;
+    }
+    return true;
+}
+
 // http://2ality.com/2015/01/es6-set-operations.html
 
 // Difference (a \ b): create a set that contains those elements of set a that are not in set b.

--- a/modules/util/index.js
+++ b/modules/util/index.js
@@ -2,6 +2,7 @@ export { utilArrayChunk } from './array';
 export { utilArrayDifference } from './array';
 export { utilArrayFlatten } from './array';
 export { utilArrayGroupBy } from './array';
+export { utilArrayIdentical } from './array';
 export { utilArrayIntersection } from './array';
 export { utilArrayUnion } from './array';
 export { utilArrayUniq } from './array';

--- a/test/spec/ui/raw_tag_editor.js
+++ b/test/spec/ui/raw_tag_editor.js
@@ -3,7 +3,7 @@ describe('iD.uiRawTagEditor', function() {
 
     function render(tags) {
         taglist = iD.uiRawTagEditor(context)
-            .entityID(entity.id)
+            .entityIDs([entity.id])
             .preset({isFallback: function() { return false; }})
             .tags(tags)
             .expanded(true);


### PR DESCRIPTION
This brings the multiselect tag editing (#1761) from `master` to `2.x`. There's no real reason this feature has to wait for the v3 UI.

It's not done yet but I wanted to get a PR drafted before the week was out.

<img width="890" alt="Screen Shot 2020-01-17 at 5 48 49 PM" src="https://user-images.githubusercontent.com/2046746/72651713-36571680-3952-11ea-87ac-025e6ecb8e49.png">
