### PR TITLE
[Issue8871] Do not open disabled localized combobox when clicking on it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Fix a bug where the validator might show wrong tagging suggestions for a preset if another preset has a partial match ([#8828], thanks [@bhousel])
 * Show correct vintage and other metadata for "Esri World Imagery"'s higher zoom levels
 * Fix wrong order of route relation members after a split operation ([#8519], thanks [@tpetillon])
-* Do not open disabled localized combobox when clicking on it ([#8871])
+* Do not open disabled localized combobox when clicking on it ([#8871], thanks [@hodigabi])
 #### :earth_asia: Localization
 * Deprecate ~`t.html`~ for providing localized texts, which is replaced by the new method `t.append` which directly and safely appends the localized strings to the DOM ([#8817])
 #### :hourglass: Performance
@@ -99,6 +99,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#8835]: https://github.com/openstreetmap/iD/pull/8835
 [#8836]: https://github.com/openstreetmap/iD/issues/8836
 [#8839]: https://github.com/openstreetmap/iD/pull/8839
+[#8871]: https://github.com/openstreetmap/iD/issues/8871
 [@k-yle]: https://github.com/k-yle
 [@tpetillon]: https://github.com/tpetillon
 [@mbrzakovic]: https://github.com/mbrzakovic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Fix a bug where the validator might show wrong tagging suggestions for a preset if another preset has a partial match ([#8828], thanks [@bhousel])
 * Show correct vintage and other metadata for "Esri World Imagery"'s higher zoom levels
 * Fix wrong order of route relation members after a split operation ([#8519], thanks [@tpetillon])
+* Do not open disabled localized combobox when clicking on it ([#8871])
 #### :earth_asia: Localization
 * Deprecate ~`t.html`~ for providing localized texts, which is replaced by the new method `t.append` which directly and safely appends the localized strings to the DOM ([#8817])
 #### :hourglass: Performance

--- a/modules/ui/combobox.js
+++ b/modules/ui/combobox.js
@@ -77,6 +77,7 @@ export function uiCombobox(context, klass) {
 
         function mousedown(d3_event) {
             if (d3_event.button !== 0) return;    // left click only
+            if (input.classed('disabled')) return;
             _tDown = +new Date();
 
             // clear selection
@@ -95,6 +96,7 @@ export function uiCombobox(context, klass) {
         function mouseup(d3_event) {
             input.on('mouseup.combo-input', null);
             if (d3_event.button !== 0) return;    // left click only
+            if (input.classed('disabled')) return;
             if (input.node() !== document.activeElement) return;   // exit if this input is not focused
 
             var start = input.property('selectionStart');

--- a/modules/ui/fields/localized.js
+++ b/modules/ui/fields/localized.js
@@ -213,7 +213,7 @@ export function uiFieldLocalized(field, context) {
         localizedInputs.selectAll('button, input')
             .classed('disabled', !!isLocked)
             .attr('readonly', isLocked || null);
-
+        selection.selectAll('.combobox-caret').classed('nope', true);
 
 
         function addNew(d3_event) {


### PR DESCRIPTION
This PR is a potential fix to #8871. If there is a better way to fix the problem, I'm open for suggestions.

Changing the localized.js was necessary only to fix the cursor of the small unfold 'icon' on the right side of the dropdown.