### PR TITLE
treat chipseal as a paved surface

### DIFF
--- a/modules/osm/tags.js
+++ b/modules/osm/tags.js
@@ -136,6 +136,7 @@ export var osmPavedTags = {
         'paved': true,
         'asphalt': true,
         'concrete': true,
+        'chipseal': true,
         'concrete:lanes': true,
         'concrete:plates': true
     },


### PR DESCRIPTION
`surface=chipseal` is currently rendered the same as a dirt road which is confusing.

This shouldn't be a controversial change, [chipseal ](https://en.wikipedia.org/wiki/Chipseal) is pretty obviously on the paved end of the spectrum. The wiki lists it as paved, and I can't find any prior discussions where chipseal's solidness was disputed. 