### PR TITLE
fix railway=platform_edge rendering as a train track

### DIFF
--- a/css/30_highways.css
+++ b/css/30_highways.css
@@ -466,6 +466,7 @@ path.line.stroke.tag-footway-access_aisle,
 path.line.stroke.tag-public_transport-platform,
 path.line.stroke.tag-highway-platform,
 path.line.stroke.tag-railway-platform,
+path.line.stroke.tag-railway-platform_edge,
 path.line.stroke.tag-man_made-pier {
     stroke: #dca;
 }

--- a/css/40_railways.css
+++ b/css/40_railways.css
@@ -20,7 +20,7 @@ path.line.casing.tag-railway {
 path.line.stroke.tag-railway {
     stroke-width: 2;
     stroke-linecap: butt;
-    stroke-dasharray: 12,12;
+    stroke-dasharray: 12, 12;
 }
 .low-zoom path.line.shadow.tag-railway {
     stroke-width: 12;
@@ -30,16 +30,18 @@ path.line.stroke.tag-railway {
 }
 .low-zoom path.line.stroke.tag-railway {
     stroke-width: 2;
-    stroke-dasharray: 6,6;
+    stroke-dasharray: 6, 6;
 }
 .preset-icon-container path.line.stroke.tag-railway:not(.tag-status),
 .preset-icon-container path.line.stroke.tag-railway.tag-status-disused {
     stroke-dasharray: 6;
 }
 
+path.line.casing.tag-railway.tag-railway-platform_edge,
 path.line.casing.tag-railway.tag-railway-platform {
     stroke-width: 0;
 }
+path.line.stroke.tag-railway.tag-railway-platform_edge,
 path.line.stroke.tag-railway.tag-railway-platform {
     stroke-dasharray: none;
 }
@@ -51,7 +53,6 @@ path.line.casing.tag-railway {
 path.line.stroke.tag-railway {
     stroke: #eee;
 }
-
 
 .preset-icon .icon.tag-railway.tag-status {
     color: #999;
@@ -68,7 +69,6 @@ path.line.stroke.tag-railway.tag-status:not(.tag-service) {
 path.line.casing.tag-railway.tag-status-disused {
     stroke: #808080;
 }
-
 
 path.line.casing.tag-railway-subway {
     stroke: #222;


### PR DESCRIPTION
[`railway=platform_edge`](http://wiki.osm.org/Tag:railway=platform_edge) is an unusual tag, but it makes the map look really confusing when it's used, since iD renders it like a train track.

<table>
<tr>
	<td>Before
	<td>After
<tr>
	<td><img src="https://user-images.githubusercontent.com/16009897/171327220-f8f25486-5adb-4f7d-a9a1-958597050730.png" />
	<td><img src="https://user-images.githubusercontent.com/16009897/171327225-3e89853b-8dad-4237-859c-91764b62a6d4.png" />
</table>

