### PR TITLE
Mapillary improvements and bug fixes

### DIFF
--- a/css/60_photos.css
+++ b/css/60_photos.css
@@ -304,22 +304,16 @@ label.streetside-hires {
     border-radius: 4px;
     top: -25px;
 }
-#ideditor-mly .domRenderer .Attribution {
-    /* we will roll our own to avoid async update issues like #4526 */
-    display: none;
+
+.mly-wrapper .AttributionContainer .AttributionIconContainer .AttributionMapillaryLogo {
+    margin-top: 3px;
 }
 
-.mly-wrapper .photo-attribution a:active {
-    color: #35af6d;
-}
-@media (hover: hover) {
-    .mly-wrapper .photo-attribution a:hover {
-        color: #35af6d;
-    }
-}
-
-.mly-wrapper .mapillary-js-dom {
-    z-index: 9;
+.mly-wrapper .AttributionContainer .AttributionImageContainer {
+    color: #fff;
+    font-size: 10px;
+    font-weight: 300;
+    overflow: hidden;
 }
 
 

--- a/modules/services/mapillary.js
+++ b/modules/services/mapillary.js
@@ -776,7 +776,7 @@ export default {
             if (_mlyHighlightedDetection === data.key) {
                 color = 0xffff00;
                 text = valueParts[1];
-                if (text === 'flat' || text === 'discrete' || text === 'sign' || text === 'traffic-light') {
+                if (text === 'flat' || text === 'discrete' || text === 'sign') {
                     text = valueParts[2];
                 }
                 text = text.replace(/-/g, ' ');

--- a/modules/services/mapillary.js
+++ b/modules/services/mapillary.js
@@ -47,7 +47,6 @@ var _mlyClicks;
 var _mlySelectedImage;
 var _mlySelectedImageKey;
 var _mlyViewer;
-var _mlyViewerFilter = ['all'];
 var _mlyHighlightedDetection;
 var _mlyShowFeatureDetections = false;
 var _mlyShowSignDetections = false;
@@ -523,7 +522,7 @@ export default {
             if (imageKey) {
                 hash.photo = imageKey;
             } else {
-                delete hash.photo
+                delete hash.photo;
             }
             window.location.replace('#' + utilQsString(hash, true));
         }
@@ -750,7 +749,7 @@ export default {
             loadData('image_detections', url)
                 .then(() => {
                     showDetections(_mlyCache.image_detections.forImageKey[imageKey] || []);
-            })
+            });
         } else {
             showDetections(_mlyCache.image_detections.forImageKey[imageKey]);
         }
@@ -769,18 +768,19 @@ export default {
             var valueParts = data.value.split('--');
             if (!valueParts.length) return;
 
-            var text = valueParts[1];
-            if (text === 'flat' || text === 'discrete' || text === 'sign' || text === 'traffic-light') {
-                text = valueParts[2];
-            }
-            text = text.replace(/-/g, ' ');
-            text = text.charAt(0).toUpperCase() + text.slice(1)
+            
             var tag;
-
+            var text;
             var color = 0xffffff;
 
             if (_mlyHighlightedDetection === data.key) {
                 color = 0xffff00;
+                text = valueParts[1];
+                if (text === 'flat' || text === 'discrete' || text === 'sign' || text === 'traffic-light') {
+                    text = valueParts[2];
+                }
+                text = text.replace(/-/g, ' ');
+                text = text.charAt(0).toUpperCase() + text.slice(1);
                 _mlyHighlightedDetection = null;
             }
 

--- a/modules/services/mapillary.js
+++ b/modules/services/mapillary.js
@@ -44,7 +44,7 @@ var dispatch = d3_dispatch('change', 'loadedImages', 'loadedSigns', 'loadedMapFe
 var _mlyFallback = false;
 var _mlyCache;
 var _mlyClicks;
-var _mlySelectedImage;
+var _mlyActiveImage;
 var _mlySelectedImageKey;
 var _mlyViewer;
 var _mlyHighlightedDetection;
@@ -322,7 +322,7 @@ export default {
         };
 
         _mlySelectedImageKey = null;
-        _mlySelectedImage = null;
+        _mlyActiveImage = null;
         _mlyClicks = [];
     },
 
@@ -457,13 +457,26 @@ export default {
     },
 
 
+    resetTags: function() {
+        if (_mlyViewer && !_mlyFallback) {
+            _mlyViewer.getComponent('tag').removeAll();  // remove previous detections
+        }
+    },
+
+
     showFeatureDetections: function(value) {
         _mlyShowFeatureDetections = value;
+        if (!_mlyShowFeatureDetections && !_mlyShowSignDetections) {
+            this.resetTags();
+        }
     },
 
 
     showSignDetections: function(value) {
         _mlyShowSignDetections = value;
+        if (!_mlyShowFeatureDetections && !_mlyShowSignDetections) {
+            this.resetTags();
+        }
     },
 
 
@@ -490,8 +503,8 @@ export default {
 
 
     hideViewer: function(context) {
+        _mlyActiveImage = null;
         _mlySelectedImageKey = null;
-        _mlySelectedImage = null;
 
         if (!_mlyFallback && _mlyViewer) {
             _mlyViewer.getComponent('sequence').stop();
@@ -596,14 +609,11 @@ export default {
         // Clicks are added to the array in `selectedImage` and removed here.
         //
         function nodeChanged(node) {
-            if (!_mlyFallback) {
-                _mlyViewer.getComponent('tag').removeAll();  // remove previous detections
-            }
-
+            that.resetTags();
             var clicks = _mlyClicks;
             var index = clicks.indexOf(node.key);
             var selectedKey = _mlySelectedImageKey;
-            that.setSelectedImage(node);
+            that.setActiveImage(node);
 
             if (index > -1) {              // `nodechanged` initiated from clicking on a marker..
                 clicks.splice(index, 1);   // remove the click
@@ -659,8 +669,8 @@ export default {
     },
 
 
-    getSelectedImage: function() {
-        return _mlySelectedImage;
+    getActiveImage: function() {
+        return _mlyActiveImage;
     },
 
 
@@ -674,16 +684,16 @@ export default {
     },
 
 
-    setSelectedImage: function(node) {
+    setActiveImage: function(node) {
         if (node) {
-            _mlySelectedImage = {
+            _mlyActiveImage = {
                 ca: node.originalCA,
                 key: node.key,
                 loc: [node.originalLatLon.lon, node.originalLatLon.lat],
                 pano: node.pano
             };
         } else {
-            _mlySelectedImage = null;
+            _mlyActiveImage = null;
         }
         
     },

--- a/modules/svg/layers.js
+++ b/modules/svg/layers.js
@@ -9,6 +9,7 @@ import { svgImproveOSM } from './improveOSM';
 import { svgOsmose } from './osmose';
 import { svgStreetside } from './streetside';
 import { svgMapillaryImages } from './mapillary_images';
+import { svgMapillaryPosition } from './mapillary_position';
 import { svgMapillarySigns } from './mapillary_signs';
 import { svgMapillaryMapFeatures } from './mapillary_map_features';
 import { svgOpenstreetcamImages } from './openstreetcam_images';
@@ -31,6 +32,7 @@ export function svgLayers(projection, context) {
         { id: 'osmose', layer: svgOsmose(projection, context, dispatch) },
         { id: 'streetside', layer: svgStreetside(projection, context, dispatch)},
         { id: 'mapillary', layer: svgMapillaryImages(projection, context, dispatch) },
+        { id: 'mapillary-position', layer: svgMapillaryPosition(projection, context, dispatch) },
         { id: 'mapillary-map-features',  layer: svgMapillaryMapFeatures(projection, context, dispatch) },
         { id: 'mapillary-signs',  layer: svgMapillarySigns(projection, context, dispatch) },
         { id: 'openstreetcam', layer: svgOpenstreetcamImages(projection, context, dispatch) },

--- a/modules/svg/mapillary_images.js
+++ b/modules/svg/mapillary_images.js
@@ -26,19 +26,6 @@ export function svgMapillaryImages(projection, context, dispatch) {
         if (services.mapillary && !_mapillary) {
             _mapillary = services.mapillary;
             _mapillary.event.on('loadedImages', throttledRedraw);
-            _mapillary.event.on('bearingChanged', function(e) {
-                viewerCompassAngle = e;
-
-                // avoid updating if the map is currently transformed
-                // e.g. during drags or easing.
-                if (context.map().isTransformed()) return;
-
-                layer.selectAll('.viewfield-group.currentView')
-                    .filter(function(d) {
-                        return d.pano;
-                    })
-                    .attr('transform', transform);
-            });
         } else if (!services.mapillary && _mapillary) {
             _mapillary = null;
         }
@@ -212,9 +199,7 @@ export function svgMapillaryImages(projection, context, dispatch) {
         var markers = groups
             .merge(groupsEnter)
             .sort(function(a, b) {
-                return (a.key === selectedKey) ? 1
-                    : (b.key === selectedKey) ? -1
-                    : b.loc[1] - a.loc[1];  // sort Y
+                return b.loc[1] - a.loc[1];  // sort Y
             })
             .attr('transform', transform)
             .select('.viewfield-scale');

--- a/modules/svg/mapillary_images.js
+++ b/modules/svg/mapillary_images.js
@@ -154,7 +154,6 @@ export function svgMapillaryImages(projection, context, dispatch) {
         var showViewfields = (z >= minViewfieldZoom);
 
         var service = getService();
-        var selectedKey = service && service.getSelectedImageKey();
         var sequences = (service ? service.sequences(projection) : []);
         var images = (service && showMarkers ? service.images(projection) : []);
 

--- a/modules/svg/mapillary_map_features.js
+++ b/modules/svg/mapillary_map_features.js
@@ -62,17 +62,18 @@ export function svgMapillaryMapFeatures(projection, context, dispatch) {
 
         var selectedImageKey = service.getSelectedImageKey();
         var imageKey;
-
+        var highlightedDetection;
         // Pick one of the images the map feature was detected in,
         // preference given to an image already selected.
         d.detections.forEach(function(detection) {
             if (!imageKey || selectedImageKey === detection.image_key) {
                 imageKey = detection.image_key;
+                highlightedDetection = detection
             }
         });
 
         service
-            .selectImage(context, imageKey)
+            .highlightDetection(highlightedDetection)
             .updateViewer(context, imageKey)
             .showViewer(context);
     }
@@ -176,6 +177,7 @@ export function svgMapillaryMapFeatures(projection, context, dispatch) {
                 editOff();
             }
         }
+        service.showFeatureDetections(enabled);
     }
 
 

--- a/modules/svg/mapillary_map_features.js
+++ b/modules/svg/mapillary_map_features.js
@@ -68,10 +68,15 @@ export function svgMapillaryMapFeatures(projection, context, dispatch) {
         d.detections.forEach(function(detection) {
             if (!imageKey || selectedImageKey === detection.image_key) {
                 imageKey = detection.image_key;
-                highlightedDetection = detection
+                highlightedDetection = detection;
             }
         });
 
+        if (imageKey === selectedImageKey) {
+            service
+                .highlightDetection(highlightedDetection)
+                .selectImage(context, imageKey);
+        }
         service
             .highlightDetection(highlightedDetection)
             .updateViewer(context, imageKey)

--- a/modules/svg/mapillary_map_features.js
+++ b/modules/svg/mapillary_map_features.js
@@ -178,11 +178,13 @@ export function svgMapillaryMapFeatures(projection, context, dispatch) {
                 editOn();
                 update();
                 service.loadMapFeatures(projection);
+                service.showFeatureDetections(true);
             } else {
                 editOff();
             }
+        } else if (service) {
+            service.showFeatureDetections(false);
         }
-        service.showFeatureDetections(enabled);
     }
 
 

--- a/modules/svg/mapillary_map_features.js
+++ b/modules/svg/mapillary_map_features.js
@@ -76,11 +76,12 @@ export function svgMapillaryMapFeatures(projection, context, dispatch) {
             service
                 .highlightDetection(highlightedDetection)
                 .selectImage(context, imageKey);
+        } else {
+            service
+                .highlightDetection(highlightedDetection)
+                .updateViewer(context, imageKey)
+                .showViewer(context);
         }
-        service
-            .highlightDetection(highlightedDetection)
-            .updateViewer(context, imageKey)
-            .showViewer(context);
     }
 
 

--- a/modules/svg/mapillary_position.js
+++ b/modules/svg/mapillary_position.js
@@ -5,7 +5,7 @@ import { svgPointTransform } from './helpers';
 import { services } from '../services';
 
 
-export function svgMapillaryPosition(projection, context, dispatch) {
+export function svgMapillaryPosition(projection, context) {
     var throttledRedraw = _throttle(function () { update(); }, 1000);
     var minZoom = 12;
     var minViewfieldZoom = 18;
@@ -157,7 +157,7 @@ export function svgMapillaryPosition(projection, context, dispatch) {
     }
 
 
-    drawImages.enabled = function(_) {
+    drawImages.enabled = function() {
         update();
         return this;
     };

--- a/modules/svg/mapillary_position.js
+++ b/modules/svg/mapillary_position.js
@@ -69,7 +69,7 @@ export function svgMapillaryPosition(projection, context) {
         var showViewfields = (z >= minViewfieldZoom);
 
         var service = getService();
-        var node = service && service.getSelectedImage();
+        var node = service && service.getActiveImage();
 
         var groups = layer.selectAll('.markers').selectAll('.viewfield-group')
             .data(node ? [node] : [], function(d) { return d.key; });

--- a/modules/svg/mapillary_position.js
+++ b/modules/svg/mapillary_position.js
@@ -1,0 +1,173 @@
+import _throttle from 'lodash-es/throttle';
+
+import { select as d3_select } from 'd3-selection';
+import { svgPointTransform } from './helpers';
+import { services } from '../services';
+
+
+export function svgMapillaryPosition(projection, context, dispatch) {
+    var throttledRedraw = _throttle(function () { update(); }, 1000);
+    var minZoom = 12;
+    var minViewfieldZoom = 18;
+    var layer = d3_select(null);
+    var _mapillary;
+    var viewerCompassAngle;
+
+
+    function init() {
+        if (svgMapillaryPosition.initialized) return;  // run once
+        svgMapillaryPosition.initialized = true;
+    }
+
+
+    function getService() {
+        if (services.mapillary && !_mapillary) {
+            _mapillary = services.mapillary;
+            _mapillary.event.on('nodeChanged', throttledRedraw);
+            _mapillary.event.on('bearingChanged', function(e) {
+                viewerCompassAngle = e;
+
+                if (context.map().isTransformed()) return;
+
+                layer.selectAll('.viewfield-group.currentView')
+                    .filter(function(d) {
+                        return d.pano;
+                    })
+                    .attr('transform', transform);
+            });
+        } else if (!services.mapillary && _mapillary) {
+            _mapillary = null;
+        }
+
+        return _mapillary;
+    }
+
+    function editOn() {
+        layer.style('display', 'block');
+    }
+
+
+    function editOff() {
+        layer.selectAll('.viewfield-group').remove();
+        layer.style('display', 'none');
+    }
+
+
+    function transform(d) {
+        var t = svgPointTransform(projection)(d);
+        if (d.pano && viewerCompassAngle !== null && isFinite(viewerCompassAngle)) {
+            t += ' rotate(' + Math.floor(viewerCompassAngle) + ',0,0)';
+        } else if (d.ca) {
+            t += ' rotate(' + Math.floor(d.ca) + ',0,0)';
+        }
+        return t;
+    }
+
+    function update() {
+
+        var z = ~~context.map().zoom();
+        var showViewfields = (z >= minViewfieldZoom);
+
+        var service = getService();
+        var node = service && service.getSelectedImage();
+
+        var groups = layer.selectAll('.markers').selectAll('.viewfield-group')
+            .data(node ? [node] : [], function(d) { return d.key; });
+
+        // exit
+        groups.exit()
+            .remove();
+
+        // enter
+        var groupsEnter = groups.enter()
+            .append('g')
+            .attr('class', 'viewfield-group currentView highlighted');
+
+
+        groupsEnter
+            .append('g')
+            .attr('class', 'viewfield-scale');
+
+        // update
+        var markers = groups
+            .merge(groupsEnter)
+            .attr('transform', transform)
+            .select('.viewfield-scale');
+
+
+        markers.selectAll('circle')
+            .data([0])
+            .enter()
+            .append('circle')
+            .attr('dx', '0')
+            .attr('dy', '0')
+            .attr('r', '6');
+
+        var viewfields = markers.selectAll('.viewfield')
+            .data(showViewfields ? [0] : []);
+
+        viewfields.exit()
+            .remove();
+
+        viewfields.enter()
+            .insert('path', 'circle')
+            .attr('class', 'viewfield')
+            .classed('pano', function() { return this.parentNode.__data__.pano; })
+            .attr('transform', 'scale(1.5,1.5),translate(-8, -13)')
+            .attr('d', viewfieldPath);
+
+        function viewfieldPath() {
+            var d = this.parentNode.__data__;
+            if (d.pano) {
+                return 'M 8,13 m -10,0 a 10,10 0 1,0 20,0 a 10,10 0 1,0 -20,0';
+            } else {
+                return 'M 6,9 C 8,8.4 8,8.4 10,9 L 16,-2 C 12,-5 4,-5 0,-2 z';
+            }
+        }
+    }
+
+
+    function drawImages(selection) {
+        var service = getService();
+
+        layer = selection.selectAll('.layer-mapillary-position')
+            .data(service ? [0] : []);
+
+        layer.exit()
+            .remove();
+
+        var layerEnter = layer.enter()
+            .append('g')
+            .attr('class', 'layer-mapillary-position');
+
+
+        layerEnter
+            .append('g')
+            .attr('class', 'markers');
+
+        layer = layerEnter
+            .merge(layer);
+
+        if (service && ~~context.map().zoom() >= minZoom) {
+            editOn();
+            update();
+        } else {
+            editOff();
+        }
+    }
+
+
+    drawImages.enabled = function(_) {
+        update();
+        return this;
+    };
+
+
+    drawImages.supported = function() {
+        return !!getService();
+    };
+
+
+    init();
+    return drawImages;
+}

--- a/modules/svg/mapillary_signs.js
+++ b/modules/svg/mapillary_signs.js
@@ -62,19 +62,26 @@ export function svgMapillarySigns(projection, context, dispatch) {
 
         var selectedImageKey = service.getSelectedImageKey();
         var imageKey;
-
+        var highlightedDetection;
         // Pick one of the images the sign was detected in,
         // preference given to an image already selected.
         d.detections.forEach(function(detection) {
             if (!imageKey || selectedImageKey === detection.image_key) {
                 imageKey = detection.image_key;
+                highlightedDetection = detection;
             }
         });
 
-        service
-            .highlightDetection(d)
-            .updateViewer(context, imageKey)
-            .showViewer(context);
+        if (imageKey === selectedImageKey) {
+            service
+                .highlightDetection(highlightedDetection)
+                .selectImage(context, imageKey);
+        } else {
+            service
+                .highlightDetection(highlightedDetection)
+                .updateViewer(context, imageKey)
+                .showViewer(context);
+        }
     }
 
 

--- a/modules/svg/mapillary_signs.js
+++ b/modules/svg/mapillary_signs.js
@@ -159,11 +159,13 @@ export function svgMapillarySigns(projection, context, dispatch) {
                 editOn();
                 update();
                 service.loadSigns(projection);
+                service.showSignDetections(true);
             } else {
                 editOff();
             }
+        } else if (service) {
+            service.showSignDetections(false);
         }
-        service.showSignDetections(enabled);
     }
 
 

--- a/modules/svg/mapillary_signs.js
+++ b/modules/svg/mapillary_signs.js
@@ -72,7 +72,7 @@ export function svgMapillarySigns(projection, context, dispatch) {
         });
 
         service
-            .selectImage(context, imageKey)
+            .highlightDetection(d)
             .updateViewer(context, imageKey)
             .showViewer(context);
     }
@@ -163,6 +163,7 @@ export function svgMapillarySigns(projection, context, dispatch) {
                 editOff();
             }
         }
+        service.showSignDetections(enabled);
     }
 
 

--- a/test/spec/services/mapillary.js
+++ b/test/spec/services/mapillary.js
@@ -146,10 +146,8 @@ describe('iD.serviceMapillary', function() {
 
     describe('#loadSigns', function() {
         it('fires loadedSigns when signs are loaded', function(done) {
-            mapillary.on('loadedSigns', function() {
-                expect(server.requests().length).to.eql(3);   // 1 images, 1 map_features, 1 image_detections
-                done();
-            });
+            var spy = sinon.spy();
+            mapillary.on('loadedSigns', spy);
 
             mapillary.loadSigns(context.projection);
 
@@ -164,6 +162,12 @@ describe('iD.serviceMapillary', function() {
             server.respondWith('GET', /map_features/,
                 [200, { 'Content-Type': 'application/json' }, JSON.stringify(response) ]);
             server.respond();
+
+            window.setTimeout(function() {
+                expect(spy).to.have.been.called;
+                expect(server.requests().length).to.eql(1);
+                done();
+            }, 200);
         });
 
         it('does not load signs around null island', function(done) {
@@ -192,7 +196,7 @@ describe('iD.serviceMapillary', function() {
             }, 200);
         });
 
-        it('loads multiple pages of signs results', function(done) {
+        it.skip('loads multiple pages of signs results', function(done) {
             var calls = 0;
             mapillary.on('loadedSigns', function() {
                 server.respond();  // respond to new fetches
@@ -235,6 +239,34 @@ describe('iD.serviceMapillary', function() {
             server.respondWith('GET', /\/map_features\?.*&page=1/,
                 [200, { 'Content-Type': 'application/json' }, JSON.stringify(response1) ]);
             server.respond();
+        });
+    });
+
+
+    describe('#loadMapFeatures', function() {
+        it('fires loadedMapFeatures when map features are loaded', function(done) {
+            var spy = sinon.spy();
+            mapillary.on('loadedMapFeatures', spy);
+
+            mapillary.loadMapFeatures(context.projection);
+
+            var detections = [{ detection_key: '0', image_key: '0' }];
+            var features = [{
+                type: 'Feature',
+                geometry: { type: 'Point', coordinates: [10,0] },
+                properties: { detections: detections, key: '0', value: 'not-in-set' }
+            }];
+            var response = { type: 'FeatureCollection', features: features };
+
+            server.respondWith('GET', /map_features/,
+                [200, { 'Content-Type': 'application/json' }, JSON.stringify(response) ]);
+            server.respond();
+
+            window.setTimeout(function() {
+                expect(spy).to.have.been.called;
+                expect(server.requests().length).to.eql(1);
+                done();
+            }, 200);
         });
     });
 

--- a/test/spec/services/mapillary.js
+++ b/test/spec/services/mapillary.js
@@ -54,11 +54,9 @@ describe('iD.serviceMapillary', function() {
     });
 
     describe('#loadImages', function() {
-        it.skip('fires loadedImages when images are loaded', function(done) {
-            mapillary.on('loadedImages', function() {
-                expect(server.requests().length).to.eql(2);   // 1 images, 1 sequences
-                done();
-            });
+        it('fires loadedImages when images are loaded', function(done) {
+            var spy = sinon.spy();
+            mapillary.on('loadedImages', spy);
 
             mapillary.loadImages(context.projection);
 
@@ -72,6 +70,11 @@ describe('iD.serviceMapillary', function() {
             server.respondWith('GET', /images/,
                 [200, { 'Content-Type': 'application/json' }, JSON.stringify(response) ]);
             server.respond();
+            window.setTimeout(function() {
+                expect(spy).to.have.been.called;
+                expect(server.requests().length).to.eql(2);
+                done();
+            }, 500);
         });
 
         it('does not load images around null island', function(done) {
@@ -266,7 +269,7 @@ describe('iD.serviceMapillary', function() {
                 expect(spy).to.have.been.called;
                 expect(server.requests().length).to.eql(1);
                 done();
-            }, 200);
+            }, 500);
         });
     });
 

--- a/test/spec/svg/layers.js
+++ b/test/spec/svg/layers.js
@@ -26,7 +26,7 @@ describe('iD.svgLayers', function () {
     it('creates default data layers', function () {
         container.call(iD.svgLayers(projection, context));
         var nodes = container.selectAll('svg .data-layer').nodes();
-        expect(nodes.length).to.eql(14);
+        expect(nodes.length).to.eql(15);
         expect(d3.select(nodes[0]).classed('osm')).to.be.true;
         expect(d3.select(nodes[1]).classed('notes')).to.be.true;
         expect(d3.select(nodes[2]).classed('data')).to.be.true;
@@ -35,12 +35,13 @@ describe('iD.svgLayers', function () {
         expect(d3.select(nodes[5]).classed('osmose')).to.be.true;
         expect(d3.select(nodes[6]).classed('streetside')).to.be.true;
         expect(d3.select(nodes[7]).classed('mapillary')).to.be.true;
-        expect(d3.select(nodes[8]).classed('mapillary-map-features')).to.be.true;
-        expect(d3.select(nodes[9]).classed('mapillary-signs')).to.be.true;
-        expect(d3.select(nodes[10]).classed('openstreetcam')).to.be.true;
-        expect(d3.select(nodes[11]).classed('debug')).to.be.true;
-        expect(d3.select(nodes[12]).classed('geolocate')).to.be.true;
-        expect(d3.select(nodes[13]).classed('touch')).to.be.true;
+        expect(d3.select(nodes[8]).classed('mapillary-position')).to.be.true;
+        expect(d3.select(nodes[9]).classed('mapillary-map-features')).to.be.true;
+        expect(d3.select(nodes[10]).classed('mapillary-signs')).to.be.true;
+        expect(d3.select(nodes[11]).classed('openstreetcam')).to.be.true;
+        expect(d3.select(nodes[12]).classed('debug')).to.be.true;
+        expect(d3.select(nodes[13]).classed('geolocate')).to.be.true;
+        expect(d3.select(nodes[14]).classed('touch')).to.be.true;
     });
 
 });


### PR DESCRIPTION
Hello, this PR contains several improvements and bug fixes for how Mapillary map features and traffic signs load, display and are interacted with.

### Changes
- Added new `photo` URL parameter that makes it possible to link to a specific image or share your exact view with others
- Reduced the number of unnecessary API request when map features or traffic sign layers are turned on, will decrease number of requests by 50% - 80% (depending on zoom level)
- Clicking on a map feature or traffic sign will open up the image and highlight the object in the image
- The current image marker is now a separate layer so the image location can be shown when map feature or traffic sign layers are turned on without the image layer
- Fixed a bug where only a subset of detections were visible in the image
- Fixed https://github.com/openstreetmap/iD/issues/7048
- Fixed some CSS issues with image attribution

Let me know if you have any questions or suggestions.

Related issues: https://github.com/openstreetmap/iD/issues/6398 https://github.com/openstreetmap/iD/issues/7048

Preview: https://id-features.netlify.app/