### PR TITLE
Filtering for photo overlay layers

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -168,7 +168,8 @@ input[type=search],
 input[type=number],
 input[type=url],
 input[type=tel],
-input[type=email] {
+input[type=email],
+input[type=date] {
     background-color: #fff;
     color: #333;
     border: 1px solid #ccc;
@@ -177,6 +178,11 @@ input[type=email] {
     border-radius: 4px;
     text-overflow: ellipsis;
     overflow: hidden;
+}
+input.list-item-input {
+    height: 20px;
+    padding: 0px 4px;
+    width: 160px;
 }
 .ideditor[dir='rtl'] textarea,
 .ideditor[dir='rtl'] input[type=text],

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -740,6 +740,16 @@ en:
       panoramic:
         title: "Panoramic Photos"
         tooltip: "360° photos"
+    date_filter:
+      fromDate:
+        title: "From"
+        tooltip: "Show photos taken after this date"
+      toDate:
+        title: "To"
+        tooltip: "Show photos taken before this date"
+    username_filter:
+      title: "Username"
+      tooltip: "Show only photos by this user"
   feature:
     points:
       description: Points

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -928,6 +928,20 @@
                     "title": "Panoramic Photos",
                     "tooltip": "360° photos"
                 }
+            },
+            "date_filter": {
+                "fromDate": {
+                    "title": "From",
+                    "tooltip": "Show photos taken after this date"
+                },
+                "toDate": {
+                    "title": "To",
+                    "tooltip": "Show photos taken before this date"
+                }
+            },
+            "username_filter": {
+                "title": "Username",
+                "tooltip": "Show only photos by this user"
             }
         },
         "feature": {

--- a/modules/renderer/photos.js
+++ b/modules/renderer/photos.js
@@ -9,6 +9,10 @@ export function rendererPhotos(context) {
     var _layerIDs = ['streetside', 'mapillary', 'mapillary-map-features', 'mapillary-signs', 'openstreetcam'];
     var _allPhotoTypes = ['flat', 'panoramic'];
     var _shownPhotoTypes = _allPhotoTypes.slice();   // shallow copy
+    var _dateFilters = ['fromDate', 'toDate'];
+    var _fromDate;
+    var _toDate;
+    var _username;
 
     function photos() {}
 
@@ -37,14 +41,41 @@ export function rendererPhotos(context) {
         return _allPhotoTypes;
     };
 
+    photos.dateFilters = function() {
+        return _dateFilters;
+    };
+
+    photos.dateFilterValue = function(val) {
+        return val === _dateFilters[0] ? _fromDate : _toDate;
+    };
+
+    photos.setDateFilter = function(type, val) {
+        if (type === _dateFilters[0]) _fromDate = val;
+        if (type === _dateFilters[1]) _toDate = val;
+        dispatch.call('change', this);
+    };
+
+    photos.setUsernameFilter = function(val) {
+        _username = val;
+        dispatch.call('change', this);
+    };
+
     function showsLayer(id) {
         var layer = context.layers().layer(id);
         return layer && layer.supported() && layer.enabled();
     }
 
+    photos.shouldFilterByDate = function() {
+        return showsLayer('mapillary') || showsLayer('openstreetcam') || showsLayer('streetside');
+    };
+
     photos.shouldFilterByPhotoType = function() {
         return showsLayer('mapillary') ||
             (showsLayer('streetside') && showsLayer('openstreetcam'));
+    };
+
+    photos.shouldFilterByUsername = function() {
+        return showsLayer('mapillary') || showsLayer('openstreetcam');
     };
 
     photos.showsPhotoType = function(val) {
@@ -61,6 +92,14 @@ export function rendererPhotos(context) {
         return photos.showsPhotoType('panoramic');
     };
 
+    photos.fromDate = function() {
+        return _fromDate;
+    };
+
+    photos.toDate = function() {
+        return _toDate;
+    };
+    
     photos.togglePhotoType = function(val) {
         var index = _shownPhotoTypes.indexOf(val);
         if (index !== -1) {
@@ -70,6 +109,10 @@ export function rendererPhotos(context) {
         }
         dispatch.call('change', this);
         return photos;
+    };
+
+    photos.username = function() {
+        return _username;
     };
 
     photos.init = function() {

--- a/modules/renderer/photos.js
+++ b/modules/renderer/photos.js
@@ -75,7 +75,7 @@ export function rendererPhotos(context) {
     };
 
     photos.shouldFilterByUsername = function() {
-        return showsLayer('mapillary') || showsLayer('openstreetcam');
+        return showsLayer('mapillary') || showsLayer('openstreetcam') || showsLayer('streetside');
     };
 
     photos.showsPhotoType = function(val) {

--- a/modules/services/mapillary.js
+++ b/modules/services/mapillary.js
@@ -46,6 +46,7 @@ var _mlyCache;
 var _mlyClicks;
 var _mlySelectedImageKey;
 var _mlyViewer;
+var _mlyViewerFilter = ['all'];
 
 
 function abortRequest(controller) {
@@ -417,6 +418,34 @@ export default {
         });
     },
 
+    filterViewer: function(context) {
+        var showsPano = context.photos().showsPanoramic();
+        var showsFlat = context.photos().showsFlat();
+        var fromDate = context.photos().fromDate();
+        var toDate = context.photos().toDate();
+        var username = context.photos().username();
+        var filter = ['all'];
+        
+        if (!showsPano) filter.push(['==', 'pano', false]);
+        if (!showsFlat && showsPano) filter.push(['==', 'pano', true]);
+        if (username) filter.push(['==', 'username', username]);
+        if (fromDate) {
+            var fromTimestamp = new Date(fromDate).getTime();
+            filter.push(['>=', 'capturedAt', fromTimestamp]);
+        }
+        if (toDate) {
+            var toTimestamp = new Date(toDate).getTime();
+            filter.push(['>=', 'capturedAt', toTimestamp]);
+        } 
+
+        if (_mlyViewer) {
+            _mlyViewer.setFilter(filter);
+        }
+        _mlyViewerFilter = filter;
+
+        return filter;
+    },
+
 
     showViewer: function(context) {
         var wrap = context.container().select('.photoviewer')
@@ -512,6 +541,9 @@ export default {
             _mlyViewer.on('bearingchanged', bearingChanged);
             _mlyViewer.moveToKey(imageKey)
                 .catch(function(e) { console.error('mly3', e); });  // eslint-disable-line no-console
+            if (_mlyViewerFilter) {
+                _mlyViewer.setFilter(_mlyViewerFilter);
+            }
         }
 
         // nodeChanged: called after the viewer has changed images and is ready.

--- a/modules/services/openstreetcam.js
+++ b/modules/services/openstreetcam.js
@@ -217,11 +217,16 @@ export default {
             .forEach(function(sequenceKey) {
                 var seq = _oscCache.sequences[sequenceKey];
                 var images = seq && seq.images;
+
                 if (images) {
                     lineStrings.push({
                         type: 'LineString',
                         coordinates: images.map(function (d) { return d.loc; }).filter(Boolean),
-                        properties: { key: sequenceKey }
+                        properties: { 
+                            captured_at: images[0] ? images[0].captured_at: null,
+                            captured_by: images[0] ? images[0].captured_by: null,
+                            key: sequenceKey 
+                        }
                     });
                 }
             });

--- a/modules/services/streetside.js
+++ b/modules/services/streetside.js
@@ -177,7 +177,11 @@ function connectSequences() {
       // create a GeoJSON LineString
       sequence.geojson = {
         type: 'LineString',
-        properties: { key: sequence.key },
+        properties: { 
+          captured_at: sequence.bubbles[0] ? sequence.bubbles[0].captured_at : null,
+          captured_by: sequence.bubbles[0] ? sequence.bubbles[0].captured_by : null,
+          key: sequence.key 
+        },
         coordinates: sequence.bubbles.map(d => d.loc)
       };
 

--- a/modules/svg/mapillary_images.js
+++ b/modules/svg/mapillary_images.js
@@ -124,10 +124,31 @@ export function svgMapillaryImages(projection, context, dispatch) {
     function filterImages(images) {
         var showsPano = context.photos().showsPanoramic();
         var showsFlat = context.photos().showsFlat();
+        var fromDate = context.photos().fromDate();
+        var toDate = context.photos().toDate();
+        var username = context.photos().username();
+
         if (!showsPano || !showsFlat) {
             images = images.filter(function(image) {
                 if (image.pano) return showsPano;
                 return showsFlat;
+            });
+        }
+        if (fromDate) {
+            var fromTimestamp = new Date(fromDate).getTime();
+            images = images.filter(function(image) {
+                return new Date(image.captured_at).getTime() >= fromTimestamp;
+            });
+        }
+        if (toDate) {
+            var toTimestamp = new Date(toDate).getTime();
+            images = images.filter(function(image) {
+                return new Date(image.captured_at).getTime() <= toTimestamp;
+            });
+        }
+        if (username) {
+            images = images.filter(function(image) {
+                return image.captured_by === username;
             });
         }
         return images;
@@ -136,6 +157,10 @@ export function svgMapillaryImages(projection, context, dispatch) {
     function filterSequences(sequences, service) {
         var showsPano = context.photos().showsPanoramic();
         var showsFlat = context.photos().showsFlat();
+        var fromDate = context.photos().fromDate();
+        var toDate = context.photos().toDate();
+        var username = context.photos().username();
+
         if (!showsPano || !showsFlat) {
             sequences = sequences.filter(function(sequence) {
                 if (sequence.properties.hasOwnProperty('pano')) {
@@ -157,6 +182,23 @@ export function svgMapillaryImages(projection, context, dispatch) {
                 }
             });
         }
+        if (fromDate) {
+            var fromTimestamp = new Date(fromDate).getTime();
+            sequences = sequences.filter(function(sequence) {
+                return new Date(sequence.captured_at).getTime() >= fromTimestamp;
+            });
+        }
+        if (toDate) {
+            var toTimestamp = new Date(toDate).getTime();
+            sequences = sequences.filter(function(sequence) {
+                return new Date(sequence.captured_at).getTime() <= toTimestamp;
+            });
+        }
+        if (username) {
+            sequences = sequences.filter(function(sequence) {
+                return sequence.captured_by === username;
+            });
+        }
         return sequences;
     }
 
@@ -173,6 +215,7 @@ export function svgMapillaryImages(projection, context, dispatch) {
 
         images = filterImages(images);
         sequences = filterSequences(sequences, service);
+        service.filterViewer(context);
 
         var traces = layer.selectAll('.sequences').selectAll('.sequence')
             .data(sequences, function(d) { return d.properties.key; });

--- a/modules/svg/mapillary_images.js
+++ b/modules/svg/mapillary_images.js
@@ -185,20 +185,21 @@ export function svgMapillaryImages(projection, context, dispatch) {
         if (fromDate) {
             var fromTimestamp = new Date(fromDate).getTime();
             sequences = sequences.filter(function(sequence) {
-                return new Date(sequence.captured_at).getTime() >= fromTimestamp;
+                return new Date(sequence.properties.captured_at).getTime() >= fromTimestamp;
             });
         }
         if (toDate) {
             var toTimestamp = new Date(toDate).getTime();
             sequences = sequences.filter(function(sequence) {
-                return new Date(sequence.captured_at).getTime() <= toTimestamp;
+                return new Date(sequence.properties.captured_at).getTime() <= toTimestamp;
             });
         }
         if (username) {
             sequences = sequences.filter(function(sequence) {
-                return sequence.captured_by === username;
+                return sequence.properties.username === username;
             });
         }
+
         return sequences;
     }
 

--- a/modules/svg/openstreetcam_images.js
+++ b/modules/svg/openstreetcam_images.js
@@ -112,23 +112,49 @@ export function svgOpenstreetcamImages(projection, context, dispatch) {
 
         if (fromDate) {
             var fromTimestamp = new Date(fromDate).getTime();
-            images = images.filter(function(image) {
-                return new Date(image.captured_at).getTime() >= fromTimestamp;
+            images = images.filter(function(item) {
+                return new Date(item.captured_at).getTime() >= fromTimestamp;
             });
         }
         if (toDate) {
             var toTimestamp = new Date(toDate).getTime();
-            images = images.filter(function(image) {
-                return new Date(image.captured_at).getTime() <= toTimestamp;
+            images = images.filter(function(item) {
+                return new Date(item.captured_at).getTime() <= toTimestamp;
             });
         }
         if (username) {
-            images = images.filter(function(image) {
-                return image.captured_by === username;
+            images = images.filter(function(item) {
+                return item.captured_by === username;
             });
         }
 
         return images;
+    }
+
+    function filterSequences(sequences) {
+        var fromDate = context.photos().fromDate();
+        var toDate = context.photos().toDate();
+        var username = context.photos().username();
+
+        if (fromDate) {
+            var fromTimestamp = new Date(fromDate).getTime();
+            sequences = sequences.filter(function(image) {
+                return new Date(image.properties.captured_at).getTime() >= fromTimestamp;
+            });
+        }
+        if (toDate) {
+            var toTimestamp = new Date(toDate).getTime();
+            sequences = sequences.filter(function(image) {
+                return new Date(image.properties.captured_at).getTime() <= toTimestamp;
+            });
+        }
+        if (username) {
+            sequences = sequences.filter(function(image) {
+                return image.properties.captured_by === username;
+            });
+        }
+
+        return sequences;
     }
 
     function update() {
@@ -146,10 +172,10 @@ export function svgOpenstreetcamImages(projection, context, dispatch) {
         if (context.photos().showsFlat()) {
             sequences = (service ? service.sequences(projection) : []);
             images = (service && showMarkers ? service.images(projection) : []);
+            sequences = filterSequences(sequences);
+            images = filterImages(images);
         }
         
-        images = filterImages(images);
-
         var traces = layer.selectAll('.sequences').selectAll('.sequence')
             .data(sequences, function(d) { return d.properties.key; });
 

--- a/modules/svg/openstreetcam_images.js
+++ b/modules/svg/openstreetcam_images.js
@@ -105,6 +105,32 @@ export function svgOpenstreetcamImages(projection, context, dispatch) {
 
     context.photos().on('change.openstreetcam_images', update);
 
+    function filterImages(images) {
+        var fromDate = context.photos().fromDate();
+        var toDate = context.photos().toDate();
+        var username = context.photos().username();
+
+        if (fromDate) {
+            var fromTimestamp = new Date(fromDate).getTime();
+            images = images.filter(function(image) {
+                return new Date(image.captured_at).getTime() >= fromTimestamp;
+            });
+        }
+        if (toDate) {
+            var toTimestamp = new Date(toDate).getTime();
+            images = images.filter(function(image) {
+                return new Date(image.captured_at).getTime() <= toTimestamp;
+            });
+        }
+        if (username) {
+            images = images.filter(function(image) {
+                return image.captured_by === username;
+            });
+        }
+
+        return images;
+    }
+
     function update() {
         var viewer = context.container().select('.photoviewer');
         var selected = viewer.empty() ? undefined : viewer.datum();
@@ -121,6 +147,8 @@ export function svgOpenstreetcamImages(projection, context, dispatch) {
             sequences = (service ? service.sequences(projection) : []);
             images = (service && showMarkers ? service.images(projection) : []);
         }
+        
+        images = filterImages(images);
 
         var traces = layer.selectAll('.sequences').selectAll('.sequence')
             .data(sequences, function(d) { return d.properties.key; });

--- a/modules/svg/streetside.js
+++ b/modules/svg/streetside.js
@@ -159,6 +159,26 @@ export function svgStreetside(projection, context, dispatch) {
 
     context.photos().on('change.streetside', update);
 
+    function filterBubbles(bubbles) {
+        var fromDate = context.photos().fromDate();
+        var toDate = context.photos().toDate();
+
+        if (fromDate) {
+            var fromTimestamp = new Date(fromDate).getTime();
+            bubbles = bubbles.filter(function(bubble) {
+                return new Date(bubble.captured_at).getTime() >= fromTimestamp;
+            });
+        }
+        if (toDate) {
+            var toTimestamp = new Date(toDate).getTime();
+            bubbles = bubbles.filter(function(bubble) {
+                return new Date(bubble.captured_at).getTime() <= toTimestamp;
+            });
+        }
+
+        return bubbles;
+    }
+
     /**
      * update().
      */
@@ -177,6 +197,8 @@ export function svgStreetside(projection, context, dispatch) {
             sequences = (service ? service.sequences(projection) : []);
             bubbles = (service && showMarkers ? service.bubbles(projection) : []);
         }
+
+        bubbles = filterBubbles(bubbles);
 
         var traces = layer.selectAll('.sequences').selectAll('.sequence')
             .data(sequences, function(d) { return d.properties.key; });

--- a/modules/svg/streetside.js
+++ b/modules/svg/streetside.js
@@ -162,6 +162,7 @@ export function svgStreetside(projection, context, dispatch) {
     function filterBubbles(bubbles) {
         var fromDate = context.photos().fromDate();
         var toDate = context.photos().toDate();
+        var username = context.photos().username();
 
         if (fromDate) {
             var fromTimestamp = new Date(fromDate).getTime();
@@ -175,8 +176,39 @@ export function svgStreetside(projection, context, dispatch) {
                 return new Date(bubble.captured_at).getTime() <= toTimestamp;
             });
         }
+        if (username) {
+            bubbles = bubbles.filter(function(bubble) {
+                return bubble.captured_by === username;
+            });
+        }
 
         return bubbles;
+    }
+
+    function filterSequences(sequences) {
+        var fromDate = context.photos().fromDate();
+        var toDate = context.photos().toDate();
+        var username = context.photos().username();
+
+        if (fromDate) {
+            var fromTimestamp = new Date(fromDate).getTime();
+            sequences = sequences.filter(function(sequences) {
+                return new Date(sequences.properties.captured_at).getTime() >= fromTimestamp;
+            });
+        }
+        if (toDate) {
+            var toTimestamp = new Date(toDate).getTime();
+            sequences = sequences.filter(function(sequences) {
+                return new Date(sequences.properties.captured_at).getTime() <= toTimestamp;
+            });
+        }
+        if (username) {
+            sequences = sequences.filter(function(sequences) {
+                return sequences.properties.captured_by === username;
+            });
+        }
+
+        return sequences;
     }
 
     /**
@@ -196,9 +228,9 @@ export function svgStreetside(projection, context, dispatch) {
         if (context.photos().showsPanoramic()) {
             sequences = (service ? service.sequences(projection) : []);
             bubbles = (service && showMarkers ? service.bubbles(projection) : []);
+            sequences = filterSequences(sequences);
+            bubbles = filterBubbles(bubbles);
         }
-
-        bubbles = filterBubbles(bubbles);
 
         var traces = layer.selectAll('.sequences').selectAll('.sequence')
             .data(sequences, function(d) { return d.properties.key; });

--- a/modules/ui/sections/photo_overlays.js
+++ b/modules/ui/sections/photo_overlays.js
@@ -24,7 +24,9 @@ export function uiSectionPhotoOverlays(context) {
             .attr('class', 'photo-overlay-container')
             .merge(container)
             .call(drawPhotoItems)
-            .call(drawPhotoTypeItems);
+            .call(drawPhotoTypeItems)
+            .call(drawDateFilter)
+            .call(drawUsernameFilter);
     }
 
     function drawPhotoItems(selection) {
@@ -91,7 +93,6 @@ export function uiSectionPhotoOverlays(context) {
                 if (id === 'mapillary-signs') id = 'photo_overlays.traffic_signs';
                 return t(id.replace(/-/g, '_') + '.title');
             });
-
 
         // Update
         li
@@ -162,6 +163,126 @@ export function uiSectionPhotoOverlays(context) {
             .classed('active', typeEnabled)
             .selectAll('input')
             .property('checked', typeEnabled);
+    }
+
+    function drawDateFilter(selection) {
+        var data = context.photos().dateFilters();
+
+        function filterEnabled(d) {
+            return context.photos().dateFilterValue(d); 
+        }
+
+        var ul = selection
+            .selectAll('.layer-list-date-filter')
+            .data(context.photos().shouldFilterByDate() ? [0] : []);
+
+        ul.exit()
+            .remove();
+
+        ul = ul.enter()
+            .append('ul')
+            .attr('class', 'layer-list layer-list-date-filter')
+            .merge(ul);
+
+        var li = ul.selectAll('.list-item-date-filter')
+            .data(data);
+
+        li.exit()
+            .remove();
+
+        var liEnter = li.enter()
+            .append('li')
+            .attr('class', 'list-item-date-filter');
+
+        var labelEnter = liEnter
+            .append('label')
+            .each(function(d) {
+                d3_select(this)
+                    .call(uiTooltip()
+                        .title(t('photo_overlays.date_filter.' + d + '.tooltip'))
+                        .placement('top')
+                    );
+            });
+
+        labelEnter
+            .append('span')
+            .text(function(d) {
+                return t('photo_overlays.date_filter.' + d + '.title');
+            });
+
+        labelEnter
+            .append('input')
+            .attr('type', 'date')
+            .attr('class', 'list-item-input')
+            .attr('placeholder', 'dd/mm/yyyy')
+            .on('change', function(d) {
+                var value = d3_select(this).property('value');
+                context.photos().setDateFilter(d, value);
+            });
+
+        li
+            .merge(liEnter)
+            .classed('active', filterEnabled)
+            .selectAll('input')
+            .property('value', function(d) {
+                return context.photos().dateFilterValue(d);
+            });
+    }
+
+    function drawUsernameFilter(selection) {
+        function filterEnabled() {
+            return context.photos().username(); 
+        }
+        var ul = selection
+            .selectAll('.layer-list-username-filter')
+            .data(context.photos().shouldFilterByUsername() ? [0] : []);
+
+        ul.exit()
+            .remove();
+
+        ul = ul.enter()
+            .append('ul')
+            .attr('class', 'layer-list layer-list-username-filter')
+            .merge(ul);
+
+        var li = ul.selectAll('.list-item-username-filter')
+            .data(['username-filter']);
+
+        li.exit()
+            .remove();
+
+        var liEnter = li.enter()
+            .append('li')
+            .attr('class', 'list-item-username-filter');
+
+        var labelEnter = liEnter
+            .append('label')
+            .each(function() {
+                d3_select(this)
+                    .call(uiTooltip()
+                        .title(t('photo_overlays.username_filter.tooltip'))
+                        .placement('top')
+                    );
+            });
+
+        labelEnter
+            .append('span')
+            .text(t('photo_overlays.username_filter.title'));
+
+        labelEnter
+            .append('input')
+            .attr('type', 'text')
+            .attr('class', 'list-item-input')
+            .on('change', function() {
+                var value = d3_select(this).property('value');
+                context.photos().setUsernameFilter(value);
+            });
+        
+        li
+            .merge(liEnter)
+            .classed('active', filterEnabled)
+            .selectAll('input')
+            .property('value', context.photos().username());
     }
 
     function toggleLayer(which) {

--- a/modules/ui/sections/photo_overlays.js
+++ b/modules/ui/sections/photo_overlays.js
@@ -215,6 +215,9 @@ export function uiSectionPhotoOverlays(context) {
             .attr('type', 'date')
             .attr('class', 'list-item-input')
             .attr('placeholder', 'dd/mm/yyyy')
+            .property('value', function(d) {
+                return context.photos().dateFilterValue(d);
+            })
             .on('change', function(d) {
                 var value = d3_select(this).property('value');
                 context.photos().setDateFilter(d, value);
@@ -222,11 +225,7 @@ export function uiSectionPhotoOverlays(context) {
 
         li
             .merge(liEnter)
-            .classed('active', filterEnabled)
-            .selectAll('input')
-            .property('value', function(d) {
-                return context.photos().dateFilterValue(d);
-            });
+            .classed('active', filterEnabled);
     }
 
     function drawUsernameFilter(selection) {
@@ -273,6 +272,7 @@ export function uiSectionPhotoOverlays(context) {
             .append('input')
             .attr('type', 'text')
             .attr('class', 'list-item-input')
+            .property('value', context.photos().username())
             .on('change', function() {
                 var value = d3_select(this).property('value');
                 context.photos().setUsernameFilter(value);
@@ -280,9 +280,7 @@ export function uiSectionPhotoOverlays(context) {
         
         li
             .merge(liEnter)
-            .classed('active', filterEnabled)
-            .selectAll('input')
-            .property('value', context.photos().username());
+            .classed('active', filterEnabled);
     }
 
     function toggleLayer(which) {

--- a/test/spec/services/mapillary.js
+++ b/test/spec/services/mapillary.js
@@ -368,4 +368,19 @@ describe('iD.serviceMapillary', function() {
         });
     });
 
+    describe('#filterViewer', function() {
+        it('filters images by username', function() {
+            context.photos().setUsernameFilter('mapillary');
+            var filter = mapillary.filterViewer(context);
+            expect(filter.length).to.be.equal(2);
+        });
+
+        it('filters images by dates', function() {
+            context.photos().setDateFilter('fromDate', '2020-01-01');
+            context.photos().setDateFilter('toDate', '2021-01-01');
+            var filter = mapillary.filterViewer(context);
+            expect(filter.length).to.be.equal(3);
+        });
+    });
+
 });

--- a/test/spec/services/openstreetcam.js
+++ b/test/spec/services/openstreetcam.js
@@ -253,7 +253,11 @@ describe('iD.serviceOpenstreetcam', function() {
             expect(res).to.deep.eql([{
                 type: 'LineString',
                 coordinates: [[10,0], [10,0], [10,1]],
-                properties: { key: '100' }
+                properties: {
+                    captured_at: undefined,
+                    captured_by: undefined,
+                    key: '100' 
+                }
             }]);
         });
     });


### PR DESCRIPTION
Hello, this PR adds filtering for photo overlay layers. Included are date and username filters.

The filters are applied to all photo overlays (Mapillary, Openstreetcam and Bing Streetside) at the same time.

Filter UI is in the `Photo Overlays` section. Will become visible when filterable photo layers are turned on.

![filters](https://user-images.githubusercontent.com/3823786/88376657-235c4d80-cd9e-11ea-911f-185fe39f9af5.png)


## Changes
- Added date (from and to) filters for photo layers. Uses default browser date picker (input with type `date`).
- Added username filter for photo layers

Let me know if you have any questions or suggestions. There has been discussion in the linked issues on how the filters should look and behave so I'm open to modifying it based on feedback.

Related issues: https://github.com/openstreetmap/iD/issues/7342 https://github.com/openstreetmap/iD/issues/5307 https://github.com/openstreetmap/iD/issues/4518