### PR TITLE
fix tile stacking order

### DIFF
--- a/modules/renderer/tile_layer.js
+++ b/modules/renderer/tile_layer.js
@@ -208,7 +208,8 @@ export function rendererTileLayer(context) {
             .style(transformProp, imageTransform)
             .classed('tile-debug', showDebug)
             .classed('tile-removing', false)
-            .classed('tile-center', function(d) { return d === nearCenter; });
+            .classed('tile-center', function(d) { return d === nearCenter; })
+            .sort((a, b) => a[2] - b[2]);
 
 
 


### PR DESCRIPTION
set the z-index to the respective zoom level to bring tiles with higher detail in front of lower detail tiles (e.g. the first tile request has failed) to ensure maximum visibility of loaded details