### PR TITLE
Fix bug: Wikidata field displays [object Object]

### DIFF
--- a/modules/ui/combobox.js
+++ b/modules/ui/combobox.js
@@ -386,7 +386,17 @@ export function uiCombobox(context, klass) {
                     return 'combobox-option ' + (d.klass || '');
                 })
                 .attr('title', function(d) { return d.title; })
-                .html(function(d) { return d.display || d.value; })
+                .html(function(d) {
+                    // d.display can be an object
+                    if ( typeof d.display === 'object' &&
+                         !Array.isArray(d.display) &&
+                         d.display !== null
+                    ) {
+                        return d.display.label.value;
+                    }
+
+                    return d.display || d.value;
+                })
                 .on('mouseenter', _mouseEnterHandler)
                 .on('mouseleave', _mouseLeaveHandler)
                 .merge(options)


### PR DESCRIPTION
the `wbsearchentities` response adds a `display` section that contains the label and description of the returned entity (if available) with their language code.

It means `display` in this case is an object and not a string.