### PR TITLE
Remember map location hash

### DIFF
--- a/modules/behavior/hash.js
+++ b/modules/behavior/hash.js
@@ -111,9 +111,9 @@ export function behaviorHash(context) {
             updateTitle(true /* includeChangeCount */);
 
             //save last used map hash/location for future
-            const mapHash = latestHash.split("map=");
-            if (mapHash.length == 2) {
-                prefs("map-hash", mapHash[1]);
+            const mapHash = latestHash.split('map=');
+            if (mapHash.length === 2) {
+                prefs('map-hash', mapHash[1]);
             }
         }
     }
@@ -198,13 +198,12 @@ export function behaviorHash(context) {
 
             if (q.map) {
                 behavior.hadHash = true;
-            }
-            else if (prefs("map-hash")) {
+            } else if (prefs('map-hash')) {
                 //user has existing map location hash, set hash & map to location
-                const mapHash = prefs("map-hash");
+                const mapHash = prefs('map-hash');
                 let currentHash = computedHash();
 
-                currentHash = currentHash.substring(0, currentHash.indexOf("map=")) + "map=" + mapHash;
+                currentHash = currentHash.substring(0, currentHash.indexOf('map=')) + 'map=' + mapHash;
 
                 window.history.replaceState(null, computedTitle(false /* includeChangeCount */), currentHash);
                 const mapArgs = mapHash.split('/').map(Number);


### PR DESCRIPTION
Fixes request #7790

On map view / map hash change, the code will now store the latest map hash (zoom. coordinates) in local storage. 

On init or refresh of the map, if no "map" is present in hash/url, it will check to apply the user's last known map hash and zoom to location.