### PR TITLE
Header size didn't include padding above buttons

### DIFF
--- a/modules/renderer/map.js
+++ b/modules/renderer/map.js
@@ -981,7 +981,7 @@ export function rendererMap(context) {
 
     map.trimmedExtent = function(val) {
         if (!arguments.length) {
-            var headerY = 60;
+            var headerY = 71; 
             var footerY = 30;
             var pad = 10;
             return new geoExtent(

--- a/modules/renderer/map.js
+++ b/modules/renderer/map.js
@@ -981,7 +981,7 @@ export function rendererMap(context) {
 
     map.trimmedExtent = function(val) {
         if (!arguments.length) {
-            var headerY = 71; 
+            var headerY = 71;
             var footerY = 30;
             var pad = 10;
             return new geoExtent(


### PR DESCRIPTION
Resolves #7640 

This is the spacing after the changes
![cleared_header](https://user-images.githubusercontent.com/6207661/83362842-59a2c100-a349-11ea-9739-86cec111b282.png)

**Root cause**
The header size in `trimmedExtent` was set to the size of only the inner `div` (i.e. from the top of the buttons to the bottom of the bar). I changed the value to include the padding space above the buttons.
![header_height](https://user-images.githubusercontent.com/6207661/83362851-66bfb000-a349-11ea-99d7-853c54f27033.png)

I also confirmed the footer size of 30px is correct
![footer_height](https://user-images.githubusercontent.com/6207661/83362857-73dc9f00-a349-11ea-87f8-5b12a5fe2e84.png)

