### PR TITLE
add a validator for `lanes=1` + `oneway=no`

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -2050,6 +2050,9 @@ en:
       tag_as_oneway_reversible:
         title: Tag as reversible
         annotation: Marked a way as reversible.
+      tag_as_oneway_no_markings:
+        title: There are no painted lanes
+        annotation: Tagged the absense of lane markings.
       tag_this_as_higher:
         title: Tag this as higher
       tag_this_as_lower:

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1829,6 +1829,9 @@ en:
       message: '{feature} has the suspicious name "{name}"'
       message_language: '{feature} has the suspicious name "{name}" in {language}'
       reference: "Names should be the actual, on-the-ground names of features."
+    oneway_onelane:
+      message: '{feature} needs a one-way tag since it only has 1 lane'
+      reference: "A road that only has 1 lane must one-way or bidirectional."
     help_request:
       title: 'Help Requests'
       tip: 'Find features where others requested assistance'
@@ -1956,6 +1959,8 @@ en:
         annotation: Added a tunnel.
       address_the_concern:
         title: Address the concern
+      change_lane_tag:
+        title: Increase the number of lanes
       connect_almost_junction:
         annotation: Connected very close features.
       connect_crossing_features:
@@ -2036,6 +2041,15 @@ en:
       tag_as_unsquare:
         title: Tag as physically unsquare
         annotation: Tagged a way as having unsquare corners.
+      tag_as_oneway_yes:
+        title: Tag as one-way
+        annotation: Marked a way as one-way.
+      tag_as_oneway_alternating:
+        title: Tag as bidirectional
+        annotation: Marked a way as bidirectional.
+      tag_as_oneway_reversible:
+        title: Tag as reversible
+        annotation: Marked a way as reversible.
       tag_this_as_higher:
         title: Tag this as higher
       tag_this_as_lower:

--- a/modules/validations/index.js
+++ b/modules/validations/index.js
@@ -11,6 +11,7 @@ export { validationMismatchedGeometry } from './mismatched_geometry';
 export { validationMissingRole } from './missing_role';
 export { validationMissingTag } from './missing_tag';
 export { validationMutuallyExclusiveTags } from './mutually_exclusive_tags';
+export { validationOneLaneWithNoOneway } from './oneway_onelane';
 export { validationOutdatedTags } from './outdated_tags';
 export { validationPrivateData } from './private_data';
 export { validationSuspiciousName } from './suspicious_name';

--- a/modules/validations/oneway_onelane.js
+++ b/modules/validations/oneway_onelane.js
@@ -1,0 +1,76 @@
+import { actionChangeTags } from '../actions/change_tags';
+import { t } from '../core/localizer';
+import { validationIssue, validationIssueFix } from '../core/validation';
+import { utilDisplayLabel } from '../util';
+
+
+export function validationOneLaneWithNoOneway() {
+  const type = 'oneway_onelane';
+
+  /** @param {string} onewayValue  @param {osmEntity} entity */
+  function createSuggestion(onewayValue, entity) {
+    return new validationIssueFix({
+      icon: 'iD-icon-data',
+      title: t.append(`issues.fix.tag_as_oneway_${onewayValue}.title`),
+      onClick: (context) => {
+        const newTags = { ...entity.tags, oneway: onewayValue };
+        context.perform(
+          actionChangeTags(entity.id, newTags), t(`issues.fix.tag_as_oneway_${onewayValue}.annotation`)
+        );
+      }
+    });
+  }
+
+  /** @param {osmEntity} entity */
+  function makeOneLaneIssue(entity) {
+    return new validationIssue({
+      type,
+      subtype: type,
+      severity: 'warning',
+      message: (context) => t.append(
+        'issues.oneway_onelane.message',
+        { feature: utilDisplayLabel(entity, context.graph()) }
+      ),
+      reference: showReference,
+      entityIds: [entity.id],
+      hash: type,
+      dynamicFixes: () => [
+        // suggest adding `oneway` tag (automatic)
+        ...['yes', 'alternating'].map(onewayValue => createSuggestion(onewayValue, entity)),
+
+        // or changing the `lanes` tag (manual)
+        new validationIssueFix({ title: t.append('issues.fix.change_lane_tag.title') })
+      ]
+    });
+  }
+
+
+  function showReference(selection) {
+    selection.selectAll('.issue-reference')
+      .data([0])
+      .enter()
+      .append('div')
+      .attr('class', 'issue-reference')
+      .call(t.append(`issues.${type}.reference`));
+  }
+
+  /** @param {osmEntity} entity */
+  const validation = (entity) => {
+    const isOneLane = entity.tags.lanes === '1';
+
+    if (
+      entity.type !== 'way' ||
+      entity.isOneWay() ||
+      !isOneLane ||
+      entity.tags.leisure === 'slipway'
+    ) return [];
+
+    // this line has lanes=1, but is not oneway. This makes no sense.
+    return [makeOneLaneIssue(entity)];
+  };
+
+
+  validation.type = type;
+
+  return validation;
+}

--- a/modules/validations/oneway_onelane.js
+++ b/modules/validations/oneway_onelane.js
@@ -39,7 +39,20 @@ export function validationOneLaneWithNoOneway() {
         ...['yes', 'alternating'].map(onewayValue => createSuggestion(onewayValue, entity)),
 
         // or changing the `lanes` tag (manual)
-        new validationIssueFix({ title: t.append('issues.fix.change_lane_tag.title') })
+        new validationIssueFix({ title: t.append('issues.fix.change_lane_tag.title') }),
+
+        // or suggest adding the `lane_markings=no` tag (automatic)
+        new validationIssueFix({
+          icon: 'iD-icon-data',
+          title: t.append('issues.fix.tag_as_oneway_no_markings.title'),
+          onClick: (context) => {
+            const newTags = { ...entity.tags, lane_markings: 'no' };
+            delete newTags.lanes;
+            context.perform(
+              actionChangeTags(entity.id, newTags), t('issues.fix.tag_as_oneway_no_markings.annotation')
+            );
+          }
+        }),
       ]
     });
   }

--- a/test/spec/validations/oneway_onelane.js
+++ b/test/spec/validations/oneway_onelane.js
@@ -44,6 +44,16 @@ describe('iD.validations.oneway_onelane', () => {
         }, 20);
     });
 
+    it('has no errors for roads that are implicitly oneway', (done) => {
+        createWay({ lanes: '1', 'junction': 'roundabout' });
+        const validator = iD.validationOneLaneWithNoOneway();
+        window.setTimeout(() => {   // async, so data will be available
+            const issues = validate(validator);
+            expect(issues).to.have.lengthOf(0);
+            done();
+        }, 20);
+    });
+
     it('has no errors for multi-lane roads', (done) => {
         createWay({ lanes: '2' });
         const validator = iD.validationOneLaneWithNoOneway();

--- a/test/spec/validations/oneway_onelane.js
+++ b/test/spec/validations/oneway_onelane.js
@@ -1,0 +1,88 @@
+describe('iD.validations.oneway_onelane', () => {
+    let context;
+
+    beforeEach(() => {
+        context = iD.coreContext().init();
+    });
+
+
+    function createWay(tags) {
+        const n1 = iD.osmNode({ id: 'n-1', loc: [4,4] });
+        const n2 = iD.osmNode({ id: 'n-2', loc: [4,5] });
+        const w1 = iD.osmWay({ id: 'w-1', nodes: ['n-1', 'n-2'], tags: tags });
+
+        context.perform(
+            iD.actionAddEntity(n1),
+            iD.actionAddEntity(n2),
+            iD.actionAddEntity(w1)
+        );
+    }
+
+
+    function validate(validator) {
+        const changes = context.history().changes();
+        const entities = changes.modified.concat(changes.created);
+        return entities.flatMap((entity) => validator(entity, context.graph()));
+    }
+
+    it('has no errors on init', (done) => {
+        const validator = iD.validationOneLaneWithNoOneway();
+        window.setTimeout(() => {   // async, so data will be available
+            const issues = validate(validator);
+            expect(issues).to.have.lengthOf(0);
+            done();
+        }, 20);
+    });
+
+    it('has no errors for properly tagged one-lane roads', (done) => {
+        createWay({ lanes: '1', 'oneway': 'yes' });
+        const validator = iD.validationOneLaneWithNoOneway();
+        window.setTimeout(() => {   // async, so data will be available
+            const issues = validate(validator);
+            expect(issues).to.have.lengthOf(0);
+            done();
+        }, 20);
+    });
+
+    it('has no errors for multi-lane roads', (done) => {
+        createWay({ lanes: '2' });
+        const validator = iD.validationOneLaneWithNoOneway();
+        window.setTimeout(() => {   // async, so data will be available
+            const issues = validate(validator);
+            expect(issues).to.have.lengthOf(0);
+            done();
+        }, 20);
+    });
+
+    it('flags roads with lanes=1 + oneway=no', (done) => {
+        createWay({ lanes: '1', 'oneway': 'no' });
+        const validator = iD.validationOneLaneWithNoOneway();
+        window.setTimeout(() => {   // async, so data will be available
+            const issues = validate(validator);
+            expect(issues).to.have.lengthOf(1);
+            const issue = issues[0];
+            expect(issue.type).to.eql('oneway_onelane');
+            expect(issue.subtype).to.eql('oneway_onelane');
+            expect(issue.severity).to.eql('warning');
+            expect(issue.entityIds).to.have.lengthOf(1);
+            expect(issue.entityIds[0]).to.eql('w-1');
+            done();
+        }, 20);
+    });
+
+    it('flags roads with lanes=1 no oneway tag', (done) => {
+        createWay({ lanes: '1' });
+        const validator = iD.validationOneLaneWithNoOneway();
+        window.setTimeout(() => {   // async, so data will be available
+            const issues = validate(validator);
+            expect(issues).to.have.lengthOf(1);
+            const issue = issues[0];
+            expect(issue.type).to.eql('oneway_onelane');
+            expect(issue.subtype).to.eql('oneway_onelane');
+            expect(issue.severity).to.eql('warning');
+            expect(issue.entityIds).to.have.lengthOf(1);
+            expect(issue.entityIds[0]).to.eql('w-1');
+            done();
+        }, 20);
+    });
+});


### PR DESCRIPTION
This PR adds a new validator warning when a road has [`lanes`](https://osm.wiki/Key:lanes)=`1` but is does not have [`oneway`](https://osm.wiki/Key:oneway)=[`yes`](https://osm.wiki/Tag:oneway=yes)/[`alternating`](https://osm.wiki/Tag:oneway=alternating)/[`reversible`](https://osm.wiki/Tag:oneway=reversible)

![image](https://github.com/openstreetmap/iD/assets/16009897/c2fba5e0-2091-49a7-873b-8667e7c19139)
