### PR TITLE
fix bug preventing cardinal direction increment

### DIFF
--- a/modules/ui/fields/input.js
+++ b/modules/ui/fields/input.js
@@ -517,8 +517,10 @@ export function uiFieldText(field, context) {
                 buttons.attr('disabled', 'disabled').classed('disabled', true);
             } else {
                 var raw_vals = tags[field.key] || '0';
-                const canIncDec = raw_vals.split(';').some(val => isFinite(Number(val))
-                        || isDirectionField && cardinal[val.trim().toLowerCase()]);
+                const canIncDec = raw_vals.split(';').some((val) =>
+                    isFinite(Number(val))
+                    || (isDirectionField && (val.trim().toLowerCase() in cardinal))
+                );
                 buttons.attr('disabled', canIncDec ? null : 'disabled').classed('disabled', !canIncDec);
             }
         }


### PR DESCRIPTION
Fixed a regression in the numeric field which caused the ⬆️/⬇️ buttons not to work for tags like `direction=north` and `direction=N`, since north is 0° and `0` is falsy

to test:
 - create a plaque node
 - type `North` into the direction field
 - the ⬆️/⬇️ buttons now work, previously they were disabled.