### PR TITLE
enable the openseamap overlay

### DIFF
--- a/scripts/update_imagery.js
+++ b/scripts/update_imagery.js
@@ -39,7 +39,6 @@ const discard = {
   'openinframap-telecoms': true,
   'openpt_map': true,
   'openrailwaymap': true,
-  'openseamap': true,
   'opensnowmap-overlay': true,
 
   'US-TIGER-Roads-2012': true,


### PR DESCRIPTION
iD currently has 4 sources of overlay imagery that cover the whole world, from editor-layer-index:

- Locator Overlay
- OpenRailwayMap Maxspeeds
- OpenRailwayMap Signalling
- OpenStreetMap GPS traces

There is currently an override to hide [OpenSeaMap](https://map.openseamap.org) from that list. 

This PR removes that override so that you can use OpenSeaMap. This is useful because pretty much all other imagery sources just show the ocean as blue, which isn't very helpful when you're mapping in the ocean. 