### PR TITLE
support `no` and "other" states of options of multiCombo/manyCombo fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 
 # Unreleased (2.26.0-dev)
 #### :tada: New Features
-* Combo fields for tags with `yes/no` values now correctly display the `no` state and allow to toggle between the two states ([#7427])
+* Combo fields for tags with `yes/no` values now also display the `no` state and allow to toggle between the two states ([#7427])
 #### :sparkles: Usability & Accessibility
 * Make it easier to search for OSM objects by id ([#9520], thanks [@k-yle])
 #### :scissors: Operations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 
 # Unreleased (2.26.0-dev)
 #### :tada: New Features
+* Combo fields for tags with `yes/no` values now correctly display the `no` state and allow to toggle between the two states ([#7427])
 #### :sparkles: Usability & Accessibility
 * Make it easier to search for OSM objects by id ([#9520], thanks [@k-yle])
 #### :scissors: Operations
@@ -65,6 +66,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Bundle `package-lock.json` file in repository for faster `clean-install` builds
 * Build icons from configured presets source and also process field value `icons` in `npm run build:data`
 
+[#7427]: https://github.com/openstreetmap/iD/issues/7427
 [#9482]: https://github.com/openstreetmap/iD/pull/9482
 [#9483]: https://github.com/openstreetmap/iD/pull/9483
 [#9492]: https://github.com/openstreetmap/iD/pull/9492

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -1676,6 +1676,12 @@ input.date-selector {
     max-width: 100%;
     color: #7092ff;
 }
+.form-field-input-multicombo li.chip.negated span {
+    text-decoration: line-through;
+}
+.form-field-input-multicombo li.chip input {
+    width: 1em;
+}
 .ideditor[dir='ltr'] .form-field-input-multicombo li.chip {
     padding: 2px 0px 2px 5px;
 }

--- a/modules/ui/fields/combo.js
+++ b/modules/ui/fields/combo.js
@@ -151,7 +151,7 @@ export function uiFieldCombo(field, context) {
     function objectDifference(a, b) {
         return a.filter(function(d1) {
             return !b.some(function(d2) {
-                return !d2.isMixed && d1.value === d2.value;
+                return d1.value === d2.value;
             });
         });
     }


### PR DESCRIPTION
For `multiCombo` and `manyCombo` fields: `no` values are not ignored anymore. Values are rendered with a checkbox which allows to toggle the states. Non yes/no values are rendered using a "undetermined" checkbox state, in which case the hover text shows the value of the tag.

### example

```
female=no
male=unknown
unisex=yes
```

old:
![image](https://github.com/openstreetmap/iD/assets/1927298/747d8e88-e707-425e-9b7f-254c380144ab) 

new:
![image](https://github.com/openstreetmap/iD/assets/1927298/e94f2bf9-b8a8-4d1f-b214-47516a6c9452)

### multiselection example

* ```
  female=yes
  male=no
  unisex=no
  ```
* ```
  female=no
  male=yes
  unisex=no
  ```

old:
![image](https://github.com/openstreetmap/iD/assets/1927298/05884f7e-eac9-4e7b-8703-e3038eb2eeea)


new: 
![image](https://github.com/openstreetmap/iD/assets/1927298/ebde746c-6943-4776-96d5-49b8361a738a)

