### PR TITLE
Introduce issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,6 @@ contact_links:
   - name: There is an issue with presets or osm tagging recommendations
     url: https://github.com/openstreetmap/id-tagging-schema/issues
     about: Please share your feedback in the id-tagging-schema repository.
-  - name: There is an issue with brand icons or brands tagging.
+  - name: There is an issue with brand icons or brand tagging recommendations.
     url: https://github.com/osmlab/name-suggestion-index/issues
     about: Please create a feature request in the name-suggestion-index repository.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: There is an issue with presets or osm tagging recommendations
+    url: https://github.com/openstreetmap/id-tagging-schema/issues
+    about: Please share your feedback in the id-tagging-schema repository.
+  - name: There is an issue with brand icons or brands tagging.
+    url: https://github.com/osmlab/name-suggestion-index/issues
+    about: Please create a feature request in the name-suggestion-index repository.

--- a/.github/ISSUE_TEMPLATE/id_editor_bug.yaml
+++ b/.github/ISSUE_TEMPLATE/id_editor_bug.yaml
@@ -1,0 +1,57 @@
+name: 'iD Editor: Bug'
+description: You found an issue with iD Editor on openstreetmap.org/edit.
+# title:
+# labels:
+# assignees:
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: input
+    id: url
+    attributes:
+      label: URL
+      description: Please share the URL where the issue can be seen.
+      placeholder: https://www.openstreetmap.org/edit#map=…
+    validations:
+      required: false
+  - type: textarea
+    id: steps-reproduce
+    attributes:
+      label: How to reproduce the issue?
+      description: Please share the steps to reproduce the issue.
+      placeholder: 1. …, 2. …, 3. …
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Screenshot(s) or anything else?
+      description: Please add screenshots or additional information to help us understand your issue.
+      placeholder:
+    validations:
+      required: false
+  - type: dropdown
+    id: environment-variant
+    attributes:
+      label: Which iD Editor versions do you see the issue on?
+      description: Please test your issue on the development version as well (if possible) so make sure it is not fixed already.
+      multiple: true
+      options:
+        - Released version at openstreetmap.org/edit
+        - Development version at ideditor.netlify.com
+        - RapiD version at mapwith.ai/rapid
+    validations:
+      required: false
+  - type: dropdown
+    id: browsers
+    attributes:
+      label: Which browsers are you seeing this problem on?
+      multiple: true
+      options:
+        - Firefox
+        - Chrome
+        - Safari
+        - Microsoft Edge
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/id_editor_feature.yaml
+++ b/.github/ISSUE_TEMPLATE/id_editor_feature.yaml
@@ -1,0 +1,21 @@
+name: 'iD Editor: Feature, Idea, Question'
+description: You want to request a feature, share an idea or have a question.
+# title:
+# labels:
+# assignees:
+body:
+  - type: textarea
+    id: idea
+    attributes:
+      label: Description
+      description: Please describe you feature request, idea or question.
+      placeholder:
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Screenshots
+      description: Please add screenshots if they can help us understand your request/idea/question.
+      placeholder:
+    validations:
+      required: false


### PR DESCRIPTION
This is a take to solve https://github.com/openstreetmap/iD/issues/8723.

Test: https://github.com/tordans/iD/issues/new/choose

It introduces …

- one template for bugs - example https://github.com/tordans/iD/issues/1
- one template for features/ideas – example https://github.com/tordans/iD/issues/2
- and most importantly one link to the id-tagging-schema repo, so there is a better chance that issues get created in the correct repository

There is still a link on the `/choose` page to create a blank issue.

## Docs

- About setting up the link to an external URL, which is used for the id-tagging-schema repo in this case https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
- Syntax for issue forms https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms
- Syntax for GitHub's form schema https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema
- Its important to understand, that this PR uses the `.yaml` version of issue templates, which allows to configure a form. Most resources online talk about the `.md` version, which allow to pre fill the form with markdown.