### PR TITLE
Fix issue #9530

### DIFF
--- a/modules/core/validator.js
+++ b/modules/core/validator.js
@@ -689,6 +689,9 @@ export function coreValidator(context) {
         const entity = graph.hasEntity(entityID);   // Sanity check: don't validate deleted entities
         if (!entity) return;
 
+        // If we are validating base entity and it has been modified in the head, skip it #9530.
+        if (entity === graph.base().entities[entityID] && _completeDiff.hasOwnProperty(entityID)) return;
+        
         // detect new issues and update caches
         const result = validateEntity(entity, graph);
         if (result.provisional) {                       // provisional result


### PR DESCRIPTION
We check that validation is still needed on base Entity (no modification on head entity) before performing validation. This allows for less unnecessary validations and fixes the concurrency problem with head cache validation that makes some base cache issues still visible even though they are fixed in head.

Fixes #9530 