### PR TITLE
Walkthrough hangs on "line" module when splitting "Washington Street"

### DIFF
--- a/modules/ui/intro/line.js
+++ b/modules/ui/intro/line.js
@@ -725,7 +725,7 @@ export function uiIntroLine(context, reveal) {
         context.history().on('change.intro', function(changed) {
             wasChanged = true;
             timeout(function() {
-                if (context.history().undoAnnotation() === t('operations.split.annotation.line')) {
+                if (context.history().undoAnnotation() === t('operations.split.annotation.line', { n: 1 })) {
                     _washingtonSegmentID = changed.created()[0].id;
                     continueTo(didSplit);
                 } else {


### PR DESCRIPTION
I think the problem is that operations.split.annotation now has two different values depending on a numerical argument which is missing in the current code.

I haven't tested my patch, I just copied the format from /modules/ui/intro/building.js .