### PR TITLE
Fix export of `geoVecLengthSquare`

### DIFF
--- a/modules/geo/index.js
+++ b/modules/geo/index.js
@@ -37,7 +37,7 @@ export { geoVecEqual } from './vector.js';
 export { geoVecFloor } from './vector.js';
 export { geoVecInterp } from './vector.js';
 export { geoVecLength } from './vector.js';
-export { geoVecLengthSquare } from '/vector.js';
+export { geoVecLengthSquare } from './vector.js';
 export { geoVecNormalize } from './vector.js';
 export { geoVecNormalizedDot } from './vector.js';
 export { geoVecProject } from './vector.js';


### PR DESCRIPTION
This fixes a typo (missing `.`): file path is `./vector.js`, not `/vector.js`