### PR TITLE
Declare missed but used dependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "node-diff3": "2.1.0",
     "osm-auth": "1.1.0",
     "pannellum": "2.5.6",
+    "pbf": "^3.2.1",
     "polygon-clipping": "~0.15.1",
     "rbush": "3.0.1",
     "whatwg-fetch": "^3.4.1",


### PR DESCRIPTION
I found out that some of the dependencies aren't declared in the package.json. I used [depcheck ](https://www.npmjs.com/package/depcheck) to get the list of missed dependencies and added them to the package.json