### PR TITLE
Change history panel link names

### DIFF
--- a/modules/ui/panels/history.js
+++ b/modules/ui/panels/history.js
@@ -49,7 +49,7 @@ export function uiPanelHistory(context) {
             .attr('href', 'https://hdyc.neis-one.org/?' + userName)
             .attr('target', '_blank')
             .attr('tabindex', -1)
-            .html('HDYC');
+            .html('Profile');
     }
 
 
@@ -200,7 +200,7 @@ export function uiPanelHistory(context) {
             .attr('href', 'https://pewu.github.io/osm-history/#/' + entity.type + '/' + entity.osmId())
             .attr('target', '_blank')
             .attr('tabindex', -1)
-            .html('PeWu');
+            .html('History');
 
         var list = selection
             .append('ul');


### PR DESCRIPTION
- "PeWu" has been changed to "History"
- "HDYC" has been changed to "Profile"

Addresses [this issue](https://github.com/openstreetmap/iD/issues/8784#issue-1041696152) 🙂 