### PR TITLE
Open external links in OSM notes in a new tab

### DIFF
--- a/modules/ui/note_comments.js
+++ b/modules/ui/note_comments.js
@@ -68,7 +68,12 @@ export function uiNoteComments() {
         mainEnter
             .append('div')
             .attr('class', 'comment-text')
-            .html(function(d) { return d.html; });
+            .html(function(d) { return d.html; })
+            .selectAll('a')
+                .filter(isExternalLink)
+                .attr('rel', 'noopener')
+                .attr('rel', 'nofollow')
+                .attr('target', '_blank');
 
         comments
             .call(replaceAvatars);
@@ -107,6 +112,22 @@ export function uiNoteComments() {
         var d = new Date(s);
         if (isNaN(d.getTime())) return null;
         return d.toLocaleDateString(localizer.localeCode(), options);
+    }
+
+
+    // A quick test for external links. 'this' is the node passed in by selection.filter()
+    function isExternalLink() {
+        try {
+            // Possibly more domains to be added
+            const internalDomains = ['.openstreetmap.org', '.osm.org']; 
+            const hostname = new URL(this.href).hostname;
+
+            // If the link's hostname comprises any internalDomains, return false
+            return internalDomains.findIndex((d) => hostname.includes(d)) === -1; 
+        } catch (error) {
+            // If anything goes wrong, bail and assume not external (original behaviour)
+            return false;
+        }   
     }
 
 

--- a/modules/ui/note_comments.js
+++ b/modules/ui/note_comments.js
@@ -70,9 +70,7 @@ export function uiNoteComments() {
             .attr('class', 'comment-text')
             .html(function(d) { return d.html; })
             .selectAll('a')
-                .filter(isExternalLink)
-                .attr('rel', 'noopener')
-                .attr('rel', 'nofollow')
+                .attr('rel', 'noopener nofollow')
                 .attr('target', '_blank');
 
         comments
@@ -112,22 +110,6 @@ export function uiNoteComments() {
         var d = new Date(s);
         if (isNaN(d.getTime())) return null;
         return d.toLocaleDateString(localizer.localeCode(), options);
-    }
-
-
-    // A quick test for external links. 'this' is the node passed in by selection.filter()
-    function isExternalLink() {
-        try {
-            // Possibly more domains to be added
-            const internalDomains = ['.openstreetmap.org', '.osm.org']; 
-            const hostname = new URL(this.href).hostname;
-
-            // If the link's hostname comprises any internalDomains, return false
-            return internalDomains.findIndex((d) => hostname.includes(d)) === -1; 
-        } catch (error) {
-            // If anything goes wrong, bail and assume not external (original behaviour)
-            return false;
-        }   
     }
 
 


### PR DESCRIPTION
This addresses #7883.

The solution determines if a link is external using a basic hostname check, and if so, applies the attribute `target="_blank"` to the link tag.

At the moment, a link is external if its hostname contains either `.osm.org` or `.openstreetmap.org`. The prefixed `.` is used to allow for any prefix such as `api06.dev.osm.org` or `www.osm.org`. 

The idea here is that most internal links will probably be pointing to nodes on the map, so opening a second map in a new tab is not ideal. However, if the link is to a non-map route, such as a user profile, then this will unfortunately not open in a new tab.

Open to suggestions regarding implementation, but as a v1 this should cover a lot of cases.