### PR TITLE
seamark:type=separation_lane implies oneway

### DIFF
--- a/modules/osm/tags.js
+++ b/modules/osm/tags.js
@@ -106,6 +106,10 @@ export var osmOneWayTags = {
         'sled': true,
         'yes': true
     },
+    'seamark:type': {
+        'separation_lane': true,
+        'separation_roundabout': true
+    },
     'waterway': {
         'canal': true,
         'ditch': true,


### PR DESCRIPTION
`seamark:type=separation_lane` implies `oneway=yes` (and so does `seamark:type=separation_roundabout`), so this PR makes iD treat them as one-way tags. 

They are rendered as purple arrows in OpenSeaMap (see [wiki](https://wiki.osm.org/Seamarks/Seamark_Objects), [example](http://map.openseamap.org/?zoom=12&lat=55.29486&lon=12.70406), and [background info](https://en.wikipedia.org/wiki/Traffic_separation_scheme)).