### PR TITLE
render paths under construction thinner than roads

### DIFF
--- a/css/50_misc.css
+++ b/css/50_misc.css
@@ -425,6 +425,32 @@ path.line.stroke.tag-highway.tag-status.tag-status-construction,
     stroke-dasharray: 8, 8;
 }
 
+/** Closed Paths */
+path.line.shadow.tag-highway.tag-status.tag-status-construction.tag-construction-path,
+path.line.shadow.tag-highway.tag-status.tag-status-construction.tag-construction-footway,
+path.line.shadow.tag-highway.tag-status.tag-status-construction.tag-construction-cycleway,
+path.line.shadow.tag-highway.tag-status.tag-status-construction.tag-construction-bridleway,
+path.line.shadow.tag-highway.tag-status.tag-status-construction.tag-construction-steps {
+    stroke-width: 10;
+}
+path.line.casing.tag-highway.tag-status.tag-status-construction.tag-construction-path,
+path.line.casing.tag-highway.tag-status.tag-status-construction.tag-construction-footway,
+path.line.casing.tag-highway.tag-status.tag-status-construction.tag-construction-cycleway,
+path.line.casing.tag-highway.tag-status.tag-status-construction.tag-construction-bridleway,
+path.line.casing.tag-highway.tag-status.tag-status-construction.tag-construction-steps {
+    stroke-width: 5;
+    stroke-linecap: butt;
+    stroke-dasharray: none
+}
+path.line.stroke.tag-highway.tag-status.tag-status-construction.tag-construction-path,
+path.line.stroke.tag-highway.tag-status.tag-status-construction.tag-construction-footway,
+path.line.stroke.tag-highway.tag-status.tag-status-construction.tag-construction-cycleway,
+path.line.stroke.tag-highway.tag-status.tag-status-construction.tag-construction-bridleway,
+path.line.stroke.tag-highway.tag-status.tag-status-construction.tag-construction-steps {
+    stroke-width: 4;
+    stroke-linecap: butt;
+    stroke-dasharray: 10, 10;
+}
 
 /* Buildings */
 path.stroke.tag-building {

--- a/modules/svg/tag_classes.js
+++ b/modules/svg/tag_classes.js
@@ -27,7 +27,7 @@ export function svgTagClasses() {
         'oneway', 'bridge', 'tunnel', 'embankment', 'cutting', 'barrier',
         'surface', 'tracktype', 'footway', 'crossing', 'service', 'sport',
         'public_transport', 'location', 'parking', 'golf', 'type', 'leisure',
-        'man_made', 'indoor'
+        'man_made', 'indoor', 'construction'
     ];
     var _tags = function(entity) { return entity.tags; };
 


### PR DESCRIPTION
Closes #8743

This PR renders  `highway=construction` + `construction=path/footway/cycleway/bridleway/steps` thinner than `highway=construction` + `construction=(any other value)`

Example:

<table>
<tr>
	<td><strong>Before
	<td><strong>After
<tr>
	<td><img src="https://user-images.githubusercontent.com/16009897/136644791-fa9dc801-eb5f-40b3-be62-8d8fa7d5f82c.png"/>
	<td><img src="https://user-images.githubusercontent.com/16009897/136644679-e209bcb1-84f7-48b2-8718-462dc13c4822.png"/>
</table>

<details>
<summary>Same Example in OSM Carto</summary>

![image](https://user-images.githubusercontent.com/16009897/136687027-683d5ef7-7da1-418f-a96d-ceba569f6b92.png)


</details>