### PR TITLE
[Issue8906] Fix broken html in the Area part of the Walkthrough

### DIFF
--- a/modules/core/context.js
+++ b/modules/core/context.js
@@ -8,7 +8,6 @@ import { t } from '../core/localizer';
 
 import { fileFetcher } from './file_fetcher';
 import { localizer } from './localizer';
-import { prefs } from './preferences';
 import { coreHistory } from './history';
 import { coreValidator } from './validator';
 import { coreUploader } from './uploader';
@@ -31,9 +30,6 @@ export function coreContext() {
 
   // iD will alter the hash so cache the parameters intended to setup the session
   context.initialHashParams = window.location.hash ? utilStringQs(window.location.hash) : {};
-
-  context.isFirstSession = !prefs('sawSplash') && !prefs('sawPrivacyVersion');
-
 
   /* Changeset */
   // An osmChangeset object. Not loaded until needed.

--- a/modules/ui/intro/area.js
+++ b/modules/ui/intro/area.js
@@ -328,8 +328,8 @@ export function uiIntroArea(context, reveal) {
             timeout(function() {
                 reveal('.more-fields .combobox-input',
                     helpHtml('intro.areas.add_field', {
-                        name: nameField.label(),
-                        description: descriptionField.label()
+                        name: { html: nameField.label() },
+                        description: { html: descriptionField.label() }
                     }),
                     { duration: 300 }
                 );
@@ -395,7 +395,7 @@ export function uiIntroArea(context, reveal) {
         }, 300);
 
         reveal('div.combobox',
-            helpHtml('intro.areas.choose_field', { field: descriptionField.label() }),
+            helpHtml('intro.areas.choose_field', { field: { html: descriptionField.label() } }),
             { duration: 300 }
         );
 
@@ -456,7 +456,7 @@ export function uiIntroArea(context, reveal) {
         context.container().select('.inspector-wrap .panewrap').style('right', '0%');
 
         reveal('.entity-editor-pane',
-            helpHtml('intro.areas.retry_add_field', { field: descriptionField.label() }), {
+            helpHtml('intro.areas.retry_add_field', { field: { html: descriptionField.label() } }), {
             buttonText: t.html('intro.ok'),
             buttonCallback: function() { continueTo(clickAddField); }
         });


### PR DESCRIPTION
This PR would fix [issue 8906](https://github.com/openstreetmap/iD/issues/8906).

I removed `isFirstSession` property from the core context.js because it was set but never used. The Walkthrough is anyway displayed based on [this](https://github.com/openstreetmap/iD/blob/97ed56bc3a93a6f06d0e373bc473e1a3d054eed1/modules/ui/init.js#L435) and [this](https://github.com/openstreetmap/iD/blob/97ed56bc3a93a6f06d0e373bc473e1a3d054eed1/modules/ui/splash.js#L25) conditions.

I tested the fix and it is working for me, even with localisation:
![fix](https://user-images.githubusercontent.com/12541454/150395370-eba17c81-6bfc-4d13-9338-9eab81ba13d0.JPG)
