### PR TITLE
CrossEditableZoom event firing fix - Use fresh zoom level value to determine if event should be fired

### DIFF
--- a/modules/renderer/map.js
+++ b/modules/renderer/map.js
@@ -589,15 +589,6 @@ export function rendererMap(context) {
             return;  // no change
         }
 
-        var withinEditableZoom = map.withinEditableZoom();
-        if (_lastWithinEditableZoom !== withinEditableZoom) {
-            if (_lastWithinEditableZoom !== undefined) {
-                // notify that the map zoomed in or out over the editable zoom threshold
-                dispatch.call('crossEditableZoom', this, withinEditableZoom);
-            }
-            _lastWithinEditableZoom = withinEditableZoom;
-        }
-
         if (geoScaleToZoom(k, TILESIZE) < _minzoom) {
             surface.interrupt();
             dispatch.call('hitMinZoom', this, map);
@@ -608,6 +599,15 @@ export function rendererMap(context) {
         }
 
         projection.transform(eventTransform);
+    
+        var withinEditableZoom = map.withinEditableZoom();
+        if (_lastWithinEditableZoom !== withinEditableZoom) {
+            if (_lastWithinEditableZoom !== undefined) {
+                // notify that the map zoomed in or out over the editable zoom threshold
+                dispatch.call('crossEditableZoom', this, withinEditableZoom);
+            }
+            _lastWithinEditableZoom = withinEditableZoom;
+        }
 
         var scale = k / _transformStart.k;
         var tX = (x / scale - _transformStart.x) * scale;


### PR DESCRIPTION
(solves #8472)

Sidepanel behavior is dependent on crossEditableZoom event which has small issue: 
- Map uses old zoom level value in zoomPan method to condition firing the abovementioned event.

Fix is simple: First transform the projection and then look into firing the event. 