### PR TITLE
tweak regex when searching for a feature ID

### DIFF
--- a/modules/ui/feature_list.js
+++ b/modules/ui/feature_list.js
@@ -137,7 +137,7 @@ export function uiFeatureList(context) {
             }
 
             // A location search takes priority over an ID search
-            var idMatch = !locationMatch && q.match(/(?:^|\W)(node|way|relation|[nwr])\W?0*([1-9]\d*)(?:\W|$)/i);
+            var idMatch = !locationMatch && q.match(/(?:^|\W)(node|way|relation|[nwr])\W{0,2}0*([1-9]\d*)(?:\W|$)/i);
 
             if (idMatch) {
                 var elemType = idMatch[1].charAt(0);


### PR DESCRIPTION
Once you've started editting, to navigate to a specific node/way/relation, a easy solution is to copy-paste the header from [a feature's page](https://openstreetmap.org/way/1123456789) into the search box in iD. For example, `Way: 1123456789`.

Currently iD doesn't recognize that format until you delete either the space character or the `:`. This PR fixes that issue to make the workflow marginally more efficient 