### PR TITLE
Replace node 10 with node 16 in test matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Node 10 is no longer in LTS maintenance. v16 will move to maintenance LTS on Tuesday.

https://nodejs.org/en/about/releases/