### PR TITLE
Add custom features filter functionality

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -5177,6 +5177,9 @@ img.tile-debug {
     margin-bottom: 20px;
 }
 
+.settings-custom_features .instructions-template {
+    margin-bottom: 10px;
+}
 
 /* Save Mode
 ------------------------------------------------------- */

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -932,6 +932,9 @@ en:
     others:
       description: Other Features
       tooltip: "Everything Else"
+    custom:
+      description: Custom filter
+      tooltip: "Set a key=value filter"
   area_fill:
     wireframe:
       description: No Fill (Wireframe)
@@ -977,6 +980,14 @@ en:
       url:
         instructions: "Enter a data file URL or vector tile URL template. Valid tokens are:\n   {zoom} or {z}, {x}, {y} for Z/X/Y tile scheme"
         placeholder: Enter a url
+    custom_features:
+        tooltip: Edit custom filter
+        header: Custom Features Filter Settings
+        template:
+          placeholder: Enter a key=value
+        instructions:
+          info: "Enter an OpenStreetMap tag combination, example:"
+          additional_info: You can also use `*` to filter any value for a key, like `highway=*`.
   preferences:
     title: Preferences
     description: Preferences

--- a/index.html
+++ b/index.html
@@ -47,10 +47,11 @@
           window.context = window.id = context;  // for debugging
           context.init();
 
-          // disable boundaries (unless we have an explicit disable_features list)
+          // disable boundaries and custom (unless we have an explicit disable_features list)
           var q = iD.utilStringQs(window.location.hash);
           if (!q.hasOwnProperty('disable_features')) {
             context.features().disable('boundaries');
+            context.features().disable('custom');
           }
         }
       }

--- a/modules/renderer/features.js
+++ b/modules/renderer/features.js
@@ -189,8 +189,8 @@ export function rendererFeatures(context) {
 
     defineRule('aerialways', function isPiste(tags) {
         return tags.aerialway &&
-            tags.aerialway !== 'yes' &&
-            tags.aerialway !== 'station';
+        tags.aerialway !== 'yes' &&
+        tags.aerialway !== 'station';
     });
 
     defineRule('power', function isPower(tags) {
@@ -203,7 +203,7 @@ export function rendererFeatures(context) {
             traffic_roads[tags.highway] ||
             service_roads[tags.highway] ||
             paths[tags.highway]
-        ) { return false; }
+            ) {return false; }
 
         var strings = Object.keys(tags);
 
@@ -221,15 +221,20 @@ export function rendererFeatures(context) {
         return (geometry === 'line' || geometry === 'area');
     });
 
-
+    defineRule('custom', function isCustom(tags) {
+        const [key, value] = prefs('map-features-custom').split('=');
+        if (key) {
+            if (value === '*') return tags[key];
+            return tags[key] === value;
+        }
+    });
 
     features.features = function() {
         return _rules;
     };
 
-
     features.keys = function() {
-        return _keys;
+    return _keys;
     };
 
 
@@ -282,7 +287,6 @@ export function rendererFeatures(context) {
         }
         if (didEnable) update();
     };
-
 
     features.disable = function(k) {
         if (_rules[k] && _rules[k].enabled) {
@@ -380,6 +384,12 @@ export function rendererFeatures(context) {
         });
 
         _cache = {};
+    };
+
+    features.updateCustom = function() {
+        features.reset();
+        features.disable('custom');
+        features.enable('custom');
     };
 
     // only certain relations are worth checking

--- a/modules/ui/settings/custom_features.js
+++ b/modules/ui/settings/custom_features.js
@@ -1,0 +1,92 @@
+import { dispatch as d3_dispatch } from 'd3-dispatch';
+import { marked } from 'marked';
+
+import { prefs } from '../../core/preferences';
+import { t } from '../../core/localizer';
+import { uiConfirm } from '../confirm';
+import { utilNoAuto, utilRebind } from '../../util';
+
+
+export function uiCustomFeatures() {
+    var dispatch = d3_dispatch('change');
+
+    function render(selection) {
+        // keep separate copies of original and current settings
+        var _origSettings = {
+            template: prefs('map-features-custom')
+        };
+        var _currSettings = {
+            template: prefs('map-features-custom')
+        };
+
+        var modal = uiConfirm(selection).okButton();
+
+        modal
+            .classed('custom_features-modal settings-custom_features', true);
+
+        modal.select('.modal-section.header')
+            .append('h3')
+            .call(t.append('settings.custom_features.header'));
+
+
+        var textSection = modal.select('.modal-section.message-text');
+
+        var instructions =
+            `${t.html('settings.custom_features.instructions.info')}\n` +
+            '<code>building=yes</code>.\n' +
+            '\n' +
+            `${t.html('settings.custom_features.instructions.additional_info')}`;
+
+        textSection
+            .append('div')
+            .attr('class', 'instructions-template')
+            .html(marked(instructions));
+
+        textSection
+            .append('input')
+            .attr('type', 'text')
+            .attr('class', 'field-template')
+            .attr('placeholder', t('settings.custom_features.template.placeholder'))
+            .call(utilNoAuto)
+            .property('value', _currSettings.template);
+
+        // insert a cancel button
+        var buttonSection = modal.select('.modal-section.buttons');
+
+        buttonSection
+            .insert('button', '.ok-button')
+            .attr('class', 'button cancel-button secondary-action')
+            .call(t.append('confirm.cancel'));
+
+
+        buttonSection.select('.cancel-button')
+            .on('click.cancel', clickCancel);
+
+        buttonSection.select('.ok-button')
+            .attr('disabled', isSaveDisabled)
+            .on('click.save', clickSave);
+
+        function isSaveDisabled() {
+            return null;
+        }
+
+        // restore the original template
+        function clickCancel() {
+            textSection.select('.field-template').property('value', _origSettings.template);
+            prefs('map-features-custom', _origSettings.template);
+            this.blur();
+            modal.close();
+        }
+
+        // accept the current template
+        function clickSave() {
+            _currSettings.template = textSection.select('.field-template').property('value');
+            prefs('map-features-custom', _currSettings.template);
+            this.blur();
+            modal.close();
+            dispatch.call('change', this, _currSettings);
+        }
+    }
+
+    return utilRebind(render, dispatch, 'on');
+}

--- a/test/spec/renderer/features.js
+++ b/test/spec/renderer/features.js
@@ -17,7 +17,7 @@ describe('iD.rendererFeatures', function() {
             expect(keys).to.include(
                 'points', 'traffic_roads', 'service_roads', 'paths',
                 'buildings', 'landuse', 'boundaries', 'water', 'rail',
-                'power', 'past_future', 'others'
+                'power', 'past_future', 'others', 'custom'
             );
         });
     });


### PR DESCRIPTION
Closes #2580

Related to #2676. It adds a new option in the Map Features section that allows the user to set a key=value filter.

You can see it in action in the video below:

<video src="https://user-images.githubusercontent.com/666291/231590706-94ba07df-93b9-4663-96e7-40148b33a55b.mov"></video>

