### PR TITLE
Remove dotall regex flag

### DIFF
--- a/modules/renderer/background_source.js
+++ b/modules/renderer/background_source.js
@@ -112,7 +112,7 @@ export function rendererBackgroundSource(data) {
 
 
     source.url = function(coord) {
-        var result = _template.replace(/#.*/su, ''); // strip hash part of URL
+        var result = _template.replace(/#[\s\S]*/u, ''); // strip hash part of URL
         if (result === '') return result;   // source 'none'
 
 


### PR DESCRIPTION
Fixed compatibility with Chrome 61, Firefox 77, Safari 11 by replacing the dotall regular expression flag with an older equivalent syntax.

Fixes #9163.