### PR TITLE
allow broken (unclosed) areas to be continued

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 
 #### :sparkles: Usability & Accessibility
 * Also show search result for coordinates in `lon/lat` order in search results ([#10720], thanks [@Deeptanshu-sankhwar])
+* Allow broken (unclosed) areas to be continued ([#9635], thanks [@k-yle])
 #### :scissors: Operations
 * Fix splitting of closed ways (or areas) when two or more split-points are selected
 #### :camera: Street-Level
@@ -58,6 +59,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :hammer: Development
 
 [#7381]: https://github.com/openstreetmap/iD/issues/7381
+[#9635]: https://github.com/openstreetmap/iD/pull/9635
 [#10003]: https://github.com/openstreetmap/iD/pull/10003
 [#10720]: https://github.com/openstreetmap/iD/issues/10720
 [#10747]: https://github.com/openstreetmap/iD/issues/10747

--- a/modules/operations/continue.js
+++ b/modules/operations/continue.js
@@ -16,7 +16,8 @@ export function operationContinue(context, selectedIDs) {
 
     function candidateWays() {
         return _vertex ? context.graph().parentWays(_vertex).filter(function(parent) {
-            return parent.geometry(context.graph()) === 'line' &&
+            const geom = parent.geometry(context.graph());
+            return (geom === 'line' || geom === 'area') &&
                 !parent.isClosed() &&
                 parent.affix(_vertex.id) &&
                 (_geometries.line.length === 0 || _geometries.line[0] === parent);


### PR DESCRIPTION
The continue operation cannot be used on broken areas at the moment. This is a bit frustrating, because it makes it hard to repair these areas.

The only solution right now is to delete all tags so that iD thinks it's a line, and then allows you to use the 'continue' operation.

This PR makes the operation also support unclosed area:

<img width="296" alt="Screenshot 2023-05-13 141141" src="https://github.com/openstreetmap/iD/assets/16009897/8e350316-da7f-43ae-ab97-2ef88c90f8c8">
