### PR TITLE
activate new access values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :rocket: Presets
 * Radio-button based presets fields can be in an non-unique state (e.g. a tunnel which is also a ford) – this is now rendered like a multi selection with conflicting states ([#8796])
 * Add colours for preset categories ([#8799])
+* Activate new access values (`customers` and `unknown`) introduced in `id-tagging-schema` v3.2 ([#8876])
 #### :hammer: Development
 * switch test runner to [karma](https://karma-runner.github.io/) ([#8764], thanks [@wvanderp])
 
@@ -98,6 +99,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#8835]: https://github.com/openstreetmap/iD/pull/8835
 [#8836]: https://github.com/openstreetmap/iD/issues/8836
 [#8839]: https://github.com/openstreetmap/iD/pull/8839
+[#8876]: https://github.com/openstreetmap/iD/pull/8876
 [@k-yle]: https://github.com/k-yle
 [@tpetillon]: https://github.com/tpetillon
 [@mbrzakovic]: https://github.com/mbrzakovic

--- a/modules/ui/fields/access.js
+++ b/modules/ui/fields/access.js
@@ -79,7 +79,7 @@ export function uiFieldAccess(field, context) {
 
 
     access.options = function(type) {
-        var options = ['no', 'permissive', 'private', 'permit', 'destination'];
+        var options = ['no', 'permissive', 'private', 'permit', 'destination', 'customers', 'unknown'];
 
         if (type !== 'access') {
             options.unshift('yes');


### PR DESCRIPTION
to be merged after next release of the id-tagging-schema is released which contains two new access values: `unknown` (https://github.com/openstreetmap/id-tagging-schema/pull/316) and `customers` (https://github.com/openstreetmap/id-tagging-schema/pull/326).

todo:
* ~~bump the required minimum version of the loaded id tagging schema from the CDN (e.g. `v3.2`)~~