### PR TITLE
Update issue template for Bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/id_editor_bug.yaml
+++ b/.github/ISSUE_TEMPLATE/id_editor_bug.yaml
@@ -63,5 +63,6 @@ body:
         - Opera
         - Safari
         - Vivaldi
+        - Other (please specify)
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/id_editor_bug.yaml
+++ b/.github/ISSUE_TEMPLATE/id_editor_bug.yaml
@@ -43,15 +43,25 @@ body:
         - RapiD version at mapwith.ai/rapid
     validations:
       required: false
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: What version of iD are you using?
+      placeholder: This can be found in the bottom right corner, next to the language selector
+    validations:
+      required: false
   - type: dropdown
     id: browsers
     attributes:
       label: Which browsers are you seeing this problem on?
       multiple: true
       options:
-        - Firefox
         - Chrome
-        - Safari
+        - Firefox
         - Microsoft Edge
+        - Opera
+        - Safari
+        - Vivaldi
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/id_editor_bug.yaml
+++ b/.github/ISSUE_TEMPLATE/id_editor_bug.yaml
@@ -34,7 +34,7 @@ body:
   - type: dropdown
     id: environment-variant
     attributes:
-      label: Which iD Editor versions do you see the issue on?
+      label: Which iD Editor deployment do you see the issue on?
       description: Please test your issue on the development version as well (if possible) so make sure it is not fixed already.
       multiple: true
       options:
@@ -47,8 +47,8 @@ body:
     id: version
     attributes:
       label: Version
-      description: What version of iD are you using?
-      placeholder: This can be found in the bottom right corner, next to the language selector
+      description: What is the version number of iD you are using?
+      placeholder: This can be found in the bottom right corner
     validations:
       required: false
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/id_editor_bug.yaml
+++ b/.github/ISSUE_TEMPLATE/id_editor_bug.yaml
@@ -35,7 +35,7 @@ body:
     id: environment-variant
     attributes:
       label: Which deployed environments do you see the issue in?
-      description: If possible, please test this issue in the development version (here: https://ideditor.netlify.app) as well, to make sure it is not already fixed.
+      description: "If possible, please test this issue in the development version (here: https://ideditor.netlify.app) as well, to make sure it is not already fixed."
       multiple: true
       options:
         - Released version at openstreetmap.org/edit
@@ -48,7 +48,7 @@ body:
     attributes:
       label: What version numbers does this issue effect?
       description: This can be found in the bottom right corner, next to the 'Help translate' button.
-      placeholder: For example- 2.20.3, 2.21.0, etc.
+      placeholder: "For example: 2.20.3, 2.21.0, etc."
     validations:
       required: false
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/id_editor_bug.yaml
+++ b/.github/ISSUE_TEMPLATE/id_editor_bug.yaml
@@ -35,7 +35,7 @@ body:
     id: environment-variant
     attributes:
       label: Which deployed environments do you see the issue in?
-      description: Please test your issue on the development version as well (if possible) so make sure it is not fixed already.
+      description: If possible, please test this issue in the development version (here: https://ideditor.netlify.app) as well, to make sure it is not already fixed.
       multiple: true
       options:
         - Released version at openstreetmap.org/edit

--- a/.github/ISSUE_TEMPLATE/id_editor_bug.yaml
+++ b/.github/ISSUE_TEMPLATE/id_editor_bug.yaml
@@ -34,7 +34,7 @@ body:
   - type: dropdown
     id: environment-variant
     attributes:
-      label: Which iD Editor deployment do you see the issue on?
+      label: Which iD Editor deployments do you see the issue on?
       description: Please test your issue on the development version as well (if possible) so make sure it is not fixed already.
       multiple: true
       options:
@@ -47,7 +47,7 @@ body:
     id: version
     attributes:
       label: Version
-      description: What is the version number of iD you are using?
+      description: What version numbers does this issue effect?
       placeholder: This can be found in the bottom right corner
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/id_editor_bug.yaml
+++ b/.github/ISSUE_TEMPLATE/id_editor_bug.yaml
@@ -34,7 +34,7 @@ body:
   - type: dropdown
     id: environment-variant
     attributes:
-      label: Which iD Editor deployments do you see the issue on?
+      label: Which deployed environments do you see the issue in?
       description: Please test your issue on the development version as well (if possible) so make sure it is not fixed already.
       multiple: true
       options:
@@ -46,9 +46,9 @@ body:
   - type: input
     id: version
     attributes:
-      label: Version
-      description: What version numbers does this issue effect?
-      placeholder: This can be found in the bottom right corner
+      label: What version numbers does this issue effect?
+      description: This can be found in the bottom right corner, next to the 'Help translate' button.
+      placeholder: For example: 2.20.3, 2.21.0, etc.
     validations:
       required: false
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/id_editor_bug.yaml
+++ b/.github/ISSUE_TEMPLATE/id_editor_bug.yaml
@@ -48,7 +48,7 @@ body:
     attributes:
       label: What version numbers does this issue effect?
       description: This can be found in the bottom right corner, next to the 'Help translate' button.
-      placeholder: For example: 2.20.3, 2.21.0, etc.
+      placeholder: For example- 2.20.3, 2.21.0, etc.
     validations:
       required: false
   - type: dropdown


### PR DESCRIPTION
Changes
- Add 'Opera', 'Vivaldi', and 'Other (please specify)' as browser options
  - Vivaldi and Opera are both popular Chromium-based browsers
  - Also made this list in alphabetical order
- Add prompt for the version number of iD
- Give a clickable link to development deployment so the reporter of an issue can easily go there to check