### PR TITLE
only show accepted file types in custom data file chooser

### DIFF
--- a/modules/ui/settings/custom_data.js
+++ b/modules/ui/settings/custom_data.js
@@ -44,6 +44,7 @@ export function uiSettingsCustomData(context) {
             .append('input')
             .attr('class', 'field-file')
             .attr('type', 'file')
+            .attr('accept', '.gpx,.kml,.geojson,.json,application/gpx+xml,application/vnd.google-earth.kml+xml,application/geo+json,application/json')
             .property('files', _currSettings.fileList)  // works for all except IE11
             .on('change', function(d3_event) {
                 var files = d3_event.target.files;


### PR DESCRIPTION
Tested and confirmed this works. Closes  #8676.