### PR TITLE
Replace nested ternary expressions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -53,6 +53,7 @@
         "no-loop-func": "error",
         "no-loss-of-precision": "error",
         "no-multi-str": "error",
+        "no-nested-ternary": "warn",
         "no-new": "error",
         "no-new-func": "error",
         "no-new-wrappers": "error",

--- a/modules/actions/join.js
+++ b/modules/actions/join.js
@@ -34,9 +34,9 @@ export function actionJoin(ids) {
         ways.sort(function(a, b) {
             var aSided = a.isSided();
             var bSided = b.isSided();
-            return (aSided && !bSided) ? -1
-                : (bSided && !aSided) ? 1
-                : 0;
+            if (aSided && !bSided) return -1;
+            if (bSided && !aSided) return 1;
+            return 0;
         });
 
         // Prefer to keep an existing way.

--- a/modules/behavior/draw_way.js
+++ b/modules/behavior/draw_way.js
@@ -238,8 +238,13 @@ export function behaviorDrawWay(context, wayID, mode, startGraph) {
         _drawNode = undefined;
         _didResolveTempEdit = false;
         _origWay = context.entity(wayID);
-        _headNodeID = typeof _nodeIndex === 'number' ? _origWay.nodes[_nodeIndex] :
-            (_origWay.isClosed() ? _origWay.nodes[_origWay.nodes.length - 2] : _origWay.nodes[_origWay.nodes.length - 1]);
+        if (typeof _nodeIndex === 'number') {
+            _headNodeID = _origWay.nodes[_nodeIndex];
+        } else if (_origWay.isClosed()) {
+            _headNodeID = _origWay.nodes[_origWay.nodes.length - 2];
+        } else {
+            _headNodeID = _origWay.nodes[_origWay.nodes.length - 1];
+        }
         _wayGeometry = _origWay.geometry(context.graph());
         _annotation = t((_origWay.nodes.length === (_origWay.isClosed() ? 2 : 1) ?
             'operations.start.annotation.' :

--- a/modules/osm/way.js
+++ b/modules/osm/way.js
@@ -215,7 +215,14 @@ Object.assign(osmWay.prototype, {
             var b = coords[(i+2) % coords.length];
             var res = geoVecCross(a, b, o);
 
-            curr = (res > 0) ? 1 : (res < 0) ? -1 : 0;
+            if (res > 0) {
+                curr = 1;
+            } else if (res < 0) {
+                curr = -1;
+            } else {
+                curr = 0;
+            }
+
             if (curr === 0) {
                 continue;
             } else if (prev && curr !== prev) {

--- a/modules/services/improveOSM.js
+++ b/modules/services/improveOSM.js
@@ -108,8 +108,13 @@ function cardinalDirection(bearing) {
 function preventCoincident(loc, bumpUp) {
   let coincident = false;
   do {
+    let delta = [0, 0];
     // first time, move marker up. after that, move marker right.
-    let delta = coincident ? [0.00001, 0] : (bumpUp ? [0, 0.00001] : [0, 0]);
+    if (coincident) {
+      delta = [0.00001, 0];
+    } else if (bumpUp) {
+      delta = [0, 0.00001];
+    }
     loc = geoVecAdd(loc, delta);
     let bbox = geoExtent(loc).bbox();
     coincident = _cache.rtree.search(bbox).length;

--- a/modules/services/taginfo.js
+++ b/modules/services/taginfo.js
@@ -133,9 +133,9 @@ function roleKey(d) {
 
 // sort keys with ':' lower than keys without ':'
 function sortKeys(a, b) {
-    return (a.key.indexOf(':') === -1 && b.key.indexOf(':') !== -1) ? -1
-        : (a.key.indexOf(':') !== -1 && b.key.indexOf(':') === -1) ? 1
-        : 0;
+    if (a.key.indexOf(':') === -1 && b.key.indexOf(':') !== -1) return -1;
+    if (a.key.indexOf(':') !== -1 && b.key.indexOf(':') === -1) return 1;
+    return 0;
 }
 
 

--- a/modules/svg/improveOSM.js
+++ b/modules/svg/improveOSM.js
@@ -174,9 +174,9 @@ export function svgImproveOSM(projection, context, dispatch) {
         .attr('transform', getTransform);
 
     function sortY(a, b) {
-      return (a.id === selectedID) ? 1
-        : (b.id === selectedID) ? -1
-        : b.loc[1] - a.loc[1];
+      if (a.id === selectedID) return 1;
+      if (b.id === selectedID) return -1;
+      return b.loc[1] - a.loc[1];
     }
   }
 

--- a/modules/svg/keepRight.js
+++ b/modules/svg/keepRight.js
@@ -162,11 +162,11 @@ export function svgKeepRight(projection, context, dispatch) {
 
 
     function sortY(a, b) {
-      return (a.id === selectedID) ? 1
-        : (b.id === selectedID) ? -1
-        : (a.severity === 'error' && b.severity !== 'error') ? 1
-        : (b.severity === 'error' && a.severity !== 'error') ? -1
-        : b.loc[1] - a.loc[1];
+      if (a.id === selectedID) return 1;
+      if (b.id === selectedID) return -1;
+      if (a.severity === 'error' && b.severity !== 'error') return 1;
+      if (b.severity === 'error' && a.severity !== 'error') return -1;
+      return b.loc[1] - a.loc[1];
     }
   }
 

--- a/modules/svg/notes.js
+++ b/modules/svg/notes.js
@@ -153,7 +153,9 @@ export function svgNotes(projection, context, dispatch) {
             .attr('x', '-3px')
             .attr('y', '-19px')
             .attr('xlink:href', function(d) {
-                return '#iD-icon-' + (d.id < 0 ? 'plus' : (d.status === 'open' ? 'close' : 'apply'));
+                if (d.id < 0) return '#iD-icon-plus';
+                if (d.status === 'open') return '#iD-icon-close';
+                return '#iD-icon-apply';
             });
 
         // update
@@ -196,7 +198,9 @@ export function svgNotes(projection, context, dispatch) {
 
 
         function sortY(a, b) {
-            return (a.id === selectedID) ? 1 : (b.id === selectedID) ? -1 : b.loc[1] - a.loc[1];
+            if (a.id === selectedID) return 1;
+            if (b.id === selectedID) return -1;
+            return b.loc[1] - a.loc[1];
         }
     }
 

--- a/modules/svg/openstreetcam_images.js
+++ b/modules/svg/openstreetcam_images.js
@@ -216,9 +216,9 @@ export function svgOpenstreetcamImages(projection, context, dispatch) {
         var markers = groups
             .merge(groupsEnter)
             .sort(function(a, b) {
-                return (a === selected) ? 1
-                    : (b === selected) ? -1
-                    : b.loc[1] - a.loc[1];  // sort Y
+                if (a === selected) return 1;
+                if (b === selected) return -1;
+                return b.loc[1] - a.loc[1];  // sort Y
             })
             .attr('transform', transform)
             .select('.viewfield-scale');

--- a/modules/svg/osmose.js
+++ b/modules/svg/osmose.js
@@ -173,9 +173,9 @@ export function svgOsmose(projection, context, dispatch) {
         .attr('transform', getTransform);
 
     function sortY(a, b) {
-      return (a.id === selectedID) ? 1
-        : (b.id === selectedID) ? -1
-        : b.loc[1] - a.loc[1];
+      if (a.id === selectedID) return 1;
+      if (b.id === selectedID) return -1;
+      return b.loc[1] - a.loc[1];
     }
   }
 

--- a/modules/svg/streetside.js
+++ b/modules/svg/streetside.js
@@ -273,9 +273,9 @@ export function svgStreetside(projection, context, dispatch) {
         var markers = groups
             .merge(groupsEnter)
             .sort(function(a, b) {
-                return (a === selected) ? 1
-                    : (b === selected) ? -1
-                    : b.loc[1] - a.loc[1];
+                if (a === selected) return 1;
+                if (b === selected) return -1;
+                return b.loc[1] - a.loc[1];
             })
             .attr('transform', transform)
             .select('.viewfield-scale');

--- a/modules/svg/turns.js
+++ b/modules/svg/turns.js
@@ -25,9 +25,17 @@ export function svgTurns(projection, context) {
             var toVertex = graph.entity(d.to.vertex);
             var a = geoAngle(toVertex, toNode, projection);
             var o = projection(toVertex.loc);
-            var r = d.u ? 0                  // u-turn: no radius
-                : !toWay.__via ? pxRadius    // leaf way: put marker at pxRadius
-                : Math.min(mid, pxRadius);   // via way: prefer pxRadius, fallback to mid for very short ways
+            var r;
+            if (d.u) {
+                // u-turn: no radius
+                r = 0;
+            } else if (!toWay.__via) {
+                // leaf way: put marker at pxRadius
+                r = pxRadius;
+            } else {
+                // via way: prefer pxRadius, fallback to mid for very short ways
+                r = Math.min(mid, pxRadius);
+            }
 
             return 'translate(' + (r * Math.cos(a) + o[0]) + ',' + (r * Math.sin(a) + o[1]) + ') ' +
                 'rotate(' + a * 180 / Math.PI + ')';

--- a/modules/svg/vertices.js
+++ b/modules/svg/vertices.js
@@ -43,7 +43,14 @@ export function svgVertices(projection, context) {
         var directions = {};
         var wireframe = context.surface().classed('fill-wireframe');
         var zoom = geoScaleToZoom(projection.scale());
-        var z = (zoom < 17 ? 0 : zoom < 18 ? 1 : 2);
+        var z = 0;
+        if (zoom >= 17) {
+            if (zoom < 18) {
+               z = 1;
+           } else {
+               z = 2;
+           }
+        }
         var activeID = context.activeID();
         var base = context.history().base();
 

--- a/modules/ui/disclosure.js
+++ b/modules/ui/disclosure.js
@@ -50,10 +50,13 @@ export function uiDisclosure(context, key, expandedDefault) {
         hideToggle.selectAll('.hide-toggle-text')
             .html(_label());
 
+        var icon = '#iD-icon-down';
+        if (!_expanded) {
+            icon = localizer.textDirection() === 'rtl' ? '#iD-icon-backward' : '#iD-icon-forward';
+        }
+
         hideToggle.selectAll('.hide-toggle-icon')
-            .attr('xlink:href', _expanded ? '#iD-icon-down'
-                : (localizer.textDirection() === 'rtl') ? '#iD-icon-backward' : '#iD-icon-forward'
-            );
+            .attr('xlink:href', icon);
 
 
         var wrap = selection.selectAll('.disclosure-wrap')
@@ -84,10 +87,13 @@ export function uiDisclosure(context, key, expandedDefault) {
             hideToggle
                 .classed('expanded', _expanded);
 
+            var icon = '#iD-icon-down';
+            if (!_expanded) {
+                icon = localizer.textDirection() === 'rtl' ? '#iD-icon-backward' : '#iD-icon-forward';
+            }
+
             hideToggle.selectAll('.hide-toggle-icon')
-                .attr('xlink:href', _expanded ? '#iD-icon-down'
-                    : (localizer.textDirection() === 'rtl') ? '#iD-icon-backward' : '#iD-icon-forward'
-                );
+                .attr('xlink:href', icon);
 
             wrap
                 .call(uiToggle(_expanded));

--- a/modules/ui/feature_list.js
+++ b/modules/ui/feature_list.js
@@ -142,10 +142,23 @@ export function uiFeatureList(context) {
             if (idMatch) {
                 var elemType = idMatch[1].charAt(0);
                 var elemId = idMatch[2];
+                var geometry;
+                var label;
+                if (elemType === 'n') {
+                    geometry = 'point';
+                    label = t('inspector.node');
+                } else if (elemType === 'w') {
+                    geometry = 'line';
+                    label = t('inspector.way');
+                } else {
+                    geometry = 'relation';
+                    label = t('inspector.relation');
+                }
+
                 result.push({
                     id: elemType + elemId,
-                    geometry: elemType === 'n' ? 'point' : elemType === 'w' ? 'line' : 'relation',
-                    type: elemType === 'n' ? t('inspector.node') : elemType === 'w' ? t('inspector.way') : t('inspector.relation'),
+                    geometry: geometry,
+                    type: label,
                     name: elemId
                 });
             }

--- a/modules/ui/fields/address.js
+++ b/modules/ui/fields/address.js
@@ -195,9 +195,12 @@ export function uiFieldAddress(field, context) {
         function addDropdown(d) {
             if (dropdowns.indexOf(d.id) === -1) return;  // not a dropdown
 
-            var nearValues = (d.id === 'street') ? getNearStreets
-                : (d.id === 'city') ? getNearCities
-                : getNearValues;
+            var nearValues = getNearValues;
+            if (d.id === 'street') {
+                nearValues = getNearStreets;
+            } else if (d.id === 'city') {
+                nearValues = getNearCities;
+            }
 
             d3_select(this)
                 .call(uiCombobox(context, 'address-' + d.id)

--- a/modules/ui/fields/restrictions.js
+++ b/modules/ui/fields/restrictions.js
@@ -436,7 +436,6 @@ export function uiFieldRestrictions(field, context) {
                 for (var i = 0; i < turns.length; i++) {
                     var turn = turns[i];
                     var ids = [turn.to.way];
-                    var klass = (turn.no ? 'restrict' : (turn.only ? 'only' : 'allow'));
 
                     if (turn.only || turns.length === 1) {
                         if (turn.via.ways) {
@@ -448,9 +447,9 @@ export function uiFieldRestrictions(field, context) {
 
                     surface.selectAll(utilEntitySelector(ids))
                         .classed('related', true)
-                        .classed('allow', (klass === 'allow'))
-                        .classed('restrict', (klass === 'restrict'))
-                        .classed('only', (klass === 'only'));
+                        .classed('restrict', turn.no)
+                        .classed('only', !turn.no && turn.only)
+                        .classed('allow', !turn.no && !turn.only);
                 }
             }
         }
@@ -602,9 +601,9 @@ export function uiFieldRestrictions(field, context) {
 
 
     function displayMaxVia(maxVia) {
-        return maxVia === 0 ? t.html('restriction.controls.via_node_only')
-            : maxVia === 1 ? t.html('restriction.controls.via_up_to_one')
-            : t.html('restriction.controls.via_up_to_two');
+        if (maxVia === 0) return t.html('restriction.controls.via_node_only');
+        if (maxVia === 1) return t.html('restriction.controls.via_up_to_one');
+        return t.html('restriction.controls.via_up_to_two');
     }
 
 

--- a/modules/ui/note_header.js
+++ b/modules/ui/note_header.js
@@ -31,7 +31,15 @@ export function uiNoteHeader() {
             .call(svgIcon('#iD-icon-note', 'note-fill'));
 
         iconEnter.each(function(d) {
-            var statusIcon = '#iD-icon-' + (d.id < 0 ? 'plus' : (d.status === 'open' ? 'close' : 'apply'));
+            var statusIcon;
+            if (d.id < 0) {
+                statusIcon = '#iD-icon-plus';
+            } else if (d.status === 'open') {
+                statusIcon = '#iD-icon-close';
+            } else {
+                statusIcon = '#iD-icon-apply';
+            }
+
             iconEnter
                 .append('div')
                 .attr('class', 'note-icon-annotation')

--- a/modules/ui/preset_icon.js
+++ b/modules/ui/preset_icon.js
@@ -278,6 +278,61 @@ export function uiPresetIcon() {
   }
 
 
+  function renderSvgIcon(container, picon, geom, isFramed, tagClasses) {
+    const isMaki = picon && /^maki-/.test(picon);
+    const isTemaki = picon && /^temaki-/.test(picon);
+    const isFa = picon && /^fa[srb]-/.test(picon);
+    const isiDIcon = picon && !(isMaki || isTemaki || isFa);
+
+    let icon = container.selectAll('.preset-icon')
+      .data(picon ? [0] : []);
+
+    icon.exit()
+      .remove();
+
+    icon = icon.enter()
+      .append('div')
+      .attr('class', 'preset-icon')
+      .call(svgIcon(''))
+      .merge(icon);
+
+    icon
+      .attr('class', 'preset-icon ' + (geom ? geom + '-geom' : ''))
+      .classed('framed', isFramed)
+      .classed('preset-icon-iD', isiDIcon);
+
+    icon.selectAll('svg')
+      .attr('class', 'icon ' + picon + ' ' + (!isiDIcon && geom !== 'line'  ? '' : tagClasses));
+
+    var suffix = '';
+    if (isMaki) {
+      suffix = isSmall() && geom === 'point' ? '-11' : '-15';
+    }
+
+    icon.selectAll('use')
+      .attr('href', '#' + picon + suffix);
+  }
+
+
+  function renderImageIcon(container, imageURL) {
+    let imageIcon = container.selectAll('img.image-icon')
+      .data(imageURL ? [0] : []);
+
+    imageIcon.exit()
+      .remove();
+
+    imageIcon = imageIcon.enter()
+      .append('img')
+      .attr('class', 'image-icon')
+      .on('load', () => container.classed('showing-img', true) )
+      .on('error', () => container.classed('showing-img', false) )
+      .merge(imageIcon);
+
+    imageIcon
+      .attr('src', imageURL);
+  }
+
+
   // Route icons are drawn with a zigzag annotation underneath:
   //     o   o
   //    / \ /
@@ -316,10 +371,6 @@ export function uiPresetIcon() {
     const isFallback = isSmall() && p.isFallback && p.isFallback();
     const imageURL = (showThirdPartyIcons === 'true') && p.imageURL;
     const picon = getIcon(p, geom);
-    const isMaki = picon && /^maki-/.test(picon);
-    const isTemaki = picon && /^temaki-/.test(picon);
-    const isFa = picon && /^fa[srb]-/.test(picon);
-    const isiDIcon = picon && !(isMaki || isTemaki || isFa);
     const isCategory = !p.setTags;
     const drawPoint = picon && geom === 'point' && isSmall() && !isFallback;
     const drawVertex = picon !== null && geom === 'vertex' && (!isSmall() || !isFallback);
@@ -355,45 +406,8 @@ export function uiPresetIcon() {
     renderSquareFill(container, drawArea, tagClasses);
     renderLine(container, drawLine, tagClasses);
     renderRoute(container, drawRoute, p);
-
-    let icon = container.selectAll('.preset-icon')
-      .data(picon ? [0] : []);
-
-    icon.exit()
-      .remove();
-
-    icon = icon.enter()
-      .append('div')
-      .attr('class', 'preset-icon')
-      .call(svgIcon(''))
-      .merge(icon);
-
-    icon
-      .attr('class', 'preset-icon ' + (geom ? geom + '-geom' : ''))
-      .classed('framed', isFramed)
-      .classed('preset-icon-iD', isiDIcon);
-
-    icon.selectAll('svg')
-      .attr('class', 'icon ' + picon + ' ' + (!isiDIcon && geom !== 'line'  ? '' : tagClasses));
-
-    icon.selectAll('use')
-      .attr('href', '#' + picon + (isMaki ? (isSmall() && geom === 'point' ? '-11' : '-15') : ''));
-
-    let imageIcon = container.selectAll('img.image-icon')
-      .data(imageURL ? [0] : []);
-
-    imageIcon.exit()
-      .remove();
-
-    imageIcon = imageIcon.enter()
-      .append('img')
-      .attr('class', 'image-icon')
-      .on('load', () => container.classed('showing-img', true) )
-      .on('error', () => container.classed('showing-img', false) )
-      .merge(imageIcon);
-
-    imageIcon
-      .attr('src', imageURL);
+    renderSvgIcon(container, picon, geom, isFramed, tagClasses);
+    renderImageIcon(container, imageURL);
   }
 
 

--- a/modules/ui/preset_list.js
+++ b/modules/ui/preset_list.js
@@ -275,8 +275,10 @@ export function uiPresetList(context) {
 
             function click() {
                 var isExpanded = d3_select(this).classed('expanded');
-                var iconName = isExpanded ?
-                    (localizer.textDirection() === 'rtl' ? '#iD-icon-backward' : '#iD-icon-forward') : '#iD-icon-down';
+                var iconName = '#iD-icon-down';
+                if (isExpanded) {
+                    iconName = localizer.textDirection() === 'rtl' ? '#iD-icon-backward' : '#iD-icon-forward';
+                }
                 d3_select(this)
                     .classed('expanded', !isExpanded);
                 d3_select(this).selectAll('div.label-inner svg.icon use')

--- a/modules/ui/sections/background_list.js
+++ b/modules/ui/sections/background_list.js
@@ -169,9 +169,11 @@ export function uiSectionBackgroundList(context) {
             .sources(context.map().extent(), context.map().zoom(), true)
             .filter(filter)
             .sort(function(a, b) {
-                return a.best() && !b.best() ? -1
-                    : b.best() && !a.best() ? 1
-                    : d3_descending(a.area(), b.area()) || d3_ascending(a.name(), b.name()) || 0;
+                if (a.best() && !b.best()) return -1;
+                if (b.best() && !a.best()) return 1;
+                return d3_descending(a.area(), b.area()) ||
+                    d3_ascending(a.name(), b.name()) ||
+                    0;
             });
 
         var layerLinks = layerList.selectAll('li')

--- a/modules/ui/sections/overlay_list.js
+++ b/modules/ui/sections/overlay_list.js
@@ -91,9 +91,11 @@ export function uiSectionOverlayList(context) {
 
 
         function sortSources(a, b) {
-            return a.best() && !b.best() ? -1
-                : b.best() && !a.best() ? 1
-                : d3_descending(a.area(), b.area()) || d3_ascending(a.name(), b.name()) || 0;
+            if (a.best() && !b.best()) return -1;
+            if (b.best() && !a.best()) return 1;
+            return d3_descending(a.area(), b.area()) ||
+                d3_ascending(a.name(), b.name()) ||
+                0;
         }
     }
 

--- a/modules/ui/success.js
+++ b/modules/ui/success.js
@@ -277,7 +277,9 @@ export function uiSuccess(context) {
         return !isNaN(t) && t >= now;
       })
       .sort((a, b) => {       // sort by date ascending
-        return a.date < b.date ? -1 : a.date > b.date ? 1 : 0;
+        if (a.date < b.date) return -1;
+        if (a.date > b.date) return 1;
+        return 0;
       })
       .slice(0, MAXEVENTS);   // limit number of events shown
 

--- a/modules/util/get_set_value.js
+++ b/modules/util/get_set_value.js
@@ -21,9 +21,9 @@ export function utilGetSetValue(selection, value) {
             }
         }
 
-        return (value === null || value === undefined)
-            ? valueNull : (typeof value === 'function'
-            ? valueFunction : valueConstant);
+        if (value === null || value === undefined) return valueNull;
+        if (typeof value === 'function') return valueFunction;
+        return valueConstant;
     }
 
     if (arguments.length === 1) {

--- a/modules/util/jxon.js
+++ b/modules/util/jxon.js
@@ -16,7 +16,9 @@ export var JXON = new (function () {
   EmptyTree.prototype.valueOf = function () { return null; };
 
   function objectify (vValue) {
-    return vValue === null ? new EmptyTree() : vValue instanceof Object ? vValue : new vValue.constructor(vValue);
+    if (vValue === null) return new EmptyTree();
+    if (vValue instanceof Object) return vValue;
+    return new vValue.constructor(vValue);
   }
 
   function createObjTree (oParentNode, nVerb, bFreeze, bNesteAttr) {

--- a/scripts/build_data.js
+++ b/scripts/build_data.js
@@ -768,9 +768,11 @@ function validateDefaults(defaults, categories, presets) {
 function translationsToYAML(translations) {
   // comment keys end with '#' and should sort immediately before their related key.
   function commentFirst(a, b) {
-    return (a === b + '#') ? -1
-      : (b === a + '#') ? 1
-      : (a > b ? 1 : a < b ? -1 : 0);
+    if (a === b + '#') return -1;
+    if (b === a + '#') return 1;
+    if (a > b) return 1;
+    if (a < b) return -1;
+    return 0;
   }
 
   return YAML.safeDump({ en: { presets: translations }}, { sortKeys: commentFirst, lineWidth: -1 })


### PR DESCRIPTION
Nested ternary expressions can be inaccessible to beginners and are unnecessarily difficult to read for developers of all levels. For an open source app like iD, I contend it's better to avoid them. This PR enables the [no-nested-ternary](https://eslint.org/docs/rules/no-nested-ternary) linting rule and replaces all existing usage with less complex syntax.