### PR TITLE
Fix geometries detection in preset_fields.js

### DIFF
--- a/modules/ui/sections/preset_fields.js
+++ b/modules/ui/sections/preset_fields.js
@@ -34,7 +34,8 @@ export function uiSectionPresetFields(context) {
             var graph = context.graph();
 
             var geometries = Object.keys(_entityIDs.reduce(function(geoms, entityID) {
-                return geoms[graph.entity(entityID).geometry(graph)] = true;
+                geoms[graph.entity(entityID).geometry(graph)] = true;
+                return geoms;
             }, {}));
 
             var presetsManager = presetManager;


### PR DESCRIPTION
`renderDisclosureContent` in `preset_fields.js` tries to detect the geometry types of the selected entities, but the result is always `[]`.

Reason: The handler of `_entityIDs.reduce` always returns `true`. So the result of the `reduce` call is `true` as well. `Object.keys(true)` results in `[]`.

Fix: The handler of `_entityIDs.reduce` should return the map which collects the geometry types, so `geometries` will be be something like `["line", "vertex"]`.