### PR TITLE
Add shortcut to select parent way(s)

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -2258,6 +2258,7 @@ en:
         next: "Jump to next node"
         first: "Jump to first node"
         last: "Jump to last node"
+        parent: "Select parent way"
         change_parent: "Switch parent way"
     editing:
       title: "Editing"

--- a/data/shortcuts.json
+++ b/data/shortcuts.json
@@ -159,7 +159,7 @@
             "text": "shortcuts.browsing.vertex_selected.last"
           },
           {
-            "shortcuts": [">"],
+            "shortcuts": ["<"],
             "text": "shortcuts.browsing.vertex_selected.parent"
           },
           {

--- a/data/shortcuts.json
+++ b/data/shortcuts.json
@@ -159,6 +159,10 @@
             "text": "shortcuts.browsing.vertex_selected.last"
           },
           {
+            "shortcuts": [">"],
+            "text": "shortcuts.browsing.vertex_selected.parent"
+          },
+          {
             "shortcuts": ["\\", "shortcuts.key.pause"],
             "text": "shortcuts.browsing.vertex_selected.change_parent"
           }

--- a/data/shortcuts.json
+++ b/data/shortcuts.json
@@ -159,7 +159,8 @@
             "text": "shortcuts.browsing.vertex_selected.last"
           },
           {
-            "shortcuts": ["<"],
+            "modifiers": ["⌘"],
+            "shortcuts": ["↑"],
             "text": "shortcuts.browsing.vertex_selected.parent"
           },
           {

--- a/modules/modes/select.js
+++ b/modules/modes/select.js
@@ -245,7 +245,7 @@ export function modeSelect(context, selectedIDs) {
             .on(utilKeybinding.minusKeys.map((key) => uiCmd('⇧' + key)), scaleSelection(1/1.05))
             .on(utilKeybinding.minusKeys.map((key) => uiCmd('⇧⌥' + key)), scaleSelection(1/Math.pow(1.05, 5)))
             .on(['\\', 'pause'], nextParent)
-            .on('<', selectParent)
+            .on(uiCmd('⌘↑'), selectParent)
             .on('⎋', esc, true);
 
         d3_select(document)

--- a/modules/modes/select.js
+++ b/modules/modes/select.js
@@ -565,11 +565,12 @@ export function modeSelect(context, selectedIDs) {
 
         function selectParent(d3_event) {
             d3_event.preventDefault();
-            if (_relatedParent) {
-                context.enter(
-                    modeSelect(context, [_relatedParent])
-                );
-            }
+            var parents = _relatedParent ? [_relatedParent] : commonParents();
+            if (!parents) return;
+
+            context.enter(
+                modeSelect(context, parents)
+            );
         }
     };
 

--- a/modules/modes/select.js
+++ b/modules/modes/select.js
@@ -245,6 +245,7 @@ export function modeSelect(context, selectedIDs) {
             .on(utilKeybinding.minusKeys.map((key) => uiCmd('⇧' + key)), scaleSelection(1/1.05))
             .on(utilKeybinding.minusKeys.map((key) => uiCmd('⇧⌥' + key)), scaleSelection(1/Math.pow(1.05, 5)))
             .on(['\\', 'pause'], nextParent)
+            .on('>', selectParent)
             .on('⎋', esc, true);
 
         d3_select(document)
@@ -559,6 +560,15 @@ export function modeSelect(context, selectedIDs) {
             if (_relatedParent) {
                 surface.selectAll(utilEntitySelector([_relatedParent]))
                     .classed('related', true);
+            }
+        }
+
+        function selectParent(d3_event) {
+            d3_event.preventDefault();
+            if (_relatedParent) {
+                context.enter(
+                    modeSelect(context, [_relatedParent])
+                );
             }
         }
     };

--- a/modules/modes/select.js
+++ b/modules/modes/select.js
@@ -245,7 +245,7 @@ export function modeSelect(context, selectedIDs) {
             .on(utilKeybinding.minusKeys.map((key) => uiCmd('⇧' + key)), scaleSelection(1/1.05))
             .on(utilKeybinding.minusKeys.map((key) => uiCmd('⇧⌥' + key)), scaleSelection(1/Math.pow(1.05, 5)))
             .on(['\\', 'pause'], nextParent)
-            .on('>', selectParent)
+            .on('<', selectParent)
             .on('⎋', esc, true);
 
         d3_select(document)

--- a/modules/modes/select.js
+++ b/modules/modes/select.js
@@ -566,7 +566,7 @@ export function modeSelect(context, selectedIDs) {
         function selectParent(d3_event) {
             d3_event.preventDefault();
             var parents = _relatedParent ? [_relatedParent] : multipleParents(false);
-            if (!parents) return;
+            if (!parents || parents.length === 0) return;
 
             context.enter(
                 modeSelect(context, parents)


### PR DESCRIPTION
Pressing <kbd>Ctrl</kbd><kbd>↑</kbd> on Windows or ⌘↑ on macOS selects the selected node’s highlighted parent way, or all the node’s parent ways if none is currently highlighted.

## Rationale

This keyboard shortcut is helpful for keyboard accessibility, reducing the need to use the mouse in some cases. For example, in this scenario, the crosswalk way’s hit target is crowded out by the crosswalk node’s icon and adjacent road and sidewalk ways:

<img width="216" alt="crosswalk" src="https://user-images.githubusercontent.com/1231218/102869934-2dd44f00-43f1-11eb-8681-0430083e8596.png">

Without this keyboard shortcut, you would have to switch to wireframe mode, zoom in, or meticulously move the mouse until the cursor changes to indicate a line selection. These workarounds would be inconvenient for users who prefer to stay at a single zoom level while mapping without switching modes.

The lasso selection tool (<kbd>Shift</kbd>-drag) only selects nodes, which is adequate if you want to delete or move entire lines or areas. If you want to change tags on multiple lines or areas, then you can use this keyboard shortcut after making a lasso selection.

The keyboard shortcut is especially helpful when multiple ways (lines or areas) are joined at multiple consecutive nodes, such as a power substation that shares its nodes with the fence that surrounds it, or an office building with multiple tenants occupying entire floors. Without this shortcut, users have to try their luck selecting the joined lines or areas, often having to resort to complicated workarounds like creating temporary nodes, disconnecting them, and deleting them one by one.

iD has long had a <kbd>\\</kbd> shortcut (also <kbd>Pause</kbd> on Windows) that works like Potlatch’s <kbd>/</kbd> to cycle among the ways that are joined at the selected node, but until now, it hasn’t had anything like Potlatch’s <kbd>W</kbd> shortcut to select the highlighted way. Potlatch is about to disappear from the Web, so it feels like an appropriate time to bring this feature to iD for safekeeping. (JOSM’s [UtilsPlugin2](https://josm.openstreetmap.de/wiki/Help/Plugin/UtilsPlugin2#Selection) plugin has a similar command, [Adjacent Ways](https://josm.openstreetmap.de/wiki/Help/Action/AdjacentWays).)

## Examples

The following screen recordings depict three hypothetical but realistic examples:

* A dog park surrounded by a fence with a gate at the entrance
* A road that follows a boundary; see https://github.com/openstreetmap/iD/issues/7619#issuecomment-749299874 for some concrete examples
* A three-story building, with a pizza joint occupying most of the ground floor, two offices occupying the entire middle and top floors respectively, and a solar panel on the rooftop

If you select a shared node and press <kbd>Ctrl</kbd><kbd>↑</kbd> or ⌘↑, all the parent ways are selected:

https://user-images.githubusercontent.com/1231218/102862671-4db24580-43e6-11eb-9e90-5a4d67564bd4.mov

Thanks to the multiselection support added in #1761, you can select the parent way you want from the Features list:

https://user-images.githubusercontent.com/1231218/102863482-80a90900-43e7-11eb-9354-5d1f23537b39.mov

If you select a shared node and highlight a specific parent way using <kbd>\\</kbd>, then pressing <kbd>Ctrl</kbd><kbd>↑</kbd> or ⌘↑ causes only that highlighted way to be selected:

https://user-images.githubusercontent.com/1231218/102863754-e2697300-43e7-11eb-80ff-2f933232fb12.mov

Intuitively, if you’re already following the nodes along a specific way (using the <kbd>[</kbd> and <kbd>]</kbd> shortcuts), then you’d want to select that way instead of having to choose it again from the Features list.

If you select multiple shared nodes, pressing <kbd>↑</kbd> or ⌘↑ selects all their parents, even if some of the nodes have different parents than others. In the scenario below, higher-resolution imagery shows that the rooftop solar panel doesn’t extend to the edges of the building, so you’d lasso-select all the nodes that make up the building, select the union of their parent ways, select the solar panel from the Features list, and use the Disconnect and Scale operations to refine the solar panel independently of the rest of the features:

https://user-images.githubusercontent.com/1231218/102927590-1c6c6080-444c-11eb-8231-8de1f2bdc100.mov

## Internationalization

iD seems to generally reserve letters for editing operations and uses control keys or punctuation for navigation, which makes sense. The problem is that there are very few control keys left that aren’t used by iD or the browser, and very few punctuation characters are universal among keyboard layouts. I went with <kbd>Ctrl</kbd><kbd>↑</kbd> on Windows and ⌘↑ on macOS because these are physical keys on every keyboard, regardless of locale.

This combination is unlikely to cause a conflict with browsers. On Windows, <kbd>Ctrl</kbd><kbd>↑</kbd> would move the caret to the beginning of the paragraph, but this shortcut would take effect when no text field has focus. On macOS, ⌘↑ would move the caret to the beginning of a text field or scroll to the top of the page, but iD doesn’t scroll like a page (cue request to jump to the North Pole). It’s also Finder’s shortcut for moving up to the containing folder.

## Other caveats

I’m unsure of a good way to expose this functionality to touchscreens. From #7590, it looks like iD does support multiple selection on touch screens, but I’m unsure about <kbd>[</kbd> and <kbd>]</kbd> navigation. Maybe we could add a context menu item that corresponds to the “Select parent way” command?

Fixes #1239, fixes #2225, fixes #5009, and fixes #7375.