### PR TITLE
Ignore invalid units in field input

### DIFF
--- a/modules/ui/fields/roadheight.js
+++ b/modules/ui/fields/roadheight.js
@@ -101,7 +101,12 @@ export function uiFieldRoadheight(field, context) {
 
 
         function changeUnits() {
-            _isImperial = utilGetSetValue(primaryUnitInput) === 'ft';
+            var primaryUnit = utilGetSetValue(primaryUnitInput);
+            if (primaryUnit === 'm') {
+                _isImperial = false;
+            } else if (primaryUnit === 'ft') {
+                _isImperial = true;
+            }
             utilGetSetValue(primaryUnitInput, _isImperial ? 'ft' : 'm');
             setUnitSuggestions();
             change();

--- a/modules/ui/fields/roadspeed.js
+++ b/modules/ui/fields/roadspeed.js
@@ -70,7 +70,12 @@ export function uiFieldRoadspeed(field, context) {
 
 
         function changeUnits() {
-            _isImperial = utilGetSetValue(unitInput) === 'mph';
+            var unit = utilGetSetValue(unitInput);
+            if (unit === 'km/h') {
+                _isImperial = false;
+            } else if (unit === 'mph') {
+                _isImperial = true;
+            }
             utilGetSetValue(unitInput, _isImperial ? 'mph' : 'km/h');
             setUnitSuggestions();
             change();


### PR DESCRIPTION
If the user enters something into the unit box of the Speed Limit or Max Height field that isn’t one of the two recognized units, revert the unit to what it was before without changing the measurement system.

Fixes #9110.