### PR TITLE
Fix incorrect Google validation warnings when viewing esri Africa buildings

### DIFF
--- a/modules/validations/incompatible_source.js
+++ b/modules/validations/incompatible_source.js
@@ -17,7 +17,7 @@ export function validationIncompatibleSource() {
     {
       id: 'google',
       regex: /google/i,
-      exceptRegex: /((books|drive)\.google|google\s?(books|drive|plus))/i
+      exceptRegex: /((books|drive)\.google|google\s?(books|drive|plus))|(esri\/Google_Africa_Buildings)/i
     }
   ];
 

--- a/test/spec/validations/incompatible_source.js
+++ b/test/spec/validations/incompatible_source.js
@@ -63,4 +63,9 @@ describe('iD.validations.incompatible_source', function () {
         expect(issue.entityIds[0]).to.eql('w-1');
     });
 
+    it('does not flag buildings in the google-africa-buildings dataset', function() {
+        createWay({ building: 'yes', source: 'esri/Google_Africa_Buildings' });
+        var issues = validate();
+        expect(issues).to.have.lengthOf(0);
+    });
 });


### PR DESCRIPTION
If viewing areas that include buildings from the ESRI africa building dataset, folks might see a validation error declaring 'Google products are proprietary and must not be used as references'.  This validation does NOT apply to the Africa buildings dataset since it is licensed correctly and approved for use in OSM.

Related RapiD issue: https://github.com/facebookincubator/RapiD/issues/403:

Image with the validation:  
![image](https://user-images.githubusercontent.com/1887955/145448448-16382ef0-38f6-4f9c-a585-b70df3c975d7.png)

This fix adds a small exception to the regex and a quick test to ensure it's correct. 

