### PR TITLE
fix bug with numeric properties in custom map data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :bug: Bugfixes
 * Fix hidden tooltips on map control toolbar ([#8781])
 * Fix glitching out turn restriction minimap on narrow sidebars ([#8792])
+* Fix non-string properties of GeoJSON custom map data not being displayed correctly ([#8825], thanks [@k-yle])
 #### :earth_asia: Localization
 #### :hourglass: Performance
 #### :mortar_board: Walkthrough / Help
@@ -60,6 +61,8 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Radio-button based presets fields can be in an non-unique state (e.g. a tunnel which is also a ford) – this is now rendered like a multi selection with conflicting states ([#8796])
 * Add colours for preset categories ([#8799])
 #### :hammer: Development
+
+[@k-yle]: https://github.com/k-yle
 
 [#8771]: https://github.com/openstreetmap/iD/issues/8771
 [#8781]: https://github.com/openstreetmap/iD/issues/8781
@@ -69,6 +72,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#8800]: https://github.com/openstreetmap/iD/pull/8800
 [#8805]: https://github.com/openstreetmap/iD/issues/8805
 [#8807]: https://github.com/openstreetmap/iD/issues/8807
+[#8825]: https://github.com/openstreetmap/iD/pull/8825
 
 # 2.20.2
 ##### 2021-Oct-28

--- a/modules/svg/data.js
+++ b/modules/svg/data.js
@@ -315,6 +315,21 @@ export function svgData(projection, context, dispatch) {
     }
 
 
+    function stringifyGeojsonProperties(feature) {
+        const properties = feature.properties;
+        for (const key in properties) {
+            const property = properties[key];
+            if (typeof property === 'number' || typeof property === 'boolean' || Array.isArray(property)) {
+                properties[key] = property.toString();
+            } else if (property === null) {
+                properties[key] = 'null';
+            } else if (typeof property === 'object') {
+                properties[key] = JSON.stringify(property);
+            }
+        }
+    }
+
+
     drawData.setFile = function(extension, data) {
         _template = null;
         _fileList = null;
@@ -332,6 +347,11 @@ export function svgData(projection, context, dispatch) {
             case '.geojson':
             case '.json':
                 gj = JSON.parse(data);
+                if (gj.type === 'FeatureCollection') {
+                    gj.features.forEach(stringifyGeojsonProperties);
+                } else if (gj.type === 'Feature') {
+                    stringifyGeojsonProperties(gj);
+                }
                 break;
         }
 

--- a/modules/ui/sections/raw_tag_editor.js
+++ b/modules/ui/sections/raw_tag_editor.js
@@ -11,20 +11,6 @@ import { t } from '../../core/localizer';
 import { utilArrayDifference, utilArrayIdentical } from '../../util/array';
 import { utilGetSetValue, utilNoAuto, utilRebind, utilTagDiff } from '../../util';
 
-/**
- * This component is also used for custom map data,
- * and geojson can contain numbers as values.
- * We convert numbers to strings to avoid unexpected bugs.
- * @param {{ [key: string]: any }} tags
- */
-function stringifyNumbers(tags) {
-    for (const key in tags) {
-        if (typeof tags[key] === 'number') {
-            tags[key] = tags[key].toString();
-        }
-    }
-    return tags;
-}
 
 export function uiSectionRawTagEditor(id, context) {
 
@@ -609,7 +595,7 @@ export function uiSectionRawTagEditor(id, context) {
 
     section.tags = function(val) {
         if (!arguments.length) return _tags;
-        _tags = stringifyNumbers(val);
+        _tags = val;
         return section;
     };
 

--- a/modules/ui/sections/raw_tag_editor.js
+++ b/modules/ui/sections/raw_tag_editor.js
@@ -11,6 +11,21 @@ import { t } from '../../core/localizer';
 import { utilArrayDifference, utilArrayIdentical } from '../../util/array';
 import { utilGetSetValue, utilNoAuto, utilRebind, utilTagDiff } from '../../util';
 
+/**
+ * This component is also used for custom map data,
+ * and geojson can contain numbers as values.
+ * We convert numbers to strings to avoid unexpected bugs.
+ * @param {{ [key: string]: any }} tags
+ */
+function stringifyNumbers(tags) {
+    for (const key in tags) {
+        if (typeof tags[key] === 'number') {
+            tags[key] = tags[key].toString();
+        }
+    }
+    return tags;
+}
+
 export function uiSectionRawTagEditor(id, context) {
 
     var section = uiSection(id, context)
@@ -594,7 +609,7 @@ export function uiSectionRawTagEditor(id, context) {
 
     section.tags = function(val) {
         if (!arguments.length) return _tags;
-        _tags = val;
+        _tags = stringifyNumbers(val);
         return section;
     };
 

--- a/test/spec/svg/data.js
+++ b/test/spec/svg/data.js
@@ -22,7 +22,11 @@ describe('iD.svgData', function () {
         '        "area": 19717.8,' +
         '        "name": "New Jersey",' +
         '        "name_en": "New Jersey",' +
-        '        "osm_id": 316973311' +
+        '        "osm_id": 316973311,' +
+        '        "flag": true,' +
+        '        "list": [1,2,3],' +
+        '        "null": null,' +
+        '        "object": {}' +
         '      },' +
         '      "id": 316973311' +
         '    }' +
@@ -171,6 +175,11 @@ describe('iD.svgData', function () {
                 path = surface.selectAll('path.stroke');
                 expect(path.nodes().length).to.eql(1);
                 expect(path.attr('d')).to.match(/^M.*z$/);
+                expect(render.geojson().features[0].properties.osm_id).to.be.a('string');
+                expect(render.geojson().features[0].properties.flag).to.be.a('string');
+                expect(render.geojson().features[0].properties.list).to.be.a('string');
+                expect(render.geojson().features[0].properties.null).to.be.a('string');
+                expect(render.geojson().features[0].properties.object).to.be.a('string');
                 done();
             }, 200);
         });


### PR DESCRIPTION
If you upload a geojson file under "Custom Map Data" with properties that are numbers, the tag editor gets confused:

![image](https://user-images.githubusercontent.com/16009897/142984923-0e18f77f-59f7-45c6-ad5f-b98e1b8a06cd.png)

This PR fixes that bug. It can be tested with this file:
```geojson
{
  "type": "FeatureCollection",
  "features": [
    {
      "type": "Feature",
      "properties": { "a": 1 },
      "geometry": {
        "type": "LineString",
        "coordinates": [
          [174.70733642578122, -36.83456911447563],
          [174.90234375, -36.83237080155681]
        ]
      }
    },
    {
      "type": "Feature",
      "properties": { "a": 2 },
      "geometry": {
        "type": "LineString",
        "coordinates": [
          [174.89273071289062, -36.80928470205938],
          [174.94491577148438, -36.890604744644705]
        ]
      }
    }
  ]
}
```