### PR TITLE
Enable scaling the selection via hotkeys

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -400,6 +400,28 @@ en:
         line: Reversed a line.
         lines: Reversed multiple lines.
         features: Reversed multiple features.
+    scale:
+      annotation:
+        down:
+          feature:
+            one: Scaled down a feature.
+            other: "Scaled down {n} features."
+        up:
+          feature:
+            one: Scaled up a feature.
+            other: "Scaled up {n} features."
+      too_small:
+        single: This feature can't be scaled down because it would become too small.
+        multiple: These features can't be scaled down because they would become too small.
+      too_large:
+        single: This feature can't be scaled because not enough of it is currently visible.
+        multiple: These features can't be scaled because not enough of them are currently visible.
+      connected_to_hidden:
+        single: This feature can't be scaled because it is connected to a hidden feature.
+        multiple: These features can't be scaled because some are connected to hidden features.
+      not_downloaded:
+        single: This feature can't be scaled because parts of it have not yet been downloaded.
+        multiple: These features can't be scaled because parts of them have not yet been downloaded.
     split:
       title: Split
       description:
@@ -2172,6 +2194,8 @@ en:
         move: "Move selected features"
         nudge: "Nudge selected features"
         nudge_more: "Nudge selected features by a lot"
+        scale: "Scale selected features"
+        scale_more: "Scale selected features by a lot"
         rotate: "Rotate selected features"
         orthogonalize: "Square corners of a line or area"
         straighten: "Straighten a line or points"

--- a/data/shortcuts.json
+++ b/data/shortcuts.json
@@ -282,6 +282,18 @@
             "separator": ","
           },
           {
+            "modifiers": ["⇧"],
+            "shortcuts": ["+", "-"],
+            "text": "shortcuts.editing.operations.scale",
+            "separator": ","
+          },
+          {
+            "modifiers": ["⌥", "⇧"],
+            "shortcuts": ["+", "-"],
+            "text": "shortcuts.editing.operations.scale_more",
+            "separator": ","
+          },
+          {
             "shortcuts": ["operations.rotate.key"],
             "text": "shortcuts.editing.operations.rotate"
           },

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -527,6 +527,38 @@
                     "features": "Reversed multiple features."
                 }
             },
+            "scale": {
+                "annotation": {
+                    "down": {
+                        "feature": {
+                            "one": "Scaled down a feature.",
+                            "other": "Scaled down {n} features."
+                        }
+                    },
+                    "up": {
+                        "feature": {
+                            "one": "Scaled up a feature.",
+                            "other": "Scaled up {n} features."
+                        }
+                    }
+                },
+                "too_small": {
+                    "single": "This feature can't be scaled down because it would become too small.",
+                    "multiple": "These features can't be scaled down because they would become too small."
+                },
+                "too_large": {
+                    "single": "This feature can't be scaled because not enough of it is currently visible.",
+                    "multiple": "These features can't be scaled because not enough of them are currently visible."
+                },
+                "connected_to_hidden": {
+                    "single": "This feature can't be scaled because it is connected to a hidden feature.",
+                    "multiple": "These features can't be scaled because some are connected to hidden features."
+                },
+                "not_downloaded": {
+                    "single": "This feature can't be scaled because parts of it have not yet been downloaded.",
+                    "multiple": "These features can't be scaled because parts of them have not yet been downloaded."
+                }
+            },
             "split": {
                 "title": "Split",
                 "description": {
@@ -2674,6 +2706,8 @@
                     "move": "Move selected features",
                     "nudge": "Nudge selected features",
                     "nudge_more": "Nudge selected features by a lot",
+                    "scale": "Scale selected features",
+                    "scale_more": "Scale selected features by a lot",
                     "rotate": "Rotate selected features",
                     "orthogonalize": "Square corners of a line or area",
                     "straighten": "Straighten a line or points",

--- a/modules/actions/index.js
+++ b/modules/actions/index.js
@@ -30,6 +30,7 @@ export { actionRestrictTurn } from './restrict_turn';
 export { actionReverse } from './reverse';
 export { actionRevert } from './revert';
 export { actionRotate } from './rotate';
+export { actionScale } from './scale';
 export { actionSplit } from './split';
 export { actionStraightenNodes } from './straighten_nodes';
 export { actionStraightenWay } from './straighten_way';

--- a/modules/actions/scale.js
+++ b/modules/actions/scale.js
@@ -1,0 +1,24 @@
+import { utilGetAllNodes } from '../util';
+
+export function actionScale(ids, pivotLoc, scaleFactor, projection) {
+    return function(graph) {
+        return graph.update(function(graph) {
+            let point, radial;
+
+            utilGetAllNodes(ids, graph).forEach(function(node) {
+
+                point = projection(node.loc);
+                radial = [
+                    point[0] - pivotLoc[0],
+                    point[1] - pivotLoc[1]
+                ];
+                point = [
+                    pivotLoc[0] + (scaleFactor * radial[0]),
+                    pivotLoc[1] + (scaleFactor * radial[1])
+                ];
+
+                graph = graph.replace(node.move(projection.invert(point)));
+            });
+        });
+    };
+}

--- a/modules/ui/zoom.js
+++ b/modules/ui/zoom.js
@@ -35,21 +35,25 @@ export function uiZoom(context) {
     }];
 
     function zoomIn() {
+        if (d3_event.shiftKey) return;
         d3_event.preventDefault();
         context.map().zoomIn();
     }
 
     function zoomOut() {
+        if (d3_event.shiftKey) return;
         d3_event.preventDefault();
         context.map().zoomOut();
     }
 
     function zoomInFurther() {
+        if (d3_event.shiftKey) return;
         d3_event.preventDefault();
         context.map().zoomInFurther();
     }
 
     function zoomOutFurther() {
+        if (d3_event.shiftKey) return;
         d3_event.preventDefault();
         context.map().zoomOutFurther();
     }

--- a/modules/util/keybinding.js
+++ b/modules/util/keybinding.js
@@ -28,17 +28,22 @@ export function utilKeybinding(namespace) {
             if (matches(binding, true)) {
                 binding.callback();
                 didMatch = true;
+
+                // match a max of one binding per event
+                break;
             }
         }
 
-        // then unshifted keybindings
         if (didMatch) return;
+
+        // then unshifted keybindings
         for (i = 0; i < bindings.length; i++) {
             binding = bindings[i];
             if (binding.event.modifiers.shiftKey) continue;   // shift
             if (!!binding.capture !== isCapturing) continue;
             if (matches(binding, false)) {
                 binding.callback();
+                break;
             }
         }
 
@@ -214,8 +219,8 @@ utilKeybinding.modifierProperties = {
     91: 'metaKey'
 };
 
-utilKeybinding.plusKeys = ['plus', 'ffplus', '=', 'ffequals'];
-utilKeybinding.minusKeys = ['_', '-', 'ffminus', 'dash'];
+utilKeybinding.plusKeys = ['plus', 'ffplus', '=', 'ffequals', '≠', '±'];
+utilKeybinding.minusKeys = ['_', '-', 'ffminus', 'dash', '–', '—'];
 
 utilKeybinding.keys = {
     // Backspace key, on Mac: ⌫ (Backspace)


### PR DESCRIPTION
Closes #3372.

This implements my proposal in https://github.com/openstreetmap/iD/issues/3372#issuecomment-696161712 of scaling the selection by pressing the <kbd>–</kbd><kbd>+</kbd> keys while holding <kbd>Shift</kbd>. To support high detail situations, the scale factor is relatively small, but you can hold <kbd>Alt</kbd>/<kbd>Option</kbd> to scale by a wider factor.

The operation is disabled and gives error feedback in the following situations:

- The selection is already very small and you're trying to scale down.
- The selection isn't mostly visible.
- The selection contains relations that aren't fully downloaded.
- The selection includes nodes that are on undownloaded tiles.
- The selection includes nodes connected to hidden features.

Further work would involve scaling without a keyboard, e.g. via a mouse or multitouch. Though there's no rush since scaling isn't a highly common workflow and mappers can always scale manually by moving individual nodes.