### PR TITLE
More validator fixes

### DIFF
--- a/modules/core/validator.js
+++ b/modules/core/validator.js
@@ -495,19 +495,6 @@ export function coreValidator(context) {
     const incrementalDiff = coreDifference(prevGraph, currGraph);
     const entityIDs = Object.keys(incrementalDiff.complete());
 
-    // const difference = coreDifference(prevGraph, currGraph);
-
-    // // Gather all entities related to this difference..
-    // // For created/modified, use the head graph
-    // let entityIDs = difference.extantIDs(true);   // created/modified (true = w/relation members)
-    // entityIDs = entityIDsToValidate(entityIDs, currGraph);  // expand set
-
-    // // For modified/deleted, use the previous graph
-    // // (e.g. deleting the only highway connected to a road should create a disconnected highway issue)
-    // let previousEntityIDs = difference.deleted().concat(difference.modified()).map(entity => entity.id);
-    // previousEntityIDs = entityIDsToValidate(previousEntityIDs, prevGraph);
-    // previousEntityIDs.forEach(entityIDs.add, entityIDs);   // concat the sets
-
     // if (!entityIDs.size) {
     if (!entityIDs.length) {
       dispatch.call('validated');
@@ -635,64 +622,6 @@ export function coreValidator(context) {
       }
     }
   }
-
-
-  // // `entityIDsToValidate()`   (private)
-  // // Collects the complete list of entityIDs related to the input entityIDs.
-  // //
-  // // Arguments
-  // //   `entityIDs` - Set or Array containing entityIDs.
-  // //   `graph` - graph containing the entities
-  // //
-  // // Returns
-  // //   Set containing entityIDs
-  // //
-  // function entityIDsToValidate(entityIDs, graph) {
-  //   let seen = new Set();
-  //   let collected = new Set();
-
-  //   entityIDs.forEach(entityID => {
-  //     // keep `seen` separate from `collected` because an `entityID`
-  //     // could have been added to `collected` as a related entity through an earlier pass
-  //     if (seen.has(entityID)) return;
-  //     seen.add(entityID);
-
-  //     const entity = graph.hasEntity(entityID);
-  //     if (!entity) return;
-
-  //     collected.add(entityID);   // collect self
-
-  //     let checkParentRels = [entity];
-
-  //     if (entity.type === 'node') {
-  //       graph.parentWays(entity).forEach(parentWay => {
-  //         collected.add(parentWay.id);    // collect parent ways
-  //         checkParentRels.push(parentWay);
-  //       });
-
-  //     } else if (entity.type === 'relation' && entity.isMultipolygon()) {
-  //       entity.members.forEach(member => collected.add(member.id));  // collect members
-
-  //     } else if (entity.type === 'way') {
-  //       entity.nodes.forEach(nodeID => {
-  //         collected.add(nodeID);    // collect child nodes
-  //         graph._parentWays[nodeID].forEach(wayID => collected.add(wayID));  // collect connected ways
-  //       });
-  //     }
-
-  //     checkParentRels.forEach(entity => {    // collect parent relations
-  //       if (entity.type !== 'relation') {    // but not super-relations
-  //         graph.parentRelations(entity).forEach(parentRelation => {
-  //           if (parentRelation.isMultipolygon()) {
-  //             collected.add(parentRelation.id);
-  //           }
-  //         });
-  //       }
-  //     });
-  //   });
-
-  //   return collected;
-  // }
 
 
   // `updateResolvedIssues()`   (private)

--- a/modules/validations/crossing_ways.js
+++ b/modules/validations/crossing_ways.js
@@ -8,7 +8,7 @@ import { geoAngle, geoExtent, geoLatToMeters, geoLonToMeters, geoLineIntersectio
 import { osmNode } from '../osm/node';
 import { osmFlowingWaterwayTagValues, osmPathHighwayTagValues, osmRailwayTrackTagValues, osmRoutableHighwayTagValues } from '../osm/tags';
 import { t } from '../core/localizer';
-import { utilDisplayLabel, utilHashcode } from '../util';
+import { utilDisplayLabel } from '../util';
 import { validationIssue, validationIssueFix } from '../core/validation';
 
 
@@ -395,10 +395,8 @@ export function validationCrossingWays(context) {
             crossingTypeID += '_connectable';
         }
 
-        // include crossing point, edges (sorted for determinism), and connection tags
-        var uniqueID = crossing.crossPoint.toString() +
-            edges.slice().sort(function(edge1, edge2) { return edge1[0] < edge2[0] ? -1 : 1; }).toString() +
-            JSON.stringify(connectionTags);
+        // Differentiate based on the loc rounded to 4 digits, since two ways can cross multiple times.
+        var uniqueID = '' + crossing.crossPoint[0].toFixed(4) + ',' + crossing.crossPoint[1].toFixed(4);
 
         return new validationIssue({
             type: type,
@@ -422,8 +420,7 @@ export function validationCrossingWays(context) {
                 featureTypes: featureTypes,
                 connectionTags: connectionTags
             },
-            // differentiate based on the loc since two ways can cross multiple times
-            hash: utilHashcode(uniqueID),
+            hash: uniqueID,
             loc: crossing.crossPoint,
             dynamicFixes: function(context) {
                 var mode = context.mode();


### PR DESCRIPTION
This includes a fix for #8632, and a bunch of other miscellaneous things.. main stuff listed below:

- 1f172d562 Make the crossing_ways hash less strict 
Previously it was including a lot of data about the edge, and a very specific
crossing location.  This meant that any tiny perturbation in the crossing ways
would generate a new issue hash, effectively "fixing" the old crossing issue and
creating a new one.

- 34c3ea472 / 93b868d95 Improvements to the code that credits a user with fixing an issue (re: #8632)

- bb0b5786d Use `context.graph()`/`context.hasEntity()` in code that collect the issues to display to the user, not `cache.graph`, because that is the graph that the calling code will be using.  (this was causing "Entity not found" errors)

- 2434e5eda In the head cache, only validate features that the user is responsible for (closes #8632)
For example, a user can undo some work and an issue will still present in the
head graph, but we don't want to credit the user for causing that issue.

- 3e8d33a66 Use `coreDifference.complete()` instead of `entityIDsToValidate()` 
From what I can tell, this code is nearly the same as what the "complete" difference already gives us - combined nodes from both previous and current, multipolygon members, parents of nodes/relations

- 96c5dd1c7 Store graph with validation cache, give them names, es6 some things

