### PR TITLE
Change None background to white, change color of roads

### DIFF
--- a/css/30_highways.css
+++ b/css/30_highways.css
@@ -198,7 +198,7 @@ path.line.casing.tag-tertiary {
 }
 path.line.stroke.tag-highway-residential,
 path.line.stroke.tag-residential {
-    stroke: #fff;
+    stroke: #d3d3d3;
 }
 path.line.casing.tag-highway-residential,
 path.line.casing.tag-residential {
@@ -404,7 +404,7 @@ path.line.casing.tag-road {
 /* service roads */
 path.line.stroke.tag-highway-service,
 path.line.stroke.tag-service {
-    stroke: #fff;
+    stroke: #d3d3d3;
 }
 path.line.casing.tag-highway-service,
 path.line.casing.tag-service {
@@ -428,7 +428,7 @@ path.line.stroke.tag-highway-service.tag-service-parking_aisle {
     stroke: #cccac7;
 }
 path.line.stroke.tag-highway-service.tag-service-driveway {
-    stroke: #fff6e4;
+    stroke: #f3e9d7;
 }
 path.line.stroke.tag-highway-service.tag-service-emergency_access {
     stroke: #ddb2aa;

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -4193,7 +4193,7 @@ img.tile-debug {
     overflow: hidden;
     height: 100%;
     width: 100%;
-    background: #000;
+    background: #fff;
     user-select: none;
     touch-action: none;
     -webkit-touch-callout: none;


### PR DESCRIPTION
Address Issue #9281 

Changes:
- Changed default map background to white
- Also changed residential and service roads to light grey, and driveways to a darker yellow. 

Purpose:
To improve readability and UX

Visuals:
Before:
<img width="1440" alt="Screen Shot 2022-09-26 at 3 51 43 PM" src="https://user-images.githubusercontent.com/80357302/192367215-a00ce611-15ef-4654-b7b8-dfed38616ea9.png">
After:
<img width="1440" alt="Screen Shot 2022-09-26 at 3 45 36 PM" src="https://user-images.githubusercontent.com/80357302/192366144-128872c4-3975-45ce-82a2-7f84af3905a9.png">