### PR TITLE
github issue template: Fix link to discussion tab

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -10,5 +10,5 @@ contact_links:
     url: https://github.com/osmlab/editor-layer-index/issues
     about: Please create an issue in the editor-layer-index repository.
   - name: You have a general question or want to discuss something.
-    url: https://github.community/
+    url: https://github.com/openstreetmap/iD/discussions
     about: Please ask and answer questions in iD's Discussions tab.


### PR DESCRIPTION
At least I got very confused.

got into the templates in https://github.com/openstreetmap/iD/commit/ff19a1d1ad68a23f78e05d2e9a178189a1da10a1