### PR TITLE
Ignore Thunderforest Outdoors layer

### DIFF
--- a/scripts/update_imagery.js
+++ b/scripts/update_imagery.js
@@ -60,6 +60,7 @@ const discard = {
   'public_transport_oepnv': true,       // 'Public Transport (ÖPNV)'
   'tf-cycle': true,                     // 'Thunderforest OpenCycleMap'
   'tf-landscape': true,                 // 'Thunderforest Landscape'
+  'tf-outdoors': true,                  // 'Thunderforest Outdoors'
   'qa_no_address': true,                // 'QA No Address'
   'wikimedia-map': true,                // 'Wikimedia Map'
 


### PR DESCRIPTION
This PR discards the Thunderforest Outdoors layer, as it needs an API key to be displayed without a watermark. Currently only a black background is shown, since the URL still contains the `{apikey}` parameter and is therefore invalid.

This was reported in osmlab/editor-layer-index#577.