### PR TITLE
Support Latvian address scheme

### DIFF
--- a/data/address_formats.json
+++ b/data/address_formats.json
@@ -203,6 +203,26 @@
     }
   },
   {
+    "countryCodes": ["lv"],
+    "format": [
+      ["street", "housenumber"],
+      ["housename", "subdistrict"],
+      ["district", "city", "postcode"]
+    ],
+    "dropdowns": [
+      "street", "city", "subdistrict", "district", "postcode"
+    ],
+    "widths": {
+      "street": 0.7,
+      "housenumber": 0.3,
+      "housename": 0.4,
+      "subdistrict": 0.6,
+      "district": 0.4,
+      "city": 0.4,
+      "postcode": 0.2
+    }
+  },
+  {
     "countryCodes": ["in"],
     "format": [
       ["housenumber", "street"],

--- a/data/address_formats.json
+++ b/data/address_formats.json
@@ -70,13 +70,6 @@
     ]
   },
   {
-    "countryCodes": ["lv"],
-    "format": [
-      ["street", "housenumber"],
-      ["city", "postcode"]
-    ]
-  },
-  {
     "countryCodes": ["br"],
     "format": [
       ["street+place"],


### PR DESCRIPTION
To [check address format](https://www.pasts.lv/en/Category/Postal_Code_Look-up/) see official Latvian Post website.

Examples:

1. A housename inside a village (no street and no house number)
```
addr:city=Sunākste
addr:country=LV
addr:district=Aizkraukles novads
addr:housename=Saulstari
addr:postcode=LV-5130
addr:subdistrict=Sunākstes pagasts
ref:LV:addr=106502324
```

2. A house with street number
```
addr:city=Aizkraukle
addr:country=LV
addr:district=Aizkraukles novads
addr:housenumber=1
addr:postcode=LV-5101
addr:street=Bērzu iela
name=Aizkraukles pasts
ref:LV:addr=101629678
```