### PR TITLE
Crossing_ways fixing - specially handle crossing nodes

### DIFF
--- a/modules/osm/node.js
+++ b/modules/osm/node.js
@@ -142,8 +142,8 @@ Object.assign(osmNode.prototype, {
     },
 
     isCrossing: function(){
-        return this.tags.highway === 'crossing' || 
-               this.tags.railway && this.tags.railway.indexOf('crossing') !== -1;  
+        return this.tags.highway === 'crossing' ||
+               this.tags.railway && this.tags.railway.indexOf('crossing') !== -1;
     },
 
     isEndpoint: function(resolver) {

--- a/modules/osm/node.js
+++ b/modules/osm/node.js
@@ -141,6 +141,10 @@ Object.assign(osmNode.prototype, {
         return utilArrayUniq(results);
     },
 
+    isCrossing: function(){
+        return this.tags.highway === 'crossing' || 
+               this.tags.railway && this.tags.railway.indexOf('crossing') !== -1;  
+    },
 
     isEndpoint: function(resolver) {
         return resolver.transient(this, 'isEndpoint', function() {

--- a/modules/validations/crossing_ways.js
+++ b/modules/validations/crossing_ways.js
@@ -721,7 +721,8 @@ export function validationCrossingWays(context) {
                             var edgeNodes = [graph.entity(edge[0]), graph.entity(edge[1])];
                             var nearby = geoSphericalClosestNode(edgeNodes, loc);
                             // if there is already a suitable node nearby, use that
-                            if (!nearby.node.hasInterestingTags() && nearby.distance < mergeThresholdInMeters) {
+                            // use the node if node has no interesting tags or if it is a crossing node #8326
+                            if ((!nearby.node.hasInterestingTags() || nearby.node.isCrossing()) && nearby.distance < mergeThresholdInMeters) {
                                 nodesToMerge.push(nearby.node.id);
                             // else add the new node to the way
                             } else {


### PR DESCRIPTION
[This change](https://github.com/openstreetmap/iD/commit/4c1d51348da76fc7afc3052ad1fafb10c12ade0b) introduced the current behavior of crossing_ways issue fixing which is following:
- Repurpose the existing nearby node if it has no interesting tags
- Create new midpoint othervise.

This was correctly done in response to raised [rapid issue](https://github.com/facebookincubator/RapiD/issues/194) duplicated as #8326 

However as @jleedev [cleverly noticed ](https://github.com/openstreetmap/iD/issues/8326#issuecomment-801073422) repurposing should be done for crossing nodes.
This PR simply covers this case as well.

After researching 'crossing' vertexes in [presets](https://github.com/openstreetmap/id-tagging-schema/blob/main/dist/presets.json) I've concluded that there are only few cases of these:
- Few types of ['Highway' crossings](https://wiki.openstreetmap.org/wiki/Tag:highway%3Dcrossing) always defined with tag: highway = crossing
- Railway/Tram crossing combinations (Railway-Railway, Railway-Road, Railway-Path, Tram-Path, Tram-Road), which are defined with tag key 'railway' and values: 'railway_crossing', 'level_crossing', 'crossing', 'tram_crossing', 'tram_level_crossing'.

Both of these are handled in isCrossing method and finally used as a special case to crossing_ways issue node repurposing logic.
