### PR TITLE
API.md: Update broken link about presets schema

### DIFF
--- a/API.md
+++ b/API.md
@@ -262,7 +262,7 @@ iD's preset database is stored in the `iD.fileFetcher.cache().presets` object an
 or modified prior to creating the iD context.
 
 The format of the `presets` object is
-[documented here](https://github.com/openstreetmap/iD/tree/develop/data/presets#custom-presets).
+[documented as part of the schema-builder project](https://github.com/ideditor/schema-builder#presets).
 
 To add a new preset to iD's existing preset database.
 ```js


### PR DESCRIPTION
This updates a broken link to `https://github.com/openstreetmap/iD/tree/master/data/presets#custom-presets` to link to the schema-builder project. The link was introduced 5 years ago https://github.com/openstreetmap/iD/blame/a7cba6a694519c93c5e432e27ec8b1aca4363196/API.md#L251-L252. The old v3-prototype branch still has the content https://github.com/openstreetmap/iD/tree/v3-prototype/data/presets#custom-presets which is an older version of the schema builder docs.