### PR TITLE
remove leading semicolon from changeset `source`

### DIFF
--- a/modules/ui/commit.js
+++ b/modules/ui/commit.js
@@ -124,7 +124,7 @@ export function uiCommit(context) {
                 }
             });
 
-            tags.source = context.cleanTagValue(sources.join(';'));
+            tags.source = context.cleanTagValue(sources.filter(Boolean).join(';'));
         }
 
         context.changeset = new osmChangeset({ tags: tags });


### PR DESCRIPTION
Closes #8199

If you edit using a streetlevel imagery service like Mapillary, the changeset `source` tag is currently set to `;streetlevel imagery;mapillary`. This PR removes the leading semicolon which is almost certainly unintentional