### PR TITLE
don't suggest discardable tags in the raw tag editor

### DIFF
--- a/modules/ui/sections/raw_tag_editor.js
+++ b/modules/ui/sections/raw_tag_editor.js
@@ -12,6 +12,7 @@ import { utilArrayDifference, utilArrayIdentical } from '../../util/array';
 import { utilGetSetValue, utilNoAuto, utilRebind, utilTagDiff } from '../../util';
 import { uiTooltip } from '..';
 import { allowUpperCaseTagValues } from '../../osm/tags';
+import { fileFetcher } from '../../core';
 
 
 export function uiSectionRawTagEditor(id, context) {
@@ -31,6 +32,11 @@ export function uiSectionRawTagEditor(id, context) {
         { id: 'list', icon: '#fas-th-list' },
         { id: 'text', icon: '#fas-i-cursor' }
     ];
+
+    let _discardTags = {};
+    fileFetcher.get('discarded')
+        .then((d) => { _discardTags = d; })
+        .catch(() => { /* ignore */ });
 
     var _tagView = (prefs('raw-tag-editor-view') || 'list');   // 'list, 'text'
     var _readOnlyTags = [];
@@ -424,6 +430,7 @@ export function uiSectionRawTagEditor(id, context) {
                     if (!err) {
                         const filtered = data
                             .filter(d => _tags[d.value] === undefined)
+                            .filter(d => !(d.value in _discardTags)) // do not suggest discardable tags (see #9817)
                             .filter(d => d.value.toLowerCase().includes(value.toLowerCase()));
                         callback(sort(value, filtered));
                     }


### PR DESCRIPTION
Keys that are listed in [discarded.json](https://github.com/openstreetmap/id-tagging-schema/blob/main/data/discarded.json) are no longer suggested in the raw tag editor.

This somewhat relates to #9422 but does not address that issue.