### PR TITLE
add default implied access values for ways with "motorroad=yes"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Better handling of rate limited API calls and other API errors ([#10299])
 * Fix info boxes for descriptions of brands referenced by [NSI](https://github.com/osmlab/name-suggestion-index) presets ([#10885])
 * Make features clickable when "Full Fill" rendering style is selected
+* Fix calculation of access field placeholders for multi selections ([#9333])
 #### :earth_asia: Localization
 #### :hourglass: Performance
 #### :mortar_board: Walkthrough / Help

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,8 +61,10 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :rocket: Presets
 * Don't inherit fields which the current preset already has a dedicated field for
 * Take location into account when setting a presets default values from regional fields
+* Roads with `motorroad=yes` show implied access restrictions (`foot=no`, `bicycle=no`, `horse=no`) ([id-tagging-schema#609], [#9333])
 #### :hammer: Development
 
+[#9333]: https://github.com/openstreetmap/iD/pull/9333
 [#10299]: https://github.com/openstreetmap/iD/issues/10299
 [#10392]: https://github.com/openstreetmap/iD/issues/10392
 [#10394]: https://github.com/openstreetmap/iD/pull/10394
@@ -71,6 +73,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#10843]: https://github.com/openstreetmap/iD/pull/10843
 [#10852]: https://github.com/openstreetmap/iD/issues/10852
 [#10885]: https://github.com/openstreetmap/iD/issues/10885
+[id-tagging-schema#609]: https://github.com/openstreetmap/id-tagging-schema/issues/609
 [@0xatulpatil]: https://github.com/0xatulpatil
 [@MohamedAli00949]: https://github.com/MohamedAli00949
 

--- a/modules/ui/fields/access.js
+++ b/modules/ui/fields/access.js
@@ -312,12 +312,19 @@ export function uiFieldAccess(field, context) {
                 if (tags[accessField]) {
                     return tags[accessField];
                 }
+                // implied access
+                // motorroad: https://wiki.openstreetmap.org/wiki/OSM_tags_for_routing/Access_restrictions
+                if (tags.motorroad === 'yes' && (accessField === 'foot' || accessField === 'bicycle' || accessField === 'horse')) {
+                    return 'no';
+                }
+                // inherited access
                 if (tags.vehicle && (accessField === 'bicycle' || accessField === 'motor_vehicle')) {
                     return tags.vehicle;
                 }
                 if (tags.access) {
                     return tags.access;
                 }
+                // default access by road/barrier type
                 for (const key in placeholdersByTag) {
                     if (tags[key]) {
                         if (placeholdersByTag[key][tags[key]] &&

--- a/modules/ui/fields/access.js
+++ b/modules/ui/fields/access.js
@@ -277,55 +277,60 @@ export function uiFieldAccess(field, context) {
         utilGetSetValue(items.selectAll('.preset-input-access'), function(d) {
                 return typeof tags[d] === 'string' ? tags[d] : '';
             })
-            .classed('mixed', function(d) {
-                return tags[d] && Array.isArray(tags[d]);
+            .classed('mixed', function(accessField) {
+                return tags[accessField] && Array.isArray(tags[accessField])
+                    || new Set(getAllPlaceholders(tags, accessField)).size > 1;
             })
-            .attr('title', function(d) {
-                return tags[d] && Array.isArray(tags[d]) && tags[d].filter(Boolean).join('\n');
+            .attr('title', function(accessField) {
+                return tags[accessField] && Array.isArray(tags[accessField]) && tags[accessField].filter(Boolean).join('\n');
             })
-            .attr('placeholder', function(d) {
-                if (tags[d] && Array.isArray(tags[d])) {
+            .attr('placeholder', function(accessField) {
+                let placeholders = getAllPlaceholders(tags, accessField);
+                if (new Set(placeholders).size === 1) {
+                    // all objects have the same implied access
+                    return placeholders[0];
+                } else {
                     return t('inspector.multiple_values');
                 }
-                if (d === 'bicycle' || d === 'motor_vehicle') {
-                    if (tags.vehicle && typeof tags.vehicle === 'string') {
-                        return tags.vehicle;
-                    }
-                }
-                if (tags.access && typeof tags.access === 'string') {
-                    return tags.access;
-                }
-                function getPlaceholdersByTag(key, placeholdersByKey) {
-                    if (typeof tags[key] === 'string') {
-                        if (placeholdersByKey[tags[key]] &&
-                            placeholdersByKey[tags[key]][d]) {
-                            return placeholdersByKey[tags[key]][d];
-                        }
-                    } else {
-                        var impliedAccesses = tags[key].filter(Boolean).map(function(val) {
-                            return placeholdersByKey[val] && placeholdersByKey[val][d];
-                        }).filter(Boolean);
+            });
 
-                        if (impliedAccesses.length === tags[key].length &&
-                            new Set(impliedAccesses).size === 1) {
-                            // if all the barrier values have the same implied access for this type then use that
-                            return impliedAccesses[0];
-                        }
-                    }
+            function getAllPlaceholders(tags, accessField) {
+                let allTags = tags[Symbol.for('allTags')];
+                if (allTags && allTags.length > 1) {
+                    // multi selection
+                    const placeholders = [];
+                    allTags.forEach(tags => {
+                        placeholders.push(getPlaceholder(tags, accessField));
+                    });
+                    return placeholders;
+                } else {
+                    return [getPlaceholder(tags, accessField)];
+                }
+            }
+
+            function getPlaceholder(tags, accessField) {
+                if (tags[accessField]) {
+                    return tags[accessField];
+                }
+                if (tags.vehicle && (accessField === 'bicycle' || accessField === 'motor_vehicle')) {
+                    return tags.vehicle;
+                }
+                if (tags.access) {
+                    return tags.access;
                 }
                 for (const key in placeholdersByTag) {
                     if (tags[key]) {
-                        const impliedAccess = getPlaceholdersByTag(key, placeholdersByTag[key]);
-                        if (impliedAccess) {
-                            return impliedAccess;
+                        if (placeholdersByTag[key][tags[key]] &&
+                            placeholdersByTag[key][tags[key]][accessField]) {
+                            return placeholdersByTag[key][tags[key]][accessField];
                         }
                     }
                 }
-                if (d === 'access' && !tags.barrier) {
+                if (accessField === 'access' && !tags.barrier) {
                     return 'yes';
                 }
                 return field.placeholder();
-            });
+            }
     };
 
 

--- a/modules/util/util.js
+++ b/modules/util/util.js
@@ -298,6 +298,7 @@ export function utilCombinedTags(entityIDs, graph) {
     var tags = {};
     var tagCounts = {};
     var allKeys = new Set();
+    var allTags = [];
 
     var entities = entityIDs.map(function(entityID) {
         return graph.hasEntity(entityID);
@@ -312,6 +313,7 @@ export function utilCombinedTags(entityIDs, graph) {
     });
 
     entities.forEach(function(entity) {
+        allTags.push(entity.tags);
 
         allKeys.forEach(function(key) {
 
@@ -358,6 +360,7 @@ export function utilCombinedTags(entityIDs, graph) {
         });
     }
 
+    tags = Object.defineProperty(tags, Symbol.for('allTags'), { enumerable: false, value: allTags });
     return tags;
 }
 

--- a/test/spec/ui/fields/access.js
+++ b/test/spec/ui/fields/access.js
@@ -121,6 +121,16 @@ describe('iD.uiFieldAccess', function() {
         expect(selection.selectAll('.preset-input-access-bicycle').attr('placeholder')).to.equal('destination');
     });
 
+    it('sets foot, bicycle and horse placeholder to "no" when there a "motorroad=yes" tag (#9333)', function() {
+        var access = iD.uiFieldAccess(field, context);
+        selection.call(access);
+
+        access.tags({highway: 'primary', motorroad: 'yes'});
+        expect(selection.selectAll('.preset-input-access-foot').attr('placeholder')).to.equal('no');
+        expect(selection.selectAll('.preset-input-access-bicycle').attr('placeholder')).to.equal('no');
+        expect(selection.selectAll('.preset-input-access-horse').attr('placeholder')).to.equal('no');
+    });
+
     it('sets correct placeholder on a multi selection', function() {
         var access = iD.uiFieldAccess(field, context);
         selection.call(access);

--- a/test/spec/ui/fields/access.js
+++ b/test/spec/ui/fields/access.js
@@ -112,4 +112,28 @@ describe('iD.uiFieldAccess', function() {
         expect(selection.selectAll('.preset-input-access-motor_vehicle').attr('placeholder')).to.equal('destination');
     });
 
+    it('sets bicycle and motor_vehicle placeholder to the value of the "vehicle" tag (id-tagging-schema#378)', function() {
+        var access = iD.uiFieldAccess(field, context);
+        selection.call(access);
+
+        access.tags({highway: 'residential', vehicle: 'destination'});
+        expect(selection.selectAll('.preset-input-access-motor_vehicle').attr('placeholder')).to.equal('destination');
+        expect(selection.selectAll('.preset-input-access-bicycle').attr('placeholder')).to.equal('destination');
+    });
+
+    it('sets correct placeholder on a multi selection', function() {
+        var access = iD.uiFieldAccess(field, context);
+        selection.call(access);
+
+        var tags = {highway: 'primary', foot: ['yes', 'no'], bicycle: ['no', undefined], vehicle: ['no', undefined]};
+        tags[Symbol.for('allTags')] = [
+            {highway: 'primary', foot: 'yes', bicycle: 'no'},
+            {highway: 'primary', foot: 'no', vehicle: 'no'}
+        ];
+        access.tags(tags);
+        expect(selection.selectAll('.preset-input-access-foot').attr('placeholder')).to.equal(iD.localizer.t('inspector.multiple_values'));
+        expect(selection.selectAll('.preset-input-access-bicycle').attr('placeholder')).to.equal('no');
+        expect(selection.selectAll('.preset-input-access-motor_vehicle').attr('placeholder')).to.equal(iD.localizer.t('inspector.multiple_values'));
+    });
+
 });


### PR DESCRIPTION
The tag `motorroad=yes` implies different access tags [depending on the region](https://wiki.openstreetmap.org/wiki/Key:motorroad#Regional_definitions), but all which are documented on the wiki include at least `foot=no`, `bicycle=no` and `horse=no`. Since that's all what iD currently displays in the _access_ field, this should be sufficient for now. This could be refined / revisited in the future if https://wiki.openstreetmap.org/wiki/OSM_tags_for_routing/Access_restrictions#By_country were to be implemented.

See https://github.com/openstreetmap/id-tagging-schema/issues/609