### PR TITLE
Treat route_master relations like route relations for matching to NSI

### DIFF
--- a/modules/services/nsi.js
+++ b/modules/services/nsi.js
@@ -182,6 +182,9 @@ function gatherKVs(tags) {
     const osmvalue = tags[osmkey];
     if (!osmvalue) return;
 
+    // Match a 'route_master' as if it were a 'route' - name-suggestion-index#5184
+    if (osmkey === 'route_master') osmkey = 'route';
+
     const vmap = _nsi.kvt.get(osmkey);
     if (!vmap) return;  // not an interesting key
 
@@ -227,6 +230,9 @@ function identifyTree(tags) {
 
     const osmvalue = tags[osmkey];
     if (!osmvalue) return;
+
+    // Match a 'route_master' as if it were a 'route' - name-suggestion-index#5184
+    if (osmkey === 'route_master') osmkey = 'route';
 
     const vmap = _nsi.kvt.get(osmkey);
     if (!vmap) return;  // this key is not in nsi
@@ -427,6 +433,8 @@ function _upgradeTags(tags, loc) {
     }
   });
 
+  // Match a 'route_master' as if it were a 'route' - name-suggestion-index#5184
+  const isRouteMaster = (tags.type === 'route_master');
 
   // Gather key/value tag pairs to try to match
   const tryKVs = gatherKVs(tags);
@@ -520,6 +528,12 @@ function _upgradeTags(tags, loc) {
 
     // Do the tag upgrade
     Object.assign(newTags, item.tags, keepTags);
+
+    // Swap `route` back to `route_master` - name-suggestion-index#5184
+    if (isRouteMaster) {
+      newTags.route_master = newTags.route;
+      delete newTags.route;
+    }
 
     // Special `branch` splitting rules - IF..
     // - NSI is suggesting to replace `name`, AND

--- a/modules/services/nsi.js
+++ b/modules/services/nsi.js
@@ -163,7 +163,7 @@ function loadNsiData() {
 // and fallbacks like
 //   "amenity/yes"
 // excluding things like
-//   "highway", "surface", "ref", etc.
+//   "tiger:reviewed", "surface", "ref", etc.
 //
 // Arguments
 //   `tags`: `Object` containing the feature's OSM tags
@@ -183,12 +183,12 @@ function gatherKVs(tags) {
     if (!osmvalue) return;
 
     const vmap = _nsi.kvt.get(osmkey);
-    if (!vmap) return;
+    if (!vmap) return;  // not an interesting key
 
-    if (osmvalue !== 'yes') {
-      primary.add(`${osmkey}/${osmvalue}`);
-    } else {
-      alternate.add(`${osmkey}/${osmvalue}`);
+    if (vmap.get(osmvalue)) {     // Matched a category in NSI
+      primary.add(`${osmkey}/${osmvalue}`);     // interesting key/value
+    } else if (osmvalue === 'yes') {
+      alternate.add(`${osmkey}/${osmvalue}`);   // fallback key/yes
     }
   });
 


### PR DESCRIPTION
- 0f913113c Match a 'route_master' as if it were a 'route' 
This code just treats `type=route_master` relations as if they were `type=route` so they will match the transit networks in NSI.
 (closes https://github.com/osmlab/name-suggestion-index/issues/5184)

Also includes a performance improvement for the NSI validator:
- 15ee63e87 Improve code for keeping only interesting key/value pairs 
Before it was not actually checking that the osmvalue was in the vmap, so we were testing a bunch of pairs like `highway/crossing` and `highway/residential` that would never match a NSI category.

