### PR TITLE
added warning when changeset comment length > 255 chars

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -615,6 +615,7 @@ en:
     comment_needed_message: Please add a changeset comment first.
     about_changeset_comments: About changeset comments
     about_changeset_comments_link: //wiki.openstreetmap.org/wiki/Good_changeset_comments
+    changeset_comment_length_warning: "Changeset comments can have a maximum of 255 characters"
     google_warning: "You mentioned Google in this comment: remember that copying from Google Maps is strictly forbidden."
     google_warning_link: https://www.openstreetmap.org/copyright
   contributors:

--- a/modules/ui/changeset_editor.js
+++ b/modules/ui/changeset_editor.js
@@ -85,10 +85,10 @@ export function uiChangesetEditor(context) {
             }
         }
 
-        // Add warning if comment mentions Google
         var hasGoogle = _tags.comment.match(/google/i);
+        var commentTooLong = _tags.comment.length > 255;
         var commentWarning = selection.select('.form-field-comment').selectAll('.comment-warning')
-            .data(hasGoogle ? [0] : []);
+            .data(hasGoogle || commentTooLong ? [0] : []);
 
         commentWarning.exit()
             .transition()
@@ -96,23 +96,30 @@ export function uiChangesetEditor(context) {
             .style('opacity', 0)
             .remove();
 
-        var commentEnter = commentWarning.enter()
-            .insert('div', '.tag-reference-body')
-            .attr('class', 'field-warning comment-warning')
-            .style('opacity', 0);
+        function displayWarningMessage(msg, link) {
+            var commentEnter = commentWarning.enter()
+                .insert('div', '.tag-reference-body')
+                .attr('class', 'field-warning comment-warning')
+                .style('opacity', 0);
 
-        commentEnter
-            .append('a')
-            .attr('target', '_blank')
-            .call(svgIcon('#iD-icon-alert', 'inline'))
-            .attr('href', t('commit.google_warning_link'))
-            .append('span')
-            .call(t.append('commit.google_warning'));
+            commentEnter
+                .append('a')
+                .attr('target', '_blank')
+                .call(svgIcon('#iD-icon-alert', 'inline'))
+                .attr('href', t(link))
+                .append('span')
+                .call(t.append(msg));
 
-        commentEnter
-            .transition()
-            .duration(200)
-            .style('opacity', 1);
+            commentEnter
+                .transition()
+                .duration(200)
+                .style('opacity', 1);
+        }
+
+        // Add warning if comment mentions Google or comment length
+        // exceeds 255 chars
+        if (hasGoogle) displayWarningMessage('commit.google_warning', 'commit.google_warning_link');
+        if (commentTooLong) displayWarningMessage('commit.changeset_comment_length_warning', 'commit.about_changeset_comments_link');
     }
 
 


### PR DESCRIPTION
Added a simple fix for the issue described in #9374 and #7943. I simply insert a warning message / box in the same format that the existing Google warning appears when the user exceeds 255 characters in their changeset message.

#6817 describes some edge cases that seem to work fine with this change, shown below:

"ZALGO" contains 58 javascript characters ([source](https://github.com/orling/grapheme-splitter#examples)), here we see exactly 255 characters being calculated as 'good' using 4 * 58 of the demon string + 18 normal chars. 

<img width="466" alt="image" src="https://user-images.githubusercontent.com/22874911/204123601-afed76ab-959a-4044-bedf-bb2f0eb5628d.png">

If we add one, we see the new warning:
<img width="466" alt="image" src="https://user-images.githubusercontent.com/22874911/204123624-b09e503e-0825-45f2-b15b-fd6e817cea51.png">

I also have come to understand that there is a more in-depth fix being worked on in #9390, but this was made as a much simpler fix that follows suit of an existing warning.