### PR TITLE
Update QA button strings

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -851,16 +851,15 @@ en:
           title: Missing Turn Restriction
           description: '{num_passed} of {num_trips} recorded trips (travelling {travel_direction}) make a turn from {from_way} to {to_way} at {junction}. There may be a missing "{turn_restriction}" restriction.'
     keepRight:
-      title: KeepRight Error
-      detail_title: Error
+      title: KeepRight
       detail_description: Description
       comment: Comment
       comment_placeholder: Enter a comment to share with other users.
-      close: Close (Error Fixed)
-      ignore: Ignore (Not an Error)
+      close: Close (Issue Fixed)
+      ignore: Remove (False Positive)
       save_comment: Save Comment
       close_comment: Close and Comment
-      ignore_comment: Ignore and Comment
+      ignore_comment: Remove and Comment
       error_parts:
         this_node: 'this node'
         this_way: 'this way'

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -1061,16 +1061,15 @@
                 }
             },
             "keepRight": {
-                "title": "KeepRight Error",
-                "detail_title": "Error",
+                "title": "KeepRight",
                 "detail_description": "Description",
                 "comment": "Comment",
                 "comment_placeholder": "Enter a comment to share with other users.",
-                "close": "Close (Error Fixed)",
-                "ignore": "Ignore (Not an Error)",
+                "close": "Close (Issue Fixed)",
+                "ignore": "Remove (False Positive)",
                 "save_comment": "Save Comment",
                 "close_comment": "Close and Comment",
-                "ignore_comment": "Ignore and Comment",
+                "ignore_comment": "Remove and Comment",
                 "error_parts": {
                     "this_node": "this node",
                     "this_way": "this way",


### PR DESCRIPTION
See https://github.com/openstreetmap/iD/pull/7095#issuecomment-570066602 for motivation.

- "Remove" better reflects that the issue is being permanently hidden for everybody. With "False Positive" also helping convey what's being flagged to the QA service.
- "Issue" is a little more suitable than "Error" because it has a slightly different meaning which can apply to a wider variety of things (e.g. "Missing Geometry" in ImproveOSM isn't necessarily an error, but could be described as an issue).
- Just removed "Error" from the KeepRight title as this is what's done in iD v3 anyway and works fine in the title spot.
- Removed the `detail_title` key since it isn't used anywhere (made me ponder whether localised string coverage should be tested).

The idea to add information buttons with more detailed explanations was also floated in Slack. Could be investigated in a further PR.

I'm somewhat unfamiliar with Transifex, will these strings be prompted for translation updates in other languages because they've changed?