### PR TITLE
Flexible Element Search

### DIFF
--- a/modules/ui/feature_list.js
+++ b/modules/ui/feature_list.js
@@ -122,11 +122,11 @@ export function uiFeatureList(context) {
 
             if (!q) return result;
 
-            var idMatch = q.match(/^(.*[^\w])?(node|n|way|w|relation|r)[^\w]?([0-9]+)([^\w].*)?$/i);
+            var idMatch = q.match(/(?:^|\W)(node|way|relation|[nwr])\W?0*([1-9]\d*)(?:\W|$)/i);
 
             if (idMatch) {
-                var elemType = idMatch[2][0];
-                var elemId = idMatch[3];
+                var elemType = idMatch[1].charAt(0);
+                var elemId = idMatch[2];
                 result.push({
                     id: elemType + elemId,
                     geometry: elemType === 'n' ? 'point' : elemType === 'w' ? 'line' : 'relation',

--- a/modules/ui/feature_list.js
+++ b/modules/ui/feature_list.js
@@ -125,8 +125,8 @@ export function uiFeatureList(context) {
             var idMatch = q.match(/^(.*[^\w])?(node|n|way|w|relation|r)[^\w]?([0-9]+)([^\w].*)?$/i);
 
             if (idMatch) {
-				var elemType = idMatch[2][0];
-				var elemId = idMatch[3];
+                var elemType = idMatch[2][0];
+                var elemId = idMatch[3];
                 result.push({
                     id: elemType + elemId,
                     geometry: elemType === 'n' ? 'point' : elemType === 'w' ? 'line' : 'relation',

--- a/modules/ui/feature_list.js
+++ b/modules/ui/feature_list.js
@@ -122,14 +122,16 @@ export function uiFeatureList(context) {
 
             if (!q) return result;
 
-            var idMatch = q.match(/^([nwr])([0-9]+)$/);
+            var idMatch = q.match(/^(.*[^\w])?(node|n|way|w|relation|r)[^\w]?([0-9]+)([^\w].*)?$/i);
 
             if (idMatch) {
+				var elemType = idMatch[2][0];
+				var elemId = idMatch[3];
                 result.push({
-                    id: idMatch[0],
-                    geometry: idMatch[1] === 'n' ? 'point' : idMatch[1] === 'w' ? 'line' : 'relation',
-                    type: idMatch[1] === 'n' ? t('inspector.node') : idMatch[1] === 'w' ? t('inspector.way') : t('inspector.relation'),
-                    name: idMatch[2]
+                    id: elemType + elemId,
+                    geometry: elemType === 'n' ? 'point' : elemType === 'w' ? 'line' : 'relation',
+                    type: elemType === 'n' ? t('inspector.node') : elemType === 'w' ? t('inspector.way') : t('inspector.relation'),
+                    name: elemId
                 });
             }
 


### PR DESCRIPTION
Fix https://github.com/openstreetmap/iD/issues/7627
Accept a variety of formats in Feature Search when specifying an element by type and id.
For example: n123, n 123, node123, node 123 or even https://www.openstreetmap.org/node/123/history#map=19/43.66140/-70.25415