### PR TITLE
remove other token formats from imagery_used

### DIFF
--- a/modules/renderer/background_source.js
+++ b/modules/renderer/background_source.js
@@ -577,8 +577,9 @@ rendererBackgroundSource.Custom = function(template) {
         }
 
         // from wms/wmts api path parameters
-        cleaned = cleaned.replace(/token\/(\w+)/, 'token/{apikey}');
-
+        cleaned = cleaned
+            .replace(/token\/(\w+)/, 'token/{apikey}')
+            .replace(/key=(\w+)/, 'key={apikey}');
         return 'Custom (' + cleaned + ' )';
     };
 

--- a/test/spec/renderer/background_source.js
+++ b/test/spec/renderer/background_source.js
@@ -96,6 +96,10 @@ describe('iD.rendererBackgroundSource.Custom', function() {
             var source = iD.rendererBackgroundSource.Custom('http://example.com/wms/v1/token/MYTOKEN/1.0.0/layer');
             expect(source.imageryUsed()).to.eql('Custom (http://example.com/wms/v1/token/{apikey}/1.0.0/layer )');
         });
+        it('sanitizes `key` in the URL path', function() {
+            var source = iD.rendererBackgroundSource.Custom('http://example.com/services;key=MYTOKEN/layer');
+            expect(source.imageryUsed()).to.eql('Custom (http://example.com/services;key={apikey}/layer )');
+        });
     });
 
 });


### PR DESCRIPTION
47aaec0d removed most API tokens from the `imagery_used` changeset tag. This PR adds another format