### PR TITLE
Can't redraw while transformed

### DIFF
--- a/modules/renderer/map.js
+++ b/modules/renderer/map.js
@@ -251,6 +251,7 @@ export function rendererMap(context) {
 
         context.on('enter.map',  function() {
             if (!map.editableDataEnabled(true /* skip zoom check */)) return;
+            if (_isTransformed) return;
 
             // redraw immediately any objects affected by a change in selectedIDs.
             var graph = context.graph();


### PR DESCRIPTION
This fixes an issue that was causing the features on the screen to jump around while the view was easing to a new position (e.g. when clicking between issues)

I guess it got introduced here: https://github.com/openstreetmap/iD/commit/41e58dc32ed10e2585f25dd5e85b24900e7a182c#diff-a1008158a41859a7de040d1a3db175073f92aeab5433ea6d1f958319993555aa
