### PR TITLE
ideditor.netlify.com redirects to TLD .app

### DIFF
--- a/.github/ISSUE_TEMPLATE/id_editor_bug.yaml
+++ b/.github/ISSUE_TEMPLATE/id_editor_bug.yaml
@@ -39,7 +39,7 @@ body:
       multiple: true
       options:
         - Released version at openstreetmap.org/edit
-        - Development version at ideditor.netlify.com
+        - Development version at ideditor.netlify.app
         - RapiD version at mapwith.ai/rapid
     validations:
       required: false


### PR DESCRIPTION
When you try to open ideditor.netlify.com, it will redirect you to ideditor.netlify.app . This changes the link in the yaml file.