### PR TITLE
adding the option "internet_access:fee=customers"

### DIFF
--- a/data/presets/fields/internet_access/fee.json
+++ b/data/presets/fields/internet_access/fee.json
@@ -7,7 +7,6 @@
             "yes": "Yes",
             "no": "No",
             "customers": "For not-facility-customers only",
-        }
     "prerequisiteTag": {
         "key": "internet_access",
         "valueNot": "no"

--- a/data/presets/fields/internet_access/fee.json
+++ b/data/presets/fields/internet_access/fee.json
@@ -1,7 +1,13 @@
 {
-    "key": "internet_access:fee",
-    "type": "check",
+ "key": "internet_access:fee",
+    "type": "combo",
     "label": "Internet Access Fee",
+    "strings": {
+        "options": {
+            "yes": "Yes",
+            "no": "No",
+            "customers": "For not-facility-customers only",
+        }
     "prerequisiteTag": {
         "key": "internet_access",
         "valueNot": "no"

--- a/data/presets/fields/internet_access/fee.json
+++ b/data/presets/fields/internet_access/fee.json
@@ -1,5 +1,5 @@
 {
- "key": "internet_access:fee",
+    "key": "internet_access:fee",
     "type": "combo",
     "label": "Internet Access Fee",
     "strings": {


### PR DESCRIPTION
make internet_access:fee to an combo field for adding the option "internet_access:fee=customers", see https://wiki.openstreetmap.org/wiki/Key:internet_access:fee