### PR TITLE
Fix undo text when deleting private tags

### DIFF
--- a/modules/validations/private_data.js
+++ b/modules/validations/private_data.js
@@ -69,7 +69,7 @@ export function validationPrivateData() {
                         icon: 'iD-operation-delete',
                         title: t.append('issues.fix.' + fixID + '.title'),
                         onClick: function(context) {
-                            context.perform(doUpgrade, t('issues.fix.upgrade_tags.annotation'));
+                            context.perform(doUpgrade, t('issues.fix.remove_tag.annotation'));
                         }
                     })
                 ];


### PR DESCRIPTION
The private tag validation rule comes with a suggested fix that deletes the tag, but accepting the suggestion results in “Upgraded old tags” being set as the undo text. This PR changes it to “Removed tag”, which already exists in core.yaml but was only being used by the mismatched geometry validation rule.