### PR TITLE
Make authentication more robust and show hint during login

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -5615,3 +5615,27 @@ li.hide + li.version .badge .tooltip .popover-arrow {
     width: 100px;
     color: #7092ff;
 }
+
+
+/* Authentication hint
+------------------------------------------------------- */
+
+.ideditor .authentication-hint {
+    position: absolute;
+    top: 100px;
+    left: 0;
+    right: 0;
+    z-index: 100;
+    text-align: center;
+}
+
+.ideditor .authentication-hint .box {
+    display: inline-block;
+    border-radius: 10px;
+    padding: 20px;
+}
+
+.ideditor .authentication-hint .show-login-button {
+    margin-top: 15px;
+    padding: 0 20px;
+}

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -494,6 +494,9 @@ en:
   login: Log In
   logout: Log Out
   loading_auth: "Connecting to OpenStreetMap..."
+  authentication_hint:
+    authentication_needed: "Please log in to OpenStreetMap."
+    show_login: Show Login
   report_a_bug: Report a bug
   help_translate: Help translate
   sidebar:

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -641,6 +641,10 @@
         "login": "Log In",
         "logout": "Log Out",
         "loading_auth": "Connecting to OpenStreetMap...",
+        "authentication_hint": {
+            "authentication_needed": "Please log in to OpenStreetMap.",
+            "show_login": "Show Login"
+        },
         "report_a_bug": "Report a bug",
         "help_translate": "Help translate",
         "sidebar": {

--- a/modules/ui/authenticationHint.js
+++ b/modules/ui/authenticationHint.js
@@ -1,0 +1,30 @@
+import { select as d3_select } from 'd3-selection';
+
+import { t } from '../core/localizer';
+
+
+export function uiAuthenticationHint(onShowLogin) {
+    var authenticationHint = d3_select(document.createElement('div'))
+        .attr('class', 'authentication-hint');
+
+    var box = authenticationHint
+        .append('div')
+        .attr('class', 'box fillD');
+
+    box
+        .append('div')
+        .text(t('authentication_hint.authentication_needed'));
+
+    box
+        .append('button')
+        .attr('class', 'action button show-login-button')
+        .text(t('authentication_hint.show_login'))
+        .on('click', onShowLogin);
+
+    d3_select(document.getElementById('id-container'))
+        .select('.main-content')
+        .node()
+        .appendChild(authenticationHint.node());
+
+    return authenticationHint;
+}

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "marked": "1.0.0",
     "martinez-polygon-clipping": "0.7.0",
     "node-diff3": "2.1.0",
-    "osm-auth": "1.0.2",
+    "osm-auth": "osmlab/osm-auth#b53e37e",
     "pannellum": "2.5.6",
     "rbush": "3.0.1",
     "string.fromcodepoint": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "marked": "1.0.0",
     "martinez-polygon-clipping": "0.7.0",
     "node-diff3": "2.1.0",
-    "osm-auth": "osmlab/osm-auth#b53e37e",
+    "osm-auth": "1.1.0",
     "pannellum": "2.5.6",
     "rbush": "3.0.1",
     "string.fromcodepoint": "1.0.0",


### PR DESCRIPTION
This PR improves the OSM authentication:

  - If `osm.authenticate` is called multiple times, an already running authentication is not reset any more.
  - While an authentication is running, a hint is shown in the main UI providing a button which brings the login popup to the front. This is helpful if the user accidentally moved the popup behind other windows - e.g. by clicking on iD's main window. (See also [my PR for osm-auth](https://github.com/osmlab/osm-auth/pull/67))
  - If the login popup was blocked by the browser, it can be shown by clicking the "Show login" button of the authentication hint.
  - `osm.authenticate` now returns a Promise. You can call it with a callback (like the current code does) or you use the Promise.

Known issues:

  - In `_showAuthenticationNeeded` of `modules/services/osm.js` I should probably pass the context to `uiAuthenticationHint`. But I didn't figure out where to get it.
  - In `uiAuthenticationHint` of `modules/ui/authenticationHint.js` I add the hint to DOM a little bit hacky. There's probably a better way to do this.