### PR TITLE
[Performance] Calculate height of the textarea instead of letting the browser do it

### DIFF
--- a/modules/ui/sections/raw_tag_editor.js
+++ b/modules/ui/sections/raw_tag_editor.js
@@ -285,8 +285,11 @@ export function uiSectionRawTagEditor(id, context) {
         if (_tagView !== 'text') return;
 
         var selection = d3_select(this);
-        selection.style('height', null);
-        selection.style('height', selection.node().scrollHeight + 5 + 'px');
+        var matches = selection.node().value.match(/\n/g);
+        var lineCount = 2 + Number(matches && matches.length);
+        var lineHeight = 20;
+
+        selection.style('height', lineCount * lineHeight + 'px');
     }
 
     function stringify(s) {


### PR DESCRIPTION
I like using the text editor for tags, but I noticed it was a bit slow to render.

Using the performance trace tool in Chrome, you can see a forced reflow when the height is unset and the browser reflows the page to calculate the new height:
![openstreetmap-before](https://user-images.githubusercontent.com/20630/92942176-3a5d1900-f48c-11ea-8064-03dd0269c375.png)

If we calculate the height ourselves, we can save a nice chunk of time:
![openstreetmap-after](https://user-images.githubusercontent.com/20630/92942355-624c7c80-f48c-11ea-9fd3-e66fde87c1f9.png)

There are two modes for the text area, this is the result of letting the browser calculate the height:
![textarea-before-edit](https://user-images.githubusercontent.com/20630/92942406-72645c00-f48c-11ea-8264-8c8abe2f98a1.png)
![textarea-before-readonly](https://user-images.githubusercontent.com/20630/92942414-72fcf280-f48c-11ea-9f4a-48a190eac306.png)

And this is when we supply the height ourselves:
![textarea-after-edit](https://user-images.githubusercontent.com/20630/92942551-9627a200-f48c-11ea-9aab-56dc02c6edaf.png)
![textarea-after-readonly](https://user-images.githubusercontent.com/20630/92942554-9758cf00-f48c-11ea-84f1-2ed6b606fb0f.png)

In the worst case I saw a savings of 60ms in the onClick handler on my machine, which is a noticeable improvement.
