### PR TITLE
AddNote test fix

### DIFF
--- a/test/spec/modes/add_note.js
+++ b/test/spec/modes/add_note.js
@@ -26,7 +26,7 @@ describe('iD.modeAddNote', function() {
     });
 
     describe('clicking the map', function () {
-        it('adds a note', function() {
+        it('adds a note', function(done) {
             var note =  iD.osmNote({
                 id: '-1',
                 comments: [],
@@ -35,9 +35,13 @@ describe('iD.modeAddNote', function() {
             });
             happen.mousedown(context.surface().node(), {});
             happen.mouseup(window, {});
-            expect(iD.services.osm.caches().note.note[-1]).to.eql(note);
-            context.mode().exit();
-            d3.select('window').on('click.draw-block', null);
+
+            window.setTimeout(function() {
+                expect(iD.services.osm.caches().note.note[-1]).to.eql(note);
+                context.mode().exit();
+                d3.select('window').on('click.draw-block', null);
+                done()
+            }, 50);
         });
 
         // this won't work because draw behavior can only snap to entities, not notes

--- a/test/spec/modes/add_note.js
+++ b/test/spec/modes/add_note.js
@@ -40,7 +40,7 @@ describe('iD.modeAddNote', function() {
                 expect(iD.services.osm.caches().note.note[-1]).to.eql(note);
                 context.mode().exit();
                 d3.select('window').on('click.draw-block', null);
-                done()
+                done();
             }, 50);
         });
 


### PR DESCRIPTION
I saw few examples of github actions testing failing due to iD.modeAddNote assertion error.
- https://github.com/openstreetmap/iD/runs/3303121758
- https://github.com/openstreetmap/iD/runs/3144108263

Behavior is indeterministic.

My guess is that this is due to race condition - 'expect' being executed before click event and [note adding](https://github.com/openstreetmap/iD/blob/develop/modules/modes/add_note.js)