### PR TITLE
fix the raw tag editor broken and strange cursor behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,7 +100,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Upgrade OSM data dependencies: `id-tagging-schema` to v6.3, `osm-community-index` to 5.5.3
 * Upgrade icon sets: `fortawesome` to v6.4, `temaki` to v5.4
 * Upgrade `osm-auth` to v2.1,
-* Upgrade dev dependecies, including the following major version upgrades: `glob` to v10, `marked` to v5, `cldr-core` and `cldr-localenames-full` to v43, `esbuild` to v0.18
+* Upgrade dev dependencies, including the following major version upgrades: `glob` to v10, `marked` to v5, `cldr-core` and `cldr-localenames-full` to v43, `esbuild` to v0.18
 * Build icons from configured presets source and also process field value `icons` in `npm run build:data`
 
 [#8769]: https://github.com/openstreetmap/iD/pull/8769

--- a/modules/util/get_set_value.js
+++ b/modules/util/get_set_value.js
@@ -32,11 +32,12 @@ export function utilGetSetValue(selection, value, shouldUpdate) {
         // see https://html.spec.whatwg.org/multipage/input.html#concept-input-apply
         const supportedTypes = ['text', 'search', 'url', 'tel', 'password'];
         return function() {
+            func.apply(this, arguments);
+
             if (!supportedTypes.includes(this.type)) {
                 return;
             }
             const cursor = { start: this.selectionStart, end: this.selectionEnd };
-            func.apply(this, arguments);
             this.setSelectionRange(cursor.start, cursor.end);
         };
     }

--- a/modules/util/get_set_value.js
+++ b/modules/util/get_set_value.js
@@ -28,16 +28,9 @@ export function utilGetSetValue(selection, value, shouldUpdate) {
     }
 
     function stickyCursor(func) {
-        // only certain input element types allow manipulating the cursor
-        // see https://html.spec.whatwg.org/multipage/input.html#concept-input-apply
-        const supportedTypes = ['text', 'search', 'url', 'tel', 'password'];
         return function() {
-            func.apply(this, arguments);
-
-            if (!supportedTypes.includes(this.type)) {
-                return;
-            }
             const cursor = { start: this.selectionStart, end: this.selectionEnd };
+            func.apply(this, arguments);
             this.setSelectionRange(cursor.start, cursor.end);
         };
     }
@@ -48,6 +41,13 @@ export function utilGetSetValue(selection, value, shouldUpdate) {
 
     if (shouldUpdate === undefined) {
         shouldUpdate = (a, b) => a !== b;
+    }
+
+    // only certain input element types allow manipulating the cursor
+    // see https://html.spec.whatwg.org/multipage/input.html#concept-input-apply
+    const supportedTypes = ['text', 'search', 'url', 'tel', 'password'];
+    if (!supportedTypes.includes(this.type)) {
+        return selection.each(setValue(value, shouldUpdate));
     }
 
     return selection.each(stickyCursor(setValue(value, shouldUpdate)));


### PR DESCRIPTION
Closes #9762, Closes #9764, Closes #9767, Closes #9773, Closes #9775, Closes #9774

to test:
 - go to https://osm.org/edit
 - select any feature with tags
 - note how the raw tag editor works again

edit: this PR indirectly fixes another bug reported on the OSM-US slack, where the changeset comment dropdown doesn't work