### PR TITLE
Fix connect features when crossing with pedestrian signals

### DIFF
--- a/modules/validations/crossing_ways.js
+++ b/modules/validations/crossing_ways.js
@@ -146,7 +146,7 @@ export function validationCrossingWays(context) {
                         return {};
                     }
                     var pathFeature = entity1IsPath ? entity1 : entity2;
-                    if (['marked', 'unmarked'].indexOf(pathFeature.tags.crossing) !== -1) {
+                    if (['marked', 'unmarked', 'traffic_signals'].indexOf(pathFeature.tags.crossing) !== -1) {
                         // if the path is a crossing, match the crossing type
                         return bothLines ? { highway: 'crossing', crossing: pathFeature.tags.crossing } : {};
                     }

--- a/test/spec/validations/crossing_ways.js
+++ b/test/spec/validations/crossing_ways.js
@@ -213,9 +213,19 @@ describe('iD.validations.crossing_ways', function () {
         verifySingleCrossingIssue(validate(), { highway: 'crossing' });
     });
 
-    it('flags road crossing crosswalk', function() {
+    it('flags road crossing marked crosswalk', function() {
         createWaysWithOneCrossingPoint({ highway: 'residential' }, { highway: 'footway', crossing: 'marked' });
         verifySingleCrossingIssue(validate(), { highway: 'crossing', crossing: 'marked' });
+    });
+
+    it('flags road crossing crosswalk with traffic_signals', function() {
+        createWaysWithOneCrossingPoint({ highway: 'residential' }, { highway: 'footway', crossing: 'traffic_signals' });
+        verifySingleCrossingIssue(validate(), { highway: 'crossing', crossing: 'traffic_signals' });
+    });
+
+    it('flags road crossing unmarked crosswalk', function() {
+        createWaysWithOneCrossingPoint({ highway: 'residential' }, { highway: 'footway', crossing: 'unmarked' });
+        verifySingleCrossingIssue(validate(), { highway: 'crossing', crossing: 'unmarked' });
     });
 
     it('flags road=track crossing footway', function() {


### PR DESCRIPTION
Fix #9176 
Add a `marked crossing` node when [connect features] with `crossing with pedestrian signals` is triggered, instead of an unspecified higway crossing.