### PR TITLE
consider other tags for labelling features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :sparkles: Usability & Accessibility
 * The flip operation now works on nodes with no `direction` tag, to support quickly adding `direction` to features like traffic signs ([#9317], thanks [@k-yle])
 * Show "add new key" placeholder text for blank row in raw tag editor ([#11211], thanks [@bhavyaKhatri2703])
+* Consider other name-like tags for labelling features, such as `lock_name` ([#9588], thanks [@k-yle])
 #### :scissors: Operations
 #### :camera: Street-Level
 #### :white_check_mark: Validation
@@ -55,6 +56,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 
 [#9317]: https://github.com/openstreetmap/iD/issues/9317
 [#9511]: https://github.com/openstreetmap/iD/pull/9511
+[#9588]: https://github.com/openstreetmap/iD/pull/9588
 [#9754]: https://github.com/openstreetmap/iD/issues/9754
 [#11206]: https://github.com/openstreetmap/iD/issues/11206
 [#11211]: https://github.com/openstreetmap/iD/issues/11211

--- a/modules/svg/labels.js
+++ b/modules/svg/labels.js
@@ -55,6 +55,16 @@ export function svgLabels(projection, context) {
         ['point', 'shop', '*', 10],
         ['point', 'tourism', '*', 10],
         ['point', 'camp_site', '*', 10],
+        ['*', 'alt_name', '*', 12],
+        ['*', 'official_name', '*', 12],
+        ['*', 'loc_name', '*', 12],
+        ['*', 'loc_ref', '*', 12],
+        ['*', 'unsigned_ref', '*', 12],
+        ['*', 'seamark:name', '*', 12],
+        ['*', 'sector:name', '*', 12],
+        ['*', 'lock_name', '*', 12],
+        ['*', 'distance', '*', 12],
+        ['*', 'railway:position', '*', 12],
         ['line', 'ref', '*', 12],
         ['area', 'ref', '*', 12],
         ['point', 'ref', '*', 10],
@@ -297,7 +307,7 @@ export function svgLabels(projection, context) {
                 var matchVal = labelStack[k][2];
                 var hasVal = entity.tags[matchKey];
 
-                if (geometry === matchGeom && hasVal && (matchVal === '*' || matchVal === hasVal)) {
+                if ((matchGeom === '*' || geometry === matchGeom) && hasVal && (matchVal === '*' || matchVal === hasVal)) {
                     labelable[k].push(entity);
                     break;
                 }

--- a/modules/util/util.js
+++ b/modules/util/util.js
@@ -242,10 +242,34 @@ export function utilDisplayName(entity, hideNetwork) {
     }
 
     if (keyComponents.length) {
-        name = t('inspector.display_name.' + keyComponents.join('_'), tags);
+        return t('inspector.display_name.' + keyComponents.join('_'), tags);
     }
 
-    return name;
+    const alternativeNameKeys = [
+        'alt_name',
+        'official_name',
+        'loc_name',
+        'loc_ref',
+        'unsigned_ref',
+        'seamark:name',
+        'sector:name',
+        'lock_name'
+    ];
+
+    if (entity.tags.highway === 'milestone' || entity.tags.railway === 'milestone') {
+        // distance & railway:position are only valid as names when used on a milestone
+        alternativeNameKeys.push('distance', 'railway:position');
+    }
+
+    // if there's still no name found, try some other name-like tags
+    for (const key of alternativeNameKeys) {
+        if (key in entity.tags) {
+            return entity.tags[key];
+        }
+    }
+
+    // no match found
+    return '';
 }
 
 

--- a/test/spec/util/util.js
+++ b/test/spec/util/util.js
@@ -300,6 +300,21 @@ describe('iD.util', function() {
             // BART Yellow Line: Antioch => Pittsburg/Bay Point => SFO Airport => Millbrae
             expect(iD.utilDisplayName({tags: {network: 'BART', ref: 'Yellow', from: 'Antioch', to: 'Millbrae', via: 'Pittsburg/Bay Point;San Francisco International Airport', route: 'subway'}})).to.eql('BART Yellow from Antioch to Millbrae via Pittsburg/Bay Point;San Francisco International Airport');
         });
+        it('can use alternative name tags', () => {
+            expect(iD.utilDisplayName({ tags: { loc_ref: 'A' } })).to.eql('A');
+            expect(iD.utilDisplayName({ tags: { 'seamark:name': 'Bean Rock' } })).to.eql('Bean Rock');
+
+            expect(iD.utilDisplayName({ tags: { highway: 'milestone', distance: '12' } })).to.eql('12');
+            expect(iD.utilDisplayName({ tags: { distance: '12' } })).to.eql(''); // `distance` is not used as a name on other features
+
+            expect(iD.utilDisplayName({ tags: { railway: 'milestone', 'railway:position': '12' } })).to.eql('12');
+            expect(iD.utilDisplayName({ tags: { 'railway:position': '12' } })).to.eql(''); // `railway:position` is not used as a name on other features
+        });
+        it('prefers standard tags over alternative names', () => {
+            expect(iD.utilDisplayName({ tags: { name: '1', official_name: '2' } })).to.eql('1');
+            expect(iD.utilDisplayName({ tags: { ref: '1', loc_ref: '2' } })).to.eql('1');
+            expect(iD.utilDisplayName({ tags: { ref: '1', network: 'AT', loc_ref: '2' } })).to.eql('AT 1');
+        });
         it('distinguishes named features by name', function() {
             expect(iD.utilDisplayName({tags: { name: 'Ohio Turnpike', route: 'road' }})).to.eql('Ohio Turnpike');
             expect(iD.utilDisplayName({tags: { name: 'Lynfield Express', ref: '25L', route: 'bus' }})).to.eql('25L: Lynfield Express');


### PR DESCRIPTION
Closes #8966, Closes #9526

This PR considers other name tags when labelling features in the UI and on the map.

These tags are considered: [`alt_name`](https://wiki.osm.org/Key:alt_name), [`official_name`](https://wiki.osm.org/Key:official_name), [`loc_name`](https://wiki.osm.org/Key:loc_name), [`loc_ref`](https://wiki.osm.org/Key:loc_ref),  [`unsigned_ref`](https://wiki.osm.org/Key:unsigned_ref), [`seamark:name`](https://wiki.osm.org/Key:seamark:name), [`sector:name`](https://wiki.osm.org/Key:sector:name), [`addr:housename`](https://wiki.osm.org/Key:addr:housename), [`lock_name`](https://wiki.osm.org/Key:lock_name) and in some cases [`distance`](https://wiki.osm.org/Key:distance) and [`railway:position`](https://wiki.osm.org/Key:railway:position) (see #9526)

#8707 and #8440 turned out to be controversial but I can't think of any reason why this change would be unwelcome (?)
