### PR TITLE
Add rendering for roller_coaster=track and roller_coaster=support

### DIFF
--- a/css/50_misc.css
+++ b/css/50_misc.css
@@ -143,7 +143,7 @@ path.line.stroke.tag-roller_coaster-support {
     stroke: #707070;
 }
 path.line.casing.tag-roller_coaster-support {
-    stroke: #707070;
+    visibility: hidden;
 }
 
 

--- a/css/50_misc.css
+++ b/css/50_misc.css
@@ -6,6 +6,8 @@ path.line.shadow.tag-attraction-water_slide,
 path.line.shadow.tag-golf-cartpath,
 path.line.shadow.tag-man_made-pipeline,
 path.line.shadow.tag-natural-tree_row,
+path.line.shadow.tag-roller_coaster-track,
+path.line.shadow.tag-roller_coaster-support,
 path.line.shadow.tag-piste {
     stroke-width: 16;
 }
@@ -15,6 +17,8 @@ path.line.casing.tag-attraction-water_slide,
 path.line.casing.tag-golf-cartpath,
 path.line.casing.tag-man_made-pipeline,
 path.line.casing.tag-natural-tree_row,
+path.line.casing.tag-roller_coaster-track,
+path.line.casing.tag-roller_coaster-support,
 path.line.casing.tag-piste {
     stroke-width: 7;
 }
@@ -24,6 +28,8 @@ path.line.stroke.tag-attraction-water_slide,
 path.line.stroke.tag-golf-cartpath,
 path.line.stroke.tag-man_made-pipeline,
 path.line.stroke.tag-natural-tree_row,
+path.line.stroke.tag-roller_coaster-track,
+path.line.stroke.tag-roller_coaster-support,
 path.line.stroke.tag-piste {
     stroke-width: 5;
 }
@@ -34,6 +40,8 @@ path.line.stroke.tag-piste {
 .low-zoom path.line.shadow.tag-golf-cartpath,
 .low-zoom path.line.shadow.tag-man_made-pipeline,
 .low-zoom path.line.shadow.tag-natural-tree_row,
+.low-zoom path.line.shadow.tag-roller_coaster-track,
+.low-zoom path.line.shadow.tag-roller_coaster-support,
 .low-zoom path.line.shadow.tag-piste {
     stroke-width: 12;
 }
@@ -43,6 +51,8 @@ path.line.stroke.tag-piste {
 .low-zoom path.line.casing.tag-golf-cartpath,
 .low-zoom path.line.casing.tag-man_made-pipeline,
 .low-zoom path.line.casing.tag-natural-tree_row,
+.low-zoom path.line.casing.tag-roller_coaster-track,
+.low-zoom path.line.casing.tag-roller_coaster-support,
 .low-zoom path.line.casing.tag-piste {
     stroke-width: 5;
 }
@@ -52,6 +62,8 @@ path.line.stroke.tag-piste {
 .low-zoom path.line.stroke.tag-golf-cartpath,
 .low-zoom path.line.stroke.tag-man_made-pipeline,
 .low-zoom path.line.stroke.tag-natural-tree_row,
+.low-zoom path.line.stroke.tag-roller_coaster-track,
+.low-zoom path.line.stroke.tag-roller_coaster-support,
 .low-zoom path.line.stroke.tag-piste {
     stroke-width: 3;
 }
@@ -115,6 +127,23 @@ path.line.stroke.tag-attraction-water_slide {
 }
 path.line.casing.tag-attraction-water_slide {
     stroke: #3d6c71;
+}
+
+path.line.stroke.tag-roller_coaster-track {
+    stroke: #dddddd;
+    stroke-width: 3;
+    stroke-dasharray: 5, 1;
+    stroke-linecap: butt;
+}
+path.line.casing.tag-roller_coaster-track {
+    stroke: #707070;
+}
+
+path.line.stroke.tag-roller_coaster-support {
+    stroke: #707070;
+}
+path.line.casing.tag-roller_coaster-support {
+    stroke: #707070;
 }
 
 

--- a/modules/svg/tag_classes.js
+++ b/modules/svg/tag_classes.js
@@ -7,7 +7,7 @@ export function svgTagClasses() {
         'building', 'highway', 'railway', 'waterway', 'aeroway', 'aerialway',
         'piste:type', 'boundary', 'power', 'amenity', 'natural', 'landuse',
         'leisure', 'military', 'place', 'man_made', 'route', 'attraction',
-        'building:part', 'indoor'
+        'roller_coaster', 'building:part', 'indoor'
     ];
     var statuses = Object.keys(osmLifecyclePrefixes);
     var secondaries = [


### PR DESCRIPTION
Closes #9839 by adding rendering to `roller_coaster=track` and `roller_coaster=support`. 
Fits the [preset PR](https://github.com/openstreetmap/id-tagging-schema/pull/985) and [the rendering used in OpenStreetMap Carto](https://github.com/gravitystorm/openstreetmap-carto/pull/4666).

I am a bit unsure on the rendering of the support beams. Are they being rendered too thick, is the contrast too low?

Before:
<img width="792" alt="Screenshot 2023-09-07 at 14 36 15" src="https://github.com/openstreetmap/iD/assets/11056766/d11b621b-e1c7-4db5-95d9-a646f5ad9e1a">

After:
<img width="792" alt="Screenshot 2023-09-07 at 14 35 47" src="https://github.com/openstreetmap/iD/assets/11056766/d04bc643-3970-44d6-83b8-24cdb58a88d7">

