### PR TITLE
Offer to connect sidewalk to service road without tagging crossing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :scissors: Operations
 #### :camera: Street-Level
 #### :white_check_mark: Validation
+* Offer to connect sidewalk to service road without tagging the connection as a crossing ([#9650], thanks [@1ec5])
 #### :bug: Bugfixes
 * Fix `multi/many/semiCombo` options for not being selectable immediately after removing them for fields with predefined options
 * Fix a bug where the _Add_ input element on comboboxes with a fixed set of allowed options is still hidden after an option of a previously "fully saturated" field is removed
@@ -73,6 +74,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#9637]: https://github.com/openstreetmap/iD/pull/9637
 [#9638]: https://github.com/openstreetmap/iD/pull/9638
 [#9640]: https://github.com/openstreetmap/iD/issues/9640
+[#9650]: https://github.com/openstreetmap/iD/pull/9650
 [@biswajit-k]: https://github.com/biswajit-k
 
 

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1931,6 +1931,8 @@ en:
         title: Connect this feature
       connect_features:
         title: Connect the features
+      connect_using_crossing:
+        title: Connect using a crossing
       connect_using_ford:
         title: Connect using a ford
       continue_from_start:

--- a/modules/validations/crossing_ways.js
+++ b/modules/validations/crossing_ways.js
@@ -123,9 +123,8 @@ export function validationCrossingWays(context) {
         motorway: true, motorway_link: true, trunk: true, trunk_link: true,
         primary: true, primary_link: true, secondary: true, secondary_link: true
     };
-    var nonCrossingHighways = { track: true };
 
-    function tagsForConnectionNodeIfAllowed(entity1, entity2, graph) {
+    function tagsForConnectionNodeIfAllowed(entity1, entity2, graph, lessLikelyTags) {
         var featureType1 = getFeatureType(entity1, graph);
         var featureType2 = getFeatureType(entity2, graph);
 
@@ -141,11 +140,18 @@ export function validationCrossingWays(context) {
                     // one feature is a path but not both
 
                     var roadFeature = entity1IsPath ? entity2 : entity1;
-                    if (nonCrossingHighways[roadFeature.tags.highway]) {
-                        // don't mark path connections with certain roads as crossings
+                    var pathFeature = entity1IsPath ? entity1 : entity2;
+                    // don't mark path connections with tracks as crossings
+                    if (roadFeature.tags.highway === 'track') {
                         return {};
                     }
-                    var pathFeature = entity1IsPath ? entity1 : entity2;
+                    // a sidewalk crossing a driveway is unremarkable and unlikely to be interrupted by the driveway
+                    // a sidewalk crossing another kind of service road may be similarly unremarkable
+                    if (!lessLikelyTags &&
+                        roadFeature.tags.highway === 'service' &&
+                        pathFeature.tags.highway === 'footway' && pathFeature.tags.footway === 'sidewalk') {
+                        return {};
+                    }
                     if (['marked', 'unmarked', 'traffic_signals', 'uncontrolled'].indexOf(pathFeature.tags.crossing) !== -1) {
                         // if the path is a crossing, match the crossing type
                         return bothLines ? { highway: 'crossing', crossing: pathFeature.tags.crossing } : {};
@@ -435,6 +441,10 @@ export function validationCrossingWays(context) {
 
                 if (connectionTags) {
                     fixes.push(makeConnectWaysFix(this.data.connectionTags));
+                    let lessLikelyConnectionTags = tagsForConnectionNodeIfAllowed(entities[0], entities[1], graph, true);
+                    if (lessLikelyConnectionTags && JSON.stringify(connectionTags) !== JSON.stringify(lessLikelyConnectionTags)) {
+                        fixes.push(makeConnectWaysFix(lessLikelyConnectionTags));
+                    }
                 }
 
                 if (isCrossingIndoors) {
@@ -692,16 +702,21 @@ export function validationCrossingWays(context) {
     function makeConnectWaysFix(connectionTags) {
 
         var fixTitleID = 'connect_features';
+        var fixIcon = 'iD-icon-crossing';
+        if (connectionTags.highway === 'crossing') {
+            fixTitleID = 'connect_using_crossing';
+            fixIcon = 'temaki-pedestrian';
+        }
         if (connectionTags.ford) {
             fixTitleID = 'connect_using_ford';
+            fixIcon = 'temaki-pedestrian';
         }
 
         return new validationIssueFix({
-            icon: 'iD-icon-crossing',
+            icon: fixIcon,
             title: t.append('issues.fix.' + fixTitleID + '.title'),
             onClick: function(context) {
                 var loc = this.issue.loc;
-                var connectionTags = this.issue.data.connectionTags;
                 var edges = this.issue.data.edges;
 
                 context.perform(


### PR DESCRIPTION
When a driveway or other service road crosses a sidewalk, offer to either connect them without any tags or connect them with `highway=crossing`. Previously, there was only one option that implied nothing about tags but added `highway=crossing` anyways:

<img src="https://github.com/openstreetmap/iD/assets/1231218/0d507e0f-80af-4db8-b743-a54a3edd0d2a" width="379" alt="Driveway crosses Sidewalk"> <img src="https://github.com/openstreetmap/iD/assets/1231218/e52c528a-0a95-4f44-ac18-fcf6e14b9014" width="379" alt="Service Road crosses Sidewalk">

When a service road crosses an ordinary footpath, or when a larger road crosses a sidewalk, continue to offer just the option to connect them with `highway=crossing`, but with the same icon as the crossing presets. Similarly, when a stream crosses a sidewalk, show the same icon as the Ford preset:

<img src="https://github.com/openstreetmap/iD/assets/1231218/07546ba8-6a34-4eb8-a1f8-4777c5545117" width="379" alt="Foot Path crosses Service Road"> <img src="https://github.com/openstreetmap/iD/assets/1231218/324dc336-db29-4106-8c8d-8a476f21a80b" width="379" alt="Residential Road crosses Sidewalk"> <img src="https://github.com/openstreetmap/iD/assets/1231218/c7804dc7-d21e-4fba-8d90-d62ece4dd5f2" width="379" alt="Sidewalk crosses Stream">

Fixes #8463.