### PR TITLE
render right-sided arrows for features with lifecycle prefixes

### DIFF
--- a/modules/osm/way.js
+++ b/modules/osm/way.js
@@ -3,7 +3,7 @@ import { geoArea as d3_geoArea } from 'd3-geo';
 import { geoExtent, geoVecCross } from '../geo';
 import { osmEntity } from './entity';
 import { osmLanes } from './lanes';
-import { osmTagSuggestingArea, osmOneWayTags, osmRightSideIsInsideTags } from './tags';
+import { osmTagSuggestingArea, osmOneWayTags, osmRightSideIsInsideTags, osmRemoveLifecyclePrefix } from './tags';
 import { utilArrayUniq } from '../util';
 
 
@@ -167,8 +167,9 @@ Object.assign(osmWay.prototype, {
     // i.e. the right side is the 'inside' (e.g. the right side of a
     // natural=cliff is lower).
     sidednessIdentifier: function() {
-        for (var key in this.tags) {
-            var value = this.tags[key];
+        for (const realKey in this.tags) {
+            const value = this.tags[realKey];
+            const key = osmRemoveLifecyclePrefix(realKey);
             if (key in osmRightSideIsInsideTags && (value in osmRightSideIsInsideTags[key])) {
                 if (osmRightSideIsInsideTags[key][value] === true) {
                     return key;

--- a/test/spec/osm/way.js
+++ b/test/spec/osm/way.js
@@ -359,6 +359,7 @@ describe('iD.osmWay', function() {
             expect(iD.osmWay({tags: { barrier: 'guard_rail' }}).sidednessIdentifier()).to.eql('barrier');
             expect(iD.osmWay({tags: { barrier: 'city_wall' }}).sidednessIdentifier()).to.eql('barrier');
             expect(iD.osmWay({tags: { man_made: 'embankment' }}).sidednessIdentifier()).to.eql('man_made');
+            expect(iD.osmWay({tags: { 'abandoned:barrier': 'guard_rail' }}).sidednessIdentifier()).to.eql('barrier');
         });
 
         it('returns null when tag does not have implied sidedness', function() {
@@ -366,6 +367,8 @@ describe('iD.osmWay', function() {
             expect(iD.osmWay({tags: { barrier: 'fence' }}).sidednessIdentifier()).to.be.null;
             expect(iD.osmWay({tags: { man_made: 'dyke' }}).sidednessIdentifier()).to.be.null;
             expect(iD.osmWay({tags: { highway: 'motorway' }}).sidednessIdentifier()).to.be.null;
+            expect(iD.osmWay({tags: { 'demolished:highway': 'motorway' }}).sidednessIdentifier()).to.be.null;
+            expect(iD.osmWay({tags: { 'not:natural': 'cliff' }}).sidednessIdentifier()).to.be.null;
         });
     });
 


### PR DESCRIPTION
arrows are rendered on the right hand side of features like `natural=cliff`, but not if they have a lifecycle prefix. This PR adds rendering support for features with a lifecycle prefix, such as `abandoned:barrier=guard_rail`

![image](https://user-images.githubusercontent.com/16009897/217208417-f3aed8a9-a672-43a2-9cac-9929f8d84d83.png)
