### PR TITLE
Add rollup replace plugin for env vars subst.

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -1,0 +1,4 @@
+/* eslint-disable no-process-env */
+export const OSM_URLROOT = process.env.OSM_URLROOT || 'https://www.openstreetmap.org';
+export const OSM_OAUTH_CONSUMER_KEY = process.env.OSM_OAUTH_CONSUMER_KEY || '5A043yRSEugj4DJ5TljuapfnrflWDte8jTOcWLlT';
+export const OSM_OAUTH_SECRET = process.env.OSM_OAUTH_CONSUMER_KEY || 'aB3jKq1TRsCOUrfOIZ6oQMEDmv2ptV76PA54NGLL';

--- a/config/rollup.config.common.js
+++ b/config/rollup.config.common.js
@@ -15,7 +15,11 @@ export const output = {
   strict: false
 };
 
-const mapValues = (fn, obj) => Object.fromEntries(Object.entries(obj).map(([field, value], index) => [field, fn(value, field, index)]));
+const mapValues = (fn, obj) => Object.entries(obj)
+  .reduce((carry, [field, value], index) =>
+    Object.defineProperty(carry, field, { value: fn(value, field, index), enumerable: true }),
+    {}
+  );
 
 export const plugins = [
   replace({

--- a/config/rollup.config.common.js
+++ b/config/rollup.config.common.js
@@ -1,0 +1,43 @@
+/* eslint-disable no-console */
+import commonjs from '@rollup/plugin-commonjs';
+import includePaths from 'rollup-plugin-includepaths';
+import json from '@rollup/plugin-json';
+import nodeResolve from '@rollup/plugin-node-resolve';
+import progress from 'rollup-plugin-progress';
+import replace from 'rollup-plugin-replace';
+
+import * as config from './config';
+
+export const input = './modules/id.js';
+
+export const output = {
+  format: 'iife',
+  strict: false
+};
+
+const mapValues = (fn, obj) => Object.fromEntries(Object.entries(obj).map(([field, value], index) => [field, fn(value, field, index)]));
+
+export const plugins = [
+  replace({
+    include: ['modules/config.js'],
+    exclude: ['node_modules/**'],
+    values: mapValues(value => JSON.stringify(value), config)
+  }),
+  progress(),
+  includePaths({
+    paths: ['node_modules/d3/node_modules']  // npm2 or windows
+  }),
+  nodeResolve({ dedupe: ['object-inspect'] }),
+  commonjs(),
+  json({ indent: '' })
+];
+
+export const onwarn = (warning, warn) => {
+  // skip certain warnings
+  if (warning.code === 'CIRCULAR_DEPENDENCY') return;
+  if (warning.code === 'EVAL') return;
+
+  // Use default for everything else
+  console.log(warning.code);
+  warn(warning);
+};

--- a/config/rollup.config.dev.js
+++ b/config/rollup.config.dev.js
@@ -1,41 +1,15 @@
-/* eslint-disable no-console */
-import commonjs from '@rollup/plugin-commonjs';
-import includePaths from 'rollup-plugin-includepaths';
-import json from '@rollup/plugin-json';
-import nodeResolve from '@rollup/plugin-node-resolve';
-import progress from 'rollup-plugin-progress';
-
+import { input, output, onwarn, plugins } from './rollup.config.common';
 
 // The "dev" build includes all modules in a single bundle - for now
 // * Skips transpilation (so it includes ES6 code and must run in a modern browser)
 // * Also generates sourcemaps
 
 export default {
-  input: './modules/id.js',
-  onwarn: onWarn,
-  output: {
+  input,
+  onwarn,
+  output: Object.assign({}, {
     file: 'dist/iD.js',
-    format: 'iife',
-    sourcemap: true,
-    strict: false
-  },
-  plugins: [
-    progress(),
-    includePaths({
-      paths: ['node_modules/d3/node_modules']  // npm2 or windows
-    }),
-    nodeResolve({ dedupe: ['object-inspect'] }),
-    commonjs(),
-    json({ indent: '' })
-  ]
+    sourcemap: true
+  }, output),
+  plugins
 };
-
-function onWarn(warning, warn) {
-  // skip certain warnings
-  if (warning.code === 'CIRCULAR_DEPENDENCY') return;
-  if (warning.code === 'EVAL') return;
-
-  // Use default for everything else
-  console.log(warning.code);
-  warn(warning);
-}

--- a/config/rollup.config.legacy.js
+++ b/config/rollup.config.legacy.js
@@ -1,10 +1,6 @@
 /* eslint-disable no-console */
 import buble from '@rollup/plugin-buble';
-import commonjs from '@rollup/plugin-commonjs';
-import includePaths from 'rollup-plugin-includepaths';
-import json from '@rollup/plugin-json';
-import progress from 'rollup-plugin-progress';
-import nodeResolve from '@rollup/plugin-node-resolve';
+import { input, plugins, onwarn, output } from './rollup.config.common';
 
 
 // The "legacy" build includes all modules in a single bundle:
@@ -12,32 +8,13 @@ import nodeResolve from '@rollup/plugin-node-resolve';
 // * No sourcemaps
 
 export default {
-  input: './modules/id.js',
-  onwarn: onWarn,
-  output: {
+  input,
+  onwarn,
+  output: Object.assign({}, {
     file: 'dist/iD.legacy.js',
-    format: 'iife',
     sourcemap: false,
-    strict: false
-  },
-  plugins: [
-    progress(),
-    includePaths({
-      paths: ['node_modules/d3/node_modules']   // npm2 or windows
-    }),
-    nodeResolve({ dedupe: ['object-inspect'] }),
-    commonjs(),
-    json({ indent: '' }),
+  }, output),
+  plugins: plugins.concat([
     buble()
-  ]
+  ])
 };
-
-function onWarn(warning, warn) {
-  // skip certain warnings
-  if (warning.code === 'CIRCULAR_DEPENDENCY') return;
-  if (warning.code === 'EVAL') return;
-
-  // Use default for everything else
-  console.log(warning.code);
-  warn(warning);
-}

--- a/config/rollup.config.stats.js
+++ b/config/rollup.config.stats.js
@@ -1,45 +1,21 @@
 /* eslint-disable no-console */
-import commonjs from '@rollup/plugin-commonjs';
-import includePaths from 'rollup-plugin-includepaths';
-import json from '@rollup/plugin-json';
-import nodeResolve from '@rollup/plugin-node-resolve';
-import progress from 'rollup-plugin-progress';
 import visualizer from 'rollup-plugin-visualizer';
-
+import { input, plugins, onwarn, output } from './rollup.config.common';
 
 // The "stats" build is just like the "dev" build,
 // but it includes the visualizer plugin to generate a statistics page (slow)
 
 export default {
-  input: './modules/id.js',
-  onwarn: onWarn,
-  output: {
+  input,
+  onwarn,
+  output: Object.assign({}, {
     file: 'dist/iD.js',
-    format: 'iife',
-    sourcemap: true,
-    strict: false
-  },
-  plugins: [
-    progress(),
-    includePaths({
-      paths: ['node_modules/d3/node_modules']  // npm2 or windows
-    }),
-    nodeResolve({ dedupe: ['object-inspect'] }),
-    commonjs(),
-    json({ indent: '' }),
+    sourcemap: true
+  }, output),
+  plugins: plugins.concat([
     visualizer({
       filename: 'docs/statistics.html',
       sourcemap: true
     })
-  ]
+  ])
 };
-
-function onWarn(warning, warn) {
-  // skip certain warnings
-  if (warning.code === 'CIRCULAR_DEPENDENCY') return;
-  if (warning.code === 'EVAL') return;
-
-  // Use default for everything else
-  console.log(warning.code);
-  warn(warning);
-}

--- a/modules/config.js
+++ b/modules/config.js
@@ -1,0 +1,4 @@
+/* eslint-disable no-undef */
+export const osm_urlroot = OSM_URLROOT;
+export const oauth_consumer_key = OSM_OAUTH_CONSUMER_KEY;
+export const oauth_secret = OSM_OAUTH_SECRET;

--- a/modules/services/osm.js
+++ b/modules/services/osm.js
@@ -12,14 +12,15 @@ import { geoExtent, geoRawMercator, geoVecAdd, geoZoomToScale } from '../geo';
 import { osmEntity, osmNode, osmNote, osmRelation, osmWay } from '../osm';
 import { utilArrayChunk, utilArrayGroupBy, utilArrayUniq, utilRebind, utilTiler, utilQsString } from '../util';
 
+import { osm_urlroot, oauth_consumer_key, oauth_secret } from '../config';
 
 var tiler = utilTiler();
 var dispatch = d3_dispatch('apiStatusChange', 'authLoading', 'authDone', 'change', 'loading', 'loaded', 'loadedNotes');
-var urlroot = 'https://www.openstreetmap.org';
+var urlroot = osm_urlroot;
 var oauth = osmAuth({
     url: urlroot,
-    oauth_consumer_key: '5A043yRSEugj4DJ5TljuapfnrflWDte8jTOcWLlT',
-    oauth_secret: 'aB3jKq1TRsCOUrfOIZ6oQMEDmv2ptV76PA54NGLL',
+    oauth_consumer_key,
+    oauth_secret,
     loading: authLoading,
     done: authDone
 });

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "rollup": "~2.13.1",
     "rollup-plugin-includepaths": "~0.2.3",
     "rollup-plugin-progress": "^1.1.1",
+    "rollup-plugin-replace": "^2.2.0",
     "rollup-plugin-visualizer": "~4.0.4",
     "shelljs": "^0.8.0",
     "shx": "^0.3.0",


### PR DESCRIPTION
Hello,

I've added the ability to provide some of vars as env variables at rollup time. We are using this on our private OSM instance in a dockerized environment.

Also, I refactored the rollup config to prevent duplicate code from accumulating.