### PR TITLE
Continue drawing line or area at any point

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -70,13 +70,15 @@ en:
         area: Started an area.
     continue:
       key: A
-      title: Continue
-      description: Continue this line.
-      not_eligible: No line can be continued here.
-      multiple: Several lines can be continued here. Add one to the selection to continue.
+      title: Draw
+      description:
+        line: Continue drawing this line.
+        area: Continue drawing this area.
+      not_eligible: No line or area can be continued here.
+      multiple: Several lines or areas are connected here. Add one to the selection to continue drawing it.
       annotation:
-        line: Continued a line.
-        area: Continued an area.
+        line: Continued drawing a line.
+        area: Continued drawing an area.
     cancel_draw:
       annotation: Canceled drawing.
     change_role:
@@ -1601,7 +1603,7 @@ en:
       move: "{move_icon} **{move}** lets you drag features around the map."
       rotate: "{rotate_icon} **{rotate}** lets you swivel features around their center points."
       reflect: "{reflect_short_icon} **{reflect_short}** and {reflect_long_icon} **{reflect_long}** reflect features over their short and long axes."
-      continue: "{continue_icon} **{continue}** lets you extend existing lines from their endpoints."
+      continue: "{continue_icon} **{continue}** lets you extend an existing line or area starting from a point along it."
       reverse: "{reverse_icon} **{reverse}** changes the direction of features. The direction matters for things like one-way roads, traffic signs, waterways, and cliffs."
       disconnect: "{disconnect_icon} **{disconnect}** separates connected lines and areas from each other. You can disconnect entire features or just selected points."
       merge: "{merge_icon} **{merge}** combines multiple features into one. You can merge areas together to create multipolygons, merge lines together to create longer lines, and merge points into anything to transfer their tags."
@@ -2371,7 +2373,7 @@ en:
         stop_line: "Finish drawing a line or area"
       operations:
         title: "Operations"
-        continue_line: "Continue a line at the selected endpoint"
+        continue_line: "Continue drawing a line or area from the selected point"
         merge: "Combine (merge) selected features"
         disconnect: "Disconnect selected features"
         extract: "Extract a point from a feature"

--- a/modules/modes/draw_area.js
+++ b/modules/modes/draw_area.js
@@ -2,7 +2,7 @@ import { t } from '../core/localizer';
 import { behaviorDrawWay } from '../behavior/draw_way';
 
 
-export function modeDrawArea(context, wayID, startGraph, button) {
+export function modeDrawArea(context, wayID, startGraph, button, nodeIndex, continuing) {
     var mode = {
         button: button,
         id: 'draw-area'
@@ -15,9 +15,18 @@ export function modeDrawArea(context, wayID, startGraph, button) {
                 .label(t.append('self_intersection.error.areas'))();
         });
 
+    // The node index will be dynamic based on an offset from the end.
+    var offsetFromEndNode;
+    if (typeof nodeIndex === 'number') {
+        offsetFromEndNode = context.entity(wayID).nodes.length - nodeIndex - 1;
+    }
+
     mode.wayID = wayID;
 
+    mode.isContinuing = continuing;
+
     mode.enter = function() {
+        behavior.offsetFromEndNode(offsetFromEndNode);
         context.install(behavior);
     };
 

--- a/modules/modes/draw_line.js
+++ b/modules/modes/draw_line.js
@@ -2,7 +2,7 @@ import { t } from '../core/localizer';
 import { behaviorDrawWay } from '../behavior/draw_way';
 
 
-export function modeDrawLine(context, wayID, startGraph, button, affix, continuing) {
+export function modeDrawLine(context, wayID, startGraph, button, position, continuing) {
     var mode = {
         button: button,
         id: 'draw-line'
@@ -15,13 +15,21 @@ export function modeDrawLine(context, wayID, startGraph, button, affix, continui
                 .label(t.append('self_intersection.error.lines'))();
         });
 
+    // If the position is a node index rather than an affix string, the node index will be dynamic based on an offset from the end.
+    var offsetFromEndNode;
+    if (typeof position === 'number') {
+        offsetFromEndNode = context.entity(wayID).nodes.length - position - 1;
+    }
+
     mode.wayID = wayID;
 
     mode.isContinuing = continuing;
 
     mode.enter = function() {
-        behavior
-            .nodeIndex(affix === 'prefix' ? 0 : undefined);
+        behavior.offsetFromEndNode(offsetFromEndNode);
+        if (position === 'prefix') {
+            behavior.nodeIndex(0);
+        }
 
         context.install(behavior);
     };

--- a/modules/operations/continue.js
+++ b/modules/operations/continue.js
@@ -1,5 +1,6 @@
 import { t } from '../core/localizer';
 import { modeDrawLine } from '../modes/draw_line';
+import { modeDrawArea } from '../modes/draw_area';
 import { behaviorOperation } from '../behavior/operation';
 import { actionDeleteNode } from '../actions/delete_node';
 import { utilArrayGroupBy } from '../util';
@@ -17,8 +18,7 @@ export function operationContinue(context, selectedIDs) {
 
     function candidateWays() {
         return _vertex ? context.graph().parentWays(_vertex).filter(function(parent) {
-            return parent.geometry(context.graph()) === 'line' &&
-                parent.contains(_vertex.id) &&
+            return parent.contains(_vertex.id) &&
                 (_geometries.line.length === 0 || _geometries.line[0] === parent);
         }) : [];
     }
@@ -35,7 +35,9 @@ export function operationContinue(context, selectedIDs) {
             context.perform(actionDeleteNode(_vertex.id));
         }
         context.enter(
-            modeDrawLine(context, candidate.id, context.graph(), 'line', affix || candidate.nodes.indexOf(_vertex.id), true)
+            candidate.geometry(context.graph()) === 'line' ?
+            modeDrawLine(context, candidate.id, context.graph(), 'line', affix || candidate.nodes.indexOf(_vertex.id), true) :
+            modeDrawArea(context, candidate.id, context.graph(), 'area', candidate.nodes.indexOf(_vertex.id), true)
         );
     };
 

--- a/modules/operations/continue.js
+++ b/modules/operations/continue.js
@@ -18,7 +18,6 @@ export function operationContinue(context, selectedIDs) {
     function candidateWays() {
         return _vertex ? context.graph().parentWays(_vertex).filter(function(parent) {
             return parent.geometry(context.graph()) === 'line' &&
-                !parent.isClosed() &&
                 parent.contains(_vertex.id) &&
                 (_geometries.line.length === 0 || _geometries.line[0] === parent);
         }) : [];

--- a/modules/operations/continue.js
+++ b/modules/operations/continue.js
@@ -24,20 +24,21 @@ export function operationContinue(context, selectedIDs) {
     }
 
     var _candidates = candidateWays();
+    var _candidate = _candidates[0];
+    var _candidateGeometry = _candidate && _candidate.geometry(context.graph());
 
 
     var operation = function() {
-        var candidate = _candidates[0];
-        var affix = candidate.affix(_vertex.id);
+        var affix = _candidate.affix(_vertex.id);
         // Unless an endpoint is selected, delete the selected node in favor of whatever we're going to draw.
         // This avoids a situation where it's possible to draw along all but one of the edges.
         if (!affix) {
             context.perform(actionDeleteNode(_vertex.id));
         }
         context.enter(
-            candidate.geometry(context.graph()) === 'line' ?
-            modeDrawLine(context, candidate.id, context.graph(), 'line', affix || candidate.nodes.indexOf(_vertex.id), true) :
-            modeDrawArea(context, candidate.id, context.graph(), 'area', candidate.nodes.indexOf(_vertex.id), true)
+            _candidateGeometry === 'line' ?
+            modeDrawLine(context, _candidate.id, context.graph(), 'line', affix || _candidate.nodes.indexOf(_vertex.id), true) :
+            modeDrawArea(context, _candidate.id, context.graph(), 'area', _candidate.nodes.indexOf(_vertex.id), true)
         );
     };
 
@@ -69,12 +70,12 @@ export function operationContinue(context, selectedIDs) {
         var disable = operation.disabled();
         return disable ?
             t.append('operations.continue.' + disable) :
-            t.append('operations.continue.description');
+            t.append('operations.continue.description.' + _candidateGeometry);
     };
 
 
     operation.annotation = function() {
-        return t('operations.continue.annotation.line');
+        return t('operations.continue.annotation.' + _candidateGeometry);
     };
 
 


### PR DESCRIPTION
The Continue operation now allows you to draw freely starting from any point along the line, not only its endpoints. It works on closed lines and areas, too. This makes the operation useful for more tasks, for example:

* Refining a river with more detailed meanders
* Updating a building with a newly constructed wing
* Continuing to draw an area after you accidentally exit drawing mode by clicking twice

In recognition of the Continue operation’s expanded abilities, it has been renamed to Draw.

https://github.com/openstreetmap/iD/assets/1231218/dffc6d46-a60d-4f09-97b8-d444a56f113c

Fixes #2272.