### PR TITLE
Oci v5.1 + oci filefetch version from package.json

### DIFF
--- a/modules/core/file_fetcher.js
+++ b/modules/core/file_fetcher.js
@@ -1,4 +1,7 @@
 import { utilFetchJson } from '../util/util';
+import parseVersion from 'vparse';
+// Double check this resolves to iD's `package.json`
+import packageJSON from '../../package.json';
 
 let _mainFileFetcher = coreFileFetcher(); // singleton
 
@@ -8,6 +11,10 @@ export { _mainFileFetcher as fileFetcher };
 // coreFileFetcher asynchronously fetches data from JSON files
 //
 export function coreFileFetcher() {
+  const ociVersion = packageJSON.dependencies['osm-community-index'] || packageJSON.devDependencies['osm-community-index'];
+  const v = parseVersion(ociVersion);
+  const vMinor = `${v.major}.${v.minor}`;
+
   let _this = {};
   let _inflight = {};
   let _fileMap = {
@@ -19,9 +26,9 @@ export function coreFileFetcher() {
     'keepRight': 'data/keepRight.min.json',
     'languages': 'data/languages.min.json',
     'locales': 'locales/index.min.json',
-    'oci_defaults': 'https://cdn.jsdelivr.net/npm/osm-community-index@4/dist/defaults.min.json',
-    'oci_features': 'https://cdn.jsdelivr.net/npm/osm-community-index@4/dist/featureCollection.min.json',
-    'oci_resources': 'https://cdn.jsdelivr.net/npm/osm-community-index@4/dist/resources.min.json',
+    'oci_defaults': `https://cdn.jsdelivr.net/npm/osm-community-index@${vMinor}/dist/defaults.min.json`,
+    'oci_features': `https://cdn.jsdelivr.net/npm/osm-community-index@${vMinor}/dist/featureCollection.min.json`,
+    'oci_resources': `https://cdn.jsdelivr.net/npm/osm-community-index@${vMinor}/dist/resources.min.json`,
     'preset_categories': 'https://cdn.jsdelivr.net/npm/@openstreetmap/id-tagging-schema@3/dist/preset_categories.min.json',
     'preset_defaults': 'https://cdn.jsdelivr.net/npm/@openstreetmap/id-tagging-schema@3/dist/preset_defaults.min.json',
     'preset_fields': 'https://cdn.jsdelivr.net/npm/@openstreetmap/id-tagging-schema@3/dist/fields.min.json',

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "node-fetch": "^2.6.1",
     "npm-run-all": "^4.0.0",
     "object-inspect": "1.10.3",
-    "osm-community-index": "~4.0.2",
+    "osm-community-index": "~5.1.0",
     "phantomjs-prebuilt": "~2.1.16",
     "postcss": "^8.1.1",
     "postcss-selector-prepend": "^0.5.0",


### PR DESCRIPTION
- Oci v5.1 supersedes #8555 

- Version for oci filefetch extracted from package.json trick as introduced (https://github.com/openstreetmap/iD/pull/8305#discussion_r663055241) (probably going to extract this logic into util func in future change)