### PR TITLE
Add multilingual field exceptions

### DIFF
--- a/modules/ui/fields/localized.js
+++ b/modules/ui/fields/localized.js
@@ -116,6 +116,9 @@ export function uiFieldLocalized(field, context) {
 
     // update _multilingual, maintaining the existing order
     function calcMultilingual(tags) {
+        // tags that use the format name:<item>, but
+        // aren't languages
+        const nonLanguageTags = ["left", "right", "source", "signed"]
         var existingLangsOrdered = _multilingual.map(function(item) {
             return item.lang;
         });
@@ -124,6 +127,10 @@ export function uiFieldLocalized(field, context) {
         for (var k in tags) {
             var m = k.match(/^(.*):(.*)$/);
             if (m && m[1] === field.key && m[2]) {
+                if (nonLanguageTags.includes(m[2])) {
+                    continue;
+                }
+
                 var item = { lang: m[2], value: tags[k] };
                 if (existingLangs.has(item.lang)) {
                     // update the value

--- a/modules/ui/fields/localized.js
+++ b/modules/ui/fields/localized.js
@@ -125,7 +125,7 @@ export function uiFieldLocalized(field, context) {
             // matches for field:<code>, where <code> is a BCP 47 locale code
             // motivation is to avoid matching on similarly formatted tags that are
             // not for languages, e.g. name:left, name:source, etc.
-            var m = k.match(/^(.*):([A-Za-z]{2,3}(?:-[A-Za-z]{3}[A-Za-z]{2})?)$/);
+            var m = k.match(/^(.*):([A-Za-z]{2,3}(?:-[A-Za-z]{4})?)$/);
             if (m && m[1] === field.key && m[2]) {
                 var item = { lang: m[2], value: tags[k] };
                 if (existingLangs.has(item.lang)) {

--- a/modules/ui/fields/localized.js
+++ b/modules/ui/fields/localized.js
@@ -125,7 +125,7 @@ export function uiFieldLocalized(field, context) {
             // matches for field:<code>, where <code> is a BCP 47 locale code
             // motivation is to avoid matching on similarly formatted tags that are
             // not for languages, e.g. name:left, name:source, etc.
-            var m = k.match(/^(.*):([A-Za-z]{2,3}(?:-[A-Za-z]{4})?)$/);
+            var m = k.match(/^(.*):([a-z]{2,3}(?:-[A-Z][a-z]{3})?(?:-[A-Z]{2})?)$/);
             if (m && m[1] === field.key && m[2]) {
                 var item = { lang: m[2], value: tags[k] };
                 if (existingLangs.has(item.lang)) {

--- a/modules/ui/fields/localized.js
+++ b/modules/ui/fields/localized.js
@@ -116,21 +116,17 @@ export function uiFieldLocalized(field, context) {
 
     // update _multilingual, maintaining the existing order
     function calcMultilingual(tags) {
-        // tags that use the format name:<item>, but
-        // aren't languages
-        const nonLanguageTags = ["left", "right", "source", "signed", "etymology"]
         var existingLangsOrdered = _multilingual.map(function(item) {
             return item.lang;
         });
         var existingLangs = new Set(existingLangsOrdered.filter(Boolean));
 
         for (var k in tags) {
-            var m = k.match(/^(.*):(.*)$/);
+            // matches for field:<code>, where <code> is a BCP 47 locale code
+            // motivation is to avoid matching on similarly formatted tags that are
+            // not for languages, e.g. name:left, name:source, etc.
+            var m = k.match(/^(.*):([A-Za-z]{2,3}(?:-[A-Za-z]{3}[A-Za-z]{2})?)$/);
             if (m && m[1] === field.key && m[2]) {
-                if (nonLanguageTags.includes(m[2])) {
-                    continue;
-                }
-
                 var item = { lang: m[2], value: tags[k] };
                 if (existingLangs.has(item.lang)) {
                     // update the value

--- a/modules/ui/fields/localized.js
+++ b/modules/ui/fields/localized.js
@@ -118,7 +118,7 @@ export function uiFieldLocalized(field, context) {
     function calcMultilingual(tags) {
         // tags that use the format name:<item>, but
         // aren't languages
-        const nonLanguageTags = ["left", "right", "source", "signed"]
+        const nonLanguageTags = ["left", "right", "source", "signed", "etymology"]
         var existingLangsOrdered = _multilingual.map(function(item) {
             return item.lang;
         });


### PR DESCRIPTION
# Summary

Closes https://github.com/openstreetmap/iD/issues/9043

Adds exceptions for `name:left`, `name:right`, `name:etymology`, `name:signed`, and `name:source` when opening the multilingual tag.

# Testing
Can be tested by adding these tags to a feature, and verifying that no multilingual field appears.

![image](https://user-images.githubusercontent.com/4565200/169657943-0a6cd56c-0ff8-432d-a7ee-b07b0ce5688e.png)

![image](https://user-images.githubusercontent.com/4565200/169657963-289e7482-a87f-46a8-8fbf-016b401b6ee3.png)
