### PR TITLE
"cycleway" field: fix multiselections tag corruption + make field reusable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,11 +43,13 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :white_check_mark: Validation
 #### :bug: Bugfixes
 * Fix bug which made it impossible to change an object's preset from a sub-preset to the respective parents preset (e.g. from Driveway to Service Road) ([#9372])
+* Fix corruption of (directional) `cycleway` tags when editing a multi-selection ([#9423])
 #### :hourglass: Performance
 #### :rocket: Presets
 * Clamp degree values in `direction` fields between 0 and 359 degrees ([#9386])
 * Disable increment/decrement buttons on number fields if the input value is not numeric or when there is a multi-selection with conflicting values
 * Filter out misspelled taginfo suggestions in combo field ([#9397])
+* Rename `cycleway` field type to `directionalCombo` and make it reusable for arbitrary directional tags ([#9423])
 #### :hammer: Development
 * Upgrade to Transifex API v3 ([#9375])
 * Upgrade dependencies: `d3` to v7.7
@@ -60,6 +62,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#9390]: https://github.com/openstreetmap/iD/pull/9390
 [#9392]: https://github.com/openstreetmap/iD/pull/9392
 [#9397]: https://github.com/openstreetmap/iD/issues/9397
+[#9423]: https://github.com/openstreetmap/iD/pull/9423
 [@alanb43]: https://github.com/alanb43
 
 

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -1551,10 +1551,10 @@ a.hide-toggle {
 }
 
 
-/* Field - Access, Cycleway
+/* Field - Access, DirectionalCombo
 ------------------------------------------------------- */
 .form-field-input-access,
-.form-field-input-cycleway {
+.form-field-input-directionalcombo {
     flex: 1 1 auto;
     display: flex;
     flex-flow: row wrap;

--- a/modules/ui/entity_editor.js
+++ b/modules/ui/entity_editor.js
@@ -163,14 +163,19 @@ export function uiEntityEditor(context) {
 
             var tags = Object.assign({}, entity.tags);   // shallow copy
 
-            for (var k in changed) {
-                if (!k) continue;
-                var v = changed[k];
-                if (typeof v === 'object') {
-                    // a "key only" tag change
-                    tags[k] = tags[v.oldKey];
-                } else if (v !== undefined || tags.hasOwnProperty(k)) {
-                    tags[k] = v;
+            if (typeof changed === 'function') {
+                // a complex callback tag change
+                tags = changed(tags);
+            } else {
+                for (var k in changed) {
+                    if (!k) continue;
+                    var v = changed[k];
+                    if (typeof v === 'object') {
+                        // a "key only" tag change
+                        tags[k] = tags[v.oldKey];
+                    } else if (v !== undefined || tags.hasOwnProperty(k)) {
+                        tags[k] = v;
+                    }
                 }
             }
 

--- a/modules/ui/fields/combo.js
+++ b/modules/ui/fields/combo.js
@@ -121,8 +121,9 @@ export function uiFieldCombo(field, context) {
         tval = tval || '';
 
         var stringsField = field.resolveReference('stringsCrossReference');
-        if (stringsField.hasTextForStringId('options.' + tval)) {
-            return stringsField.t('options.' + tval, { default: tval });
+        const labelId = stringsField.hasTextForStringId(`options.${tval}.title`) ? `options.${tval}.title` : `options.${tval}`;
+        if (stringsField.hasTextForStringId(labelId)) {
+            return stringsField.t(labelId, { default: tval });
         }
 
         if (field.type === 'typeCombo' && tval.toLowerCase() === 'yes') {
@@ -139,8 +140,9 @@ export function uiFieldCombo(field, context) {
         tval = tval || '';
 
         var stringsField = field.resolveReference('stringsCrossReference');
-        if (stringsField.hasTextForStringId('options.' + tval)) {
-            return stringsField.t.append('options.' + tval, { default: tval });
+        const labelId = stringsField.hasTextForStringId(`options.${tval}.title`) ? `options.${tval}.title` : `options.${tval}`;
+        if (stringsField.hasTextForStringId(labelId)) {
+            return stringsField.t(labelId, { default: tval });
         }
 
         if (field.type === 'typeCombo' && tval.toLowerCase() === 'yes') {
@@ -184,12 +186,14 @@ export function uiFieldCombo(field, context) {
         if (!(field.options || stringsField.options)) return [];
 
         return (field.options || stringsField.options).map(function(v) {
+            const labelId = stringsField.hasTextForStringId(`options.${v}.title`) ? `options.${v}.title` : `options.${v}`;
+            const hasDescription = stringsField.hasTextForStringId(`options.${v}.description`);
             return {
                 key: v,
-                value: stringsField.t('options.' + v, { default: v }),
-                title: v,
-                display: addComboboxIcons(stringsField.t.append('options.' + v, { default: v }), v),
-                klass: stringsField.hasTextForStringId('options.' + v) ? '' : 'raw-option'
+                value: stringsField.t(labelId, { default: v }),
+                title: stringsField.t(`options.${v}.description`, { default: v }),
+                display: addComboboxIcons(stringsField.t.append(labelId, { default: v }), v),
+                klass: stringsField.hasTextForStringId(labelId) ? '' : 'raw-option'
             };
         });
     }
@@ -266,15 +270,17 @@ export function uiFieldCombo(field, context) {
             _container.classed('empty-combobox', data.length === 0);
 
             _comboData = data.concat(additionalOptions).map(function(d) {
-                var k = d.value;
-                if (_isMulti) k = k.replace(field.key, '');
-                var isLocalizable = stringsField.hasTextForStringId('options.' + k);
-                var label = stringsField.t('options.' + k, { default: k });
+                var v = d.value;
+                if (_isMulti) v = v.replace(field.key, '');
+                const labelId = stringsField.hasTextForStringId(`options.${v}.title`) ? `options.${v}.title` : `options.${v}`;
+                var isLocalizable = stringsField.hasTextForStringId(labelId);
+                var label = stringsField.t(labelId, { default: v });
                 return {
-                    key: k,
+                    key: v,
                     value: label,
-                    display: addComboboxIcons(stringsField.t.append('options.' + k, { default: k }), k),
-                    title: isLocalizable ? k : (d.title !== label ? d.title : ''),
+                    title: stringsField.t(`options.${v}.description`, { default:
+                        isLocalizable ? v : (d.title !== label ? d.title : '') }),
+                    display: addComboboxIcons(stringsField.t.append(labelId, { default: v }), v),
                     klass: isLocalizable ? '' : 'raw-option'
                 };
             });
@@ -684,7 +690,8 @@ export function uiFieldCombo(field, context) {
             }).filter(Boolean);
 
             var showsValue = !isMixed && tags[field.key] && !(field.type === 'typeCombo' && tags[field.key] === 'yes');
-            var isRawValue = showsValue && !stringsField.hasTextForStringId('options.' + tags[field.key]);
+            var isRawValue = showsValue && !stringsField.hasTextForStringId(`options.${tags[field.key]}`)
+                                        && !stringsField.hasTextForStringId(`options.${tags[field.key]}.title`);
             var isKnownValue = showsValue && !isRawValue;
 
             var isReadOnly = !_allowCustomValues || isKnownValue;

--- a/modules/ui/fields/combo.js
+++ b/modules/ui/fields/combo.js
@@ -115,13 +115,20 @@ export function uiFieldCombo(field, context) {
     }
 
 
+    function getLabelId(field, v) {
+        return field.hasTextForStringId(`options.${v}.title`)
+            ? `options.${v}.title`
+            : `options.${v}`;
+    }
+
+
     // returns the display value for a tag value
     // (for multiCombo, tval should be the key suffix, not the entire key)
     function displayValue(tval) {
         tval = tval || '';
 
         var stringsField = field.resolveReference('stringsCrossReference');
-        const labelId = stringsField.hasTextForStringId(`options.${tval}.title`) ? `options.${tval}.title` : `options.${tval}`;
+        const labelId = getLabelId(stringsField, tval);
         if (stringsField.hasTextForStringId(labelId)) {
             return stringsField.t(labelId, { default: tval });
         }
@@ -140,7 +147,7 @@ export function uiFieldCombo(field, context) {
         tval = tval || '';
 
         var stringsField = field.resolveReference('stringsCrossReference');
-        const labelId = stringsField.hasTextForStringId(`options.${tval}.title`) ? `options.${tval}.title` : `options.${tval}`;
+        const labelId = getLabelId(stringsField, tval);
         if (stringsField.hasTextForStringId(labelId)) {
             return stringsField.t(labelId, { default: tval });
         }
@@ -186,8 +193,7 @@ export function uiFieldCombo(field, context) {
         if (!(field.options || stringsField.options)) return [];
 
         return (field.options || stringsField.options).map(function(v) {
-            const labelId = stringsField.hasTextForStringId(`options.${v}.title`) ? `options.${v}.title` : `options.${v}`;
-            const hasDescription = stringsField.hasTextForStringId(`options.${v}.description`);
+            const labelId = getLabelId(stringsField, v);
             return {
                 key: v,
                 value: stringsField.t(labelId, { default: v }),
@@ -272,7 +278,7 @@ export function uiFieldCombo(field, context) {
             _comboData = data.concat(additionalOptions).map(function(d) {
                 var v = d.value;
                 if (_isMulti) v = v.replace(field.key, '');
-                const labelId = stringsField.hasTextForStringId(`options.${v}.title`) ? `options.${v}.title` : `options.${v}`;
+                const labelId = getLabelId(stringsField, v);
                 var isLocalizable = stringsField.hasTextForStringId(labelId);
                 var label = stringsField.t(labelId, { default: v });
                 return {

--- a/modules/ui/fields/directional_combo.js
+++ b/modules/ui/fields/directional_combo.js
@@ -6,13 +6,13 @@ import { utilGetSetValue, utilNoAuto, utilRebind } from '../../util';
 import { t } from '../../core/localizer';
 
 
-export function uiFieldCycleway(field, context) {
+export function uiFieldDirectionalCombo(field, context) {
     var dispatch = d3_dispatch('change');
     var items = d3_select(null);
     var wrap = d3_select(null);
     var _tags;
 
-    function cycleway(selection) {
+    function directionalCombo(selection) {
 
         function stripcolon(s) {
             return s.replace(':', '');
@@ -43,32 +43,32 @@ export function uiFieldCycleway(field, context) {
 
         var enter = items.enter()
             .append('li')
-            .attr('class', function(d) { return 'labeled-input preset-cycleway-' + stripcolon(d); });
+            .attr('class', function(d) { return 'labeled-input preset-directionalcombo-' + stripcolon(d); });
 
         enter
             .append('span')
-            .attr('class', 'label preset-label-cycleway')
-            .attr('for', function(d) { return 'preset-input-cycleway-' + stripcolon(d); })
+            .attr('class', 'label preset-label-directionalcombo')
+            .attr('for', function(d) { return 'preset-input-directionalcombo-' + stripcolon(d); })
             .html(function(d) { return field.t.html('types.' + d); });
 
         enter
             .append('div')
-            .attr('class', 'preset-input-cycleway-wrap')
+            .attr('class', 'preset-input-directionalcombo-wrap')
             .append('input')
             .attr('type', 'text')
-            .attr('class', function(d) { return 'preset-input-cycleway preset-input-' + stripcolon(d); })
+            .attr('class', function(d) { return 'preset-input-directionalcombo preset-input-' + stripcolon(d); })
             .call(utilNoAuto)
             .each(function(d) {
                 d3_select(this)
-                    .call(uiCombobox(context, 'cycleway-' + stripcolon(d))
-                        .data(cycleway.options(d))
+                    .call(uiCombobox(context, 'directionalcombo-' + stripcolon(d))
+                        .data(directionalCombo.options(d))
                     );
             });
 
         items = items.merge(enter);
 
         // Update
-        wrap.selectAll('.preset-input-cycleway')
+        wrap.selectAll('.preset-input-directionalcombo')
             .on('change', change)
             .on('blur', change);
     }
@@ -111,18 +111,20 @@ export function uiFieldCycleway(field, context) {
     }
 
 
-    cycleway.options = function() {
+    directionalCombo.options = function() {
         var stringsField = field.resolveReference('stringsCrossReference');
         return field.options.map(function(option) {
+            const hasTitle = stringsField.hasTextForStringId('options.' + option + '.title');
+            const hasDescription = stringsField.hasTextForStringId('options.' + option + '.description')
             return {
-                title: stringsField.t('options.' + option + '.description'),
-                value: option
+                title: hasDescription ? stringsField.t('options.' + option + '.description') : null,
+                value: hasTitle ? stringsField.t('options.' + option + '.title') : stringsField.t('options.' + option)
             };
         });
     };
 
 
-    cycleway.tags = function(tags) {
+    directionalCombo.tags = function(tags) {
         _tags = tags;
 
         const commonKey = field.keys[0];
@@ -130,7 +132,7 @@ export function uiFieldCycleway(field, context) {
         // If generic key is set, use that instead of individual values
         var commonValue = typeof tags[commonKey] === 'string' && tags[commonKey];
 
-        utilGetSetValue(items.selectAll('.preset-input-cycleway'), function(d) {
+        utilGetSetValue(items.selectAll('.preset-input-directionalcombo'), function(d) {
                 if (commonValue) return commonValue;
                 return !tags[commonKey] && typeof tags[d] === 'string' ? tags[d] : '';
             })
@@ -159,11 +161,11 @@ export function uiFieldCycleway(field, context) {
     };
 
 
-    cycleway.focus = function() {
+    directionalCombo.focus = function() {
         var node = wrap.selectAll('input').node();
         if (node) node.focus();
     };
 
 
-    return utilRebind(cycleway, dispatch, 'on');
+    return utilRebind(directionalCombo, dispatch, 'on');
 }

--- a/modules/ui/fields/directional_combo.js
+++ b/modules/ui/fields/directional_combo.js
@@ -1,8 +1,7 @@
 import { dispatch as d3_dispatch } from 'd3-dispatch';
 import { select as d3_select } from 'd3-selection';
 
-import { utilGetSetValue, utilNoAuto, utilRebind } from '../../util';
-import { t } from '../../core/localizer';
+import { utilRebind } from '../../util';
 import { uiFieldCombo } from './combo';
 
 

--- a/modules/ui/fields/index.js
+++ b/modules/ui/fields/index.js
@@ -3,7 +3,7 @@ export * from './combo';
 export * from './input';
 export * from './access';
 export * from './address';
-export * from './cycleway';
+export * from './directional_combo';
 export * from './lanes';
 export * from './localized';
 export * from './roadheight';
@@ -46,7 +46,7 @@ import {
 
 import { uiFieldAccess } from './access';
 import { uiFieldAddress } from './address';
-import { uiFieldCycleway } from './cycleway';
+import { uiFieldDirectionalCombo } from './directional_combo';
 import { uiFieldLanes } from './lanes';
 import { uiFieldLocalized } from './localized';
 import { uiFieldRoadheight } from './roadheight';
@@ -62,8 +62,9 @@ export var uiFields = {
     check: uiFieldCheck,
     colour: uiFieldColour,
     combo: uiFieldCombo,
-    cycleway: uiFieldCycleway,
+    cycleway: uiFieldDirectionalCombo,
     defaultCheck: uiFieldDefaultCheck,
+    directionalCombo: uiFieldDirectionalCombo,
     email: uiFieldEmail,
     identifier: uiFieldIdentifier,
     lanes: uiFieldLanes,


### PR DESCRIPTION
This addresses an important bug fix and makes the field more flexible to use

## the bug

Under some (not very obscure or rare) conditions, when the cycleway field was used to edit a multi selection, the operation resulted in a (partial) corruption of the selected entities. For example:

```
way1: highway=residential + cycleway=no
way2 :highway=residential + cycleway:left=lane
```

When now setting the "Right side" value to something like `shared_lane` the result is the following:

```
way1: highway=residential + cycleway:right=shared_lane + cycleway:left=lane
way2 :highway=residential + cycleway:right=shared_lane + cycleway:left=lane
```

Note how way 1's "Left side" was silent changed from `no` to `lane`. Instead one would expect this:

```
way1: highway=residential + cycleway:right=shared_lane + cycleway:left=no
way2 :highway=residential + cycleway:right=shared_lane + cycleway:left=lane
```

This bus was cased because for a multiselection the previous selection only looked at the first selected entity to find out what to do with the not-user-modified tag. Because the common tag vs. left/right tag can be mapped different for different entities in the multiselection, the approach to merge/split/update the tags needs to be made on a per entity basis. The fix for this introduces a new way to perform tag change action: a callback function which is called for each to be modified entity.

## the enhancement

This is mostly inspired by https://github.com/openstreetmap/id-tagging-schema/pull/674, which would benefit from a field which can edit a directional (`*:forward/backward`) tag.

* Renames the field to `directionalCombo` (keeping `cycleway` for backwards compatibility), and replacing hardcoded occurances of the `cycleway` tag key with the one supplied by the preset field.
* Gets rid of special handling of the `none` value: Previously any `cycleway:<direction>=none` was silently removed from the tags which doesn't make sense for two reasons: a) the documented tag value is `no` and b) it should be possible to map the absence of a cycleway
* When both the `cycleway` and a `cycleway:direction` tag are present, previously the field used the "common" tag value (i.e. the value of the `cycleway` tag). Now this ambiguous tagging is represented as _“multiple values”_ in the editor.
* The field now reuses the `combo` ui field under the hood, which reduces duplication in the code and brings the field up to par with regular combo fields: features like autosuggestions from taginfo are now available also for this field
* As a side effect, `combo` fields can now display fields with `strings` which include a `description` hover text in addition to the tag's label.