### PR TITLE
warn when mapy.cz is used in a source tag

### DIFF
--- a/modules/validations/incompatible_source.js
+++ b/modules/validations/incompatible_source.js
@@ -18,6 +18,10 @@ export function validationIncompatibleSource() {
       id: 'google',
       regex: /google/i,
       exceptRegex: /((books|drive)\.google|google\s?(books|drive|plus))|(esri\/Google_Africa_Buildings)/i
+    },
+    {
+      id: 'mapy.cz',
+      regex: /mapy\.cz/i
     }
   ];
 


### PR DESCRIPTION
I went through the changesets and most of them use directly `mapserver.mapy.cz` (some older used `mX.mapserver.mapy.cz` so I hope this regex should work and would not cause any false positives.

See #9708