### PR TITLE
use addr: tags as a fallback name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 # unreleased (v2.36.0-dev)
 
 #### :sparkles: Usability & Accessibility
+* use `addr:` tags to label features with no name ([#8440], thanks [@k-yle])
 * The flip operation now works on nodes with no `direction` tag, to support quickly adding `direction` to features like traffic signs ([#9317], thanks [@k-yle])
 * Show "add new key" placeholder text for blank row in raw tag editor ([#11211], thanks [@bhavyaKhatri2703])
 * Consider other name-like tags for labelling features, such as `lock_name` ([#9588], thanks [@k-yle])
@@ -62,6 +63,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :mortar_board: Walkthrough / Help
 #### :hammer: Development
 
+[#8440]: https://github.com/openstreetmap/iD/pull/8440
 [#9317]: https://github.com/openstreetmap/iD/issues/9317
 [#9511]: https://github.com/openstreetmap/iD/pull/9511
 [#9588]: https://github.com/openstreetmap/iD/pull/9588

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -766,6 +766,8 @@ en:
     add_fields: "Add field:"
     lock:
       suggestion: 'The "{label}" field is locked because there is a Wikidata tag. You can delete it or edit the tags in the "Tags" section.'
+    display_name_addr: "{housenumber} {streetOrPlace}"
+    display_name_addr_with_unit: "{unit}, {housenumber} {streetOrPlace}"
     display_name:
       direction: "{direction}"
       network: "{network}"

--- a/modules/svg/labels.js
+++ b/modules/svg/labels.js
@@ -299,7 +299,7 @@ export function svgLabels(projection, context) {
             var preset = geometry === 'area' && presetManager.match(entity, graph);
             var icon = preset && !shouldSkipIcon(preset) && preset.icon;
 
-            if (!icon && !utilDisplayName(entity)) continue;
+            if (!icon && !utilDisplayName(entity, undefined, true)) continue;
 
             for (k = 0; k < labelStack.length; k++) {
                 var matchGeom = labelStack[k][0];
@@ -328,8 +328,9 @@ export function svgLabels(projection, context) {
                 entity = labelable[k][i];
                 geometry = entity.geometry(graph);
 
-                var getName = (geometry === 'line') ? utilDisplayNameForPath : utilDisplayName;
-                var name = getName(entity);
+                let name = geometry === 'line'
+                    ? utilDisplayNameForPath(entity)
+                    : utilDisplayName(entity, undefined, true);
                 var width = name && textWidth(name, fontSize, selection.select('g.layer-osm.labels').node());
                 var p = null;
 

--- a/test/spec/util/util.js
+++ b/test/spec/util/util.js
@@ -334,6 +334,21 @@ describe('iD.util', function() {
             expect(iD.utilDisplayName({tags: { name: 'Kings Island Express', network: 'SORTA', ref: '71X', from: 'Sycamore & Court', to: 'Fields Ertel & Royal Point', route: 'bus' }})).to.eql('SORTA 71X: Kings Island Express from Sycamore & Court to Fields Ertel & Royal Point');
             expect(iD.utilDisplayName({tags: { name: 'Local', network: 'Caltrain', from: 'San Francisco', to: 'Tamien', via: 'College Park', route: 'train' }})).to.eql('Caltrain Local from San Francisco to Tamien via College Park');
         });
+        it('uses addr:housename', () => {
+            expect(iD.utilDisplayName({ tags: { 'addr:housename': 'Siglap House' } })).to.eql('Siglap House');
+        });
+        it('uses the street address as a last resort', () => {
+            expect(iD.utilDisplayName({ tags: { 'addr:housenumber': '31', 'addr:street': 'Princes Street' } })).to.eql('31 Princes Street');
+        });
+        it('uses the street address as a last resort', () => {
+            expect(iD.utilDisplayName({ tags: { 'addr:housenumber': '1', 'addr:place': 'Princes Street' } })).to.eql('1 Motutapu Island');
+        });
+        it('uses addr:unit if present', () => {
+            expect(iD.utilDisplayName({ tags: { 'addr:unit': 'Flat 1', 'addr:housenumber': '30', 'addr:street': 'Madden Street' } })).to.eql('Flat 1, 30 Madden Street');
+        });
+        it('uses just addr:housenumber if it is the only addr: tag present', () => {
+            expect(iD.utilDisplayName({ tags: { 'addr:housenumber': '32' } })).to.eql('32');
+        });
     });
 
     describe('utilOldestID', function() {

--- a/test/spec/util/util.js
+++ b/test/spec/util/util.js
@@ -341,13 +341,16 @@ describe('iD.util', function() {
             expect(iD.utilDisplayName({ tags: { 'addr:housenumber': '31', 'addr:street': 'Princes Street' } })).to.eql('31 Princes Street');
         });
         it('uses the street address as a last resort', () => {
-            expect(iD.utilDisplayName({ tags: { 'addr:housenumber': '1', 'addr:place': 'Princes Street' } })).to.eql('1 Motutapu Island');
+            expect(iD.utilDisplayName({ tags: { 'addr:housenumber': '1', 'addr:place': 'Motutapu Island' } })).to.eql('1 Motutapu Island');
         });
         it('uses addr:unit if present', () => {
             expect(iD.utilDisplayName({ tags: { 'addr:unit': 'Flat 1', 'addr:housenumber': '30', 'addr:street': 'Madden Street' } })).to.eql('Flat 1, 30 Madden Street');
         });
         it('uses just addr:housenumber if it is the only addr: tag present', () => {
             expect(iD.utilDisplayName({ tags: { 'addr:housenumber': '32' } })).to.eql('32');
+        });
+        it('uses only the housenumber for map labels', () => {
+            expect(iD.utilDisplayName({ tags: { 'addr:housenumber': '31', 'addr:street': 'Princes Street' } }, undefined, true)).to.eql('31');
         });
     });
 


### PR DESCRIPTION
Closes #8744, Closes #7327, Closes #3857, Closes #2001, Closes #1760, Closes #1524


When adding or editing addresses, the changeset upload page is not very helpful since all addresses are just called "Address". This makes it hard to review what changes you have made.

This PR makes use of the [`addr:`](https://wiki.osm.org/wiki/Key:addr) tags to provide a fallback name for a node/way/relation, if there is no [`name`](https://wiki.osm.org/wiki/Key:name) or [`ref`](https://wiki.osm.org/wiki/Key:ref) tag.

<table>
<tr>
	<td>before
	<td>after
<tr>
	<td><img src="https://user-images.githubusercontent.com/16009897/113383945-77193f00-93e1-11eb-8ec3-27a72a1d1a27.png" />
	<td><img src="https://user-images.githubusercontent.com/16009897/113383987-8d26ff80-93e1-11eb-9ae8-e4a68e682854.png" />
</table>