### PR TITLE
fix tag values with spaces causing css bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Fix a bug where the _Add_ input element on comboboxes with a fixed set of allowed options is still hidden after an option of a previously "fully saturated" field is removed
 * Fix wrongly flagged "incorrect geometry type" warnings for features with lifecycle-prefixed tags ([#9483], thanks [@biswajit-k])
 * Fix corruption of tag values of fields with referenced strings, but restricted `options`, when an unavailable option is entered manually into the field.
+* Prevent certain tag values with whitespace from corrupting css classes ([#9637], thanks [@k-yle)
 #### :earth_asia: Localization
 * Send `Accept-Language` header on Nominatim API calls ([#9501], thanks [@k-yle])
 * Add Address and Phone Format for India ([#9482], thanks [@biswajit-k])
@@ -67,6 +68,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#9493]: https://github.com/openstreetmap/iD/pull/9493
 [#9520]: https://github.com/openstreetmap/iD/pull/9520
 [#9501]: https://github.com/openstreetmap/iD/pull/9501
+[#9637]: https://github.com/openstreetmap/iD/pull/9637
 [@biswajit-k]: https://github.com/biswajit-k
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Fix a bug where the _Add_ input element on comboboxes with a fixed set of allowed options is still hidden after an option of a previously "fully saturated" field is removed
 * Fix wrongly flagged "incorrect geometry type" warnings for features with lifecycle-prefixed tags ([#9483], thanks [@biswajit-k])
 * Fix corruption of tag values of fields with referenced strings, but restricted `options`, when an unavailable option is entered manually into the field.
-* Prevent certain tag values with whitespace from corrupting css classes ([#9637], thanks [@k-yle)
+* Prevent certain tag values with whitespace from corrupting css classes ([#9637], thanks [@k-yle])
 #### :earth_asia: Localization
 * Send `Accept-Language` header on Nominatim API calls ([#9501], thanks [@k-yle])
 * Add Address and Phone Format for India ([#9482], thanks [@biswajit-k])

--- a/modules/svg/tag_classes.js
+++ b/modules/svg/tag_classes.js
@@ -159,10 +159,10 @@ export function svgTagClasses() {
             classes.push('tag-wikidata');
         }
 
-        // ensure that tags keys/values with spaces are not added to the DOM,
-        // because it can cause bizarre issues (#9448)
+        // ensure that classes for tags keys/values with special characters like spaces
+        // are not added to the DOM, because it can cause bizarre issues (#9448)
         return classes
-            .filter(clāss => !clāss.includes(' '))
+            .filter(klass => /^[-_a-z]+$/.test(klass))
             .join(' ')
             .trim();
     };

--- a/modules/svg/tag_classes.js
+++ b/modules/svg/tag_classes.js
@@ -159,7 +159,12 @@ export function svgTagClasses() {
             classes.push('tag-wikidata');
         }
 
-        return classes.join(' ').trim();
+        // ensure that tags keys/values with spaces are not added to the DOM,
+        // because it can cause bizarre issues (#9448)
+        return classes
+            .filter(clāss => !clāss.includes(' '))
+            .join(' ')
+            .trim();
     };
 
 

--- a/modules/svg/tag_classes.js
+++ b/modules/svg/tag_classes.js
@@ -162,7 +162,7 @@ export function svgTagClasses() {
         // ensure that classes for tags keys/values with special characters like spaces
         // are not added to the DOM, because it can cause bizarre issues (#9448)
         return classes
-            .filter(klass => /^[-_a-z]+$/.test(klass))
+            .filter(klass => /^[-_a-z0-9]+$/.test(klass))
             .join(' ')
             .trim();
     };


### PR DESCRIPTION
Closes #9448

Some tags (like `location`) allow special CSS classes to be applied, but if the tag values has a space, then each word is added as a seperate css class. Some word like `red` or `selected` can cause expected behaviour since they're global class names. 

This PR fixes the bug by preventing tag-based class names from being added if they contain a space (which is the delimeter for css class names)