### PR TITLE
fix crash when selecting some presets

### DIFF
--- a/modules/presets/preset.js
+++ b/modules/presets/preset.js
@@ -312,7 +312,7 @@ export function presetPreset(presetID, preset, addable, allFields, allPresets) {
         let parent = allPresets[parentID];
         if (loc) {
           const validHere = locationManager.locationSetsAt(loc);
-          if (parent.locationSetID && !validHere[parent.locationSetID]) {
+          if (parent?.locationSetID && !validHere[parent.locationSetID]) {
             // this is a preset for which a regional variant of the main preset exists
             const candidateIDs = Object.keys(allPresets).filter(k => k.startsWith(parentID));
             parent = allPresets[candidateIDs.find(candidateID => {


### PR DESCRIPTION
follow up to 5a3a2d876e3a685cfa3391b4f1aeb3c0b4b6e765

to reproduce:
- Go to https://ideditor.netlify.app/#map=20.50/-36.93539/174.71695
- Click any vertex
- Search for the "ASL" preset
- click the preset
- editor crashes

![image](https://github.com/openstreetmap/iD/assets/16009897/959f4429-ca1d-4122-828f-845d866d08f0)

![image](https://github.com/openstreetmap/iD/assets/16009897/ecc5f6d8-2f2f-4770-8e76-eb63f54d8225)



