### PR TITLE
Fix error when custom background url is empty

### DIFF
--- a/modules/ui/sections/background_list.js
+++ b/modules/ui/sections/background_list.js
@@ -266,7 +266,7 @@ export function uiSectionBackgroundList(context) {
 
 
     function editCustom(d3_event) {
-        d3_event.preventDefault();
+        if (d3_event !== undefined) d3_event.preventDefault();
         context.container()
             .call(_settingsCustomBackground);
     }


### PR DESCRIPTION
When we select the custom layer on the background panel, it prevents the dialog to open, but if the URL is not defined, it raises an error on the console: `TypeError: Cannot read property 'preventDefault' of undefined`

I believe the best would be to open the dialog when the url is not set. This PR fixes it.

