### PR TITLE
Add YoHours button to recurring schedule fields

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -8,6 +8,7 @@ en:
     copy: copy
     view_on: view on {domain}
     visit_website: visit website
+    edit_in: edit in {tool}
     favorite: favorite
     list: list
     text: text

--- a/modules/presets/index.js
+++ b/modules/presets/index.js
@@ -69,7 +69,9 @@ export function presetIndex() {
         // https://github.com/ideditor/schema-builder/issues/100
         const scheduleFields = ['opening_hours', 'opening_hours/covid19', 'service_times', 'collection_times'];
         scheduleFields.forEach(id => {
-          vals[3][id].type = 'schedule';
+          if (id in vals[3]) {
+            vals[3][id].type = 'schedule';
+          }
         });
 
         _this.merge({

--- a/modules/presets/index.js
+++ b/modules/presets/index.js
@@ -66,6 +66,12 @@ export function presetIndex() {
         fileFetcher.get('preset_fields')
       ])
       .then(vals => {
+        // https://github.com/ideditor/schema-builder/issues/100
+        const scheduleFields = ['opening_hours', 'opening_hours/covid19', 'service_times', 'collection_times'];
+        scheduleFields.forEach(id => {
+          vals[3][id].type = 'schedule';
+        });
+
         _this.merge({
           categories: vals[0],
           defaults: vals[1],

--- a/modules/presets/index.js
+++ b/modules/presets/index.js
@@ -66,14 +66,6 @@ export function presetIndex() {
         fileFetcher.get('preset_fields')
       ])
       .then(vals => {
-        // https://github.com/ideditor/schema-builder/issues/100
-        const scheduleFields = ['opening_hours', 'opening_hours/covid19', 'service_times', 'collection_times'];
-        scheduleFields.forEach(id => {
-          if (id in vals[3]) {
-            vals[3][id].type = 'schedule';
-          }
-        });
-
         _this.merge({
           categories: vals[0],
           defaults: vals[1],

--- a/modules/ui/fields/index.js
+++ b/modules/ui/fields/index.js
@@ -34,6 +34,7 @@ import {
     uiFieldEmail,
     uiFieldIdentifier,
     uiFieldNumber,
+    uiFieldSchedule,
     uiFieldTel,
     uiFieldText,
     uiFieldUrl
@@ -79,6 +80,7 @@ export var uiFields = {
     onewayCheck: uiFieldOnewayCheck,
     radio: uiFieldRadio,
     restrictions: uiFieldRestrictions,
+    schedule: uiFieldSchedule,
     semiCombo: uiFieldSemiCombo,
     structureRadio: uiFieldStructureRadio,
     tel: uiFieldTel,

--- a/modules/ui/fields/input.js
+++ b/modules/ui/fields/input.js
@@ -18,12 +18,14 @@ export {
     uiFieldText as uiFieldEmail,
     uiFieldText as uiFieldIdentifier,
     uiFieldText as uiFieldNumber,
+    uiFieldText as uiFieldSchedule,
     uiFieldText as uiFieldTel,
     uiFieldText as uiFieldUrl,
     likelyRawNumberFormat
 };
 
 const likelyRawNumberFormat = /^-?(0\.\d*|\d*\.\d{0,2}(\d{4,})?|\d{4,}\.\d{3})$/;
+const yoHoursURLFormat = 'https://projets.pavie.info/yohours/?oh={value}';
 
 export function uiFieldText(field, context) {
     var dispatch = d3_dispatch('change');
@@ -194,6 +196,26 @@ export function uiFieldText(field, context) {
                         var url = field.urlFormat.replace(/{value}/, encodeURIComponent(value));
                         window.open(url, '_blank');
                     }
+                })
+                .merge(outlinkButton);
+        } else if (field.type === 'schedule') {
+
+            input.attr('type', 'text');
+
+            outlinkButton = wrap.selectAll('.foreign-id-permalink')
+                .data([0]);
+
+            outlinkButton.enter()
+                .append('button')
+                .call(svgIcon('#iD-icon-out-link'))
+                .attr('class', 'form-field-button foreign-id-permalink')
+                .attr('title', () => t('icons.edit_in', { tool: 'YoHours' }))
+                .on('click', function(d3_event) {
+                    d3_event.preventDefault();
+
+                    var value = validIdentifierValueForLink();
+                    var url = yoHoursURLFormat.replace(/{value}/, encodeURIComponent(value || ''));
+                    window.open(url, '_blank');
                 })
                 .merge(outlinkButton);
         } else if (field.type === 'url') {
@@ -377,6 +399,9 @@ export function uiFieldText(field, context) {
         if (field.type === 'identifier' && field.pattern) {
             return value && value.match(new RegExp(field.pattern))[0];
         }
+        if (field.type === 'schedule') {
+            return value;
+        }
         return null;
     }
 
@@ -520,7 +545,7 @@ export function uiFieldText(field, context) {
         if (field.type === 'date') updateDateField();
 
         if (outlinkButton && !outlinkButton.empty()) {
-            var disabled = !validIdentifierValueForLink();
+            var disabled = !validIdentifierValueForLink() && field.type !== 'schedule';
             outlinkButton.classed('disabled', disabled);
         }
 


### PR DESCRIPTION
Fields that accept opening_hours syntax are now standard text fields with the addition of a button that links out to [YoHours](https://projets.pavie.info/yohours/). The user can use this button to compose a value or visualize an existing value, or they can compose the value manually as before.

<img src="https://github.com/openstreetmap/iD/assets/1231218/7f923c39-4efe-49cb-a229-b324a9924da3" width="359" alt="Hours">

Depends on ideditor/schema-builder#101. Itty-bitty baby steps toward #974.