### PR TITLE
Add Hungarian address format

### DIFF
--- a/data/address_formats.json
+++ b/data/address_formats.json
@@ -231,5 +231,12 @@
 	  ["district", "city"],
 	  ["postcode", "province"]
     ]
+  },
+  {
+    "countryCodes": ["hu"],
+    "format": [
+      ["postcode", "city"],
+      ["street", "housenumber"]
+    ]
   }
 ]


### PR DESCRIPTION
You may verify it at [Hungarian Post](https://www.posta.hu/szolgaltatasok/szolgaltataskereso?ln=en&types=postapoint).