### PR TITLE
Issue #8015 now displays both, as local as nativeName of language

### DIFF
--- a/modules/ui/combobox.js
+++ b/modules/ui/combobox.js
@@ -318,7 +318,7 @@ export function uiCombobox(context, klass) {
                 if (_cancelFetch) return;
 
                 _suggestions = results;
-                results.forEach(function(d) { _fetched[d.value] = d; });
+                results.forEach(function(d) {_fetched[d.value] = d;});
 
                 if (cb) {
                     cb();

--- a/modules/ui/fields/localized.js
+++ b/modules/ui/fields/localized.js
@@ -401,6 +401,7 @@ export function uiFieldLocalized(field, context) {
                 (d.localName && d.localName.toLowerCase() === lang) ||
                 (d.nativeName && d.nativeName.toLowerCase() === lang);
         });
+
         if (language) lang = language.code;
 
         if (d.lang && d.lang !== lang) {
@@ -456,12 +457,10 @@ export function uiFieldLocalized(field, context) {
         langItems = utilArrayUniq(langItems.concat(_languagesArray));
 
         cb(langItems.filter(function(d) {
-            return d.label.toLowerCase().indexOf(v) >= 0 ||
-                (d.localName && d.localName.toLowerCase().indexOf(v) >= 0) ||
-                (d.nativeName && d.nativeName.toLowerCase().indexOf(v) >= 0) ||
-                d.code.toLowerCase().indexOf(v) >= 0;
+            return d.label.toLowerCase().indexOf(v) >= 0 &&
+                (d.nativeName && d.nativeName.toLowerCase().indexOf(v) >= 0);
         }).map(function(d) {
-            return { value: d.label };
+            return { value: d.label+'-'+d.nativeName };//#8015 print multilangial fix
         }));
     }
 
@@ -563,15 +562,17 @@ export function uiFieldLocalized(field, context) {
         entries.order();
 
         entries.classed('present', function(d) {
-            return d.lang && d.value;
+            return (d.lang && d.value);
+
         });
 
         utilGetSetValue(entries.select('.localized-lang'), function(d) {
             var langItem = _languagesArray.find(function(item) {
                 return item.code === d.lang;
             });
-            if (langItem) return langItem.label;
+            if (langItem) return (langItem.label +'-'+ langItem.nativeName);//#8015 startup print fix
             return d.lang;
+
         });
 
         utilGetSetValue(entries.select('.localized-value'), function(d) {


### PR DESCRIPTION
Closes #8015

Now the list of the languages will dispalys name of the language as in local system language as well in native language as was asked in #8015 
![image](https://user-images.githubusercontent.com/72410047/99199075-e37e0380-279c-11eb-8fb6-fd6c0e013495.png)
