### PR TITLE
NSI related fixes

### DIFF
--- a/modules/services/nsi.js
+++ b/modules/services/nsi.js
@@ -349,6 +349,7 @@ function gatherNames(tags) {
   }
 
   function isNamelike(osmkey, which) {
+    if (osmkey === 'old_name') return false;
     return patterns[which].test(osmkey) && !notNames.test(osmkey);
   }
 }


### PR DESCRIPTION
closes #8615 - preserve tag values that can be toplevel tags unless it's the toplevel tag for the matched item
closes #8617 - don't consider `old_name` as a name for matching
