### PR TITLE
disable taginfo suggestions for the `via` tag

### DIFF
--- a/modules/services/taginfo.js
+++ b/modules/services/taginfo.js
@@ -205,6 +205,7 @@ export default {
             artist_name: true,
             nat_name: true,
             long_name: true,
+            via: true,
             'bridge:name': true
         };
 


### PR DESCRIPTION
suggestions from taginfo are never useful for tags like `name` and `via`, since it just suggests the most common values in the database. 

<img width=300 src="https://user-images.githubusercontent.com/16009897/171326314-cc919362-0bd2-4d4a-9972-2e856517bd17.png" />