### PR TITLE
Add ability to clone attributes of a feature to other features

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -96,6 +96,46 @@ en:
       too_large:
         one: This can't be copied because not enough of it is currently visible.
         other: These can't be copied because not enough of them are currently visible.
+    clone_address:
+      title: Clone address tags
+      description: Clone address tags from the first selected entity.
+      key: "&"
+      annotation: Clone the address tags.
+    clone_name:
+      title: Clone name and operator tags
+      description: Clone name and operator tags from the first selected entity.
+      key: "%"
+      annotation: Clone the name and operator tags.
+    clone_bus_lanes:
+      title: Clone bus lanes tags
+      description: Clone bus lanes tags from the first selected entity.
+      key: "@"
+      annotation: Clone the bus lanes tags.
+    clone_cycleway:
+      title: Clone cycleway tags
+      description: Clone cycleway tags from the first selected entity.
+      key: "("
+      annotation: Clone the cycleway tags.
+    clone_turn_lanes:
+      title: Clone turn lanes tags
+      description: Clone turn lanes tags from the first selected entity.
+      key: "$"
+      annotation: Clone the turn lanes tags.
+    clone_lanes:
+      title: Clone lanes tags
+      description: Clone lanes tags from the first selected entity.
+      key: "#"
+      annotation: Clone the lanes tags.
+    clone_transition:
+      title: Clone road transition tags
+      description: Clone road transition tags from the first selected entity.
+      key: "!"
+      annotation: Clone the road transition tags.
+    clone_sidewalk:
+      title: Clone sidewalk tags
+      description: Clone sidewalk tags from the first selected entity.
+      key: "="
+      annotation: Clone the sidewalk tags.
     paste:
       title: Paste
       description:

--- a/modules/actions/clone_tags.js
+++ b/modules/actions/clone_tags.js
@@ -1,0 +1,42 @@
+/**
+ * Clones the requested tags from the first selected entity to all the other selected enteties.
+ * @param selectedIds array containing the ids of the selected entites
+ * @param cloneTags array containing the tags to be cloned
+ * @returns action
+ */
+export function actionCloneTags(selectedIds, cloneTags=[]) {
+
+    var action = function (graph) {
+
+        const entities = selectedIds.map(function (selectedID) {
+            return graph.entity(selectedID);
+        });
+
+        const cloneFromEntityTags = entities[0].tags;
+
+        for (let i = 1; i < entities.length; i++) {
+          let entity = entities[i];
+          const tags = Object.assign({}, entity.tags);
+          for (let j = 0; j < cloneTags.length; j++) {
+              const cloneTag = cloneTags[j];
+              if (cloneFromEntityTags[cloneTag] !== undefined) {
+                tags[cloneTag] = cloneFromEntityTags[cloneTag];
+              }
+          }
+          entity = entity.update({tags});
+          graph = graph.replace(entity);
+        }
+
+        return graph;
+    };
+
+    action.disabled = function () {
+
+        return false;
+
+    };
+
+    action.transitionable = true;
+
+    return action;
+}

--- a/modules/actions/index.js
+++ b/modules/actions/index.js
@@ -6,6 +6,7 @@ export { actionChangeMember } from './change_member';
 export { actionChangePreset } from './change_preset';
 export { actionChangeTags } from './change_tags';
 export { actionCircularize } from './circularize';
+export { actionCloneTags } from './clone_tags';
 export { actionConnect } from './connect';
 export { actionCopyEntities } from './copy_entities';
 export { actionDeleteMember } from './delete_member';

--- a/modules/operations/clone_address.js
+++ b/modules/operations/clone_address.js
@@ -1,0 +1,23 @@
+import { operationCloneTags } from './clone_tags';
+
+/**
+ * Clones the address tags.
+ * @param {*} context context object which provides access to iD's internal state
+ * @param {*} selectedIDs ids of the entities which are currently selected
+ * @returns clone address operation
+ */
+export function operationCloneAddress(context, selectedIDs) {
+
+    const cloneTags = [
+        'addr:housenumber', 'addr:street', 'addr:city', 'addr:province',
+        'addr:postcode', 'addr:country', 'addr:full', 'addr:state'
+    ];
+
+    return operationCloneTags({
+        context: context,
+        selectedIDs: selectedIDs,
+        cloneTags: cloneTags,
+        operationName: 'clone_address'
+    });
+
+}

--- a/modules/operations/clone_bus_lanes.js
+++ b/modules/operations/clone_bus_lanes.js
@@ -1,0 +1,24 @@
+import { operationCloneTags } from './clone_tags';
+
+/**
+ * Clones the bus lane tags.
+ * @param {*} context context object which provides access to iD's internal state
+ * @param {*} selectedIDs ids of the entities which are currently selected
+ * @returns clone bus lane operation
+ */
+export function operationCloneBusLanes(context, selectedIDs) {
+
+    const cloneTags = [
+        'bus:lanes', 'bus:lanes:forward', 'bus:lanes:backward',
+        'lanes:bus', 'lanes:bus:forward', 'lanes:bus:backward',
+        'busway:right', 'busway:left', 'routing:bus', 'bus'
+    ];
+
+    return operationCloneTags({
+        context: context,
+        selectedIDs: selectedIDs,
+        cloneTags: cloneTags,
+        operationName: 'clone_bus_lanes'
+    });
+
+}

--- a/modules/operations/clone_cycleway.js
+++ b/modules/operations/clone_cycleway.js
@@ -1,0 +1,23 @@
+import { operationCloneTags } from './clone_tags';
+
+/**
+ * Clones the cycleway tags.
+ * @param {*} context context object which provides access to iD's internal state
+ * @param {*} selectedIDs ids of the entities which are currently selected
+ * @returns clone cycleway operation
+ */
+export function operationCloneCycleway(context, selectedIDs) {
+
+    const cloneTags = [
+        'routing:bicycle', 'bicycle', 'cycleway:both',
+        'cycleway:right', 'cycleway:left', 'oneway:bicycle'
+    ];
+
+    return operationCloneTags({
+        context: context,
+        selectedIDs: selectedIDs,
+        cloneTags: cloneTags,
+        operationName: 'clone_cycleway'
+    });
+
+}

--- a/modules/operations/clone_lanes.js
+++ b/modules/operations/clone_lanes.js
@@ -1,0 +1,22 @@
+import { operationCloneTags } from './clone_tags';
+
+/**
+ * Clones the lane tags.
+ * @param {*} context context object which provides access to iD's internal state
+ * @param {*} selectedIDs ids of the entities which are currently selected
+ * @returns clone lanes operation
+ */
+export function operationCloneLanes(context, selectedIDs) {
+
+    const cloneTags = [
+        'lanes', 'lanes:forward', 'lanes:backward'
+    ];
+
+    return operationCloneTags({
+        context: context,
+        selectedIDs: selectedIDs,
+        cloneTags: cloneTags,
+        operationName: 'clone_lanes'
+    });
+
+}

--- a/modules/operations/clone_name.js
+++ b/modules/operations/clone_name.js
@@ -1,0 +1,22 @@
+import { operationCloneTags } from './clone_tags';
+
+/**
+ * Clones the name tags.
+ * @param {*} context context object which provides access to iD's internal state
+ * @param {*} selectedIDs ids of the entities which are currently selected
+ * @returns clone name operation
+ */
+export function operationCloneName(context, selectedIDs ) {
+
+    const cloneTags = [
+        'name', 'operator', 'name_alt', 'name:fr', 'name:en'
+    ];
+
+    return operationCloneTags({
+        context: context,
+        selectedIDs: selectedIDs,
+        cloneTags: cloneTags,
+        operationName: 'clone_name'
+    });
+
+}

--- a/modules/operations/clone_sidewalk.js
+++ b/modules/operations/clone_sidewalk.js
@@ -1,0 +1,22 @@
+import { operationCloneTags } from './clone_tags';
+
+/**
+ * Clones the sidewalk tags.
+ * @param {*} context context object which provides access to iD's internal state
+ * @param {*} selectedIDs ids of the entities which are currently selected
+ * @returns clone sidewalk operation
+ */
+export function operationCloneSidewalk(context, selectedIDs) {
+
+    const cloneTags = [
+        'sidewalk', 'sidewalk:right', 'sidewalk:left', 'foot'
+    ];
+
+    return operationCloneTags({
+        context: context,
+        selectedIDs: selectedIDs,
+        cloneTags: cloneTags,
+        operationName: 'clone_sidewalk'
+    });
+
+}

--- a/modules/operations/clone_tags.js
+++ b/modules/operations/clone_tags.js
@@ -1,0 +1,72 @@
+import { t } from '../core/localizer';
+import { actionCloneTags } from '../actions/clone_tags';
+import { behaviorOperation } from '../behavior/operation';
+
+/**
+ * Base operation for cloning.
+ * It is used by the specific clone operations (cloneAddress, cloneBusLanes, ...).
+ * @param params object with the following attributes :
+ *                 context : the context
+ *                 selectedIDs : ids that are selected
+ *                 cloneTags : the tags to clone
+ *                 operationName : name of the operation that called this base operation
+ * @returns operation
+ */
+export function operationCloneTags(params) {
+
+    const context = params.context;
+    const selectedIDs = params.selectedIDs;
+    const cloneTags = params.cloneTags;
+    const operationName = params.operationName;
+
+    var action = actionCloneTags(selectedIDs, cloneTags);
+
+    var operation = function () {
+        context.perform(action, operation.annotation());
+
+        window.setTimeout(function () {
+            context.validator().validate();
+        }, 300); // after any transition
+    };
+
+
+    operation.available = function () {
+        if (selectedIDs.length >= 2) {
+            const entity = context.entity(selectedIDs[0]);
+            for (let i = 0, count = cloneTags.length; i < count; i++) {
+                if (entity.tags[cloneTags[i]] !== undefined) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    };
+
+
+    // don't cache this because the visible extent could change
+    operation.disabled = function () {
+
+        return false;
+
+    };
+
+    operation.tooltip = function () {
+        var disable = operation.disabled();
+        return disable ?
+            t('operations.' + operationName + '.' + disable) :
+            t('operations.' + operationName + '.description');
+    };
+
+
+    operation.annotation = function () {
+        return t('operations.' + operationName + '.annotation');
+    };
+
+
+    operation.id = operationName;
+    operation.keys = [t('operations.' + operationName + '.key')];
+    operation.title = t('operations.' + operationName + '.title');
+    operation.behavior = behaviorOperation(context).which(operation);
+
+    return operation;
+}

--- a/modules/operations/clone_transition.js
+++ b/modules/operations/clone_transition.js
@@ -1,0 +1,24 @@
+import { operationCloneTags } from './clone_tags';
+
+/**
+ * Clones the transition tags.
+ * @param {*} context context object which provides access to iD's internal state
+ * @param {*} selectedIDs ids of the entities which are currently selected
+ * @returns clone transition operation
+ */
+export function operationCloneTransition(context, selectedIDs) {
+
+    const cloneTags = [
+        'placement', 'placement:start', 'placement:end', 'width:lanes:start', 'width:lanes:end',
+        'placement:forward', 'width:lanes:forward:start', 'width:lanes:forward:end',
+        'placement:backward', 'width:lanes:backward:start', 'width:lanes:backward:end'
+    ];
+
+    return operationCloneTags({
+        context: context,
+        selectedIDs: selectedIDs,
+        cloneTags: cloneTags,
+        operationName: 'clone_transition'
+    });
+
+}

--- a/modules/operations/clone_turn_lanes.js
+++ b/modules/operations/clone_turn_lanes.js
@@ -1,0 +1,22 @@
+import { operationCloneTags } from './clone_tags';
+
+/**
+ * Clones the turn lane tags.
+ * @param {*} context context object which provides access to iD's internal state
+ * @param {*} selectedIDs ids of the entities which are currently selected
+ * @returns clone turn lanes operation
+ */
+export function operationCloneTurnLanes(context, selectedIDs) {
+
+    const cloneTags = [
+        'turn:lanes', 'turn:lanes:forward', 'turn:lanes:backward'
+    ];
+
+    return operationCloneTags({
+        context: context,
+        selectedIDs: selectedIDs,
+        cloneTags: cloneTags,
+        operationName: 'clone_turn_lanes'
+    });
+
+}

--- a/modules/operations/index.js
+++ b/modules/operations/index.js
@@ -1,4 +1,12 @@
 export { operationCircularize } from './circularize';
+export { operationCloneAddress } from './clone_address';
+export { operationCloneName } from './clone_name';
+export { operationCloneTurnLanes } from './clone_turn_lanes';
+export { operationCloneLanes } from './clone_lanes';
+export { operationCloneCycleway } from './clone_cycleway';
+export { operationCloneSidewalk } from './clone_sidewalk';
+export { operationCloneBusLanes } from './clone_bus_lanes';
+export { operationCloneTransition } from './clone_transition';
 export { operationContinue } from './continue';
 export { operationCopy } from './copy';
 export { operationDelete } from './delete';

--- a/svg/iD-sprite/operations/operation-clone_address.svg
+++ b/svg/iD-sprite/operations/operation-clone_address.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--! Font Awesome Pro 6.1.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. -->
+    <path d="M0 224C0 188.7 28.65 160 64 160H128V288C128 341 170.1 384 224 384H352V448C352 483.3 323.3 512 288 512H64C28.65 512 0 483.3 0 448V224zM224 352C188.7 352 160 323.3 160 288V64C160 28.65 188.7 0 224 0H448C483.3 0 512 28.65 512 64V288C512 323.3 483.3 352 448 352H224z" fill="currentColor"/>
+</svg>

--- a/svg/iD-sprite/operations/operation-clone_bus_lanes.svg
+++ b/svg/iD-sprite/operations/operation-clone_bus_lanes.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--! Font Awesome Pro 6.1.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. -->
+    <path d="M0 224C0 188.7 28.65 160 64 160H128V288C128 341 170.1 384 224 384H352V448C352 483.3 323.3 512 288 512H64C28.65 512 0 483.3 0 448V224zM224 352C188.7 352 160 323.3 160 288V64C160 28.65 188.7 0 224 0H448C483.3 0 512 28.65 512 64V288C512 323.3 483.3 352 448 352H224z" fill="currentColor"/>
+</svg>

--- a/svg/iD-sprite/operations/operation-clone_cycleway.svg
+++ b/svg/iD-sprite/operations/operation-clone_cycleway.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--! Font Awesome Pro 6.1.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. -->
+    <path d="M0 224C0 188.7 28.65 160 64 160H128V288C128 341 170.1 384 224 384H352V448C352 483.3 323.3 512 288 512H64C28.65 512 0 483.3 0 448V224zM224 352C188.7 352 160 323.3 160 288V64C160 28.65 188.7 0 224 0H448C483.3 0 512 28.65 512 64V288C512 323.3 483.3 352 448 352H224z" fill="currentColor"/>
+</svg>

--- a/svg/iD-sprite/operations/operation-clone_lanes.svg
+++ b/svg/iD-sprite/operations/operation-clone_lanes.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--! Font Awesome Pro 6.1.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. -->
+    <path d="M0 224C0 188.7 28.65 160 64 160H128V288C128 341 170.1 384 224 384H352V448C352 483.3 323.3 512 288 512H64C28.65 512 0 483.3 0 448V224zM224 352C188.7 352 160 323.3 160 288V64C160 28.65 188.7 0 224 0H448C483.3 0 512 28.65 512 64V288C512 323.3 483.3 352 448 352H224z" fill="currentColor"/>
+</svg>

--- a/svg/iD-sprite/operations/operation-clone_name.svg
+++ b/svg/iD-sprite/operations/operation-clone_name.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--! Font Awesome Pro 6.1.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. -->
+    <path d="M0 224C0 188.7 28.65 160 64 160H128V288C128 341 170.1 384 224 384H352V448C352 483.3 323.3 512 288 512H64C28.65 512 0 483.3 0 448V224zM224 352C188.7 352 160 323.3 160 288V64C160 28.65 188.7 0 224 0H448C483.3 0 512 28.65 512 64V288C512 323.3 483.3 352 448 352H224z" fill="currentColor"/>
+</svg>

--- a/svg/iD-sprite/operations/operation-clone_sidewalk.svg
+++ b/svg/iD-sprite/operations/operation-clone_sidewalk.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--! Font Awesome Pro 6.1.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. -->
+    <path d="M0 224C0 188.7 28.65 160 64 160H128V288C128 341 170.1 384 224 384H352V448C352 483.3 323.3 512 288 512H64C28.65 512 0 483.3 0 448V224zM224 352C188.7 352 160 323.3 160 288V64C160 28.65 188.7 0 224 0H448C483.3 0 512 28.65 512 64V288C512 323.3 483.3 352 448 352H224z" fill="currentColor"/>
+</svg>

--- a/svg/iD-sprite/operations/operation-clone_transition.svg
+++ b/svg/iD-sprite/operations/operation-clone_transition.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--! Font Awesome Pro 6.1.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. -->
+    <path d="M0 224C0 188.7 28.65 160 64 160H128V288C128 341 170.1 384 224 384H352V448C352 483.3 323.3 512 288 512H64C28.65 512 0 483.3 0 448V224zM224 352C188.7 352 160 323.3 160 288V64C160 28.65 188.7 0 224 0H448C483.3 0 512 28.65 512 64V288C512 323.3 483.3 352 448 352H224z" fill="currentColor"/>
+</svg>

--- a/svg/iD-sprite/operations/operation-clone_turn_lanes.svg
+++ b/svg/iD-sprite/operations/operation-clone_turn_lanes.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--! Font Awesome Pro 6.1.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. -->
+    <path d="M0 224C0 188.7 28.65 160 64 160H128V288C128 341 170.1 384 224 384H352V448C352 483.3 323.3 512 288 512H64C28.65 512 0 483.3 0 448V224zM224 352C188.7 352 160 323.3 160 288V64C160 28.65 188.7 0 224 0H448C483.3 0 512 28.65 512 64V288C512 323.3 483.3 352 448 352H224z" fill="currentColor"/>
+</svg>

--- a/test/spec/actions/clone_tags.js
+++ b/test/spec/actions/clone_tags.js
@@ -1,0 +1,94 @@
+describe('iD.actionCloneTags', function () {
+
+    it('creates new tag when there are no tags', function () {
+        let value = 'test';
+        let graph = iD.coreGraph([
+            iD.osmNode({ id: 'a', tags: { 'x': value } }),
+            iD.osmNode({ id: 'b' })
+        ]);
+        graph = iD.actionCloneTags(['a', 'b'], ['x'])(graph);
+        expect(graph.entity('b').tags.x).to.eql(graph.entity('a').tags.x);
+    });
+
+    it('creates new tag when there other tags exist', function () {
+        let value = 'test';
+        let graph = iD.coreGraph([
+            iD.osmNode({ id: 'a', tags: { 'x': value } }),
+            iD.osmNode({ id: 'b', tags: { foo: 'bar' } })
+        ]);
+        graph = iD.actionCloneTags(['a', 'b'], ['x'])(graph);
+        expect(graph.entity('b').tags.x).to.eql(graph.entity('a').tags.x);
+        expect(graph.entity('b').tags.foo).to.eql('bar');
+    });
+
+    it('overwrites existing tag', function () {
+        let value = 'test';
+        let graph = iD.coreGraph([
+            iD.osmNode({ id: 'a', tags: { 'x': value } }),
+            iD.osmNode({ id: 'b', tags: { 'x': 'foo' } })
+        ]);
+        graph = iD.actionCloneTags(['a', 'b'], ['x'])(graph);
+        expect(graph.entity('b').tags.x).to.eql(graph.entity('a').tags.x);
+    });
+
+    it('clones only the requested tags', function () {
+        let value = 'test';
+        let graph = iD.coreGraph([
+            iD.osmNode({ id: 'a', tags: { 'x': value, 'y': 'foo' } }),
+            iD.osmNode({ id: 'b', tags: { 'z': 'bar' } })
+        ]);
+        graph = iD.actionCloneTags(['a', 'b'], ['x'])(graph);
+        expect(graph.entity('b').tags.x).to.eql(graph.entity('a').tags.x);
+        expect(graph.entity('a').tags.y).to.eql('foo');
+        expect(graph.entity('b').tags.z).to.eql('bar');
+    });
+
+    it('clones several tags', function () {
+        let value1 = 'test';
+        let value2 = 'test2';
+        let value3 = 'test3';
+        let graph = iD.coreGraph([
+            iD.osmNode({ id: 'a', tags: { 'x': value1, 'y': value2, 'z': value3 } }),
+            iD.osmNode({ id: 'b' })
+        ]);
+        graph = iD.actionCloneTags(['a', 'b'], ['x', 'y', 'z'])(graph);
+        expect(graph.entity('b').tags.x).to.eql(graph.entity('a').tags.x);
+        expect(graph.entity('b').tags.y).to.eql(graph.entity('a').tags.y);
+        expect(graph.entity('b').tags.z).to.eql(graph.entity('a').tags.z);
+    });
+
+    it('clones to several nodes', function () {
+        let value = 'test';
+        let graph = iD.coreGraph([
+            iD.osmNode({ id: 'a', tags: { 'x': value } }),
+            iD.osmNode({ id: 'b', tags: { 'x': 'bar' } }),
+            iD.osmNode({ id: 'c' })
+        ]);
+        graph = iD.actionCloneTags(['a', 'b', 'c'], ['x'])(graph);
+        expect(graph.entity('b').tags.x).to.eql(graph.entity('a').tags.x);
+        expect(graph.entity('c').tags.x).to.eql(graph.entity('a').tags.x);
+    });
+
+    it('doesn\'t do anything if it doesn\'t recieve any tags to clone', function () {
+        let value = 'test';
+        let graph = iD.coreGraph([
+            iD.osmNode({ id: 'a', tags: { 'x': value } }),
+            iD.osmNode({ id: 'b', tags: { 'x': 'bar' } }),
+            iD.osmNode({ id: 'c' })
+        ]);
+        graph = iD.actionCloneTags(['a', 'b', 'c'])(graph);
+        expect(graph.entity('b').tags.x).to.not.eql(graph.entity('a').tags.x);
+        expect(graph.entity('c').tags.x).to.not.eql(graph.entity('a').tags.x);
+    });
+
+    it('doesn\'t copy if the requested tags are not found', function () {
+        let value = 'test';
+        let graph = iD.coreGraph([
+            iD.osmNode({ id: 'a', tags: { 'x': value } }),
+            iD.osmNode({ id: 'b' })
+        ]);
+        graph = iD.actionCloneTags(['a', 'b'], ['z'])(graph);
+        expect(graph.entity('b').tags.x).to.not.eql(graph.entity('a').tags.x);
+    });
+
+});

--- a/test/spec/operations/clone_address.js
+++ b/test/spec/operations/clone_address.js
@@ -1,0 +1,78 @@
+describe('iD.clone_address', function () {
+    var fakeContext;
+    var graph;
+
+    // Set up the fake context
+    fakeContext = {};
+    fakeContext.graph = function() { return graph; };
+    fakeContext.entity = function(id) { return graph.entity(id); };
+    fakeContext.hasHiddenConnections = function() { return false; };
+
+    describe('#available', function () {
+        beforeEach(function () {
+            // w1 - way with 2 nodes
+            // w2 - way with 2 nodes
+            graph = iD.coreGraph([
+                iD.osmNode({ id: 'n1', type: 'node', tags: { 'addr:housenumber': 'foo' } }),
+                iD.osmNode({ id: 'n2', type: 'node' }),
+                iD.osmNode({ id: 'n3', type: 'node' }),
+                iD.osmNode({ id: 'n4', type: 'node' }),
+                iD.osmNode({ id: 'n5', type: 'node' }),
+                iD.osmWay({ id: 'w1', nodes: ['n1', 'n2'], tags: { 'addr:street': 'foo', 'addr:city':'bar' } }),
+                iD.osmWay({ id: 'w2', nodes: ['n3', 'n4'] }),
+                iD.osmWay({ id: 'w3', nodes: ['n4', 'n5'] })
+            ]);
+        });
+
+        it('is not available for no selected ids', function () {
+            var result = iD.operationCloneAddress(fakeContext, []).available();
+            expect(result).to.be.not.ok;
+        });
+
+        it('is not available for 1 selected node', function () {
+            var result = iD.operationCloneAddress(fakeContext, ['n1']).available();
+            expect(result).to.be.not.ok;
+        });
+
+        it('is not available for 1 selected way', function () {
+            var result = iD.operationCloneAddress(fakeContext, ['w1']).available();
+            expect(result).to.be.not.ok;
+        });
+
+        it('is not available for 2 selected nodes if the first one doesn\'t have an address tag', function () {
+            var result = iD.operationCloneAddress(fakeContext, ['n2', 'n3']).available();
+            expect(result).to.be.not.ok;
+        });
+
+        it('is not available for 2 selected ways if the first one doesn\'t have an address tag', function () {
+            var result = iD.operationCloneAddress(fakeContext, ['w2', 'w3']).available();
+            expect(result).to.be.not.ok;
+        });
+
+        it('is available for 2 selected nodes if the first one has an address tag', function () {
+            var result = iD.operationCloneAddress(fakeContext, ['n1', 'n3']).available();
+            expect(result).to.be.ok;
+        });
+
+        it('is available for 2 selected ways if the first one has an address tag', function () {
+            var result = iD.operationCloneAddress(fakeContext, ['w1', 'w3']).available();
+            expect(result).to.be.ok;
+        });
+
+        it('is available for 3 selected nodes if the first one has an address tag', function () {
+            var result = iD.operationCloneAddress(fakeContext, ['n1', 'n2', 'n3']).available();
+            expect(result).to.be.ok;
+        });
+
+        it('is available for 3 selected ways if the first one an address tag', function () {
+            var result = iD.operationCloneAddress(fakeContext, ['w1', 'w2', 'w3']).available();
+            expect(result).to.be.ok;
+        });
+
+        it('is available for 1 selected node et 1 selected way if the first one has an address tag', function () {
+            var result = iD.operationCloneAddress(fakeContext, ['n1', 'w2']).available();
+            expect(result).to.be.ok;
+        });
+
+    });
+});

--- a/test/spec/operations/clone_bus_lanes.js
+++ b/test/spec/operations/clone_bus_lanes.js
@@ -1,0 +1,78 @@
+describe('iD.clone_bus_lane', function () {
+    var fakeContext;
+    var graph;
+
+    // Set up the fake context
+    fakeContext = {};
+    fakeContext.graph = function() { return graph; };
+    fakeContext.entity = function(id) { return graph.entity(id); };
+    fakeContext.hasHiddenConnections = function() { return false; };
+
+    describe('#available', function () {
+        beforeEach(function () {
+            // w1 - way with 2 nodes
+            // w2 - way with 2 nodes
+            graph = iD.coreGraph([
+                iD.osmNode({ id: 'n1', type: 'node', tags: { 'bus:lanes': 'foo' } }),
+                iD.osmNode({ id: 'n2', type: 'node' }),
+                iD.osmNode({ id: 'n3', type: 'node' }),
+                iD.osmNode({ id: 'n4', type: 'node' }),
+                iD.osmNode({ id: 'n5', type: 'node' }),
+                iD.osmWay({ id: 'w1', nodes: ['n1', 'n2'], tags: { 'bus:lanes:forward': 'foo', 'bus:lanes:backward':'bar' } }),
+                iD.osmWay({ id: 'w2', nodes: ['n3', 'n4'] }),
+                iD.osmWay({ id: 'w3', nodes: ['n4', 'n5'] })
+            ]);
+        });
+
+        it('is not available for no selected ids', function () {
+            var result = iD.operationCloneBusLanes(fakeContext, []).available();
+            expect(result).to.be.not.ok;
+        });
+
+        it('is not available for 1 selected node', function () {
+            var result = iD.operationCloneBusLanes(fakeContext, ['n1']).available();
+            expect(result).to.be.not.ok;
+        });
+
+        it('is not available for 1 selected way', function () {
+            var result = iD.operationCloneBusLanes(fakeContext, ['w1']).available();
+            expect(result).to.be.not.ok;
+        });
+
+        it('is not available for 2 selected nodes if the first one doesn\'t have a bus lane tag', function () {
+            var result = iD.operationCloneBusLanes(fakeContext, ['n2', 'n3']).available();
+            expect(result).to.be.not.ok;
+        });
+
+        it('is not available for 2 selected ways if the first one doesn\'t have a bus lane tag', function () {
+            var result = iD.operationCloneBusLanes(fakeContext, ['w2', 'w3']).available();
+            expect(result).to.be.not.ok;
+        });
+
+        it('is available for 2 selected nodes if the first one has a bus lane tag', function () {
+            var result = iD.operationCloneBusLanes(fakeContext, ['n1', 'n3']).available();
+            expect(result).to.be.ok;
+        });
+
+        it('is available for 2 selected ways if the first one has a bus lane tag', function () {
+            var result = iD.operationCloneBusLanes(fakeContext, ['w1', 'w3']).available();
+            expect(result).to.be.ok;
+        });
+
+        it('is available for 3 selected nodes if the first one has a bus lane tag', function () {
+            var result = iD.operationCloneBusLanes(fakeContext, ['n1', 'n2', 'n3']).available();
+            expect(result).to.be.ok;
+        });
+
+        it('is available for 3 selected ways if the first one a bus lane tag', function () {
+            var result = iD.operationCloneBusLanes(fakeContext, ['w1', 'w2', 'w3']).available();
+            expect(result).to.be.ok;
+        });
+
+        it('is available for 1 selected node et 1 selected way if the first one has a bus lane tag', function () {
+            var result = iD.operationCloneBusLanes(fakeContext, ['n1', 'w2']).available();
+            expect(result).to.be.ok;
+        });
+
+    });
+});

--- a/test/spec/operations/clone_cycleway.js
+++ b/test/spec/operations/clone_cycleway.js
@@ -1,0 +1,78 @@
+describe('iD.clone_cycleway', function () {
+    var fakeContext;
+    var graph;
+
+    // Set up the fake context
+    fakeContext = {};
+    fakeContext.graph = function() { return graph; };
+    fakeContext.entity = function(id) { return graph.entity(id); };
+    fakeContext.hasHiddenConnections = function() { return false; };
+
+    describe('#available', function () {
+        beforeEach(function () {
+            // w1 - way with 2 nodes
+            // w2 - way with 2 nodes
+            graph = iD.coreGraph([
+                iD.osmNode({ id: 'n1', type: 'node', tags: { 'routing:bicycle': 'foo' } }),
+                iD.osmNode({ id: 'n2', type: 'node' }),
+                iD.osmNode({ id: 'n3', type: 'node' }),
+                iD.osmNode({ id: 'n4', type: 'node' }),
+                iD.osmNode({ id: 'n5', type: 'node' }),
+                iD.osmWay({ id: 'w1', nodes: ['n1', 'n2'], tags: { 'cycleway:both': 'foo', 'bicycle':'bar' } }),
+                iD.osmWay({ id: 'w2', nodes: ['n3', 'n4'] }),
+                iD.osmWay({ id: 'w3', nodes: ['n4', 'n5'] })
+            ]);
+        });
+
+        it('is not available for no selected ids', function () {
+            var result = iD.operationCloneCycleway(fakeContext, []).available();
+            expect(result).to.be.not.ok;
+        });
+
+        it('is not available for 1 selected node', function () {
+            var result = iD.operationCloneCycleway(fakeContext, ['n1']).available();
+            expect(result).to.be.not.ok;
+        });
+
+        it('is not available for 1 selected way', function () {
+            var result = iD.operationCloneCycleway(fakeContext, ['w1']).available();
+            expect(result).to.be.not.ok;
+        });
+
+        it('is not available for 2 selected nodes if the first one doesn\'t have a cycleway tag', function () {
+            var result = iD.operationCloneCycleway(fakeContext, ['n2', 'n3']).available();
+            expect(result).to.be.not.ok;
+        });
+
+        it('is not available for 2 selected ways if the first one doesn\'t have a cycleway tag', function () {
+            var result = iD.operationCloneCycleway(fakeContext, ['w2', 'w3']).available();
+            expect(result).to.be.not.ok;
+        });
+
+        it('is available for 2 selected nodes if the first one has a cycleway tag', function () {
+            var result = iD.operationCloneCycleway(fakeContext, ['n1', 'n3']).available();
+            expect(result).to.be.ok;
+        });
+
+        it('is available for 2 selected ways if the first one has a cycleway tag', function () {
+            var result = iD.operationCloneCycleway(fakeContext, ['w1', 'w3']).available();
+            expect(result).to.be.ok;
+        });
+
+        it('is available for 3 selected nodes if the first one has a cycleway tag', function () {
+            var result = iD.operationCloneCycleway(fakeContext, ['n1', 'n2', 'n3']).available();
+            expect(result).to.be.ok;
+        });
+
+        it('is available for 3 selected ways if the first one a cycleway tag', function () {
+            var result = iD.operationCloneCycleway(fakeContext, ['w1', 'w2', 'w3']).available();
+            expect(result).to.be.ok;
+        });
+
+        it('is available for 1 selected node et 1 selected way if the first one has a cycleway tag', function () {
+            var result = iD.operationCloneCycleway(fakeContext, ['n1', 'w2']).available();
+            expect(result).to.be.ok;
+        });
+
+    });
+});

--- a/test/spec/operations/clone_lanes.js
+++ b/test/spec/operations/clone_lanes.js
@@ -1,0 +1,78 @@
+describe('iD.clone_lanes', function () {
+    var fakeContext;
+    var graph;
+
+    // Set up the fake context
+    fakeContext = {};
+    fakeContext.graph = function() { return graph; };
+    fakeContext.entity = function(id) { return graph.entity(id); };
+    fakeContext.hasHiddenConnections = function() { return false; };
+
+    describe('#available', function () {
+        beforeEach(function () {
+            // w1 - way with 2 nodes
+            // w2 - way with 2 nodes
+            graph = iD.coreGraph([
+                iD.osmNode({ id: 'n1', type: 'node', tags: { 'lanes': 'foo' } }),
+                iD.osmNode({ id: 'n2', type: 'node' }),
+                iD.osmNode({ id: 'n3', type: 'node' }),
+                iD.osmNode({ id: 'n4', type: 'node' }),
+                iD.osmNode({ id: 'n5', type: 'node' }),
+                iD.osmWay({ id: 'w1', nodes: ['n1', 'n2'], tags: { 'lanes:forward': 'foo', 'lanes:backward':'bar' } }),
+                iD.osmWay({ id: 'w2', nodes: ['n3', 'n4'] }),
+                iD.osmWay({ id: 'w3', nodes: ['n4', 'n5'] })
+            ]);
+        });
+
+        it('is not available for no selected ids', function () {
+            var result = iD.operationCloneLanes(fakeContext, []).available();
+            expect(result).to.be.not.ok;
+        });
+
+        it('is not available for 1 selected node', function () {
+            var result = iD.operationCloneLanes(fakeContext, ['n1']).available();
+            expect(result).to.be.not.ok;
+        });
+
+        it('is not available for 1 selected way', function () {
+            var result = iD.operationCloneLanes(fakeContext, ['w1']).available();
+            expect(result).to.be.not.ok;
+        });
+
+        it('is not available for 2 selected nodes if the first one doesn\'t have a lane tag', function () {
+            var result = iD.operationCloneLanes(fakeContext, ['n2', 'n3']).available();
+            expect(result).to.be.not.ok;
+        });
+
+        it('is not available for 2 selected ways if the first one doesn\'t have a lane tag', function () {
+            var result = iD.operationCloneLanes(fakeContext, ['w2', 'w3']).available();
+            expect(result).to.be.not.ok;
+        });
+
+        it('is available for 2 selected nodes if the first one has a lane tag', function () {
+            var result = iD.operationCloneLanes(fakeContext, ['n1', 'n3']).available();
+            expect(result).to.be.ok;
+        });
+
+        it('is available for 2 selected ways if the first one has a lane tag', function () {
+            var result = iD.operationCloneLanes(fakeContext, ['w1', 'w3']).available();
+            expect(result).to.be.ok;
+        });
+
+        it('is available for 3 selected nodes if the first one has a lane tag', function () {
+            var result = iD.operationCloneLanes(fakeContext, ['n1', 'n2', 'n3']).available();
+            expect(result).to.be.ok;
+        });
+
+        it('is available for 3 selected ways if the first one a lane tag', function () {
+            var result = iD.operationCloneLanes(fakeContext, ['w1', 'w2', 'w3']).available();
+            expect(result).to.be.ok;
+        });
+
+        it('is available for 1 selected node et 1 selected way if the first one has a lane tag', function () {
+            var result = iD.operationCloneLanes(fakeContext, ['n1', 'w2']).available();
+            expect(result).to.be.ok;
+        });
+
+    });
+});

--- a/test/spec/operations/clone_name.js
+++ b/test/spec/operations/clone_name.js
@@ -1,0 +1,78 @@
+describe('iD.clone_name', function () {
+    var fakeContext;
+    var graph;
+
+    // Set up the fake context
+    fakeContext = {};
+    fakeContext.graph = function() { return graph; };
+    fakeContext.entity = function(id) { return graph.entity(id); };
+    fakeContext.hasHiddenConnections = function() { return false; };
+
+    describe('#available', function () {
+        beforeEach(function () {
+            // w1 - way with 2 nodes
+            // w2 - way with 2 nodes
+            graph = iD.coreGraph([
+                iD.osmNode({ id: 'n1', type: 'node', tags: { 'name': 'foo' } }),
+                iD.osmNode({ id: 'n2', type: 'node' }),
+                iD.osmNode({ id: 'n3', type: 'node' }),
+                iD.osmNode({ id: 'n4', type: 'node' }),
+                iD.osmNode({ id: 'n5', type: 'node' }),
+                iD.osmWay({ id: 'w1', nodes: ['n1', 'n2'], tags: { 'name_alt': 'foo', 'name:fr':'bar' } }),
+                iD.osmWay({ id: 'w2', nodes: ['n3', 'n4'] }),
+                iD.osmWay({ id: 'w3', nodes: ['n4', 'n5'] })
+            ]);
+        });
+
+        it('is not available for no selected ids', function () {
+            var result = iD.operationCloneName(fakeContext, []).available();
+            expect(result).to.be.not.ok;
+        });
+
+        it('is not available for 1 selected node', function () {
+            var result = iD.operationCloneName(fakeContext, ['n1']).available();
+            expect(result).to.be.not.ok;
+        });
+
+        it('is not available for 1 selected way', function () {
+            var result = iD.operationCloneName(fakeContext, ['w1']).available();
+            expect(result).to.be.not.ok;
+        });
+
+        it('is not available for 2 selected nodes if the first one doesn\'t have a name tag', function () {
+            var result = iD.operationCloneName(fakeContext, ['n2', 'n3']).available();
+            expect(result).to.be.not.ok;
+        });
+
+        it('is not available for 2 selected ways if the first one doesn\'t have a name tag', function () {
+            var result = iD.operationCloneName(fakeContext, ['w2', 'w3']).available();
+            expect(result).to.be.not.ok;
+        });
+
+        it('is available for 2 selected nodes if the first one has a name tag', function () {
+            var result = iD.operationCloneName(fakeContext, ['n1', 'n3']).available();
+            expect(result).to.be.ok;
+        });
+
+        it('is available for 2 selected ways if the first one has a name tag', function () {
+            var result = iD.operationCloneName(fakeContext, ['w1', 'w3']).available();
+            expect(result).to.be.ok;
+        });
+
+        it('is available for 3 selected nodes if the first one has a name tag', function () {
+            var result = iD.operationCloneName(fakeContext, ['n1', 'n2', 'n3']).available();
+            expect(result).to.be.ok;
+        });
+
+        it('is available for 3 selected ways if the first one a name tag', function () {
+            var result = iD.operationCloneName(fakeContext, ['w1', 'w2', 'w3']).available();
+            expect(result).to.be.ok;
+        });
+
+        it('is available for 1 selected node et 1 selected way if the first one has a name tag', function () {
+            var result = iD.operationCloneName(fakeContext, ['n1', 'w2']).available();
+            expect(result).to.be.ok;
+        });
+
+    });
+});

--- a/test/spec/operations/clone_sidewalk.js
+++ b/test/spec/operations/clone_sidewalk.js
@@ -1,0 +1,78 @@
+describe('iD.clone_sidewalk', function () {
+    var fakeContext;
+    var graph;
+
+    // Set up the fake context
+    fakeContext = {};
+    fakeContext.graph = function() { return graph; };
+    fakeContext.entity = function(id) { return graph.entity(id); };
+    fakeContext.hasHiddenConnections = function() { return false; };
+
+    describe('#available', function () {
+        beforeEach(function () {
+            // w1 - way with 2 nodes
+            // w2 - way with 2 nodes
+            graph = iD.coreGraph([
+                iD.osmNode({ id: 'n1', type: 'node', tags: { 'sidewalk': 'foo' } }),
+                iD.osmNode({ id: 'n2', type: 'node' }),
+                iD.osmNode({ id: 'n3', type: 'node' }),
+                iD.osmNode({ id: 'n4', type: 'node' }),
+                iD.osmNode({ id: 'n5', type: 'node' }),
+                iD.osmWay({ id: 'w1', nodes: ['n1', 'n2'], tags: { 'sidewalk:right': 'foo', 'foot':'bar' } }),
+                iD.osmWay({ id: 'w2', nodes: ['n3', 'n4'] }),
+                iD.osmWay({ id: 'w3', nodes: ['n4', 'n5'] })
+            ]);
+        });
+
+        it('is not available for no selected ids', function () {
+            var result = iD.operationCloneSidewalk(fakeContext, []).available();
+            expect(result).to.be.not.ok;
+        });
+
+        it('is not available for 1 selected node', function () {
+            var result = iD.operationCloneSidewalk(fakeContext, ['n1']).available();
+            expect(result).to.be.not.ok;
+        });
+
+        it('is not available for 1 selected way', function () {
+            var result = iD.operationCloneSidewalk(fakeContext, ['w1']).available();
+            expect(result).to.be.not.ok;
+        });
+
+        it('is not available for 2 selected nodes if the first one doesn\'t have a sidewalk tag', function () {
+            var result = iD.operationCloneSidewalk(fakeContext, ['n2', 'n3']).available();
+            expect(result).to.be.not.ok;
+        });
+
+        it('is not available for 2 selected ways if the first one doesn\'t have a sidewalk tag', function () {
+            var result = iD.operationCloneSidewalk(fakeContext, ['w2', 'w3']).available();
+            expect(result).to.be.not.ok;
+        });
+
+        it('is available for 2 selected nodes if the first one has a sidewalk tag', function () {
+            var result = iD.operationCloneSidewalk(fakeContext, ['n1', 'n3']).available();
+            expect(result).to.be.ok;
+        });
+
+        it('is available for 2 selected ways if the first one has a sidewalk tag', function () {
+            var result = iD.operationCloneSidewalk(fakeContext, ['w1', 'w3']).available();
+            expect(result).to.be.ok;
+        });
+
+        it('is available for 3 selected nodes if the first one has a sidewalk tag', function () {
+            var result = iD.operationCloneSidewalk(fakeContext, ['n1', 'n2', 'n3']).available();
+            expect(result).to.be.ok;
+        });
+
+        it('is available for 3 selected ways if the first one a sidewalk tag', function () {
+            var result = iD.operationCloneSidewalk(fakeContext, ['w1', 'w2', 'w3']).available();
+            expect(result).to.be.ok;
+        });
+
+        it('is available for 1 selected node et 1 selected way if the first one has a sidewalk tag', function () {
+            var result = iD.operationCloneSidewalk(fakeContext, ['n1', 'w2']).available();
+            expect(result).to.be.ok;
+        });
+
+    });
+});

--- a/test/spec/operations/clone_transition.js
+++ b/test/spec/operations/clone_transition.js
@@ -1,0 +1,78 @@
+describe('iD.clone_transition', function () {
+    var fakeContext;
+    var graph;
+
+    // Set up the fake context
+    fakeContext = {};
+    fakeContext.graph = function() { return graph; };
+    fakeContext.entity = function(id) { return graph.entity(id); };
+    fakeContext.hasHiddenConnections = function() { return false; };
+
+    describe('#available', function () {
+        beforeEach(function () {
+            // w1 - way with 2 nodes
+            // w2 - way with 2 nodes
+            graph = iD.coreGraph([
+                iD.osmNode({ id: 'n1', type: 'node', tags: { 'placement': 'foo' } }),
+                iD.osmNode({ id: 'n2', type: 'node' }),
+                iD.osmNode({ id: 'n3', type: 'node' }),
+                iD.osmNode({ id: 'n4', type: 'node' }),
+                iD.osmNode({ id: 'n5', type: 'node' }),
+                iD.osmWay({ id: 'w1', nodes: ['n1', 'n2'], tags: { 'placement:start': 'foo', 'width:lanes:start':'bar' } }),
+                iD.osmWay({ id: 'w2', nodes: ['n3', 'n4'] }),
+                iD.osmWay({ id: 'w3', nodes: ['n4', 'n5'] })
+            ]);
+        });
+
+        it('is not available for no selected ids', function () {
+            var result = iD.operationCloneTransition(fakeContext, []).available();
+            expect(result).to.be.not.ok;
+        });
+
+        it('is not available for 1 selected node', function () {
+            var result = iD.operationCloneTransition(fakeContext, ['n1']).available();
+            expect(result).to.be.not.ok;
+        });
+
+        it('is not available for 1 selected way', function () {
+            var result = iD.operationCloneTransition(fakeContext, ['w1']).available();
+            expect(result).to.be.not.ok;
+        });
+
+        it('is not available for 2 selected nodes if the first one doesn\'t have a transition tag', function () {
+            var result = iD.operationCloneTransition(fakeContext, ['n2', 'n3']).available();
+            expect(result).to.be.not.ok;
+        });
+
+        it('is not available for 2 selected ways if the first one doesn\'t have a transition tag', function () {
+            var result = iD.operationCloneTransition(fakeContext, ['w2', 'w3']).available();
+            expect(result).to.be.not.ok;
+        });
+
+        it('is available for 2 selected nodes if the first one has a transition tag', function () {
+            var result = iD.operationCloneTransition(fakeContext, ['n1', 'n3']).available();
+            expect(result).to.be.ok;
+        });
+
+        it('is available for 2 selected ways if the first one has a transition tag', function () {
+            var result = iD.operationCloneTransition(fakeContext, ['w1', 'w3']).available();
+            expect(result).to.be.ok;
+        });
+
+        it('is available for 3 selected nodes if the first one has a transition tag', function () {
+            var result = iD.operationCloneTransition(fakeContext, ['n1', 'n2', 'n3']).available();
+            expect(result).to.be.ok;
+        });
+
+        it('is available for 3 selected ways if the first one a transition tag', function () {
+            var result = iD.operationCloneTransition(fakeContext, ['w1', 'w2', 'w3']).available();
+            expect(result).to.be.ok;
+        });
+
+        it('is available for 1 selected node et 1 selected way if the first one has a transition tag', function () {
+            var result = iD.operationCloneTransition(fakeContext, ['n1', 'w2']).available();
+            expect(result).to.be.ok;
+        });
+
+    });
+});

--- a/test/spec/operations/clone_turn_lanes.js
+++ b/test/spec/operations/clone_turn_lanes.js
@@ -1,0 +1,78 @@
+describe('iD.clone_turn_lanes', function () {
+    var fakeContext;
+    var graph;
+
+    // Set up the fake context
+    fakeContext = {};
+    fakeContext.graph = function() { return graph; };
+    fakeContext.entity = function(id) { return graph.entity(id); };
+    fakeContext.hasHiddenConnections = function() { return false; };
+
+    describe('#available', function () {
+        beforeEach(function () {
+            // w1 - way with 2 nodes
+            // w2 - way with 2 nodes
+            graph = iD.coreGraph([
+                iD.osmNode({ id: 'n1', type: 'node', tags: { 'turn:lanes': 'foo' } }),
+                iD.osmNode({ id: 'n2', type: 'node' }),
+                iD.osmNode({ id: 'n3', type: 'node' }),
+                iD.osmNode({ id: 'n4', type: 'node' }),
+                iD.osmNode({ id: 'n5', type: 'node' }),
+                iD.osmWay({ id: 'w1', nodes: ['n1', 'n2'], tags: { 'turn:lanes:forward': 'foo', 'turn:lanes:backward':'bar' } }),
+                iD.osmWay({ id: 'w2', nodes: ['n3', 'n4'] }),
+                iD.osmWay({ id: 'w3', nodes: ['n4', 'n5'] })
+            ]);
+        });
+
+        it('is not available for no selected ids', function () {
+            var result = iD.operationCloneTurnLanes(fakeContext, []).available();
+            expect(result).to.be.not.ok;
+        });
+
+        it('is not available for 1 selected node', function () {
+            var result = iD.operationCloneTurnLanes(fakeContext, ['n1']).available();
+            expect(result).to.be.not.ok;
+        });
+
+        it('is not available for 1 selected way', function () {
+            var result = iD.operationCloneTurnLanes(fakeContext, ['w1']).available();
+            expect(result).to.be.not.ok;
+        });
+
+        it('is not available for 2 selected nodes if the first one doesn\'t have a turn lane tag', function () {
+            var result = iD.operationCloneTurnLanes(fakeContext, ['n2', 'n3']).available();
+            expect(result).to.be.not.ok;
+        });
+
+        it('is not available for 2 selected ways if the first one doesn\'t have a turn lane tag', function () {
+            var result = iD.operationCloneTurnLanes(fakeContext, ['w2', 'w3']).available();
+            expect(result).to.be.not.ok;
+        });
+
+        it('is available for 2 selected nodes if the first one has a turn lane tag', function () {
+            var result = iD.operationCloneTurnLanes(fakeContext, ['n1', 'n3']).available();
+            expect(result).to.be.ok;
+        });
+
+        it('is available for 2 selected ways if the first one has a turn lane tag', function () {
+            var result = iD.operationCloneTurnLanes(fakeContext, ['w1', 'w3']).available();
+            expect(result).to.be.ok;
+        });
+
+        it('is available for 3 selected nodes if the first one has a turn lane tag', function () {
+            var result = iD.operationCloneTurnLanes(fakeContext, ['n1', 'n2', 'n3']).available();
+            expect(result).to.be.ok;
+        });
+
+        it('is available for 3 selected ways if the first one a turn lane tag', function () {
+            var result = iD.operationCloneTurnLanes(fakeContext, ['w1', 'w2', 'w3']).available();
+            expect(result).to.be.ok;
+        });
+
+        it('is available for 1 selected node et 1 selected way if the first one has a bus lane tag', function () {
+            var result = iD.operationCloneTurnLanes(fakeContext, ['n1', 'w2']).available();
+            expect(result).to.be.ok;
+        });
+
+    });
+});


### PR DESCRIPTION
Fixes #9191

Added an action that clones tags from the first selected entity to all other entities.
Created one base operation that clones a subset of tags.
Created several operations that call the base operation and pass a subset of related tags to clone.
It allows to save time by copying several related tags with one click.

Also added unit tests for those features.