### PR TITLE
Add eox.at 2019-2021 to discard list in `update_imagery` script

### DIFF
--- a/scripts/update_imagery.js
+++ b/scripts/update_imagery.js
@@ -68,7 +68,10 @@ const discard = {
   'OSM_Inspector-Routing': true,
   'OSM_Inspector-Tagging': true,
 
-  'EOXAT2018CLOUDLESS': true
+  'EOXAT2018CLOUDLESS': true,
+  'EOXAT2019CLOUDLESS': true,
+  'EOXAT2020CLOUDLESS': true,
+  'EOXAT2021CLOUDLESS': true
 };
 
 const supportedWMSProjections = [


### PR DESCRIPTION
Noticed that the update_imagery script currently discards eox.at 2018 due to the imagery being low resolution. This PR adds newer sources to the discard list which were added in https://github.com/osmlab/editor-layer-index/pull/1998