### PR TITLE
Fix tagging of localizable keys by multiCombo fields

### DIFF
--- a/modules/ui/fields/combo.js
+++ b/modules/ui/fields/combo.js
@@ -222,7 +222,7 @@ export function uiFieldCombo(field, context) {
                 var label = field.t('options.' + k, { default: k });
                 return {
                     key: k,
-                    value: label,
+                    value: _isMulti ? k : label,
                     display: field.t.append('options.' + k, { default: k }),
                     title: d.title || label,
                     klass: field.hasTextForStringId('options.' + k) ? '' : 'raw-option'


### PR DESCRIPTION
Use the raw subkey as the value of each option in a multiCombo field’s dropdown menu.

Fixes #9164.