### PR TITLE
fix highway=busway not supported in the turn restriction editor

### DIFF
--- a/modules/osm/intersection.js
+++ b/modules/osm/intersection.js
@@ -43,6 +43,7 @@ export function osmIntersection(graph, startVertexId, maxDistance) {
             'unclassified': true,
             'living_street': true,
             'service': true,
+            'busway': true,
             'road': true,
             'track': true
         };

--- a/modules/osm/tags.js
+++ b/modules/osm/tags.js
@@ -223,7 +223,7 @@ export var osmRightSideIsInsideTags = {
 export var osmRoutableHighwayTagValues = {
     motorway: true, trunk: true, primary: true, secondary: true, tertiary: true, residential: true,
     motorway_link: true, trunk_link: true, primary_link: true, secondary_link: true, tertiary_link: true,
-    unclassified: true, road: true, service: true, track: true, living_street: true, bus_guideway: true,
+    unclassified: true, road: true, service: true, track: true, living_street: true, bus_guideway: true, busway: true,
     path: true, footway: true, cycleway: true, bridleway: true, pedestrian: true, corridor: true, steps: true
 };
 // "highway" tag values that generally do not allow motor vehicles

--- a/modules/osm/way.js
+++ b/modules/osm/way.js
@@ -109,7 +109,7 @@ Object.assign(osmWay.prototype, {
                 motorway: 5, motorway_link: 5, trunk: 4.5, trunk_link: 4.5,
                 primary: 4, secondary: 4, tertiary: 4,
                 primary_link: 4, secondary_link: 4, tertiary_link: 4,
-                unclassified: 4, road: 4, living_street: 4, bus_guideway: 4, pedestrian: 4,
+                unclassified: 4, road: 4, living_street: 4, bus_guideway: 4, busway: 4, pedestrian: 4,
                 residential: 3.5, service: 3.5, track: 3, cycleway: 2.5,
                 bridleway: 2, corridor: 2, steps: 2, path: 1.5, footway: 1.5
             },

--- a/modules/svg/lines.js
+++ b/modules/svg/lines.js
@@ -25,7 +25,8 @@ export function svgLines(projection, context) {
         unclassified: 8,
         residential: 9,
         service: 10,
-        footway: 11
+        busway: 11,
+        footway: 12
     };
 
 

--- a/modules/ui/fields/access.js
+++ b/modules/ui/fields/access.js
@@ -212,6 +212,11 @@ export function uiFieldAccess(field, context) {
             },
             construction: {
                 access: 'no'
+            },
+            busway: {
+                access: 'no',
+                bus: 'designated',
+                emergency: 'yes',
             }
         },
         barrier: {

--- a/modules/ui/preset_icon.js
+++ b/modules/ui/preset_icon.js
@@ -369,6 +369,7 @@ export function uiPresetIcon() {
     subway: ['railway/subway', 'railway/subway', 'railway/subway'],
     train: ['railway/rail', 'railway/rail', 'railway/rail'],
     tram: ['railway/tram', 'railway/tram', 'railway/tram'],
+    railway: ['railway/rail', 'railway/rail', 'railway/rail'],
     waterway: ['waterway/stream', 'waterway/stream', 'waterway/stream']
   };
 


### PR DESCRIPTION
Added [`busway`](https://wiki.osm.org/Tag:highway=busway) as a routable highway type. This fixes an issue where busways would not appear in turn restriction editor, and presumably other places that use these constants.