### PR TITLE
Create payment_others_no

### DIFF
--- a/data/presets/fields/payment_others_no
+++ b/data/presets/fields/payment_others_no
@@ -1,0 +1,10 @@
+    "key": "payment:others",
+    "type": "onewayCheck",
+    "label": "The list of payment methods accepted is complete",
+    "strings": {
+        "options": {
+            "undefined": "Assumed to be No",
+            "no": "Yes",
+        }
+    }
+}


### PR DESCRIPTION
A first try to let iD support payment:others=no to show that the list of all payment methods accepted is complete, see https://github.com/openstreetmap/iD/issues/7035