### PR TITLE
Hide horizontal scrollbars in hover mode for fields

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -4137,7 +4137,7 @@ li.issue-fix-item button:not(.actionable) .fix-icon {
 
 /* scrollbars only when necessary*/
 .inspector-hover div {
-    overflow-x: visible;
+    overflow-x: hidden;
     overflow-y: auto;
 }
 


### PR DESCRIPTION
Likely resolves #10551 

Horizontal scrollbars in fields are useless since you can't hover over the element and move a specific scrollbar at the same time.

Before:
![image](https://github.com/openstreetmap/iD/assets/19364673/a0e77f11-0daf-452a-9876-eb0fe7cba066)
After:
![image](https://github.com/openstreetmap/iD/assets/19364673/4562f51f-58e0-4936-9515-9b094d9f4683)
