### PR TITLE
fix Note icon alignment in sidebar, fixes #9018

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -501,6 +501,7 @@ button.disabled .icon.operation use,
 
 .icon-annotation {
     color: #333;
+    vertical-align: baseline;
 }
 
 


### PR DESCRIPTION
## Description
Fix #9018

Interface fix to make the Note icon aligned in the sidebar.

## Before
![image](https://user-images.githubusercontent.com/2306550/157135417-312331ae-b149-4bba-8f03-b65801b97569.png)
![image](https://user-images.githubusercontent.com/2306550/157135411-cc222f32-646c-4855-ab0f-16a746551c10.png)

## After
![image](https://user-images.githubusercontent.com/2306550/157135474-6a5a567e-2d28-4b6d-ab69-295be3deedab.png)
![image](https://user-images.githubusercontent.com/2306550/157135423-79d4f662-1072-4681-a321-f7f84bf967e6.png)
