### PR TITLE
Improve performance of raw tag editor

### DIFF
--- a/modules/services/osm_wikibase.js
+++ b/modules/services/osm_wikibase.js
@@ -124,7 +124,6 @@ export default {
     // {
     //   key: 'string',
     //   value: 'string',
-    //   rtype: 'string',
     //   langCode: 'string'
     // }
     //
@@ -133,7 +132,7 @@ export default {
         var that = this;
         var titles = [];
         var result = {};
-        var rtypeSitelink = params.rtype ? ('Relation:' + params.rtype).replace(/_/g, ' ').trim() : false;
+        var rtypeSitelink = (params.key === 'type' && params.value) ? ('Relation:' + params.value).replace(/_/g, ' ').trim() : false;
         var keySitelink = params.key ? this.toSitelink(params.key) : false;
         var tagSitelink = (params.key && params.value) ? this.toSitelink(params.key, params.value) : false;
         var localeSitelink;
@@ -241,10 +240,6 @@ export default {
     // {
     //   key: 'string',     // required
     //   value: 'string'    // optional
-    // }
-    //   -or-
-    // {
-    //   rtype: 'rtype'     // relation type  (e.g. 'multipolygon')
     // }
     //
     // Get an result object used to display tag documentation

--- a/modules/ui/sections/raw_tag_editor.js
+++ b/modules/ui/sections/raw_tag_editor.js
@@ -215,6 +215,7 @@ export function uiSectionRawTagEditor(id, context) {
             .merge(itemsEnter)
             .sort(function(a, b) { return a.index - b.index; });
 
+        var includesRelation = null;
         items
             .each(function(d) {
                 var row = d3_select(this);
@@ -230,10 +231,12 @@ export function uiSectionRawTagEditor(id, context) {
                 if (typeof d.value !== 'string') {
                     reference = uiTagReference({ key: d.key }, context);
                 } else {
-                    var isRelation = _entityIDs && _entityIDs.some(function(entityID) {
-                        return context.entity(entityID).type === 'relation';
-                    });
-                    if (isRelation && d.key === 'type') {
+                    if (includesRelation === null) {
+                        includesRelation = _entityIDs && _entityIDs.some(function(entityID) {
+                            return context.entity(entityID).type === 'relation';
+                        });
+                    }
+                    if (includesRelation && d.key === 'type') {
                         reference = uiTagReference({ rtype: d.value }, context);
                     } else {
                         reference = uiTagReference({ key: d.key, value: d.value }, context);

--- a/modules/ui/sections/raw_tag_editor.js
+++ b/modules/ui/sections/raw_tag_editor.js
@@ -215,7 +215,6 @@ export function uiSectionRawTagEditor(id, context) {
             .merge(itemsEnter)
             .sort(function(a, b) { return a.index - b.index; });
 
-        var includesRelation = null;
         items
             .each(function(d) {
                 var row = d3_select(this);
@@ -226,22 +225,11 @@ export function uiSectionRawTagEditor(id, context) {
                     bindTypeahead(key, value);
                 }
 
-                var reference;
-
-                if (typeof d.value !== 'string') {
-                    reference = uiTagReference({ key: d.key }, context);
-                } else {
-                    if (includesRelation === null) {
-                        includesRelation = _entityIDs && _entityIDs.some(function(entityID) {
-                            return context.entity(entityID).type === 'relation';
-                        });
-                    }
-                    if (includesRelation && d.key === 'type') {
-                        reference = uiTagReference({ rtype: d.value }, context);
-                    } else {
-                        reference = uiTagReference({ key: d.key, value: d.value }, context);
-                    }
+                var referenceOptions = { key: d.key };
+                if (typeof d.value === 'string') {
+                    referenceOptions.value = d.value;
                 }
+                var reference = uiTagReference(referenceOptions, context);
 
                 if (_state === 'hover') {
                     reference.showing(false);

--- a/modules/ui/tag_reference.js
+++ b/modules/ui/tag_reference.js
@@ -8,14 +8,10 @@ import { services } from '../services';
 import { svgIcon } from '../svg/icon';
 
 
-// Pass `which` object of the form:
+// Pass `what` object of the form:
 // {
 //   key: 'string',     // required
 //   value: 'string'    // optional
-// }
-//   -or-
-// {
-//   rtype: 'string'    // relation type  (e.g. 'multipolygon')
 // }
 //   -or-
 // {


### PR DESCRIPTION
The detection whether `_entityIDs ` includes a relation is performed many times inside a loop. Instead this should be done only once (lazy).

Besides I changed the name of the variable to `includesRelation` because the old name (`isRelation`) could be misunderstood.