### PR TITLE
Show private and customers access with different casing colour

### DIFF
--- a/css/30_highways.css
+++ b/css/30_highways.css
@@ -589,6 +589,13 @@ path.line.stroke.tag-highway-steps,
     stroke: #fff;
 }
 
+/* access: private, customers */
+path.line.casing.tag-access-customers.tag-highway-service {
+    stroke: rgb(255, 136, 0);
+}
+path.line.casing.tag-access-private.tag-highway-service {
+    stroke: rgb(189, 0, 0);
+}
 
 /* crossings */
 path.line.stroke.tag-highway.tag-crossing-unmarked {

--- a/modules/svg/tag_classes.js
+++ b/modules/svg/tag_classes.js
@@ -132,18 +132,30 @@ export function svgTagClasses() {
         }
 
         // For highways, look for surface tagging..
-        if ((primary === 'highway' && !osmPathHighwayTagValues[t.highway]) || primary === 'aeroway') {
-            var surface = t.highway === 'track' ? 'unpaved' : 'paved';
+        if (primary === 'highway' || primary === 'aeroway') {
+            var isNonPathHighwayTags = !osmPathHighwayTagValues[t.highway];
+            var surface = isNonPathHighwayTags ? t.highway === 'track' ? 'unpaved' : 'paved' : undefined;
+            var access = null;
             for (k in t) {
                 v = t[k];
-                if (k in osmPavedTags) {
-                    surface = osmPavedTags[k][v] ? 'paved' : 'unpaved';
+                if (isNonPathHighwayTags) {
+                    if (k in osmPavedTags) {
+                        surface = osmPavedTags[k][v] ? 'paved' : 'unpaved';
+                    }
+                    if (k in osmSemipavedTags && !!osmSemipavedTags[k][v]) {
+                        surface = 'semipaved';
+                    }
                 }
-                if (k in osmSemipavedTags && !!osmSemipavedTags[k][v]) {
-                    surface = 'semipaved';
+                // access tag
+                if (k === 'access') {
+                    access = v;
+                    classes.push('tag-access-' + access);
                 }
             }
-            classes.push('tag-' + surface);
+            if (surface) {
+                classes.push('tag-' + surface);
+            }
+            
         }
 
         // If this is a wikidata-tagged item, add a class for that..


### PR DESCRIPTION
Fixes #9207

Added access to the tag classes.
For a highway=service with access=private the casing is red.
For a highway=service with access=customers the casing is orange.
I allows to quickly see the access type.