### PR TITLE
Show input string length indicator & warning when nearing maximum tag value length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 
 # Unreleased
 
+#### :tada: New Features
+* Show a _remaining input length_ indicator and a warning if the maximum for OSM tags (typically, 255 characters) is exceeded ([#9390], [#9392] thanks [@alanb43], [#7943], [#9374])
 #### :sparkles: Usability & Accessibility
 #### :white_check_mark: Validation
 #### :bug: Bugfixes
@@ -48,9 +50,14 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :hammer: Development
 * Upgrade to Transifex API v3 ([#9375])
 
+[#7943]: https://github.com/openstreetmap/iD/issues/7943
 [#9372]: https://github.com/openstreetmap/iD/issues/9372
+[#9374]: https://github.com/openstreetmap/iD/issues/9374
 [#9375]: https://github.com/openstreetmap/iD/pull/9375
 [#9386]: https://github.com/openstreetmap/iD/issues/9386
+[#9390]: https://github.com/openstreetmap/iD/pull/9390
+[#9392]: https://github.com/openstreetmap/iD/pull/9392
+[@alanb43]: https://github.com/alanb43
 
 
 # 2.23.2

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -2336,6 +2336,7 @@ div.combobox {
     right: 0;
 }
 
+.form-field-input-wrap > input:focus + span.length-indicator-wrap,
 .form-field-input-wrap > textarea:focus + span.length-indicator-wrap,
 .form-field-input-wrap > textarea:focus + div.combobox-caret + span.length-indicator-wrap {
     visibility: visible;

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -2338,6 +2338,7 @@ div.combobox {
 
 .form-field-input-wrap > input:focus + span.length-indicator-wrap,
 .form-field-input-wrap > textarea:focus + span.length-indicator-wrap,
+.form-field-input-wrap > input:focus + div.combobox-caret + span.length-indicator-wrap,
 .form-field-input-wrap > textarea:focus + div.combobox-caret + span.length-indicator-wrap {
     visibility: visible;
 }

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -2324,6 +2324,36 @@ div.combobox {
     color: #333;
 }
 
+.form-field-input-wrap {
+    position: relative;
+}
+
+.form-field-input-wrap span.length-indicator-wrap {
+    visibility: hidden;
+    position: absolute;
+    top: -5px;
+    left: 0;
+    right: 0;
+}
+
+.form-field-input-wrap > textarea:focus + span.length-indicator-wrap,
+.form-field-input-wrap > textarea:focus + div.combobox-caret + span.length-indicator-wrap {
+    visibility: visible;
+}
+
+.form-field-input-wrap span.length-indicator {
+    display: block;
+    left: 0;
+    right: 0;
+    height: 4px;
+    background-color: #7092ff;
+    border-right-style: solid;
+    border-right-color: lightgray;
+}
+
+.form-field-input-wrap span.length-indicator.limit-reached {
+    border-right-color: red;
+}
 
 /* Field Help
 ------------------------------------------------------- */

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -1717,7 +1717,7 @@ a.hide-toggle {
 
 .form-field-input-multicombo .input-wrap {
     border: 1px solid #ddd;
-    width: 100px;
+    width: 180px;
 }
 .form-field-input-multicombo input {
     border: none;
@@ -2336,10 +2336,10 @@ div.combobox {
     right: 0;
 }
 
-.form-field-input-wrap > input:focus + span.length-indicator-wrap,
-.form-field-input-wrap > textarea:focus + span.length-indicator-wrap,
-.form-field-input-wrap > input:focus + div.combobox-caret + span.length-indicator-wrap,
-.form-field-input-wrap > textarea:focus + div.combobox-caret + span.length-indicator-wrap {
+.form-field-input-wrap input:focus + span.length-indicator-wrap,
+.form-field-input-wrap textarea:focus + span.length-indicator-wrap,
+.form-field-input-wrap input:focus + div.combobox-caret + span.length-indicator-wrap,
+.form-field-input-wrap textarea:focus + div.combobox-caret + span.length-indicator-wrap {
     visibility: visible;
 }
 
@@ -2355,6 +2355,10 @@ div.combobox {
 
 .form-field-input-wrap span.length-indicator.limit-reached {
     border-right-color: red;
+}
+
+.tooltip.max-length-warning {
+    z-index: 10;
 }
 
 /* Field Help

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -5201,11 +5201,14 @@ a.user-info {
     display: none;
 }
 
-.field-warning,
 .changeset-info,
 .request-review,
 .commit-info {
     margin-bottom: 10px;
+}
+
+.field-warning {
+    margin-top: 10px;
 }
 
 .request-review label {

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -615,6 +615,7 @@ en:
     comment_needed_message: Please add a changeset comment first.
     about_changeset_comments: About changeset comments
     about_changeset_comments_link: //wiki.openstreetmap.org/wiki/Good_changeset_comments
+    changeset_comment_length_warning: "Changeset comments can have a maximum of 255 characters"
     google_warning: "You mentioned Google in this comment: remember that copying from Google Maps is strictly forbidden."
     google_warning_link: https://www.openstreetmap.org/copyright
   contributors:

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -782,6 +782,7 @@ en:
       foot: ft
       # abbreviation of inches
       inch: in
+    max_length_reached: "Please keep in mind that texts cannot be longer than a maximum of {maxChars} characters. Anything exceeding that length will be truncated."
   background:
     title: Background
     description: Background Settings

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -782,7 +782,7 @@ en:
       foot: ft
       # abbreviation of inches
       inch: in
-    max_length_reached: "Please keep in mind that texts cannot be longer than a maximum of {maxChars} characters. Anything exceeding that length will be truncated."
+    max_length_reached: "This string is longer than the maximum length of {maxChars} characters. Anything exceeding that length will be truncated."
   background:
     title: Background
     description: Background Settings

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -615,7 +615,7 @@ en:
     comment_needed_message: Please add a changeset comment first.
     about_changeset_comments: About changeset comments
     about_changeset_comments_link: //wiki.openstreetmap.org/wiki/Good_changeset_comments
-    changeset_comment_length_warning: "Changeset comments can have a maximum of {maxChars} characters"
+    changeset_comment_length_warning: "Changeset comments can have a maximum of {maxChars} characters."
     google_warning: "You mentioned Google in this comment: remember that copying from Google Maps is strictly forbidden."
     google_warning_link: https://www.openstreetmap.org/copyright
   contributors:

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -615,7 +615,7 @@ en:
     comment_needed_message: Please add a changeset comment first.
     about_changeset_comments: About changeset comments
     about_changeset_comments_link: //wiki.openstreetmap.org/wiki/Good_changeset_comments
-    changeset_comment_length_warning: "Changeset comments can have a maximum of 255 characters"
+    changeset_comment_length_warning: "Changeset comments can have a maximum of {maxChars} characters"
     google_warning: "You mentioned Google in this comment: remember that copying from Google Maps is strictly forbidden."
     google_warning_link: https://www.openstreetmap.org/copyright
   contributors:

--- a/modules/core/context.js
+++ b/modules/core/context.js
@@ -19,7 +19,7 @@ import { presetManager } from '../presets';
 import { rendererBackground, rendererFeatures, rendererMap, rendererPhotos } from '../renderer';
 import { services } from '../services';
 import { uiInit } from '../ui/init';
-import { utilKeybinding, utilRebind, utilStringQs, utilUnicodeCharsTruncated } from '../util';
+import { utilKeybinding, utilRebind, utilStringQs, utilCleanOsmString } from '../util';
 
 
 export function coreContext() {
@@ -220,26 +220,9 @@ export function coreContext() {
   context.maxCharsForTagValue = () => 255;
   context.maxCharsForRelationRole = () => 255;
 
-  function cleanOsmString(val, maxChars) {
-    // be lenient with input
-    if (val === undefined || val === null) {
-      val = '';
-    } else {
-      val = val.toString();
-    }
-
-    // remove whitespace
-    val = val.trim();
-
-    // use the canonical form of the string
-    if (val.normalize) val = val.normalize('NFC');
-
-    // trim to the number of allowed characters
-    return utilUnicodeCharsTruncated(val, maxChars);
-  }
-  context.cleanTagKey = (val) => cleanOsmString(val, context.maxCharsForTagKey());
-  context.cleanTagValue = (val) => cleanOsmString(val, context.maxCharsForTagValue());
-  context.cleanRelationRole = (val) => cleanOsmString(val, context.maxCharsForRelationRole());
+  context.cleanTagKey = (val) => utilCleanOsmString(val, context.maxCharsForTagKey());
+  context.cleanTagValue = (val) => utilCleanOsmString(val, context.maxCharsForTagValue());
+  context.cleanRelationRole = (val) => utilCleanOsmString(val, context.maxCharsForRelationRole());
 
 
   /* History */

--- a/modules/osm/entity.js
+++ b/modules/osm/entity.js
@@ -156,7 +156,7 @@ osmEntity.prototype = {
                 changed = true;
                 merged[k] = utilUnicodeCharsTruncated(
                     utilArrayUnion(t1.split(/;\s*/), t2.split(/;\s*/)).join(';'),
-                    255 // avoid exceeding character limit; see also services/osm.js -> maxCharsForTagValue()
+                    255 // avoid exceeding character limit; see also context.maxCharsForTagValue()
                 );
             }
         }

--- a/modules/renderer/background_source.js
+++ b/modules/renderer/background_source.js
@@ -503,8 +503,8 @@ rendererBackgroundSource.Esri = function(data) {
                     vintage: vintage,
                     source: clean(result.NICE_NAME),
                     description: clean(result.NICE_DESC),
-                    resolution: clean(+parseFloat(result.SRC_RES).toFixed(4)),
-                    accuracy: clean(+parseFloat(result.SRC_ACC).toFixed(4))
+                    resolution: clean(+Number(result.SRC_RES).toFixed(4)),
+                    accuracy: clean(+Number(result.SRC_ACC).toFixed(4))
                 };
 
                 // append units - meters

--- a/modules/ui/changeset_editor.js
+++ b/modules/ui/changeset_editor.js
@@ -1,4 +1,5 @@
 import { dispatch as d3_dispatch } from 'd3-dispatch';
+import { select as d3_select } from 'd3-selection';
 
 import { presetManager } from '../presets';
 import { t } from '../core/localizer';
@@ -6,7 +7,7 @@ import { svgIcon } from '../svg/icon';
 import { uiCombobox} from './combobox';
 import { uiField } from './field';
 import { uiFormFields } from './form_fields';
-import { utilArrayUniqBy, utilRebind, utilTriggerEvent } from '../util';
+import { utilArrayUniqBy, utilCleanOsmString, utilRebind, utilTriggerEvent, utilUnicodeCharsCount } from '../util';
 
 
 export function uiChangesetEditor(context) {
@@ -85,10 +86,26 @@ export function uiChangesetEditor(context) {
             }
         }
 
-        var hasGoogle = _tags.comment.match(/google/i);
-        var commentTooLong = _tags.comment.length > 255;
+        // Show warning(s) if comment mentions Google or comment length exceeds 255 chars
+        const warnings = [];
+        if (_tags.comment.match(/google/i)) {
+            warnings.push({
+                id: 'contains "google"',
+                msg: t.append('commit.google_warning'),
+                link: t('commit.google_warning_link')
+            });
+        }
+        const maxChars = context.maxCharsForTagValue();
+        const strLen = utilUnicodeCharsCount(utilCleanOsmString(_tags.comment, Number.POSITIVE_INFINITY));
+        if (strLen > maxChars || !true) {
+            warnings.push({
+                id: 'message too long',
+                msg: t.append('commit.changeset_comment_length_warning', { maxChars: maxChars }),
+            });
+        }
+
         var commentWarning = selection.select('.form-field-comment').selectAll('.comment-warning')
-            .data(hasGoogle || commentTooLong ? [0] : []);
+            .data(warnings, d => d.id);
 
         commentWarning.exit()
             .transition()
@@ -96,30 +113,31 @@ export function uiChangesetEditor(context) {
             .style('opacity', 0)
             .remove();
 
-        function displayWarningMessage(msg, link) {
-            var commentEnter = commentWarning.enter()
-                .insert('div', '.tag-reference-body')
-                .attr('class', 'field-warning comment-warning')
-                .style('opacity', 0);
+        var commentEnter = commentWarning.enter()
+            .insert('div', '.comment-warning')
+            .attr('class', 'comment-warning field-warning')
+            .style('opacity', 0);
 
-            commentEnter
-                .append('a')
-                .attr('target', '_blank')
-                .call(svgIcon('#iD-icon-alert', 'inline'))
-                .attr('href', t(link))
-                .append('span')
-                .call(t.append(msg));
+        commentEnter
+            .call(svgIcon('#iD-icon-alert', 'inline'))
+            .append('span');
 
-            commentEnter
-                .transition()
-                .duration(200)
-                .style('opacity', 1);
-        }
+        commentEnter
+            .transition()
+            .duration(200)
+            .style('opacity', 1);
 
-        // Add warning if comment mentions Google or comment length
-        // exceeds 255 chars
-        if (hasGoogle) displayWarningMessage('commit.google_warning', 'commit.google_warning_link');
-        if (commentTooLong) displayWarningMessage('commit.changeset_comment_length_warning', 'commit.about_changeset_comments_link');
+        commentWarning.merge(commentEnter).selectAll('div > span')
+            .text('')
+            .each(function(d) {
+                let selection = d3_select(this);
+                if (d.link) {
+                    selection = selection.append('a')
+                        .attr('target', '_blank')
+                        .attr('href', d.link);
+                }
+                selection.call(d.msg);
+            });
     }
 
 

--- a/modules/ui/changeset_editor.js
+++ b/modules/ui/changeset_editor.js
@@ -85,10 +85,10 @@ export function uiChangesetEditor(context) {
             }
         }
 
-        // Add warning if comment mentions Google
         var hasGoogle = _tags.comment.match(/google/i);
+        var commentTooLong = _tags.comment.length > 255;
         var commentWarning = selection.select('.form-field-comment').selectAll('.comment-warning')
-            .data(hasGoogle ? [0] : []);
+            .data(hasGoogle || commentTooLong ? [0] : []);
 
         commentWarning.exit()
             .transition()
@@ -96,23 +96,30 @@ export function uiChangesetEditor(context) {
             .style('opacity', 0)
             .remove();
 
-        var commentEnter = commentWarning.enter()
-            .insert('div', '.tag-reference-body')
-            .attr('class', 'field-warning comment-warning')
-            .style('opacity', 0);
+        function displayWarningMessage(msg, link) {
+            var commentEnter = commentWarning.enter()
+                .insert('div', '.tag-reference-body')
+                .attr('class', 'field-warning comment-warning')
+                .style('opacity', 0);
 
-        commentEnter
-            .append('a')
-            .attr('target', '_blank')
-            .call(svgIcon('#iD-icon-alert', 'inline'))
-            .attr('href', t('commit.google_warning_link'))
-            .append('span')
-            .call(t.append('commit.google_warning'));
+            commentEnter
+                .append('a')
+                .attr('target', '_blank')
+                .call(svgIcon('#iD-icon-alert', 'inline'))
+                .attr('href', t(link))
+                .append('span')
+                .call(t.append(msg));
 
-        commentEnter
-            .transition()
-            .duration(200)
-            .style('opacity', 1);
+            commentEnter
+                .transition()
+                .duration(200)
+                .style('opacity', 1);
+        }
+
+        // Add warning if comment mentions Google or comment length
+        // exceeds 255 chars
+        if (hasGoogle) displayWarningMessage('commit.google_warning', 'commit.google_warning_link');
+        if (commentTooLong) displayWarningMessage('commit.changeset_comment_length_warning', 'commit.about_changeset_comments_link');
     }
 
 

--- a/modules/ui/feature_list.js
+++ b/modules/ui/feature_list.js
@@ -126,7 +126,7 @@ export function uiFeatureList(context) {
             var locationMatch = sexagesimal.pair(q.toUpperCase()) || q.match(/^(-?\d+\.?\d*)\s+(-?\d+\.?\d*)$/);
 
             if (locationMatch) {
-                var loc = [parseFloat(locationMatch[0]), parseFloat(locationMatch[1])];
+                var loc = [Number(locationMatch[0]), Number(locationMatch[1])];
                 result.push({
                     id: -1,
                     geometry: 'point',
@@ -205,8 +205,8 @@ export function uiFeatureList(context) {
                         type: type,
                         name: d.display_name,
                         extent: new geoExtent(
-                            [parseFloat(d.boundingbox[3]), parseFloat(d.boundingbox[0])],
-                            [parseFloat(d.boundingbox[2]), parseFloat(d.boundingbox[1])])
+                            [Number(d.boundingbox[3]), Number(d.boundingbox[0])],
+                            [Number(d.boundingbox[2]), Number(d.boundingbox[1])])
                     });
                 }
             });

--- a/modules/ui/fields/combo.js
+++ b/modules/ui/fields/combo.js
@@ -12,6 +12,7 @@ import { svgIcon } from '../../svg/icon';
 
 import { utilKeybinding } from '../../util/keybinding';
 import { utilArrayUniq, utilGetSetValue, utilNoAuto, utilRebind, utilTotalExtent, utilUnicodeCharsCount } from '../../util';
+import { uiLengthIndicator } from '../length_indicator';
 
 export {
     uiFieldCombo as uiFieldManyCombo,
@@ -52,6 +53,7 @@ export function uiFieldCombo(field, context) {
     var _container = d3_select(null);
     var _inputWrap = d3_select(null);
     var _input = d3_select(null);
+    var _lengthIndicator = uiLengthIndicator(context.maxCharsForTagValue());
     var _comboData = [];
     var _multiData = [];
     var _entityIDs = [];
@@ -447,6 +449,8 @@ export function uiFieldCombo(field, context) {
             .call(initCombo, selection)
             .merge(_input);
 
+        _container.call(_lengthIndicator);
+
         if (_isNetwork) {
             var extent = combinedEntityExtent();
             var countryCode = extent && countryCoder.iso1A2Code(extent.center());
@@ -457,7 +461,9 @@ export function uiFieldCombo(field, context) {
             .on('change', change)
             .on('blur', change)
             .on('input', function() {
-                updateIcon(utilGetSetValue(_input));
+                const val = utilGetSetValue(_input);
+                updateIcon(val);
+                _lengthIndicator.update(val);
             });
 
         _input
@@ -687,6 +693,10 @@ export function uiFieldCombo(field, context) {
 
             if (!Array.isArray(tags[field.key])) {
                 updateIcon(tags[field.key]);
+            }
+
+            if (!isMixed) {
+                _lengthIndicator.update(tags[field.key]);
             }
         }
     };

--- a/modules/ui/fields/combo.js
+++ b/modules/ui/fields/combo.js
@@ -390,6 +390,8 @@ export function uiFieldCombo(field, context) {
 
             arr = utilArrayUniq(arr);
             t[field.key] = arr.length ? arr.join(';') : undefined;
+
+            _lengthIndicator.update(t[field.key]);
         }
         dispatch.call('change', this, t);
     }
@@ -449,7 +451,13 @@ export function uiFieldCombo(field, context) {
             .call(initCombo, selection)
             .merge(_input);
 
-        _container.call(_lengthIndicator);
+        if (_isSemi) {
+            _inputWrap.call(_lengthIndicator);
+        } else if (_isMulti) {
+            // todo: implement
+        } else {
+            _container.call(_lengthIndicator);
+        }
 
         if (_isNetwork) {
             var extent = combinedEntityExtent();
@@ -461,8 +469,12 @@ export function uiFieldCombo(field, context) {
             .on('change', change)
             .on('blur', change)
             .on('input', function() {
-                const val = utilGetSetValue(_input);
+                let val = utilGetSetValue(_input);
                 updateIcon(val);
+                if (_isSemi && _tags[field.key]) {
+                    // when adding a new value to existing ones
+                    val += ';' + _tags[field.key];
+                }
                 _lengthIndicator.update(val);
             });
 

--- a/modules/ui/fields/combo.js
+++ b/modules/ui/fields/combo.js
@@ -453,9 +453,7 @@ export function uiFieldCombo(field, context) {
 
         if (_isSemi) {
             _inputWrap.call(_lengthIndicator);
-        } else if (_isMulti) {
-            // todo: implement
-        } else {
+        } else if (!_isMulti) {
             _container.call(_lengthIndicator);
         }
 

--- a/modules/ui/fields/input.js
+++ b/modules/ui/fields/input.js
@@ -9,6 +9,7 @@ import { t, localizer } from '../../core/localizer';
 import { utilGetSetValue, utilNoAuto, utilRebind, utilTotalExtent } from '../../util';
 import { svgIcon } from '../../svg/icon';
 import { cardinal } from '../../osm/node';
+import { uiLengthIndicator } from '..';
 
 export {
     uiFieldText as uiFieldColour,
@@ -25,6 +26,7 @@ export function uiFieldText(field, context) {
     var input = d3_select(null);
     var outlinkButton = d3_select(null);
     var wrap = d3_select(null);
+    var _lengthIndicator = uiLengthIndicator(context.maxCharsForTagValue());
     var _entityIDs = [];
     var _tags;
     var _phoneFormats = {};
@@ -93,6 +95,7 @@ export function uiFieldText(field, context) {
             .on('blur', change())
             .on('change', change());
 
+        wrap.call(_lengthIndicator);
 
         if (field.type === 'tel') {
             updatePhonePlaceholder();
@@ -364,6 +367,10 @@ export function uiFieldText(field, context) {
         if (outlinkButton && !outlinkButton.empty()) {
             var disabled = !validIdentifierValueForLink();
             outlinkButton.classed('disabled', disabled);
+        }
+
+        if (!isMixed) {
+            _lengthIndicator.update(tags[field.key]);
         }
     };
 

--- a/modules/ui/fields/localized.js
+++ b/modules/ui/fields/localized.js
@@ -10,6 +10,7 @@ import { svgIcon } from '../../svg';
 import { uiTooltip } from '../tooltip';
 import { uiCombobox } from '../combobox';
 import { utilArrayUniq, utilGetSetValue, utilNoAuto, utilRebind, utilTotalExtent, utilUniqueDomId } from '../../util';
+import { uiLengthIndicator } from '../length_indicator';
 
 var _languagesArray = [];
 
@@ -19,6 +20,7 @@ export function uiFieldLocalized(field, context) {
     var wikipedia = services.wikipedia;
     var input = d3_select(null);
     var localizedInputs = d3_select(null);
+    var _lengthIndicator = uiLengthIndicator(context.maxCharsForTagValue());
     var _countryCode;
     var _tags;
 
@@ -180,6 +182,8 @@ export function uiFieldLocalized(field, context) {
             .on('input', change(true))
             .on('blur', change())
             .on('change', change());
+
+        wrap.call(_lengthIndicator);
 
 
         var translateButton = wrap.selectAll('.localized-add')
@@ -497,6 +501,10 @@ export function uiFieldLocalized(field, context) {
 
         _selection
             .call(localized);
+
+        if (!isMixed) {
+            _lengthIndicator.update(tags[field.key]);
+        }
     };
 
 

--- a/modules/ui/fields/textarea.js
+++ b/modules/ui/fields/textarea.js
@@ -7,11 +7,13 @@ import {
     utilNoAuto,
     utilRebind
 } from '../../util';
+import { uiLengthIndicator } from '../length_indicator';
 
 
 export function uiFieldTextarea(field, context) {
     var dispatch = d3_dispatch('change');
     var input = d3_select(null);
+    var _lengthIndicator = uiLengthIndicator(context.maxCharsForTagValue());
     var _tags;
 
 
@@ -22,6 +24,7 @@ export function uiFieldTextarea(field, context) {
         wrap = wrap.enter()
             .append('div')
             .attr('class', 'form-field-input-wrap form-field-input-' + field.type)
+            .style('position', 'relative')
             .merge(wrap);
 
         input = wrap.selectAll('textarea')
@@ -35,22 +38,23 @@ export function uiFieldTextarea(field, context) {
             .on('blur', change())
             .on('change', change())
             .merge(input);
-    }
 
+        wrap.call(_lengthIndicator);
 
-    function change(onInput) {
-        return function() {
+        function change(onInput) {
+            return function() {
 
-            var val = utilGetSetValue(input);
-            if (!onInput) val = context.cleanTagValue(val);
+                var val = utilGetSetValue(input);
+                if (!onInput) val = context.cleanTagValue(val);
 
-            // don't override multiple values with blank string
-            if (!val && Array.isArray(_tags[field.key])) return;
+                // don't override multiple values with blank string
+                if (!val && Array.isArray(_tags[field.key])) return;
 
-            var t = {};
-            t[field.key] = val || undefined;
-            dispatch.call('change', this, t, onInput);
-        };
+                var t = {};
+                t[field.key] = val || undefined;
+                dispatch.call('change', this, t, onInput);
+            };
+        }
     }
 
 
@@ -63,6 +67,10 @@ export function uiFieldTextarea(field, context) {
             .attr('title', isMixed ? tags[field.key].filter(Boolean).join('\n') : undefined)
             .attr('placeholder', isMixed ? t('inspector.multiple_values') : (field.placeholder() || t('inspector.unknown')))
             .classed('mixed', isMixed);
+
+        if (!isMixed) {
+            _lengthIndicator.update(tags[field.key]);
+        }
     };
 
 

--- a/modules/ui/fields/textarea.js
+++ b/modules/ui/fields/textarea.js
@@ -13,7 +13,8 @@ import { uiLengthIndicator } from '..';
 export function uiFieldTextarea(field, context) {
     var dispatch = d3_dispatch('change');
     var input = d3_select(null);
-    var _lengthIndicator = uiLengthIndicator(context.maxCharsForTagValue());
+    var _lengthIndicator = uiLengthIndicator(context.maxCharsForTagValue())
+        .silent(field.usage === 'changeset' && field.key === 'comment');
     var _tags;
 
 

--- a/modules/ui/fields/textarea.js
+++ b/modules/ui/fields/textarea.js
@@ -7,7 +7,7 @@ import {
     utilNoAuto,
     utilRebind
 } from '../../util';
-import { uiLengthIndicator } from '../length_indicator';
+import { uiLengthIndicator } from '..';
 
 
 export function uiFieldTextarea(field, context) {

--- a/modules/ui/index.js
+++ b/modules/ui/index.js
@@ -33,6 +33,7 @@ export { uiIssuesInfo } from './issues_info';
 export { uiKeepRightDetails } from './keepRight_details';
 export { uiKeepRightEditor } from './keepRight_editor';
 export { uiKeepRightHeader } from './keepRight_header';
+export { uiLengthIndicator } from './length_indicator';
 export { uiLasso } from './lasso';
 export { uiLoading } from './loading';
 export { uiMapInMap } from './map_in_map';

--- a/modules/ui/length_indicator.js
+++ b/modules/ui/length_indicator.js
@@ -1,0 +1,58 @@
+import { select as d3_select } from 'd3-selection';
+
+import { t } from '../core/localizer';
+import {
+    utilUnicodeCharsCount,
+    utilCleanOsmString
+} from '../util';
+import { uiPopover } from './popover';
+
+
+export function uiLengthIndicator(maxChars) {
+    var _wrap = d3_select(null);
+    var _tooltip = uiPopover('tooltip')
+        .placement('bottom')
+        .hasArrow(true)
+        .content(() => selection => {
+            selection.text('');
+            t.append('inspector.max_length_reached', { maxChars })(selection);
+        });
+
+    var lengthIndicator = function(selection) {
+        _wrap = selection.selectAll('span.length-indicator-wrap').data([0]);
+        _wrap = _wrap.enter()
+            .append('span')
+            .merge(_wrap)
+            .classed('length-indicator-wrap', true);
+        selection.call(_tooltip);
+    };
+
+    lengthIndicator.update = function(val) {
+        const strLen = utilUnicodeCharsCount(utilCleanOsmString(val, Number.POSITIVE_INFINITY));
+
+        var lengthIndicator = _wrap.selectAll('span.length-indicator')
+            .data([strLen]);
+
+        lengthIndicator = lengthIndicator.enter()
+            .append('span')
+            .merge(lengthIndicator)
+            .classed('length-indicator', true)
+            .classed('limit-reached', d => d > maxChars)
+            .style('border-right-width', d => `${Math.abs(maxChars - d) * 2}px`)
+            .style('margin-right', d => d > maxChars
+                ? `${(maxChars - d) * 2}px`
+                : 0)
+            .style('opacity', d => d > maxChars * 0.8
+                ? Math.min(1, (d / maxChars - 0.8) / (1 - 0.8))
+                : 0)
+            .style('pointer-events', d => d > maxChars * 0.8 ? null: 'none');
+
+        if (strLen > maxChars) {
+            _tooltip.show();
+        } else {
+            _tooltip.hide();
+        }
+    }
+
+    return lengthIndicator;
+}

--- a/modules/ui/length_indicator.js
+++ b/modules/ui/length_indicator.js
@@ -10,7 +10,7 @@ import { uiPopover } from './popover';
 
 export function uiLengthIndicator(maxChars) {
     var _wrap = d3_select(null);
-    var _tooltip = uiPopover('tooltip')
+    var _tooltip = uiPopover('tooltip max-length-warning')
         .placement('bottom')
         .hasArrow(true)
         .content(() => selection => {

--- a/modules/ui/length_indicator.js
+++ b/modules/ui/length_indicator.js
@@ -1,6 +1,7 @@
 import { select as d3_select } from 'd3-selection';
 
 import { t } from '../core/localizer';
+import { svgIcon } from '../svg';
 import {
     utilUnicodeCharsCount,
     utilCleanOsmString
@@ -15,7 +16,8 @@ export function uiLengthIndicator(maxChars) {
         .hasArrow(true)
         .content(() => selection => {
             selection.text('');
-            t.append('inspector.max_length_reached', { maxChars })(selection);
+            selection.call(svgIcon('#iD-icon-alert', 'inline'));
+            selection.call(t.append('inspector.max_length_reached', { maxChars }));
         });
     var _silent = false;
 

--- a/modules/ui/length_indicator.js
+++ b/modules/ui/length_indicator.js
@@ -17,6 +17,7 @@ export function uiLengthIndicator(maxChars) {
             selection.text('');
             t.append('inspector.max_length_reached', { maxChars })(selection);
         });
+    var _silent = false;
 
     var lengthIndicator = function(selection) {
         _wrap = selection.selectAll('span.length-indicator-wrap').data([0]);
@@ -47,11 +48,18 @@ export function uiLengthIndicator(maxChars) {
                 : 0)
             .style('pointer-events', d => d > maxChars * 0.8 ? null: 'none');
 
+        if (_silent) return;
         if (strLen > maxChars) {
             _tooltip.show();
         } else {
             _tooltip.hide();
         }
+    };
+
+    lengthIndicator.silent = function(val) {
+        if (!arguments.length) return _silent;
+        _silent = val;
+        return lengthIndicator;
     };
 
     return lengthIndicator;

--- a/modules/ui/length_indicator.js
+++ b/modules/ui/length_indicator.js
@@ -30,12 +30,12 @@ export function uiLengthIndicator(maxChars) {
     lengthIndicator.update = function(val) {
         const strLen = utilUnicodeCharsCount(utilCleanOsmString(val, Number.POSITIVE_INFINITY));
 
-        var lengthIndicator = _wrap.selectAll('span.length-indicator')
+        let indicator = _wrap.selectAll('span.length-indicator')
             .data([strLen]);
 
-        lengthIndicator = lengthIndicator.enter()
+        indicator.enter()
             .append('span')
-            .merge(lengthIndicator)
+            .merge(indicator)
             .classed('length-indicator', true)
             .classed('limit-reached', d => d > maxChars)
             .style('border-right-width', d => `${Math.abs(maxChars - d) * 2}px`)
@@ -52,7 +52,7 @@ export function uiLengthIndicator(maxChars) {
         } else {
             _tooltip.hide();
         }
-    }
+    };
 
     return lengthIndicator;
 }

--- a/modules/util/index.js
+++ b/modules/util/index.js
@@ -54,3 +54,4 @@ export { utilUnicodeCharsCount } from './util';
 export { utilUnicodeCharsTruncated } from './util';
 export { utilUniqueDomId } from './util';
 export { utilWrap } from './util';
+export { utilCleanOsmString } from './util';

--- a/modules/util/util.js
+++ b/modules/util/util.js
@@ -629,3 +629,22 @@ export function utilOldestID(ids) {
 
     return ids[oldestIDIndex];
 }
+
+// returns a normalized and truncated string to `maxChars` utf-8 characters
+export function utilCleanOsmString(val, maxChars) {
+    // be lenient with input
+    if (val === undefined || val === null) {
+      val = '';
+    } else {
+      val = val.toString();
+    }
+
+    // remove whitespace
+    val = val.trim();
+
+    // use the canonical form of the string
+    if (val.normalize) val = val.normalize('NFC');
+
+    // trim to the number of allowed characters
+    return utilUnicodeCharsTruncated(val, maxChars);
+  }


### PR DESCRIPTION
This is intended to solve #7943, #9374. It not only works on the changeset comment field, but most input fields (e.g. text fields for tags, combo boxes, etc.), to solve similar problems, e.g. when entering multiple long URLs into the `source` field or a particular long `description` or `note`.

Looks like this at the moment:

* text area, almost empty
  ![image](https://user-images.githubusercontent.com/1927298/204036612-0998529f-dcde-44a6-899a-5a6e90fa5f5a.png)
* text area, almost "full"
  ![image](https://user-images.githubusercontent.com/1927298/204036419-d553be2b-d55e-4cd5-8128-2cde0db8c6c9.png)
* text area, exactly 255 characters
  ![image](https://user-images.githubusercontent.com/1927298/204036500-0d005fb1-03ee-49f9-9c49-5fc71a718aa4.png)
* text area, over limit
  ![image](https://user-images.githubusercontent.com/1927298/204036542-bf3ffb34-da70-4a67-9f82-673e4397d971.png)

Looks similar for combo boxes, regular text fields and translatable text fields. For `semiCombo` fields, it takes preexisting value-parts into account:

![image](https://user-images.githubusercontent.com/1927298/204037184-fff9fc99-439a-467e-8a5e-52bbd6b25197.png)

Currently, the remaining field types do not implement the length indicator (e.g. the `number`, `multiCombo`, `address`, `wikidata` fields), as the likelihood is quite low that a users would want to enter a string > 255 characters there. And if it is done by mistake, the silent truncate is acceptable IMO.