### PR TITLE
Add max length to the changeset comment

### DIFF
--- a/modules/ui/changeset_editor.js
+++ b/modules/ui/changeset_editor.js
@@ -56,6 +56,10 @@ export function uiChangesetEditor(context) {
 
         if (initial) {
             var commentField = selection.select('.form-field-comment textarea');
+
+            // Give the comment field a max length of 255 characters since anything over that length would be truncated
+            commentField.attr('maxlength', 255);
+
             var commentNode = commentField.node();
 
             if (commentNode) {


### PR DESCRIPTION
The changeset comment will be silently truncated otherwise, causing confusion for folks writing a detailed changeset comment and finding that some of the info they added is cut off.

For an example of this issue effecting a changeset that I made, see: https://www.openstreetmap.org/changeset/119343887