### PR TITLE
Corrections and additions to languages listed in territory_language.json for Pakistan (pk)

### DIFF
--- a/data/territory_languages.json
+++ b/data/territory_languages.json
@@ -181,7 +181,7 @@
   "pf": ["fr", "ty", "zh-Hant"],
   "pg": ["tpi", "en", "ho"],
   "ph": ["en", "fil", "es", "ceb", "ilo", "hil", "bik", "war", "bhk", "pam", "pag", "mdh", "tsg", "zh-Hant", "cps", "krj", "bto", "hnn", "tbw", "bku"],
-  "pk": ["ur", "pa-Arab", "en", "lah", "ps", "sd", "skr", "bal", "brh", "hno", "fa", "bgn", "hnd", "tg-Arab", "gju", "bft", "kvx", "khw", "mvy", "gjk", "kxp", "ks", "btv"],
+  "pk": ["ur", "pnb", "en", "ps", "sd", "skr", "bal", "brh", "hno", "fa", "bgn", "hnd", "gju", "bft", "kvx", "khw", "mvy", "gjk", "kxp", "ks", "btv", "scl", "trw", "kls"],
   "pl": ["pl", "en", "de", "ru", "szl", "be", "uk", "csb", "sli", "lt"],
   "pm": ["fr", "en"],
   "pn": ["en"],


### PR DESCRIPTION
Some notes:
* `pa-Arab` changed to `pnb` to match the standard tag for Punjabi Shahmukhi used on OSM and elsewhere (more detail on this in previous issue I just created #9241)
* removed `lah`. This has a code for some reason but it is not a real language. Lahnda is a term originally used by colonial surveyor George Grierson because he thought he had identified a Dardic language spoken in western Punjab. The name was supposed to be based on the Punjabi word for "west" lahnda/lahndi, but because he did not understand much of Punjabi grammar he incorrectly used the masculine form of the adjective despite the fact that languages are typically grammatically feminine. This idea has long been discredited by Punjabi linguists. What Grierson misidentified as a separate language was actually just plain Punjabi with some very minor dialectal variation. Contemporary Punjabi linguists use a similar name for western Punjabi dialects because lahnda/lahndi is just a common word, but this is not understood as a separate language and rather a continuum of variation within the language (this is made less confusing by the fact that contemporary linguists always use the grammatically correct lahndi or lahendi, for example in https://clrjournal.com/ojs/index.php/clrjournal/article/view/10). Something that may have lead early linguists like Grierson astray is that while "standard" Punjabi mostly lacks grammatical tense and doesn't require verbs to indicate time with respect to the situation, in some western regions like Mirpur the future tense verb forms from Sanskrit have been preserved. To someone unaware of these verbs came from Sanskrit just like the rest of Punjabi it might have seemed like they came from another language. That is maybe too much detail, but I thought I should elaborate so it's clear that this code I'm recommending to remove isn't actually usable for anything, and this is something that many sources still get wrong.
* removed `tg-Arab`. There are people of Tajik ethnicity in Pakistan who use the Arabic script, but the Tajik language itself is just a dialect of Persian which happens to use the Cyrillic script. I don't think anybody has actually ever used `tg-Arab` for anything as this is essentially saying "Persian in Cyrillic script in Arabic script" which is already covered completely by just default Persian `fa`.
* Added codes for Torwali, Kalasha, Shina