### PR TITLE
Bump min nodejs to version to v18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ['16', '18']
+        node-version: ['18', '20']
 
     steps:
     - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Come on in, the water's lovely. More help? Ping `Martin Raifer`/`tyr_asd` or `bh
 
 ## Prerequisites
 
-* [Node.js](https://nodejs.org/) version 16.14 or newer
+* [Node.js](https://nodejs.org/) version 18 or newer
 * [`git`](https://www.atlassian.com/git/tutorials/install-git/) for your platform
   * Note for Windows users:
     * Edit `$HOME\.gitconfig`:<br/>

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "vparse": "~1.1.0"
   },
   "engines": {
-    "node": ">=16.14"
+    "node": ">=18"
   },
   "browserslist": [
     "> 0.2%, last 6 major versions, Firefox ESR, maintained node versions"


### PR DESCRIPTION
As of v6.0.20230928, NSI now requires nodejs v18 or higher (see https://github.com/osmlab/name-suggestion-index/commit/113ba9176a0cf40de3f3441267f6974a00894b35)