### PR TITLE
Introduce the hash URL param `presetUrlOverwrite`

### DIFF
--- a/API.md
+++ b/API.md
@@ -62,6 +62,7 @@ of iD (e.g. `https://ideditor-release.netlify.app`), the following parameters ar
 * __`validationError`__ - The issues identified by these types/subtypes will be treated as errors (i.e. Issues will be surfaced to the user but will block changeset upload). Each parameter value should contain a urlencoded, comma-separated list of type/subtype match rules.  An asterisk `*` may be used as a wildcard.<br/>
   _Example:_ `validationError=crossing_ways/highway*,crossing_ways/tunnel*`
 * __`walkthrough=true`__ - Start the walkthrough automatically
+* __`presetUrlOverwrite=https://example.com`__ - Overwrite the source for presets. Default is the [id-tagging-schema](https://github.com/openstreetmap/id-tagging-schema) release on jsdelivery ([Code](https://github.com/openstreetmap/iD/blob/develop/config/id.js#L2)). The URL has to serve the root of the id-tagging-schema repo after running `npm run dist`.
 
 ##### iD on openstreetmap.org (Rails Port)
 

--- a/config/id.js
+++ b/config/id.js
@@ -1,8 +1,8 @@
 // cdns for external data packages
-const presetsCdnUrl = 'https://cdn.jsdelivr.net/npm/@openstreetmap/id-tagging-schema@{presets_version}/';
-const ociCdnUrl = 'https://cdn.jsdelivr.net/npm/osm-community-index@{version}/';
-const wmfSitematrixCdnUrl = 'https://cdn.jsdelivr.net/npm/wmf-sitematrix@{version}/';
-const nsiCdnUrl = 'https://cdn.jsdelivr.net/npm/name-suggestion-index@{version}/';
+const presetsCdnUrlTemplate = 'https://cdn.jsdelivr.net/npm/@openstreetmap/id-tagging-schema@{presets_version}/';
+const ociCdnUrlTemplate = 'https://cdn.jsdelivr.net/npm/osm-community-index@{version}/';
+const wmfSitematrixCdnUrlTemplate = 'https://cdn.jsdelivr.net/npm/wmf-sitematrix@{version}/';
+const nsiCdnUrlTemplate = 'https://cdn.jsdelivr.net/npm/name-suggestion-index@{version}/';
 
 // api urls and settings
 const osmApiConnections = [
@@ -20,10 +20,10 @@ const taginfoApiUrl = 'https://taginfo.openstreetmap.org/api/4/';
 const nominatimApiUrl = 'https://nominatim.openstreetmap.org/';
 
 export {
-  presetsCdnUrl,
-  ociCdnUrl,
-  wmfSitematrixCdnUrl,
-  nsiCdnUrl,
+  presetsCdnUrlTemplate,
+  ociCdnUrlTemplate,
+  wmfSitematrixCdnUrlTemplate,
+  nsiCdnUrlTemplate,
   osmApiConnections,
   taginfoApiUrl,
   nominatimApiUrl,

--- a/modules/core/file_fetcher.js
+++ b/modules/core/file_fetcher.js
@@ -1,5 +1,5 @@
 import parseVersion from 'vparse';
-import { presetsCdnUrl, ociCdnUrl, wmfSitematrixCdnUrl } from '../../config/id.js';
+import { presetsCdnUrlTemplate, ociCdnUrlTemplate, wmfSitematrixCdnUrlTemplate } from '../../config/id.js';
 
 import packageJSON from '../../package.json';
 
@@ -11,10 +11,15 @@ export { _mainFileFetcher as fileFetcher };
 // coreFileFetcher asynchronously fetches data from JSON files
 //
 export function coreFileFetcher() {
+  const presetsVersion = packageJSON.devDependencies['@openstreetmap/id-tagging-schema'];
+  const presetsCdnUrl = presetsCdnUrlTemplate.replace('{presets_version}', presetsVersion);
+
   const ociVersion = packageJSON.dependencies['osm-community-index'] || packageJSON.devDependencies['osm-community-index'];
   const v = parseVersion(ociVersion);
   const ociVersionMinor = `${v.major}.${v.minor}`;
-  const presetsVersion = packageJSON.devDependencies['@openstreetmap/id-tagging-schema'];
+  const ociCdnUrl = ociCdnUrlTemplate.replace('{version}', ociVersionMinor);
+
+  const wmfSitematrixCdnUrl = wmfSitematrixCdnUrlTemplate.replace('{version}', '0.1');
 
   let _this = {};
   let _inflight = {};
@@ -29,23 +34,22 @@ export function coreFileFetcher() {
     'qa_data': 'data/qa_data.min.json',
     'shortcuts': 'data/shortcuts.min.json',
     'territory_languages': 'data/territory_languages.min.json',
-    'oci_defaults': ociCdnUrl.replace('{version}', ociVersionMinor) + 'dist/defaults.min.json',
-    'oci_features': ociCdnUrl.replace('{version}', ociVersionMinor) + 'dist/featureCollection.min.json',
-    'oci_resources': ociCdnUrl.replace('{version}', ociVersionMinor) + 'dist/resources.min.json',
-    'presets_package': presetsCdnUrl.replace('{presets_version}', presetsVersion) + 'package.json',
+    'oci_defaults': ociCdnUrl + 'dist/defaults.min.json',
+    'oci_features': ociCdnUrl + 'dist/featureCollection.min.json',
+    'oci_resources': ociCdnUrl + 'dist/resources.min.json',
+    'presets_package': presetsCdnUrl + 'package.json',
     'deprecated': presetsCdnUrl + 'dist/deprecated.min.json',
     'discarded': presetsCdnUrl + 'dist/discarded.min.json',
     'preset_categories': presetsCdnUrl + 'dist/preset_categories.min.json',
     'preset_defaults': presetsCdnUrl + 'dist/preset_defaults.min.json',
     'preset_fields': presetsCdnUrl + 'dist/fields.min.json',
     'preset_presets': presetsCdnUrl + 'dist/presets.min.json',
-    'wmf_sitematrix': wmfSitematrixCdnUrl.replace('{version}', '0.1') + 'wikipedia.min.json'
+    'wmf_sitematrix': wmfSitematrixCdnUrl + 'wikipedia.min.json'
   };
 
   let _cachedData = {};
   // expose the cache; useful for tests
   _this.cache = () => _cachedData;
-
 
   // Returns a Promise to fetch data
   // (resolved with the data if we have it already)

--- a/modules/core/file_fetcher.js
+++ b/modules/core/file_fetcher.js
@@ -1,5 +1,6 @@
 import parseVersion from 'vparse';
 import { presetsCdnUrlTemplate, ociCdnUrlTemplate, wmfSitematrixCdnUrlTemplate } from '../../config/id.js';
+import { utilStringQs } from '../util';
 
 import packageJSON from '../../package.json';
 
@@ -12,7 +13,13 @@ export { _mainFileFetcher as fileFetcher };
 //
 export function coreFileFetcher() {
   const presetsVersion = packageJSON.devDependencies['@openstreetmap/id-tagging-schema'];
-  const presetsCdnUrl = presetsCdnUrlTemplate.replace('{presets_version}', presetsVersion);
+  let presetsCdnUrl = presetsCdnUrlTemplate.replace('{presets_version}', presetsVersion);
+  // Allow to overwrite the preset source to enable testing PRs for the id-editor-presets repo.
+  const presetUrlOverwrite = utilStringQs(window.location.hash)?.presetUrlOverwrote;
+  if (presetUrlOverwrite) {
+    presetsCdnUrl = presetUrlOverwrite;
+    console.info('`presetUrlOverwrite` applied. Presets are fetched from', presetsCdnUrl);
+  }
 
   const ociVersion = packageJSON.dependencies['osm-community-index'] || packageJSON.devDependencies['osm-community-index'];
   const v = parseVersion(ociVersion);

--- a/modules/core/localizer.js
+++ b/modules/core/localizer.js
@@ -4,7 +4,8 @@ import { fileFetcher } from './file_fetcher';
 import { utilDetect } from '../util/detect';
 import { utilStringQs } from '../util';
 import { utilArrayUniq } from '../util/array';
-import { presetsCdnUrl } from '../../config/id.js';
+import { presetsCdnUrlTemplate } from '../../config/id.js';
+import packageJSON from '../../package.json';
 
 let _mainLocalizer = coreLocalizer(); // singleton
 let _t = _mainLocalizer.t;
@@ -88,6 +89,8 @@ export function coreLocalizer() {
             'locales'     // load the list of supported locales
         ];
 
+        const presetsVersion = packageJSON.devDependencies['@openstreetmap/id-tagging-schema'];
+        const presetsCdnUrl = presetsCdnUrlTemplate.replace('{presets_version}', presetsVersion);
         const localeDirs = {
             general: 'locales',
             tagging: presetsCdnUrl + 'dist/translations'

--- a/modules/services/nsi.js
+++ b/modules/services/nsi.js
@@ -4,7 +4,7 @@ import parseVersion from 'vparse';
 import { fileFetcher, locationManager } from '../core';
 import { presetManager } from '../presets';
 
-import { nsiCdnUrl } from '../../config/id.js';
+import { nsiCdnUrlTemplate } from '../../config/id.js';
 
 // Make very sure this resolves to iD's `package.json`
 // If you mess up the `../`s, the resolver may import another random package.json from somewhere else.
@@ -50,7 +50,7 @@ function setNsiSources() {
   const nsiVersion = packageJSON.dependencies['name-suggestion-index'] || packageJSON.devDependencies['name-suggestion-index'];
   const v = parseVersion(nsiVersion);
   const vMinor = `${v.major}.${v.minor}`;
-  const cdn = nsiCdnUrl.replace('{version}', vMinor);
+  const cdn = nsiCdnUrlTemplate.replace('{version}', vMinor);
   const sources = {
     'nsi_data': cdn + 'dist/nsi.min.json',
     'nsi_dissolved': cdn + 'dist/dissolved.min.json',


### PR DESCRIPTION
This enables us to create branch deployments that run `npm run dist` in the 
 id-editor-schema repo and preview the schema using an URL like `http://preview.ideditor.com/master/#locale=en&presetUrlOverwrote=https://branch-preview-123.netlify.app/`.

One Issue I found was, that translations don't work well. That might be due to the way I ran `npm run dist` my id-tagging-schema folder locally. Or maybe some piece is missing. One thing we will likely need to do is force the locale to `en` via URL (as I did in the example above) so the fallback values from the dist-folder are applied.

---

This is the first piece to solve https://github.com/openstreetmap/id-tagging-schema/issues/289. The other part would be to setup netlify with branch deployments in the id-editor-schema repo. — Update: My comment https://github.com/openstreetmap/id-tagging-schema/issues/289#issuecomment-1398366533 outlines who I would set that up.