### PR TITLE
DX improvements for the unit tests

### DIFF
--- a/modules/global.d.ts
+++ b/modules/global.d.ts
@@ -1,0 +1,6 @@
+declare global {
+  declare const expect: Chai.ExpectStatic;
+  declare const iD: typeof import(".");
+}
+
+export {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "@openstreetmap/id-tagging-schema": "^6.3.0",
         "@rapideditor/temaki": "~5.4.0",
         "@transifex/api": "^5.4.0",
+        "@types/chai": "^4.3.5",
         "autoprefixer": "^10.4.14",
         "chai": "^4.3.7",
         "chalk": "^4.1.2",
@@ -1429,6 +1430,12 @@
       "funding": {
         "url": "https://opencollective.com/turf"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.5.tgz",
+      "integrity": "sha512-mEo1sAde+UCE6b2hxn332f1g1E8WfYRu6p5SvTKr2ZKC1f7gFJXk4h5PyGP9Dt6gCaG8y8XhwnXWC6Iy2cmBng==",
+      "dev": true
     },
     "node_modules/@types/cookie": {
       "version": "0.4.1",
@@ -10901,6 +10908,12 @@
       "requires": {
         "@turf/helpers": "^6.5.0"
       }
+    },
+    "@types/chai": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.5.tgz",
+      "integrity": "sha512-mEo1sAde+UCE6b2hxn332f1g1E8WfYRu6p5SvTKr2ZKC1f7gFJXk4h5PyGP9Dt6gCaG8y8XhwnXWC6Iy2cmBng==",
+      "dev": true
     },
     "@types/cookie": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@mapbox/maki": "^8.0.1",
     "@openstreetmap/id-tagging-schema": "^6.3.0",
     "@transifex/api": "^5.4.0",
+    "@types/chai": "^4.3.5",
     "autoprefixer": "^10.4.14",
     "chai": "^4.3.7",
     "chalk": "^4.1.2",


### PR DESCRIPTION
Installing `@types/chai` and declaring `expect` as a global means that IDEs like VS Code can provide auto-complete suggestions as you type, which makes it much easier to write tests for people who aren't familiar with chai

![](https://github.com/openstreetmap/iD/assets/16009897/edaf37aa-c77e-473e-9b6b-ce95cdf2f49d)

likewise, declaring the type of `window.iD` means that IDEs can show suggestions and allow you to use a keyboard shortcut like <kbd>F12</kbd> to jump to the definition of any function. I think this would pretty helpful for occasional contributors like myself

![](https://github.com/openstreetmap/iD/assets/16009897/578447ac-ea10-4810-a56a-1d0900e118c3)


<sub>partially fixes #8651, many more steps required</sub>