### PR TITLE
show when and who last modified a feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Consider other name-like tags for labelling features, such as `lock_name` ([#9588], thanks [@k-yle])
 * Always take reduced map size due to open side panels into account when zooming to selected entities
 * Limit landuse tags that are considered for "Landuse" area features ([#11184], thanks [@youssefelzedy])
+* When a feature is selected, show when and who last modified it ([#7629], thanks [@k-yle])
 * Render climbing routes and via ferrata ways as dotted lines ([#11133], thanks [@harahu])
 #### :scissors: Operations
 #### :camera: Street-Level
@@ -64,6 +65,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :hammer: Development
 * Add signatures audit to CI build pipeline and pin github action's versions ([#11103], thanks [@Harvester57])
 
+[#7629]: https://github.com/openstreetmap/iD/pull/7629
 [#8440]: https://github.com/openstreetmap/iD/pull/8440
 [#9317]: https://github.com/openstreetmap/iD/issues/9317
 [#9511]: https://github.com/openstreetmap/iD/pull/9511

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -705,6 +705,7 @@ en:
       title: Zoom To Selection
       no_selection: Nothing to zoom to.
     show_more: Show More
+    last_modified: Last modified {timeago} by {user}
     view_on_osm: View on openstreetmap.org
     view_on_osmose: View on osmose.openstreetmap.fr
     view_on_keepRight: View on keepright.at

--- a/modules/util/date.ts
+++ b/modules/util/date.ts
@@ -1,0 +1,30 @@
+import { utilDetect } from './detect';
+
+const preferredLanguage = utilDetect().browserLocales[0];
+
+function timeSince(date: Date): [value: number, unit: Intl.RelativeTimeFormatUnit] {
+    const seconds = Math.floor((+new Date() - +date) / 1000);
+    const s = (n: number) => Math.floor(seconds / n);
+
+    if (s(60 * 60 * 24 * 365) > 1) return [s(60 * 60 * 24 * 365), 'years'];
+    if (s(60 * 60 * 24 * 30) > 1) return [s(60 * 60 * 24 * 30), 'months'];
+    if (s(60 * 60 * 24) > 1) return [s(60 * 60 * 24), 'days'];
+    if (s(60 * 60) > 1) return [s(60 * 60), 'hours'];
+    if (s(60) > 1) return [s(60), 'minutes'];
+    return [s(1), 'seconds'];
+}
+
+/**
+ * Show the relative time if {@link Intl.RelativeTimeFormat} is supported
+ * Otherwise fallback to the current date
+ */
+export function getRelativeDate(date: Date) {
+    if (typeof Intl === 'undefined' || typeof Intl.RelativeTimeFormat === 'undefined') {
+        return `on ${date.toLocaleDateString(preferredLanguage)}`;
+    }
+
+    const [number, units] = timeSince(date);
+    if (!Number.isFinite(number)) return '-';
+
+    return new Intl.RelativeTimeFormat(preferredLanguage).format(-number, units);
+}

--- a/test/spec/ui/view_on_osm.js
+++ b/test/spec/ui/view_on_osm.js
@@ -1,0 +1,13 @@
+describe('iD.uiViewOnOSM.findLastModifiedChild', () => {
+    it('can recurse through relations and ways', () => {
+        const graph = iD.coreGraph([
+            iD.osmNode({ id: 'n1', loc: [0, 0], timestamp: 2024 }),
+            iD.osmNode({ id: 'n2', loc: [0, 0], timestamp: 2025 }),
+            iD.osmNode({ id: 'n3', loc: [0, 0], timestamp: 2024 }),
+            iD.osmWay({ id: 'w1', nodes: ['n1', 'n2', 'n3'], timestamp: 2018 }),
+            iD.osmRelation({ id: 'r1', members: [{ id: 'w1', type: 'way', role: '' }], timestamp: 2023 }),
+            iD.osmRelation({ id: 'r2', members: [{ id: 'r1', type: 'relation', role: '' }], timestamp: 2023 }),
+        ]);
+        expect(iD.uiViewOnOSM.findLastModifiedChild(graph, graph.entity('r2'))).toStrictEqual(graph.entity('n2'));
+    });
+});


### PR DESCRIPTION
Closes #9691

It would be very helpful if you could see when a feature was last modified from within the iD editor. I've changed the `View on openstreetmap.org` message to `Last modified by <user> xx <days/months/...> ago`. The original message is still shown when you hover over the link.

<img width="342" height="136" alt="image" src="https://github.com/user-attachments/assets/dc56ea41-3ecc-4a1f-97f3-8f861d5fc19f" />

&nbsp;

~~I haven't added localization yet - wasn't sure if it's okay to use the new [Intl.RelativeTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat) API.~~