### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/modules/renderer/photos.js
+++ b/modules/renderer/photos.js
@@ -54,7 +54,7 @@ export function rendererPhotos(context) {
         // validate the date
         var date = val && new Date(val);
         if (date && !isNaN(date)) {
-            val = date.toISOString().substr(0, 10);
+            val = date.toISOString().slice(0, 10);
         } else {
             val = null;
         }

--- a/modules/ui/fields/combo.js
+++ b/modules/ui/fields/combo.js
@@ -417,7 +417,7 @@ export function uiFieldCombo(field, context) {
                     var v = tags[k];
                     if (!v || (typeof v === 'string' && v.toLowerCase() === 'no')) continue;
 
-                    var suffix = field.key ? k.substr(field.key.length) : k;
+                    var suffix = field.key ? k.slice(field.key.length) : k;
                     _multiData.push({
                         key: k,
                         value: displayValue(suffix),

--- a/modules/ui/success.js
+++ b/modules/ui/success.js
@@ -71,7 +71,7 @@ export function uiSuccess(context) {
     }
 
     const parsed = new Date(raw);
-    return new Date(parsed.toUTCString().substr(0, 25));  // convert to local timezone
+    return new Date(parsed.toUTCString().slice(0, 25));  // convert to local timezone
   }
 
 

--- a/modules/util/util.js
+++ b/modules/util/util.js
@@ -403,7 +403,7 @@ export function utilPrefixDOMProperty(property) {
 
     if (property in s) return property;
 
-    property = property.substr(0, 1).toUpperCase() + property.substr(1);
+    property = property.slice(0, 1).toUpperCase() + property.slice(1);
 
     while (++i < n) {
         if (prefixes[i] + property in s) {


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.