### PR TITLE
fix crash in fr-FR locale

### DIFF
--- a/modules/core/localizer.js
+++ b/modules/core/localizer.js
@@ -176,8 +176,17 @@ export function coreLocalizer() {
 
         let locale = _localeCode;
         if (locale.toLowerCase() === 'en-us') locale = 'en';
-        _languageNames = _localeStrings.general[locale].languageNames;
-        _scriptNames = _localeStrings.general[locale].scriptNames;
+
+        // some locales (like fr-FR) have no languageNames or scriptNames,
+        // so we need to load them from the base language (see #8673)
+        _languageNames = (
+          _localeStrings.general[locale].languageNames ||
+          _localeStrings.general[_languageCode].languageNames
+        );
+        _scriptNames = (
+          _localeStrings.general[locale].scriptNames ||
+          _localeStrings.general[_languageCode].scriptNames
+        );
 
         _usesMetric = _localeCode.slice(-3).toLowerCase() !== '-us';
     }
@@ -232,7 +241,7 @@ export function coreLocalizer() {
     * the given `stringId`. If no string can be found in the requested locale,
     * we'll recurse down all the `_localeCodes` until one is found.
     *
-    * @param  {string}   stringId      string identifier
+    * @param  {string}   origStringId  string identifier
     * @param  {object?}  replacements  token replacements and default string
     * @param  {string?}  locale        locale to use (defaults to currentLocale)
     * @return {string?}  localized string


### PR DESCRIPTION
Closes #8673 

[dist/locales/fr-FR.min.json](https://github.com/openstreetmap/iD/blob/develop/dist/locales/fr-FR.min.json) doesn't have `languageNames` or `scriptNames`, so we need to lookup these properties from the file for the base language ([dist/locales/fr.min.json](https://github.com/openstreetmap/iD/blob/develop/dist/locales/fr.min.json))

I can't add unit tests because the test suite deliberately only loads the `en` locale, and you can't override this for individual test cases