### PR TITLE
Bing imagery - ensure freshness

### DIFF
--- a/modules/renderer/background_source.js
+++ b/modules/renderer/background_source.js
@@ -278,8 +278,8 @@ rendererBackgroundSource.Bing = function(data, dispatch) {
 
     /*
     missing tile image strictness param (n=)
-    •	n=f -> (Fail) returns a 404 
-    •	n=z -> (Empty) returns a 200 with 0 bytes (no content) 
+    •	n=f -> (Fail) returns a 404
+    •	n=z -> (Empty) returns a 200 with 0 bytes (no content)
     •	n=t -> (Transparent) returns a 200 with a transparent (png) tile
     */
     const strictParam = 'n';

--- a/modules/renderer/background_source.js
+++ b/modules/renderer/background_source.js
@@ -280,7 +280,7 @@ rendererBackgroundSource.Bing = function(data, dispatch) {
     missing tile image strictness param (n=)
     •	n=f -> (Fail) returns a 404 
     •	n=z -> (Empty) returns a 200 with 0 bytes (no content) 
-    •	n=t -> (Transparant) returns a 200 with a transparent (png) tile
+    •	n=t -> (Transparent) returns a 200 with a transparent (png) tile
     */
     const strictParam = 'n';
 

--- a/modules/renderer/background_source.js
+++ b/modules/renderer/background_source.js
@@ -308,9 +308,8 @@ rendererBackgroundSource.Bing = function(data, dispatch) {
             });
             dispatch.call('change');
         })
-        .catch(function(e) {
+        .catch(function() {
             /* ignore */
-            console.log(e);
         });
 
 

--- a/modules/renderer/background_source.js
+++ b/modules/renderer/background_source.js
@@ -269,12 +269,12 @@ rendererBackgroundSource.Bing = function(data, dispatch) {
     // https://docs.microsoft.com/en-us/bingmaps/rest-services/imagery/get-imagery-metadata
 
     //fallback url template
-    data.template = 'https://ecn.t{switch:0,1,2,3}.tiles.virtualearth.net/tiles/a{u}.jpeg?g=587&mkt=en-gb&n=z';
+    data.template = 'https://ecn.t{switch:0,1,2,3}.tiles.virtualearth.net/tiles/a{u}.jpeg?g=10555&n=z';
 
     var bing = rendererBackgroundSource(data);
     var key = 'Arzdiw4nlOJzRwOz__qailc8NiR31Tt51dN2D7cm57NrnceZnCpgOkmJhNpGoppU'; // P2, JOSM, etc
     //var key = 'Ak5oTE46TUbjRp08OFVcGpkARErDobfpuyNKa-W2mQ8wbt1K1KL8p1bIRwWwcF-Q';    // iD
-
+    const strictParam = 'n';
 
     var url = 'https://dev.virtualearth.net/REST/v1/Imagery/Metadata/Aerial?include=ImageryProviders&key=' + key;
     var cache = {};
@@ -289,7 +289,11 @@ rendererBackgroundSource.Bing = function(data, dispatch) {
             let subDomainNumbers = subDomains.map((subDomain) => {
                 return subDomain.substring(1);
             } ).join(',');
+
             template = template.replace('{subdomain}', `t{switch:${subDomainNumbers}}`).replace('{quadkey}', '{u}');
+            if (!new URLSearchParams(template).has(strictParam)){
+                template += `&${strictParam}=z`;
+            }
             bing.template(template);
             providers = imageryResource.imageryProviders.map(function(provider) {
                 return {
@@ -304,8 +308,9 @@ rendererBackgroundSource.Bing = function(data, dispatch) {
             });
             dispatch.call('change');
         })
-        .catch(function() {
+        .catch(function(e) {
             /* ignore */
+            console.log(e);
         });
 
 


### PR DESCRIPTION
The current code was using outdated Bing imagery (old tile generation g=587) and odd market setting (en-gb);
As the result:
- It was possible that users were editing based on obsolete data.
- The imagery load performance is poor as majority of requests are cdn cache miss

As implemented, correct approach is to hit imagery metadata api once on init in order to get up to date template and use it to form imagery urls during the session. 
- (I've left the hard-coded template only to serve as a fallback and for implementation simplicity)

As a short term fix, bing imagery team has set on their end that the tile generation which iD currently uses serves latest imagery.