### PR TITLE
improve rendering of turn-restriction boxes in narrow sidebars

### DIFF
--- a/modules/ui/fields/restrictions.js
+++ b/modules/ui/fields/restrictions.js
@@ -223,22 +223,24 @@ export function uiFieldRestrictions(field, context) {
             extent._extend(_intersection.vertices[i].extent());
         }
 
+        var padTop = 35; // reserve top space for hint text
+
         // If this is a large intersection, adjust zoom to fit extent
         if (_intersection.vertices.length > 1) {
-            var padding = 180;   // in z22 pixels
+            var hPadding = Math.min(160, Math.max(110, d[0] * 0.4));
+            var vPadding = 160;
             var tl = projection([extent[0][0], extent[1][1]]);
             var br = projection([extent[1][0], extent[0][1]]);
-            var hFactor = (br[0] - tl[0]) / (d[0] - padding);
-            var vFactor = (br[1] - tl[1]) / (d[1] - padding);
+            var hFactor = (br[0] - tl[0]) / (d[0] - hPadding);
+            var vFactor = (br[1] - tl[1]) / (d[1] - vPadding - padTop);
             var hZoomDiff = Math.log(Math.abs(hFactor)) / Math.LN2;
             var vZoomDiff = Math.log(Math.abs(vFactor)) / Math.LN2;
             z = z - Math.max(hZoomDiff, vZoomDiff);
             projection.scale(geoZoomToScale(z));
         }
 
-        var padTop = 35;   // reserve top space for hint text
         var extentCenter = projection(extent.center());
-        extentCenter[1] = extentCenter[1] - padTop;
+        extentCenter[1] = extentCenter[1] - padTop / 2;
 
         projection
             .translate(geoVecSubtract(c, extentCenter))


### PR DESCRIPTION
With narrow sidebars, the turn-restriction min-map view glitches out (by being much more zoomed out than can be considered usable).

Before: <img src="https://user-images.githubusercontent.com/1927298/140521064-3f369ef1-f82f-402d-bc0c-4c7a2e1976a0.png" width="45%"/>

This tweaks it such that even for the slimmest sidebar the rendering is still acceptable (i.e. no turn arrows to be rendered completely outside of the viewport) and at the same time allows generous margins to be applied at wider sidebars.

After: <img src="https://user-images.githubusercontent.com/1927298/140521009-8d0820e3-d573-4059-9373-6704d49caf24.png" width="45%">


This also fixes a minor bug where the mini-map is not properly alligned vertically.

(the issue was originally reported by @jleedev)