### PR TITLE
Add support for CRS:84 projection

### DIFF
--- a/modules/renderer/background_source.js
+++ b/modules/renderer/background_source.js
@@ -142,6 +142,7 @@ export function rendererBackgroundSource(data) {
                 var lat = Math.atan(sinh(Math.PI * (1 - 2 * y / zoomSize)));
 
                 switch (source.projection) {
+                    case 'CRS:84':
                     case 'EPSG:4326':
                         return {
                             x: lon * 180 / Math.PI,
@@ -171,7 +172,10 @@ export function rendererBackgroundSource(data) {
                 case 'wkid':
                     return projection.replace(/^EPSG:/, '');
                 case 'bbox':
-                    // WMS 1.3 flips x/y for some coordinate systems including EPSG:4326 - #7557
+                    // WMS versions prior 1.3.0 require easting / northing (x,y) coordinate order for bbox parameter
+                    // WMS version 1.3.0 requires axis ordering as specified in the CRS - #7557
+                    // E.g. http://epsg.io/4326 > Coordinate system: ... Orientations: north, east.
+                    //      http://epsg.io/3857 > Coordinate system: ... Orientations: east, north.
                     if (projection === 'EPSG:4326' &&
                         // The CRS parameter implies version 1.3 (prior versions use SRS)
                         /VERSION=1.3|CRS={proj}/.test(source.template())) {

--- a/scripts/update_imagery.js
+++ b/scripts/update_imagery.js
@@ -75,7 +75,8 @@ const supportedWMSProjections = [
   'EPSG:102100',
   'EPSG:3785',
   // WGS 84 (Equirectangular)
-  'EPSG:4326'
+  'EPSG:4326',
+  'CRS:84'
 ];
 
 


### PR DESCRIPTION
WMS server typically support the CRS:84 projection, which is very similar to  EPSG:4326. The difference is, that CRS:84 is in lon/lat axis order, while EPSG:4326 has lat/lon axis order. This is relevant for WMS 1.3.0, as with this standard the bbox coordinates should be in order as defined in the CRS, while WMS versions prior 1.3.0 require lon/lat, respectively x,y axis ordering.  

In practice, it is unlikely that a server supports CRS:84 and not also EPSG:4326, but adding support for it is not a lot of work. 