### PR TITLE
Bump preset recents from 4 to 6

### DIFF
--- a/modules/presets/index.js
+++ b/modules/presets/index.js
@@ -25,7 +25,12 @@ export { _mainPresetIndex as presetManager };
 //
 export function presetIndex() {
   const dispatch = d3_dispatch('favoritePreset', 'recentsChange');
+
+  // how many recents to store in-memory
   const MAXRECENTS = 30;
+
+  // how many recents to display during defaults() function call
+  const MAXRECENTS_DEFAULTS = 6;
 
   // seed the preset lists with geometry fallbacks
   const POINT = presetPreset('point', { name: 'Point', tags: {}, geometry: ['point', 'vertex'], matchScore: 0.1 } );
@@ -410,7 +415,7 @@ export function presetIndex() {
   _this.defaults = (geometry, n, startWithRecents, loc, extraPresets) => {
     let recents = [];
     if (startWithRecents) {
-      recents = _this.recent().matchGeometry(geometry).collection.slice(0, 4);
+      recents = _this.recent().matchGeometry(geometry).collection.slice(0, MAXRECENTS_DEFAULTS);
     }
 
     let defaults;

--- a/modules/validations/outdated_tags.js
+++ b/modules/validations/outdated_tags.js
@@ -24,11 +24,13 @@ export function validationOutdatedTags() {
 
 
   function oldTagIssues(entity, graph) {
-    const oldTags = Object.assign({}, entity.tags);  // shallow copy
-    let preset = presetManager.match(entity, graph);
-    let subtype = 'deprecated_tags';
-    if (!preset) return [];
     if (!entity.hasInterestingTags()) return [];
+
+    let preset = presetManager.match(entity, graph);
+    if (!preset) return [];
+
+    const oldTags = Object.assign({}, entity.tags);  // shallow copy
+    let subtype = 'deprecated_tags';
 
     // Upgrade preset, if a replacement is available..
     if (preset.replacement) {


### PR DESCRIPTION
I find it often quite frustrating that the menu displays only 4 recent presets. So I bumped it to 6 and made it easily configurable in the future.

![2023-01-09 20-59-01](https://user-images.githubusercontent.com/10835147/211397134-b5907abd-f307-4fa2-8ed3-a4ae791c0874.png)
