### PR TITLE
fix(scripts): metadata for taginfo

### DIFF
--- a/scripts/build_data.js
+++ b/scripts/build_data.js
@@ -481,7 +481,8 @@ function generateTaginfo(presets, fields) {
       'project_url': 'https://github.com/openstreetmap/iD',
       'doc_url': 'https://github.com/openstreetmap/iD/blob/develop/data/presets/README.md',
       'icon_url': 'https://cdn.jsdelivr.net/gh/openstreetmap/iD@release/dist/img/logo.png',
-      'keywords': ['editor']
+      'contact_name': 'Bryan Housel',
+      'contact_email': 'bryan@mapbox.com'
     },
     'tags': []
   };

--- a/scripts/build_data.js
+++ b/scripts/build_data.js
@@ -481,8 +481,8 @@ function generateTaginfo(presets, fields) {
       'project_url': 'https://github.com/openstreetmap/iD',
       'doc_url': 'https://github.com/openstreetmap/iD/blob/develop/data/presets/README.md',
       'icon_url': 'https://cdn.jsdelivr.net/gh/openstreetmap/iD@release/dist/img/logo.png',
-      'contact_name': 'Bryan Housel',
-      'contact_email': 'bryan@mapbox.com'
+      'contact_name': 'Quincy Morgan',
+      'contact_email': 'q@quincylvania.com'
     },
     'tags': []
   };


### PR DESCRIPTION
The `taginfo.json` lacks `contact_name` and `contact_email` according to https://wiki.openstreetmap.org/wiki/Taginfo/Projects

This blocks the update to the new URL (referring to the develop branch): https://github.com/taginfo/taginfo-projects/pull/95