### PR TITLE
Add eox.at 2022 to discard list in update_imagery script

### DIFF
--- a/scripts/update_imagery.js
+++ b/scripts/update_imagery.js
@@ -71,7 +71,8 @@ const discard = {
   'EOXAT2018CLOUDLESS': true,
   'EOXAT2019CLOUDLESS': true,
   'EOXAT2020CLOUDLESS': true,
-  'EOXAT2021CLOUDLESS': true
+  'EOXAT2021CLOUDLESS': true,
+  'EOXAT2022CLOUDLESS': true
 };
 
 const supportedWMSProjections = [


### PR DESCRIPTION
Following from #9807, this adds the newly published 2022 eox cloudless imagery to the discard list (osmlab/editor-layer-index#2112)