### PR TITLE
address_formats.json: add addr:housename to Turkish

### DIFF
--- a/data/address_formats.json
+++ b/data/address_formats.json
@@ -122,6 +122,7 @@
     "format": [
       ["neighbourhood"],
       ["street", "housenumber"],
+      ["housename"],
       ["postcode", "district", "city"]
     ]
   },


### PR DESCRIPTION
In Turkey it's quite common for houses and buildings to have a name as well as a number.

See https://taginfo.openstreetmap.org/keys/addr%3Ahousename for the corresponding taginfo.