### PR TITLE
change car=* to motorcar=* on charging_station

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -68,6 +68,10 @@
     "replace": {"amenity": "charging_station"}
   },
   {
+     "old": {"amenity": "charging_station", "car": "*"},
+     "replace": {"amenity": "charging_station", "motorcar": "$1"}
+  },
+  {
     "old": {"amenity": "fire_hydrant"},
     "replace": {"emergency": "fire_hydrant"}
   },


### PR DESCRIPTION
Following a discussion on the tagging mailing list and on the ​wiki, this changes the tag `car=yes/no` on `amenity=charging_station` to` motorcar=yes/no` to be consistent with the tag used for access. 