### PR TITLE
show labels for housenumbers

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -774,6 +774,7 @@ en:
       network_ref_direction: "{network} {ref} {direction}"
       network_ref_from_to: "{network} {ref} from {from} to {to}"
       network_ref_from_to_via: "{network} {ref} from {from} to {to} via {via}"
+      "addr:housenumber": "{addr:housenumber}"
     speed_unit: "Speed unit"
     roadheight:
       # symbol for meters

--- a/modules/svg/labels.js
+++ b/modules/svg/labels.js
@@ -62,7 +62,9 @@ export function svgLabels(projection, context) {
         ['point', 'ref', '*', 10],
         ['line', 'name', '*', 12],
         ['area', 'name', '*', 12],
-        ['point', 'name', '*', 10]
+        ['point', 'name', '*', 10],
+        ['area', 'addr:housenumber', '*', 8],
+        ['point', 'addr:housenumber', '*', 8]
     ];
 
 

--- a/modules/util/util.js
+++ b/modules/util/util.js
@@ -190,7 +190,8 @@ export function utilDisplayName(entity) {
         network: entity.tags.cycle_network || entity.tags.network,
         ref: entity.tags.ref,
         to: entity.tags.to,
-        via: entity.tags.via
+        via: entity.tags.via,
+        'addr:housenumber': entity.tags['addr:housenumber']
     };
     var keyComponents = [];
 
@@ -199,6 +200,9 @@ export function utilDisplayName(entity) {
     }
     if (tags.ref) {
         keyComponents.push('ref');
+    }
+    if (tags['addr:housenumber']) {
+        keyComponents.push('addr:housenumber');
     }
 
     // Routes may need more disambiguation based on direction or destination


### PR DESCRIPTION
this is a very quick and dirty go at #1524

It would look like this:

<img src="https://user-images.githubusercontent.com/1927298/200918301-e9556f4d-2013-4054-9a9c-13bad037dc24.png" width=600/>

notes: the top house has a housenumber, but isn't rendered because it also has a name, which is too long to be shown at this zoom; the two other named houses have also a housenumber, but it's not rendered as the name gets precedence.


### to do
* [ ] only use housenumber as `displayName` for rendering, not for other uses such as validator warnings (e.g. `35 crosses 37` is a bit suboptimal for a warning when two buildings overlap)
* [ ] check how much does this (negatively) affect map readability and/or map rendering speed in densely mapped areas
* [ ] check what optimizations from #3840 can/should be reused