### PR TITLE
Update API.md

### DIFF
--- a/API.md
+++ b/API.md
@@ -8,7 +8,7 @@ iD supports several URL parameters. When constructing a URL to a standalone inst
 of iD (e.g. `https://ideditor-release.netlify.app`), the following parameters are available
 **in the hash portion of the URL**:
 
-* __`background`__ - The value from a `sourcetag` property in iD's
+* __`background`__ - The value of the `id` property of the source in iD's
   [imagery list](https://github.com/openstreetmap/iD/blob/develop/data/imagery.json),
   or a custom tile URL. A custom URL is specified in the format `custom:<url>`,
   where the URL can contain the standard tile URL placeholders `{x}`, `{y}` and


### PR DESCRIPTION
The documentation for the [URL parameters](https://github.com/openstreetmap/iD/blob/develop/API.md#url-parameters) says:

> * __`background`__ - The value from a `sourcetag` property in iD's  [imagery list](https://github.com/openstreetmap/iD/blob/develop/data/imagery.json),  or a custom tile URL.

However, none of the sources in iD's  [imagery list](https://github.com/openstreetmap/iD/blob/develop/data/imagery.json?raw=true) has a `sourcetag` property.

In fact, iD is using the value of the `id` property.

For example, the URL [https://www.openstreetmap.org/edit?editor=id&background=Mapbox](https://www.openstreetmap.org/edit?editor=id&background=Mapbox) is working, based on the following entry in the imagery list:
```
  {
    "id": "Mapbox",
    "name": "Mapbox Satellite",
    "type": "tms",
    "template": "https://{switch:a,b,c,d}.tiles.mapbox.com/v4/mapbox.satellite/{zoom}/{x}/{y}@2x.jpg?access_token=pk.eyJ1Ijoib3BlbnN0cmVldG1hcCIsImEiOiJja2w5YWt5bnYwNjZmMnFwZjhtbHk1MnA1In0.eq2aumBK6JuRoIuBMm6Gew",
    "tileSize": 512,
    "zoomExtent": [0, 22],
    "terms_url": "https://www.mapbox.com/about/maps",
    "terms_text": "Terms & Feedback",
    "default": true,
    "description": "Satellite and aerial imagery.",
    "icon": "https://osmlab.github.io/editor-layer-index/sources/world/MapBoxSatellite.png"
  },
```