### PR TITLE
support incrementing cardinal directions with the up/down buttons

### DIFF
--- a/modules/osm/node.js
+++ b/modules/osm/node.js
@@ -2,6 +2,24 @@ import { osmEntity } from './entity';
 import { geoAngle, geoExtent } from '../geo';
 import { utilArrayUniq } from '../util';
 
+export const cardinal = {
+    north: 0,               n: 0,
+    northnortheast: 22,     nne: 22,
+    northeast: 45,          ne: 45,
+    eastnortheast: 67,      ene: 67,
+    east: 90,               e: 90,
+    eastsoutheast: 112,     ese: 112,
+    southeast: 135,         se: 135,
+    southsoutheast: 157,    sse: 157,
+    south: 180,             s: 180,
+    southsouthwest: 202,    ssw: 202,
+    southwest: 225,         sw: 225,
+    westsouthwest: 247,     wsw: 247,
+    west: 270,              w: 270,
+    westnorthwest: 292,     wnw: 292,
+    northwest: 315,         nw: 315,
+    northnorthwest: 337,    nnw: 337
+};
 
 export function osmNode() {
     if (!(this instanceof osmNode)) {
@@ -70,25 +88,6 @@ Object.assign(osmNode.prototype, {
         }
 
         if (val === '') return [];
-
-        var cardinal = {
-            north: 0,               n: 0,
-            northnortheast: 22,     nne: 22,
-            northeast: 45,          ne: 45,
-            eastnortheast: 67,      ene: 67,
-            east: 90,               e: 90,
-            eastsoutheast: 112,     ese: 112,
-            southeast: 135,         se: 135,
-            southsoutheast: 157,    sse: 157,
-            south: 180,             s: 180,
-            southsouthwest: 202,    ssw: 202,
-            southwest: 225,         sw: 225,
-            westsouthwest: 247,     wsw: 247,
-            west: 270,              w: 270,
-            westnorthwest: 292,     wnw: 292,
-            northwest: 315,         nw: 315,
-            northnorthwest: 337,    nnw: 337
-        };
 
 
         var values = val.split(';');

--- a/modules/ui/fields/input.js
+++ b/modules/ui/fields/input.js
@@ -8,6 +8,7 @@ import { fileFetcher } from '../../core/file_fetcher';
 import { t, localizer } from '../../core/localizer';
 import { utilGetSetValue, utilNoAuto, utilRebind, utilTotalExtent } from '../../util';
 import { svgIcon } from '../../svg/icon';
+import { cardinal } from '../../osm/node';
 
 export {
     uiFieldText as uiFieldUrl,
@@ -121,7 +122,12 @@ export function uiFieldText(field, context) {
                     var vals = raw_vals.split(';');
                     vals = vals.map(function(v) {
                         var num = parseFloat(v.trim(), 10);
-                        return isFinite(num) ? clamped(num + d) : v.trim();
+                        if (isFinite(num)) return clamped(num + d);
+
+                        const compassDir = cardinal[v.trim().toLowerCase()];
+                        if (compassDir !== undefined) return clamped(compassDir + d);
+
+                        return v.trim(); // do nothing if the value is neither a number, nor a cardinal direction
                     });
                     input.node().value = vals.join(';');
                     change()();


### PR DESCRIPTION
If the `direction` field has a compass value like `N` or `SSW` or `SW;NE;270` or `sOuThWesT`, then the 🔼/🔽 buttons currently don't work. 

The buttons now work, by converting the cardinal direction into degrees. 


![a](https://user-images.githubusercontent.com/16009897/171326660-7b4899d0-95bc-4a4e-a35b-7a9065e53ec9.png)
