### PR TITLE
Fix wrong variable used to access tags

### DIFF
--- a/modules/osm/tags.js
+++ b/modules/osm/tags.js
@@ -76,11 +76,11 @@ export function osmTagSuggestingArea(tags) {
     var returnTags = {};
     for (var realKey in tags) {
         const key = osmRemoveLifecyclePrefix(realKey);
-        if (key in osmAreaKeys && !(tags[key] in osmAreaKeys[key])) {
+        if (key in osmAreaKeys && !(tags[realKey] in osmAreaKeys[key])) {
             returnTags[realKey] = tags[realKey];
             return returnTags;
         }
-        if (key in osmAreaKeysExceptions && tags[key] in osmAreaKeysExceptions[key]) {
+        if (key in osmAreaKeysExceptions && tags[realKey] in osmAreaKeysExceptions[key]) {
             returnTags[realKey] = tags[realKey];
             return returnTags;
         }


### PR DESCRIPTION
Fixes #9436. In the code, `key` is `realKey` with any prefix removed, like in the given issue `realKey="razed:waterway"` and `key="waterway"`. 
So, to access the value field of tag, `realKey` should be used and not one with removed prefix, i.e `key`.