### PR TITLE
always use the `ref` as the label

### DIFF
--- a/modules/svg/labels.js
+++ b/modules/svg/labels.js
@@ -57,6 +57,9 @@ export function svgLabels(projection, context) {
         ['point', 'shop', '*', 10],
         ['point', 'tourism', '*', 10],
         ['point', 'camp_site', '*', 10],
+        ['line', 'ref', '*', 12],
+        ['area', 'ref', '*', 12],
+        ['point', 'ref', '*', 10],
         ['line', 'name', '*', 12],
         ['area', 'name', '*', 12],
         ['point', 'name', '*', 10]


### PR DESCRIPTION
Closes #9054

If a feature has a `name` tag, iD will always use the `name` as the label. If there is no `name` tag, iD will use the `ref` as the label, but only [in a specific list of situations](https://github.com/openstreetmap/iD/blob/bd1836f/modules/svg/labels.js#L30-L63). 

This list was introduced 9 years ago in 26dfaf81 & 14272ef2, and creates a weird inconsistency - all the features in this screenshot have `ref=12`, but the label is only shown on some features.

![image](https://user-images.githubusercontent.com/16009897/160739315-2da1048e-808a-4f20-a7f0-fce9c5b1ca92.png)

This PR allows the `ref` to always be used as a label on any feature. It seems like that was the original intention anyway - https://github.com/openstreetmap/iD/issues/546#issuecomment-12950797
