### PR TITLE
translations - small fix for YAML.load

### DIFF
--- a/scripts/update_locales.js
+++ b/scripts/update_locales.js
@@ -27,6 +27,7 @@ if (process.env.transifex_password) {
 } else {
   // Credentials can be stored in transifex.auth as a json object. This file is gitignored.
   // You can use an API key instead of your password: https://docs.transifex.com/api/introduction#authentication
+  // in which case for user parameter value should be: "api"
   // {
   //   "user": "username",
   //   "password": "password"
@@ -242,7 +243,7 @@ function getLanguage(resourceURL) {
         return res.json();
       })
       .then(json => {
-        callback(null, YAML.safeLoad(json.content)[code]);
+        callback(null, YAML.load(json.content)[code]);
       })
       .catch(err => callback(err));
   };


### PR DESCRIPTION
Executed: 'npm run translations' and got the following:

```
....
Error: Function yaml.safeLoad is removed in js-yaml 4. Use yaml.load instead, which is now safe by default.
    at Object.safeLoad (D:\iD\node_modules\js-yaml\index.js:10:11)
    at D:\iD\scripts\update_locales.js:245:29
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
```

Change is self-explanatory :) 