### PR TITLE
Fix confusion between allotment gardens and community gardens

### DIFF
--- a/data/presets/fields/garden/type.json
+++ b/data/presets/fields/garden/type.json
@@ -1,0 +1,15 @@
+{
+    "key": "garden:type",
+    "type": "combo",
+    "label": "Garden Type",
+    "strings": {
+        "options": {
+            "arboretum": "Arboretum",
+            "botanical": "Botanical",
+            "community": "Community",
+            "residential": "Residential",
+            "roof_garden": "Roof Garden",
+            "show_garden": "Show Garden"
+        }
+    }
+}

--- a/data/presets/presets/landuse/allotments.json
+++ b/data/presets/presets/landuse/allotments.json
@@ -20,5 +20,5 @@
         "allotment",
         "garden"
     ],
-    "name": "Community Garden"
+    "name": "Allotment Garden"
 }

--- a/data/presets/presets/leisure/garden.json
+++ b/data/presets/presets/leisure/garden.json
@@ -2,6 +2,7 @@
     "icon": "maki-garden",
     "fields": [
         "name",
+        "garden/type",
         "operator",
         "access_simple",
         "fee",


### PR DESCRIPTION
The current "Community Garden" present assigns the tag `landuse=allotments`.

According to both the [allotment](https://wiki.openstreetmap.org/wiki/Tag:landuse%3Dallotments) and [garden:type](https://wiki.openstreetmap.org/wiki/Key:garden:type) wiki pages, allotment gardens and community gardens are distinct.

This pull request fixes the issue, with the existing preset renamed to "Allotment Garden", and the `leisure=garden` preset extended with the `garden:type` field, which includes `garden:type=community`.

