### PR TITLE
fix clipped tooltips on controls bar

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -2958,11 +2958,10 @@ img.tag-reference-wiki-image {
     left: 0;
     right: 0;
     height: 100%;
+    z-index: 100;
     display: block;
     overflow-x: hidden;
     overflow-y: auto;
-    -ms-overflow-style: none;
-    scrollbar-width: none;
     pointer-events: none;
 }
 .map-controls-wrap::-webkit-scrollbar {
@@ -2973,7 +2972,6 @@ img.tag-reference-wiki-image {
     top: 0;
     width: 40px;
     position: absolute;
-    z-index: 100;
     bottom: 0;
     display: flex;
     flex-direction: column;

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -2963,6 +2963,8 @@ img.tag-reference-wiki-image {
     overflow-x: hidden;
     overflow-y: auto;
     pointer-events: none;
+    -ms-overflow-style: none;
+    scrollbar-width: none;
 }
 .map-controls-wrap::-webkit-scrollbar {
     display: none;

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -2953,6 +2953,21 @@ img.tag-reference-wiki-image {
 
 /* Map Controls
 ------------------------------------------------------- */
+.map-controls-wrap {
+    position: absolute;
+    left: 0;
+    right: 0;
+    height: 100%;
+    display: block;
+    overflow-x: hidden;
+    overflow-y: auto;
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+    pointer-events: none;
+}
+.map-controls-wrap::-webkit-scrollbar {
+    display: none;
+}
 .map-controls {
     right: 0;
     top: 0;
@@ -2964,11 +2979,6 @@ img.tag-reference-wiki-image {
     flex-direction: column;
     padding: 5px 0;
     pointer-events: none;
-    overflow-x: hidden;
-    overflow-y: auto;
-}
-.map-controls::-webkit-scrollbar {
-    display: none;
 }
 .map-controls:before {
     content: '';

--- a/modules/ui/init.js
+++ b/modules/ui/init.js
@@ -182,9 +182,11 @@ export function uiInit(context) {
             .call(uiSpinner(context));
 
         // Map controls
-        var controls = overMap
+        var controlsWrap = overMap
             .append('div')
-            .attr('class', 'map-controls-wrap')
+            .attr('class', 'map-controls-wrap');
+
+        var controls = controlsWrap
             .append('div')
             .attr('class', 'map-controls');
 
@@ -203,9 +205,9 @@ export function uiInit(context) {
             .attr('class', 'map-control geolocate-control')
             .call(uiGeolocate(context));
 
-        controls.on('wheel.mapControls', function(d3_event) {
+        controlsWrap.on('wheel.mapControls', function(d3_event) {
             if (!d3_event.deltaX) {
-                controls.node().scrollTop += d3_event.deltaY;
+                controlsWrap.node().scrollTop += d3_event.deltaY;
             }
         });
 

--- a/modules/ui/init.js
+++ b/modules/ui/init.js
@@ -184,6 +184,8 @@ export function uiInit(context) {
         // Map controls
         var controls = overMap
             .append('div')
+            .attr('class', 'map-controls-wrap')
+            .append('div')
             .attr('class', 'map-controls');
 
         controls


### PR DESCRIPTION
Fixes #8781. My solution was to add a full-width wrapper div (`map-controls-wrap`) which can scroll the content without clipping the area left of the buttons where tooltips would be displayed.