### PR TITLE
MapControl scroll

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -2950,6 +2950,11 @@ img.tag-reference-wiki-image {
     flex-direction: column;
     padding: 5px 0;
     pointer-events: none;
+    overflow-x: hidden;
+    overflow-y: auto;
+}
+.map-controls::-webkit-scrollbar {
+    display: none;
 }
 .map-controls:before {
     content: '';

--- a/modules/ui/init.js
+++ b/modules/ui/init.js
@@ -201,6 +201,12 @@ export function uiInit(context) {
             .attr('class', 'map-control geolocate-control')
             .call(uiGeolocate(context));
 
+        controls.on('wheel.mapControls', function(d3_event) {
+            if (!d3_event.deltaX) {
+                controls.node().scrollTop += d3_event.deltaY;
+            }
+        });
+
         // Add panes
         // This should happen after map is initialized, as some require surface()
         var panes = overMap


### PR DESCRIPTION
Minor change to enable mapControl scroll in order to avoid the loss of features for [high page zoom ](https://usability.yale.edu/web-accessibility/articles/zoom-resizing-text) or small display devices.

Top toolbar already supports this, and this could be treated as improvement to the issue it already closed: https://github.com/openstreetmap/iD/issues/6755

![MapControlScroll](https://user-images.githubusercontent.com/78906108/132863295-41e1b47a-0226-4fc3-aa7b-2ff1c052c885.gif)
