### PR TITLE
Pass d3_event to click handler

### DIFF
--- a/modules/ui/feature_list.js
+++ b/modules/ui/feature_list.js
@@ -91,7 +91,7 @@ export function uiFeatureList(context) {
             if (d3_event.keyCode === 13 && // ↩ Return
                 q.length &&
                 items.size()) {
-                click(items.datum());
+                click(d3_event, items.datum());
             }
         }
 


### PR DESCRIPTION
Small bug where d3_event needs to be passed to the click handler on the feature_list if the user has pressed return to accept the first item from the list.