### PR TITLE
CONTRIBUTING.md: update Transifex links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -217,9 +217,9 @@ switch to the development database.
 ## Translating
 
 Translations are managed using the
-[Transifex](https://www.transifex.com/projects/p/id-editor/) platform. After
+[Transifex](https://www.transifex.com/openstreetmap/id-editor/) platform. After
 signing up, you can go to [iD's project
-page](https://www.transifex.com/projects/p/id-editor/), select a language and
+page](https://www.transifex.com/openstreetmap/id-editor/), select a language and
 click **Translate** to start translating. Translations are divided into
 separate resources:
 
@@ -240,7 +240,7 @@ to the target language, separated by commas.
 You can check your translations on the [development preview site](https://ideditor.netlify.app),
 which is updated every time we change the `develop` branch.
 
-[iD translation project on Transifex](https://www.transifex.com/projects/p/id-editor/)
+[iD translation project on Transifex](https://www.transifex.com/openstreetmap/id-editor/)
 
 To get notifications when translation source files change, click **Watch
 project** button near the bottom of the project page. You can edit your
@@ -267,7 +267,7 @@ These are separate translations for uniformity reasons and because some language
 
 **Why can't I find the Osmose QA layer translations?** The Osmose QA strings are
  pulled in from the external Osmose API. You can contribute to the
- [Osmose Transifex project](https://www.transifex.com/projects/p/osmose/)
+ [Osmose Transifex project](https://explore.transifex.com/openstreetmap-france/osmose/)
  and the results will be seen in iD once deployed.
 
 Note that if you want to add/update English translations in Osmose then you will


### PR DESCRIPTION
They seem to have changed the project URLs in a non-backward-compatible way.

Weirdly, I get redirected to the `explore` subdomain (https://explore.transifex.com/openstreetmap-france/osmose/) when trying to visit https://www.transifex.com/openstreetmap-france/osmose/, whereas for the [iD link](https://www.transifex.com/openstreetmap/id-editor/) I simply get sent to the dashboard page at https://www.transifex.com/openstreetmap/id-editor/dashboard/. I suppose that's related to whether I have joined the project or not.

Since there's a redirect from `www` to `explore` in place, I think it's preferable to link directly to the `www` subdomain so that editors can skip the awkward "join this project" step (the explore doesn't seem to recognize an active login), and new translators will simply get seamlessly redirected to the explore link anyway. Thoughts?