### PR TITLE
disable the locator overlay when switching to osm carto

### DIFF
--- a/modules/renderer/background.js
+++ b/modules/renderer/background.js
@@ -337,6 +337,18 @@ export function rendererBackground(context) {
     baseLayer.source(!fail ? d : background.findSource('none'));
     dispatch.call('change');
     background.updateImagery();
+
+    // if switching to a background layer that contains labels,
+    // disable the locator overlay to avoid overlapping labels.
+    if (d.id === 'MAPNIK') {
+      const locatorOverlay = background.overlayLayerSources().find(
+        overlay => overlay.isLocatorOverlay()
+      );
+      const isLocatorOverlayActive = !!locatorOverlay;
+      if (isLocatorOverlayActive) {
+        setTimeout(() => background.toggleOverlayLayer(locatorOverlay), 0);
+      }
+    }
     return background;
   };
 

--- a/modules/renderer/background.js
+++ b/modules/renderer/background.js
@@ -30,6 +30,15 @@ export function rendererBackground(context) {
   let _sharpness = 1;
 
 
+  function visibleOverlayLayers() {
+    // if the LocatorOverlay is disabled, return everything except that layer
+    if (background.isLocatorOverlayDisabled()) {
+        return _overlayLayers.filter(layer => !layer.source().isLocatorOverlay());
+    }
+    return _overlayLayers;
+  }
+
+
   function ensureImageryIndex() {
     return fileFetcher.get('imagery')
       .then(async sources => {
@@ -179,7 +188,7 @@ export function rendererBackground(context) {
 
 
     let overlays = selection.selectAll('.layer-overlay')
-      .data(_overlayLayers, d => d.source().name());
+      .data(visibleOverlayLayers(), d => d.source().name());
 
     overlays.exit()
       .remove();
@@ -345,12 +354,20 @@ export function rendererBackground(context) {
   background.showsLayer = (d) => {
     const currSource = baseLayer.source();
     if (!d || !currSource) return false;
-    return d.id === currSource.id || _overlayLayers.some(layer => d.id === layer.source().id);
+    return d.id === currSource.id || visibleOverlayLayers().some(layer => d.id === layer.source().id);
   };
 
 
   background.overlayLayerSources = () => {
-    return _overlayLayers.map(layer => layer.source());
+    return visibleOverlayLayers().map(layer => layer.source());
+  };
+
+  /**
+   * if using a background layer that contains labels,
+   * disable the locator overlay to avoid overlapping labels.
+   */
+  background.isLocatorOverlayDisabled = () => {
+    return baseLayer.source()?.category === 'osmbasedmap';
   };
 
 

--- a/modules/ui/sections/overlay_list.js
+++ b/modules/ui/sections/overlay_list.js
@@ -112,6 +112,13 @@ export function uiSectionOverlayList(context) {
             .call(drawListItems, 'checkbox', chooseOverlay, function(d) { return !d.isHidden() && d.overlay; });
     }
 
+    context.background()
+        .on('change.background_list', () => {
+            // if the overlays change due to a keyboard shortcut or
+            // automatic update, then rerender.
+            _overlayList.call(updateLayerSelections);
+        });
+
     context.map()
         .on('move.overlay_list',
             _debounce(function() {

--- a/modules/ui/sections/overlay_list.js
+++ b/modules/ui/sections/overlay_list.js
@@ -40,11 +40,16 @@ export function uiSectionOverlayList(context) {
             return context.background().showsLayer(d);
         }
 
+        function disabled(d) {
+            return d.isLocatorOverlay() && context.background().isLocatorOverlayDisabled();
+        }
+
         selection.selectAll('li')
             .classed('active', active)
             .call(setTooltips)
             .selectAll('input')
-            .property('checked', active);
+            .property('checked', active)
+            .property('disabled', disabled);
     }
 
 
@@ -111,6 +116,13 @@ export function uiSectionOverlayList(context) {
         _overlayList
             .call(drawListItems, 'checkbox', chooseOverlay, function(d) { return !d.isHidden() && d.overlay; });
     }
+
+    context.background()
+        .on('change.overlay_list', () => {
+            // if the overlays change due to a keyboard shortcut or
+            // automatic update, then rerender.
+            _overlayList.call(updateLayerSelections);
+        });
 
     context.map()
         .on('move.overlay_list',


### PR DESCRIPTION
This PR automatically disables `Locator Overlay` when you select `OpenStreetMap (Standard)`.



If you use the `OpenStreetMap (Standard)` background imagery, the first thing you have to do after selecting `OpenStreetMap (Standard)` is disable `Locator Overlay`, because the two layers create an unreadable mess of labels:

![image](https://github.com/openstreetmap/iD/assets/16009897/3513d7ba-7986-4830-acb5-ba2181763a4f)


