### PR TITLE
add preview for colour input

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -1505,6 +1505,15 @@ a.hide-toggle {
     fill: #333;
     opacity: .5;
 }
+.form-field-button.colour-preview {
+    background-color: #fff;
+    border-radius: 0 0 4px 0;
+}
+.form-field-button.colour-preview > div {
+    border: 3px solid #fff;
+    height: 100%;
+    border-radius: 8px;
+}
 
 
 /* round corners of first/last child elements */
@@ -1703,12 +1712,13 @@ a.hide-toggle {
 
 /* Field - Text / Numeric
 ------------------------------------------------------- */
-.form-field-input-text > input:only-of-type,
+.form-field-input-text > input:only-child,
 .form-field-input-tel > input:only-of-type,
 .form-field-input-email > input:only-of-type,
 .form-field-input-url > input:only-child {
     border-radius: 0 0 4px 4px;
 }
+.form-field-input-text > input:not(:only-child),
 .form-field-input-url > input:not(:only-child) {
     border-radius: 0 0 0 4px;
 }

--- a/modules/ui/fields/address.js
+++ b/modules/ui/fields/address.js
@@ -288,7 +288,7 @@ export function uiFieldAddress(field, context) {
             })
             .attr('title', function(subfield) {
                 var val = tags[field.key + ':' + subfield.id];
-                return val && Array.isArray(val) && val.filter(Boolean).join('\n');
+                return (val && Array.isArray(val)) ? val.filter(Boolean).join('\n') : undefined;
             })
             .classed('mixed', function(subfield) {
                 return Array.isArray(tags[field.key + ':' + subfield.id]);

--- a/modules/util/get_set_value.js
+++ b/modules/util/get_set_value.js
@@ -1,5 +1,6 @@
 // Like selection.property('value', ...), but avoids no-op value sets,
 // which can result in layout/repaint thrashing in some situations.
+/** @returns {string} */
 export function utilGetSetValue(selection, value) {
     function d3_selection_value(value) {
         function valueNull() {


### PR DESCRIPTION
This PR adds a preview box next to colour inputs. This should help prevent typos, and make it easier for people who aren't familiar with hex codes.

![roof colour](https://user-images.githubusercontent.com/16009897/139614750-ed5a8592-1067-4dcd-9a6a-bedcf8d06e74.png)

---

also closes #8289 and closes #8894 , see https://github.com/openstreetmap/iD/pull/8782#discussion_r739928290
