### PR TITLE
fix non-integer `layer` tag causing invisible features

### DIFF
--- a/modules/svg/lines.js
+++ b/modules/svg/lines.js
@@ -250,7 +250,7 @@ export function svgLines(projection, context) {
         }
 
         ways = ways.filter(getPath);
-        var pathdata = utilArrayGroupBy(ways, function(way) { return way.layer(); });
+        const pathdata = utilArrayGroupBy(ways, (way) => Math.trunc(way.layer()));
 
         Object.keys(pathdata).forEach(function(k) {
             var v = pathdata[k];

--- a/test/spec/svg/lines.js
+++ b/test/spec/svg/lines.js
@@ -142,6 +142,20 @@ describe('iD.svgLines', function () {
         });
     });
 
+    it('rounds layers down to the nearest whole number for rendering', () => {
+        const graph = iD.coreGraph([
+            iD.osmNode({id: 'a', loc: [0, 0]}),
+            iD.osmNode({id: 'b', loc: [1, 1]}),
+            iD.osmWay({id: 'w1', tags: {highway: 'residential', layer: '-2.5'}, nodes: ['a', 'b']}),
+        ]);
+        surface.call(iD.svgLines(projection, context), graph, [graph.entity('w1')], none);
+
+        const layerGroup = surface.select('path.w1').nodes()[0].parentNode.parentNode;
+
+        // the feature with layer=-2.5 was rendered in layer -2
+        expect(layerGroup.className.baseVal).to.eql('layergroup layer-2');
+    });
+
     describe('oneway-markers', function() {
         it('has marker layer for oneway ways', function() {
             // use 1e-2 to make sure segments are long enough to get


### PR DESCRIPTION
If a feature has a `layer` tag like `layer=0.5` or `layer=-3.5`, then the feature becomes invisible in iD. This PR fixes that issue.

I'm not saying that fractional layers are a good idea, but it's currently impossible to clean up fractional layers using iD. It's also very confusing when you expect to see an element but there's nothing rendered. 