### PR TITLE
stop automatically adding railway crossing tags when adding tram-road/path intersection nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :tada: New Features
 #### :white_check_mark: Validation
 #### :bug: Bugfixes
-* Use standard railway crossing tags when marking tram-road/path intersections ([#9306])
+* Don't add non-standard `railway=tram_crossing/rail_level_crossing` tags when using validator to add connection nodes at tram-road/path intersections ([#9306])
 #### :rocket: Presets
 #### :hammer: Development
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,11 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :tada: New Features
 #### :white_check_mark: Validation
 #### :bug: Bugfixes
+* Use standard railway crossing tags when marking tram-road/path intersections ([#9306])
 #### :rocket: Presets
 #### :hammer: Development
+
+[#9306]: https://github.com/openstreetmap/iD/pull/9306
 
 
 # 2.22.0

--- a/modules/validations/crossing_ways.js
+++ b/modules/validations/crossing_ways.js
@@ -164,6 +164,9 @@ export function validationCrossingWays(context) {
                 if (featureTypes.indexOf('railway') !== -1) {
                     if (!bothLines) return {};
 
+                    var isTram = entity1.tags.railway === 'tram' || entity2.tags.railway === 'tram';
+                    if (isTram) return {};
+
                     if (osmPathHighwayTagValues[entity1.tags.highway] ||
                         osmPathHighwayTagValues[entity2.tags.highway]) {
                         return { railway: 'crossing' };

--- a/modules/validations/crossing_ways.js
+++ b/modules/validations/crossing_ways.js
@@ -164,21 +164,10 @@ export function validationCrossingWays(context) {
                 if (featureTypes.indexOf('railway') !== -1) {
                     if (!bothLines) return {};
 
-                    var isTram = entity1.tags.railway === 'tram' || entity2.tags.railway === 'tram';
-
                     if (osmPathHighwayTagValues[entity1.tags.highway] ||
                         osmPathHighwayTagValues[entity2.tags.highway]) {
-
-                        // path-tram connections use this tag
-                        if (isTram) return { railway: 'tram_crossing' };
-
-                        // other path-rail connections use this tag
                         return { railway: 'crossing' };
                     } else {
-                        // path-tram connections use this tag
-                        if (isTram) return { railway: 'tram_level_crossing' };
-
-                        // other road-rail connections use this tag
                         return { railway: 'level_crossing' };
                     }
                 }


### PR DESCRIPTION
Addresses concerns raised in https://wiki.openstreetmap.org/wiki/ID/Controversial_Decisions#Tram_crossings or https://wiki.openstreetmap.org/wiki/Talk:Tag:railway%3Dtram_level_crossing.

This essentially reverts #7902: Instead of using the undiscussed tags `railway=tram_level_crossing` and `railway=tram_crossing`, the regular values of railway crossing tags should be used at intersections of tram lines with roads or paths.

See https://github.com/openstreetmap/id-tagging-schema/pull/596 for a related change to the tagging schema repository.

~~Still to be discussed: Should there be a tag upgrade/deprecation rule be implemented to fix these `tram_*crossing` tags?~~

//edit: as noted below (https://github.com/openstreetmap/iD/pull/9306#issuecomment-1258412778), automatically adding any railway crossing tags is not good practice. I've changed the PR to not add any additional crossing tags in these situations.