### PR TITLE
Turn off RTL text patch on Chromium >=96

### DIFF
--- a/modules/util/svg_paths_rtl_fix.js
+++ b/modules/util/svg_paths_rtl_fix.js
@@ -1,5 +1,6 @@
 // see https://github.com/openstreetmap/iD/pull/3707
 // https://gist.github.com/mapmeld/556b09ddec07a2044c76e1ef45f01c60
+// fixed in Chromium 96.0 https://bugs.chromium.org/p/chromium/issues/detail?id=374526
 
 import { WordShaper } from 'alif-toolkit';
 

--- a/modules/util/util.js
+++ b/modules/util/util.js
@@ -225,8 +225,9 @@ export function utilDisplayName(entity) {
 export function utilDisplayNameForPath(entity) {
     var name = utilDisplayName(entity);
     var isFirefox = utilDetect().browser.toLowerCase().indexOf('firefox') > -1;
+    var isNewChromium = Number(utilDetect().version.split('.')[0]) >= 96.0;
 
-    if (!isFirefox && name && rtlRegex.test(name)) {
+    if (!isFirefox && !isNewChromium && name && rtlRegex.test(name)) {
         name = fixRTLTextForSvg(name);
     }
 


### PR DESCRIPTION
Way back in #3923 and #6018 I had a fix for right-to-left line labels in Chromium-based browsers. Long story short, iD is one of the few places on the web which uses SVG textPath elements.  A text shaping bug is making complex text (such as Indic languages , #5342) or RTL text broken for a long time - [bug reported in 2014](https://bugs.chromium.org/p/chromium/issues/detail?id=374526).  We were able to use a JS library, sort of a hack really, to show corrected letters for Arabic and other RTL languages.

This week, the bug was fixed in Chrome Canary.  In this PR I suggest that we detect the browser version and skip the right-to-left label fix in Chromium >= 96.0

Should the code and alif-toolkit dependency just be removed? Chrome, Brave, etc. are currently on Chromium 94. Once the fix is more mainstream (mid-November), we could start a grace period of 6?-18? months and then remove it.