### PR TITLE
Warn when toll_gantry on highway without toll=yes #9885 

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1903,6 +1903,9 @@ en:
     unknown_road:
       message: "{feature} has no classification"
       reference: "Roads without a specific type may not appear in maps or routing."
+    no_toll:
+      message: "Warn when toll_gantry on {feature} without toll=yes."
+      reference: "Ensure that highways with toll_gantry are properly tagged with toll=yes for accurate mapping and routing."
     impossible_oneway:
       title: Impossible One-Ways
       tip: "Find route issues with one-way features"

--- a/modules/validations/missing_tag.js
+++ b/modules/validations/missing_tag.js
@@ -42,7 +42,7 @@ export function validationMissingTag(context) {
         return entity.type === 'relation' && !entity.tags.type;
     }
 
-    function isWayWithTollNoConnectedToGantry(way, context) {
+    function isWayWithNoTollConnectedToGantry(way, context) {
         if (way.type !== 'way' || way.tags.toll !== 'no') return false;
     
         var childNodes = context.graph().childNodes(way);
@@ -72,8 +72,8 @@ export function validationMissingTag(context) {
             }
         }
 
-        if (isWayWithTollNoConnectedToGantry(entity, context)) {
-            subtype = 'toll_gantry_without_toll';
+        if (isWayWithNoTollConnectedToGantry(entity, context)) {
+            subtype = 'way_with_no_toll_connected_to_gantry';
         }
         
         // flag an unknown road even if it's a member of a relation
@@ -85,12 +85,12 @@ export function validationMissingTag(context) {
 
         if (!subtype) return [];
 
-        var messageID = subtype === 'highway_classification' ? 'unknown_road' : 'missing_tag.' + subtype;
-        var referenceID = subtype === 'highway_classification' ? 'unknown_road' : 'missing_tag';
+        var messageID = subtype === 'highway_classification' ? 'unknown_road' : subtype === 'way_with_no_toll_connected_to_gantry'? 'no_toll' : 'missing_tag.' + subtype;
+        var referenceID = subtype === 'highway_classification' ? 'unknown_road'  : subtype === 'way_with_no_toll_connected_to_gantry' ? 'no_toll' : 'missing_tag';
 
         // can always delete if the user created it in the first place..
         var canDelete = (entity.version === undefined || entity.v !== undefined);
-        var severity = (canDelete && subtype !== 'highway_classification') ? 'error' : 'warning';
+        var severity = (canDelete && (subtype !== 'highway_classification' && subtype !== 'way_with_no_toll_connected_to_gantry')) ? 'error' : 'warning';
 
         return [new validationIssue({
             type: type,
@@ -108,7 +108,7 @@ export function validationMissingTag(context) {
 
                 var fixes = [];
 
-                var selectFixType = subtype === 'highway_classification' ? 'select_road_type' : 'select_preset';
+                var selectFixType = (subtype === 'highway_classification' || subtype === 'way_with_no_toll_connected_to_gantry') ? 'select_road_type' : 'select_preset';
 
                 fixes.push(new validationIssueFix({
                     icon: 'iD-icon-search',

--- a/modules/validations/missing_tag.js
+++ b/modules/validations/missing_tag.js
@@ -44,7 +44,6 @@ export function validationMissingTag(context) {
 
     function isWayWithNoTollConnectedToGantry(way, context) {
         if (way.type !== 'way' || way.tags.toll !== 'no') return false;
-    
         var childNodes = context.graph().childNodes(way);
         return childNodes.some(node => node.tags.highway === 'toll_gantry');
     }
@@ -75,13 +74,10 @@ export function validationMissingTag(context) {
         if (isWayWithNoTollConnectedToGantry(entity, context)) {
             subtype = 'way_with_no_toll_connected_to_gantry';
         }
-        
         // flag an unknown road even if it's a member of a relation
         if (!subtype && isUnknownRoad(entity)) {
             subtype = 'highway_classification';
         }
-
-       
 
         if (!subtype) return [];
 

--- a/modules/validations/missing_tag.js
+++ b/modules/validations/missing_tag.js
@@ -42,6 +42,13 @@ export function validationMissingTag(context) {
         return entity.type === 'relation' && !entity.tags.type;
     }
 
+    function isWayWithTollNoConnectedToGantry(way, context) {
+        if (way.type !== 'way' || way.tags.toll !== 'no') return false;
+    
+        var childNodes = context.graph().childNodes(way);
+        return childNodes.some(node => node.tags.highway === 'toll_gantry');
+    }
+
     var validation = function checkMissingTag(entity, graph) {
 
         var subtype;
@@ -65,10 +72,16 @@ export function validationMissingTag(context) {
             }
         }
 
+        if (isWayWithTollNoConnectedToGantry(entity, context)) {
+            subtype = 'toll_gantry_without_toll';
+        }
+        
         // flag an unknown road even if it's a member of a relation
         if (!subtype && isUnknownRoad(entity)) {
             subtype = 'highway_classification';
         }
+
+       
 
         if (!subtype) return [];
 


### PR DESCRIPTION
Warn when toll_gantry on highway without toll=yes #9885
https://github.com/openstreetmap/iD/issues/9885

 This feature ensures that if there's a gantry on a highway, the toll attribute should be set to "yes", otherwise, a warning is given.

![image](https://github.com/openstreetmap/iD/assets/105686439/3e4ecd3b-0046-4de6-aa5e-e5c3bba0fdd4)
