### PR TITLE
fix esbuild ignoring browserslist config

### DIFF
--- a/config/esbuild.config.min.mjs
+++ b/config/esbuild.config.min.mjs
@@ -1,5 +1,6 @@
 import esbuild from 'esbuild';
 import envs from './envs.mjs';
+import browserslistToEsbuild from 'browserslist-to-esbuild';
 
 esbuild
   .build({
@@ -10,6 +11,7 @@ esbuild
     entryPoints: ['./modules/id.js'],
     legalComments: 'none',
     logLevel: 'info',
-    outfile: 'dist/iD.min.js'
+    outfile: 'dist/iD.min.js',
+    target: browserslistToEsbuild(),
   })
   .catch(() => process.exit(1));

--- a/config/esbuild.config.mjs
+++ b/config/esbuild.config.mjs
@@ -2,9 +2,9 @@ import esbuild from 'esbuild';
 import fs from 'node:fs';
 import parse from 'minimist';
 import envs from './envs.mjs';
+import browserslistToEsbuild from 'browserslist-to-esbuild';
 
 let args = parse(process.argv.slice(2), {boolean: true});
-delete args._;
 
 const context = await esbuild.context({
   define: envs,
@@ -14,7 +14,8 @@ const context = await esbuild.context({
   legalComments: 'none',
   logLevel: 'info',
   metafile: true,
-  outfile: 'dist/iD.js'
+  outfile: 'dist/iD.js',
+  target: browserslistToEsbuild(),
 });
 
 if (args.watch) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "@rapideditor/temaki": "~5.4.0",
         "@transifex/api": "^5.4.0",
         "autoprefixer": "^10.4.15",
+        "browserslist-to-esbuild": "^1.2.0",
         "chai": "^4.3.7",
         "chalk": "^4.1.2",
         "cldr-core": "^43.0.0",
@@ -2171,6 +2172,18 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/browserslist-to-esbuild": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browserslist-to-esbuild/-/browserslist-to-esbuild-1.2.0.tgz",
+      "integrity": "sha512-ftrrbI/VHBgEnmnSyhkqvQVMp6jAKybfs0qMIlm7SLBrQTGMsdCIP4q3BoKeLsZTBQllIQtY9kbxgRYV2WU47g==",
+      "dev": true,
+      "dependencies": {
+        "browserslist": "^4.17.3"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/buffer": {
@@ -11441,6 +11454,15 @@
         "electron-to-chromium": "^1.4.477",
         "node-releases": "^2.0.13",
         "update-browserslist-db": "^1.0.11"
+      }
+    },
+    "browserslist-to-esbuild": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browserslist-to-esbuild/-/browserslist-to-esbuild-1.2.0.tgz",
+      "integrity": "sha512-ftrrbI/VHBgEnmnSyhkqvQVMp6jAKybfs0qMIlm7SLBrQTGMsdCIP4q3BoKeLsZTBQllIQtY9kbxgRYV2WU47g==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.17.3"
       }
     },
     "buffer": {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@rapideditor/temaki": "~5.4.0",
     "@transifex/api": "^5.4.0",
     "autoprefixer": "^10.4.15",
+    "browserslist-to-esbuild": "^1.2.0",
     "chai": "^4.3.7",
     "chalk": "^4.1.2",
     "cldr-core": "^43.0.0",
@@ -126,6 +127,6 @@
     "node": ">=16.14"
   },
   "browserslist": [
-    "> 0.2%, last 6 major versions, Firefox ESR, maintained node versions"
+    "> 0.3%, last 6 major versions, Firefox ESR, maintained node versions"
   ]
 }


### PR DESCRIPTION
Closes #9930, Closes #9939

esbuild targets [`esnext`](https://esbuild.github.io/api/#target) by default, so new syntax like [`??=`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_assignment) isn't being transpiled. This means iD only supports the very latest browsers.

There is a `browserslist` config in package.json, but esbuild doesn't respect the `browserslist` by default, unlike the previous build system.

With these polyfills, the bundle size has increased by less than 0.1%