### PR TITLE
Add address format for Phillipines

### DIFF
--- a/data/address_formats.json
+++ b/data/address_formats.json
@@ -190,7 +190,7 @@
   {
     "countryCodes": ["ph"],
     "format": [
-      ["unit","housenumber", "street"],
+      ["unit", "housenumber", "street"],
 	  ["district", "city"],
 	  ["postcode", "province"]
     ]

--- a/data/address_formats.json
+++ b/data/address_formats.json
@@ -186,5 +186,13 @@
       ["city", "postcode"],
       ["district"]
     ]
+  },
+  {
+    "countryCodes": ["ph"],
+    "format": [
+      ["unit","housenumber", "street"],
+	  ["district", "city"],
+	  ["postcode", "province"]
+    ]
   }
 ]


### PR DESCRIPTION
This adds address fields for Philippines, based on feedback at https://github.com/bryceco/GoMap/issues/666:
* Unit (addr:unit)
* House number (addr:housenumber)
* Street (addr:street)
* District (addr:district)
* City (addr:city)
* Postcode (addr:postcode)
* Province (addr:province)