### PR TITLE
Created the field "Handrail" for #6620

### DIFF
--- a/data/presets/fields/handrail
+++ b/data/presets/fields/handrail
@@ -1,0 +1,22 @@
+{
+    "keys": ["handrail:left", "handrail:center", "handrail:right"],
+    "type": "handrail",
+    "placeholder": "unknown",
+    "strings": {
+        "types": {
+            "handrail:left": "Left side",
+            "handrail:center": "In the center"
+            "handrail:right": "Right side"
+        },
+        "options": {
+            "no": {
+                "title": "None",
+                "description": "No handrail"
+            },
+            "yes": {
+                "title": "Yes",
+                "description": "There is a handrail"
+            }
+        }
+    }
+}


### PR DESCRIPTION
See #6620 - created a field for supporting handrail:right/center/left, as the one for "cycleway" is.