### PR TITLE
introduce allowlist for disconnectable relation types

### DIFF
--- a/modules/actions/disconnect.js
+++ b/modules/actions/disconnect.js
@@ -18,6 +18,10 @@ import { osmNode } from '../osm/node';
 export function actionDisconnect(nodeId, newNodeId) {
     var wayIds;
 
+    var disconnectableRelationTypes = {
+        'site': true,
+        'assosciatedStreet': true
+    };
 
     var action = function(graph) {
         var node = graph.entity(nodeId);
@@ -88,7 +92,9 @@ export function actionDisconnect(nodeId, newNodeId) {
 
         parentWays.forEach(function(way) {
             var relations = graph.parentRelations(way);
-            relations.forEach(function(relation) {
+            relations
+            .filter(relation => !disconnectableRelationTypes[relation.tags.type])
+            .forEach(function(relation) {
                 if (relation.id in seenRelationIds) {
                     if (wayIds) {
                         if (wayIds.indexOf(way.id) !== -1 ||

--- a/modules/actions/disconnect.js
+++ b/modules/actions/disconnect.js
@@ -20,7 +20,7 @@ export function actionDisconnect(nodeId, newNodeId) {
 
     var disconnectableRelationTypes = {
         'site': true,
-        'assosciatedStreet': true
+        'associatedStreet': true
     };
 
     var action = function(graph) {

--- a/modules/actions/disconnect.js
+++ b/modules/actions/disconnect.js
@@ -19,8 +19,9 @@ export function actionDisconnect(nodeId, newNodeId) {
     var wayIds;
 
     var disconnectableRelationTypes = {
+        'associatedStreet': true,
+        'enforcement': true,
         'site': true,
-        'associatedStreet': true
     };
 
     var action = function(graph) {


### PR DESCRIPTION
This skips relation types which are only _grouping_ entities together and don't enforce connectivity or order which would be potentially broken by the disconnect operation.

Current list of disconnectable relation types:

* `site`
* `assosciatedStreet`

did I forget other relation types which have this property?

closes #8771