### PR TITLE
fix inconsistent locale in some parts of iD

### DIFF
--- a/modules/services/nominatim.js
+++ b/modules/services/nominatim.js
@@ -3,6 +3,7 @@ import { json as d3_json } from 'd3-fetch';
 import RBush from 'rbush';
 import { geoExtent } from '../geo';
 import { utilQsString } from '../util';
+import { localizer } from '../core';
 
 import { nominatimApiUrl } from '../../config/id.js';
 
@@ -56,7 +57,12 @@ export default {
         var controller = new AbortController();
         _inflight[url] = controller;
 
-        d3_json(url, { signal: controller.signal })
+        d3_json(url, {
+            signal: controller.signal,
+            headers: {
+                'Accept-Language': localizer.localeCodes().join(',')
+            }
+        })
             .then(function(result) {
                 delete _inflight[url];
                 if (result && result.error) {
@@ -82,7 +88,12 @@ export default {
         var controller = new AbortController();
         _inflight[url] = controller;
 
-        d3_json(url, { signal: controller.signal })
+        d3_json(url, {
+            signal: controller.signal,
+            headers: {
+                'Accept-Language': localizer.localeCodes().join(',')
+            }
+        })
             .then(function(result) {
                 delete _inflight[url];
                 if (result && result.error) {

--- a/test/spec/services/nominatim.js
+++ b/test/spec/services/nominatim.js
@@ -75,6 +75,9 @@ describe('iD.serviceNominatim', function() {
                     expect(parseQueryString(fetchMock.calls()[0][0])).to.eql(
                         {zoom: '13', format: 'json', addressdetails: '1', lat: '49', lon: '17'}
                     );
+                    expect(fetchMock.calls()[0][1].headers).to.eql({
+                        'Accept-Language': 'en'
+                    });
                     expect(callback).to.have.been.calledWithExactly(null, {address: {country_code:'cz'}});
                     done();
                 }, 50);
@@ -144,6 +147,9 @@ describe('iD.serviceNominatim', function() {
 
             window.setTimeout(function() {
                 expect(parseQueryString(fetchMock.calls()[0][0])).to.eql({format: 'json', limit: '10'});
+                expect(fetchMock.calls()[0][1].headers).to.eql({
+                    'Accept-Language': 'en'
+                });
                 expect(callback).to.have.been.calledOnce;
                 done();
             }, 50);


### PR DESCRIPTION
Closes #9499

When fetching data from nominatim, we now give the nominatim API the same list of locales that the iD editor uses. Otherwise, nominatim will use the browser's locales which could be different to what iD uses. See #9499