### PR TITLE
Fix connect features with uncontrolled crossing

### DIFF
--- a/modules/validations/crossing_ways.js
+++ b/modules/validations/crossing_ways.js
@@ -146,7 +146,7 @@ export function validationCrossingWays(context) {
                         return {};
                     }
                     var pathFeature = entity1IsPath ? entity1 : entity2;
-                    if (['marked', 'unmarked', 'traffic_signals'].indexOf(pathFeature.tags.crossing) !== -1) {
+                    if (['marked', 'unmarked', 'traffic_signals', 'uncontrolled'].indexOf(pathFeature.tags.crossing) !== -1) {
                         // if the path is a crossing, match the crossing type
                         return bothLines ? { highway: 'crossing', crossing: pathFeature.tags.crossing } : {};
                     }


### PR DESCRIPTION
In https://github.com/openstreetmap/id-tagging-schema/pull/590, the (searchable) Marked Crossing preset was changed to use `crossing=uncontrolled` instead of `crossing=marked`. This PR fixes a similar issue to #9176 in which using Connect the features with a Marked Crossing way adds a generic highway=crossing node as opposed to a Marked Crossing node.


I wasn't sure if the changes made to [`test/spec/validations/crossing_ways.js`](https://github.com/openstreetmap/iD/blob/develop/test/spec/validations/crossing_ways.js) in #9181 was needed so I just made changes to [`modules/validations/crossing_ways.js`](https://github.com/openstreetmap/iD/blob/develop/modules/validations/crossing_ways.js). I tested it locally and it seems to work fine.