### PR TITLE
support quickly adding a direction tag to traffic signs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 # unreleased (v2.36.0-dev)
 
 #### :sparkles: Usability & Accessibility
+* The flip operation now works on nodes with no `direction` tag, to support quickly adding `direction` to features like traffic signs ([#9317], thanks [@k-yle])
+
 #### :scissors: Operations
 #### :camera: Street-Level
 #### :white_check_mark: Validation
@@ -49,6 +51,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :mortar_board: Walkthrough / Help
 #### :hammer: Development
 
+[#9317]: https://github.com/openstreetmap/iD/issues/9317
 [#9754]: https://github.com/openstreetmap/iD/issues/9754
 [#11206]: https://github.com/openstreetmap/iD/issues/11206
 

--- a/modules/actions/reverse.js
+++ b/modules/actions/reverse.js
@@ -1,3 +1,5 @@
+import { presetManager } from '../presets';
+
 /*
 Order the nodes of a way in reverse order and reverse any direction dependent tags
 other than `oneway`. (We assume that correcting a backwards oneway is the primary
@@ -144,6 +146,29 @@ export function actionReverse(entityID, options) {
         return valueReplacements[value] || value;
     }
 
+    /** @returns {false | string} - returns false or the name of the direction key */
+    function supportsDirectionField(node, graph) {
+        const preset = presetManager.match(node, graph);
+        const loc = node.extent(graph).center();
+        const geometry = node.geometry(graph);
+
+        const fields = [...preset.fields(loc), ...preset.moreFields(loc)];
+
+        const maybeDirectionField = fields.find(field => {
+            const isDirectionField = field.key && (field.key === 'direction' || field.key.endsWith(':direction'));
+            // some direction fields are for angles, so ensure that the
+            // direction field on this preset is not a numeric field.
+            const isRelativeDirection = field.type === 'combo';
+
+            // the field's geometry might be restricted to a subset of the preset's geometry
+            const isGeometryValid = !field.geometry || field.geometry.includes(geometry);
+
+            return isDirectionField && isRelativeDirection && isGeometryValid;
+        });
+
+        return maybeDirectionField?.key || false;
+    }
+
 
     // Reverse the direction of tags attached to the nodes - #3076
     function reverseNodeTags(graph, nodeIDs) {
@@ -151,10 +176,26 @@ export function actionReverse(entityID, options) {
             var node = graph.hasEntity(nodeIDs[i]);
             if (!node || !Object.keys(node.tags).length) continue;
 
+            let anyChanges = false;
             var tags = {};
             for (var key in node.tags) {
-                tags[reverseKey(key)] = reverseValue(key, node.tags[key], node.id === entityID, node.tags);
+                const value = node.tags[key];
+
+                const newKey = reverseKey(key);
+                const newValue = reverseValue(key, value, node.id === entityID, node.tags);
+                tags[newKey] = newValue;
+                if (key !== newKey || value !== newValue) {
+                    anyChanges = true;
+                }
             }
+
+            // for features whose presets have a direction field,
+            // the first flip just adds the direction tag.
+            const directionKey = supportsDirectionField(node, graph);
+            if (node.id === entityID && !anyChanges && directionKey) {
+                tags[directionKey] = 'forward';
+            }
+
             graph = graph.replace(node.update({tags: tags}));
         }
         return graph;
@@ -204,6 +245,13 @@ export function actionReverse(entityID, options) {
                 return false;
             }
         }
+
+
+        // exception for features whose presets have a direction
+        // field - they're flipable even if they don't have a
+        // direction tag.
+        if (supportsDirectionField(entity, graph)) return false;
+
         return 'nondirectional_node';
     };
 

--- a/test/spec/actions/reverse.js
+++ b/test/spec/actions/reverse.js
@@ -1,4 +1,31 @@
 describe('iD.actionReverse', function () {
+    beforeEach(() => {
+        iD.fileFetcher.cache().preset_fields = {
+            direction: { key: 'direction', type: 'combo' },
+            'prefixed:direction': { key: 'prefixed:direction', type: 'combo' }
+        };
+        iD.fileFetcher.cache().preset_presets = {
+            'Give Way Sign': {
+                 // this preset has direction as a normal field
+                tags: { highway: 'give_way' },
+                geometry: ['point', 'vertex'],
+                fields: ['direction']
+            },
+            'Advance Stop Line': {
+                // this preset has direction under moreFields
+                tags: { cycleway: 'asl' },
+                geometry: ['point', 'vertex'],
+                moreFields: ['direction']
+            },
+            'Traffic Lights': {
+                // this preset uses a prefixed direction tag
+                tags: { highway: 'traffic_signals' },
+                geometry: ['point', 'vertex'],
+                moreFields: ['prefixed:direction']
+            },
+        };
+    });
+
     it('reverses the order of nodes in the way', function () {
         var node1 = iD.osmNode();
         var node2 = iD.osmNode();
@@ -93,6 +120,36 @@ describe('iD.actionReverse', function () {
             var node1 = iD.osmNode({ tags: { 'direction': 'both' } });
             var graph = iD.actionReverse(node1.id)(iD.coreGraph([node1]));
             expect(graph.entity(node1.id).tags).to.eql({ 'direction': 'both' });
+        });
+
+        describe('directionless nodes', () => {
+            it('adds a direction tag to directionless nodes if the preset has a direction field', async () => {
+                await iD.presetManager.ensureLoaded(true);
+                const node1 = iD.osmNode({ tags: { highway: 'give_way' } });
+                const graph = iD.actionReverse(node1.id)(iD.coreGraph([node1]));
+                expect(graph.entity(node1.id).tags).to.eql({ highway: 'give_way', direction: 'forward' });
+            });
+
+            it('adds a direction tag to directionless nodes if the preset has a direction field under moreFields', async () => {
+                await iD.presetManager.ensureLoaded(true);
+                const node1 = iD.osmNode({ tags: { cycleway: 'asl' } });
+                const graph = iD.actionReverse(node1.id)(iD.coreGraph([node1]));
+                expect(graph.entity(node1.id).tags).to.eql({ cycleway: 'asl', direction: 'forward' });
+            });
+
+            it('does not add a direction tag to directionless nodes if the preset has no direction field', async () => {
+                await iD.presetManager.ensureLoaded(true);
+                const node1 = iD.osmNode({ tags: { amenity: 'ferry_terminal' } });
+                const graph = iD.actionReverse(node1.id)(iD.coreGraph([node1]));
+                expect(graph.entity(node1.id).tags).to.eql({ amenity: 'ferry_terminal' });
+            });
+
+            it('adds a custom direction tag to directionless nodes if the preset has a custom direction field', async () => {
+                await iD.presetManager.ensureLoaded(true);
+                const node1 = iD.osmNode({ tags: { highway: 'traffic_signals' } });
+                const graph = iD.actionReverse(node1.id)(iD.coreGraph([node1]));
+                expect(graph.entity(node1.id).tags).to.eql({ highway: 'traffic_signals', 'prefixed:direction': 'forward' });
+            });
         });
     });
 


### PR DESCRIPTION
Pressing <kbd>v</kbd> flips the direction of a node, but does nothing for direction-less nodes. 

This PR makes the <kbd>v</kbd> key add a `direction` tag if you try to flip a stop sign/give-way sign without a `direction` tag. 

This significantly speeds up the process of mapping stop signs and give-way signs. 

Alternative solution to #9802