### PR TITLE
fix wikidata field broken for some languages

### DIFF
--- a/modules/services/wikidata.js
+++ b/modules/services/wikidata.js
@@ -32,9 +32,11 @@ export default {
             search: query,
             type: 'item',
             // the language to search
-            language: lang,
+            // do not include the country-code suffix
+            language: lang.split('-')[0],
             // the language for the label and description in the result
-            uselang: lang,
+            // do not include the country-code suffix
+            uselang: lang.split('-')[0],
             limit: 10,
             origin: '*'
         });


### PR DESCRIPTION
today is an amazing day.... for years I thought the `wikidata` field was a dumb readonly field, and I've always used the raw tag editor to set this key. 

I only realized today that it's supposed to have dropdown suggestions.... It's never worked for me, because my language is set to `en-NZ` which the wikidata API rejects, causing the field to delete everything you type into it

I'm not sure if simply stripping out the `-XX` country code suffix is the right solution, but this is an incredible QOL improvement


<img width="237" alt="image" src="https://github.com/openstreetmap/iD/assets/16009897/4e94b238-b863-4d87-964b-f2cc85817d0e">

(although the suggestions are a bit weird)

