### PR TITLE
Optimize oldTagIssues method

### DIFF
--- a/modules/validations/outdated_tags.js
+++ b/modules/validations/outdated_tags.js
@@ -24,11 +24,13 @@ export function validationOutdatedTags() {
 
 
   function oldTagIssues(entity, graph) {
-    const oldTags = Object.assign({}, entity.tags);  // shallow copy
-    let preset = presetManager.match(entity, graph);
-    let subtype = 'deprecated_tags';
-    if (!preset) return [];
     if (!entity.hasInterestingTags()) return [];
+
+    let preset = presetManager.match(entity, graph);
+    if (!preset) return [];
+
+    const oldTags = Object.assign({}, entity.tags);  // shallow copy
+    let subtype = 'deprecated_tags';
 
     // Upgrade preset, if a replacement is available..
     if (preset.replacement) {


### PR DESCRIPTION
By reordering the checks and shallow copies, this method can run its initial stage about 2x faster on average - reducing initial app load by about 25ms in my case.

#### Time measuring code

![2022-12-20 12-48-04](https://user-images.githubusercontent.com/10835147/208661053-68163959-d466-4bf4-abc2-8259f6f1f959.png)

<details>
  <summary>Code</summary>

  ```js
    let validation = function checkOutdatedTags(entity, graph) {
      let ts = performance.now();
      let issues = oldMultipolygonIssues(entity, graph);
      if (!issues.length) issues = oldTagIssues(entity, graph);
      let tt = performance.now() - ts;
      total += tt;
      count += 1;
      console.log(total, count, total / count);
      return issues;
    };
  ```
</details>

### Original code

Notice the `return [];` which is used to focus the time measurement on the pre-checks only.

![2022-12-20 12-48-19](https://user-images.githubusercontent.com/10835147/208661245-cb18c12b-ff6e-48cb-af03-01efa6962745.png)

### Modified code

![2022-12-20 12-48-44](https://user-images.githubusercontent.com/10835147/208661274-08a3b657-1a84-44a0-bc76-97b5664e498c.png)

### Explanation

It looks like the `hasInterestingTags` call is very quick to execute and catches more cases than the `presetManager.match` *(~20ms save)*. Also it makes more sense to perform the shallow copy after all pre-checks are run *(~5ms save)*.