### PR TITLE
fix rendering of proposed bridges

### DIFF
--- a/css/50_misc.css
+++ b/css/50_misc.css
@@ -463,6 +463,13 @@ path.line.casing.tag-highway.tag-status.tag-status-proposed.tag-proposed-bridlew
 path.line.casing.tag-highway.tag-status.tag-status-proposed.tag-proposed-steps {
     stroke-width: 4.5;
 }
+path.line.casing.tag-highway.tag-bridge.tag-status.tag-status-proposed.tag-proposed-path,
+path.line.casing.tag-highway.tag-bridge.tag-status.tag-status-proposed.tag-proposed-footway,
+path.line.casing.tag-highway.tag-bridge.tag-status.tag-status-proposed.tag-proposed-cycleway,
+path.line.casing.tag-highway.tag-bridge.tag-status.tag-status-proposed.tag-proposed-bridleway,
+path.line.casing.tag-highway.tag-bridge.tag-status.tag-status-proposed.tag-proposed-steps {
+    stroke-width: 10;
+}
 path.line.stroke.tag-highway.tag-status.tag-status-proposed.tag-proposed-path,
 path.line.stroke.tag-highway.tag-status.tag-status-proposed.tag-proposed-footway,
 path.line.stroke.tag-highway.tag-status.tag-status-proposed.tag-proposed-cycleway,


### PR DESCRIPTION
relates to #8913 and 55d38eba. Currently `bridge=yes` does not change the apperance of a way tagged with `highway=proposed` + `proposed=path`/`footway`/`cycleway`

<table>
<tr>
	<td>Before
	<td>After
<tr>
	<td><img src="https://user-images.githubusercontent.com/16009897/174237212-d1f69798-ad1f-4fd8-a23e-ac7390a6c9e3.png" />
	<td><img src="https://user-images.githubusercontent.com/16009897/174237171-a396747c-72f9-4df8-a3e9-ed4fe1cf85d1.png" />
</table>


