### PR TITLE
Remove `-alt-long` name match for S/T Chinese

### DIFF
--- a/scripts/language_names.js
+++ b/scripts/language_names.js
@@ -92,11 +92,6 @@ exports.languageNamesInLanguageOf = function(code) {
   });
 
   for (let langCode in translatedLangsByCode) {
-    let altLongIndex = langCode.indexOf('-alt-long');
-    if (altLongIndex !== -1) {    // prefer long names (e.g. Chinese -> Mandarin Chinese)
-      let base = langCode.substring(0, altLongIndex);
-      translatedLangsByCode[base] = translatedLangsByCode[langCode];
-    }
 
     if (langCode.includes('-alt-')) {
       // remove alternative names


### PR DESCRIPTION
According to #8739 , this part of code import unproper translation for S/T Chinese.

Remove those part of code, because only 2 kind of Chinese have `-alt-long` , other language only have `-alt-menu` so I think this will not affected other language in the future.

Close #8739 