### PR TITLE
add queryString option to enable notes by default

### DIFF
--- a/API.md
+++ b/API.md
@@ -38,6 +38,8 @@ of iD (e.g. `https://ideditor-release.netlify.app`), the following parameters ar
   _Example:_ `map=20.00/38.90085/-77.02271`
 * __`maprules`__ - A path to a [MapRules](https://github.com/radiant-maxar/maprules) service endpoint for enhanced tag validation.<br/>
   _Example:_ `maprules=https://path/to/file.json`
+* __`notes`__ - Enables the notes layer by default.<br/>
+  _Example:_ `notes=1`
 * __`offset`__ - Background imagery alignment offset in meters, formatted as `east,north`.<br/>
   _Example:_ `offset=-10,5`
 * __`photo_overlay`__ - The street-level photo overlay layers to enable.<br/>
@@ -77,6 +79,7 @@ _Example:_ `https://www.openstreetmap.org/edit?editor=id#gpx=https://gist.github
 * __`hashtags`__
 * __`locale`__
 * __`maprules`__
+* __`notes`__
 * __`offset`__
 * __`photo`__
 * __`photo_dates`__

--- a/API.md
+++ b/API.md
@@ -39,7 +39,7 @@ of iD (e.g. `https://ideditor-release.netlify.app`), the following parameters ar
 * __`maprules`__ - A path to a [MapRules](https://github.com/radiant-maxar/maprules) service endpoint for enhanced tag validation.<br/>
   _Example:_ `maprules=https://path/to/file.json`
 * __`notes`__ - Enables the notes layer by default.<br/>
-  _Example:_ `notes=1`
+  _Example:_ `notes=true`
 * __`offset`__ - Background imagery alignment offset in meters, formatted as `east,north`.<br/>
   _Example:_ `offset=-10,5`
 * __`photo_overlay`__ - The street-level photo overlay layers to enable.<br/>

--- a/modules/svg/notes.js
+++ b/modules/svg/notes.js
@@ -6,9 +6,11 @@ import { dispatch as d3_dispatch } from 'd3-dispatch';
 import { modeBrowse } from '../modes/browse';
 import { svgPointTransform } from './helpers';
 import { services } from '../services';
+import { utilStringQs } from '../util';
 
+var hash = utilStringQs(window.location.hash);
 
-var _notesEnabled = false;
+var _notesEnabled = !!hash.notes;
 var _osmService;
 
 


### PR DESCRIPTION
Closes #8919, Closes #9564, Closes #6806, Closes https://github.com/openstreetmap/openstreetmap-website/issues/2338

The idea is that if you're on [openstreetmap.org](https://openstreetmap.org) with the notes layer enabled, and you click "Edit", then a query parameter of `&notes=1` will be passed to iD so that it can enable the notes layer by default. 

If accepted, this will require a follow-up PR to https://github.com/openstreetmap/openstreetmap-website to fix https://github.com/openstreetmap/openstreetmap-website/issues/1212