### PR TITLE
Added Irish Pub preset (`theme=irish`)

### DIFF
--- a/data/presets/presets/amenity/pub/irish.json
+++ b/data/presets/presets/amenity/pub/irish.json
@@ -1,0 +1,17 @@
+{
+    "name": "Irish Pub",
+    "icon": "maki-beer",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "amenity": "pub",
+        "theme": "irish"
+    },
+    "terms": [
+        "irish pub",
+        "irish bar"
+    ],
+    "notCountryCodes": ["ie"]
+}


### PR DESCRIPTION
It's excluded from Ireland, because that doesn't make as much sense.
Visitors to Ireland might falsely tag every pub as an Irish Pub.