### PR TITLE
prefer the last used imagery over the 'best' imagery

### DIFF
--- a/modules/renderer/background.js
+++ b/modules/renderer/background.js
@@ -483,8 +483,8 @@ export function rendererBackground(context) {
         } else {
           background.baseLayerSource(
             background.findSource(requested) ||
-            best ||
             background.findSource(prefs('background-last-used')) ||
+            best ||
             background.findSource('Bing') ||
             first ||
             background.findSource('none')


### PR DESCRIPTION
Closes #8665, Closes #11626, Closes #11981

Note that this is only a bug in the `iframe`'d version of iD on [openstreetmap.org](https://openstreetmap.org), so it's a bit tricky to test this PR. The bug is also only present in regions that have a 'best' imagery source.


To test:
 - go to http://localhost:8080/#map=19.50/-36.81455/174.80295
 - the 'best' imagery will be selected, so select a different aerial imagery source
 - close the tab, open http://localhost:8080/#map=19.50/-36.81455/174.80295 in a new tab
 - note how the last-used imagery is selected

Current behaviour:
 - go to https://ideditor.netlify.app/#map=19.50/-36.81455/174.80295
 - the 'best' imagery will be selected, so select a different aerial imagery source
 - close the tab, open https://ideditor.netlify.app/#map=19.50/-36.81455/174.80295 in a new tab
 - note how the best imagery is selected (this is unexpected)