### PR TITLE
add a link next to foreign keys

### DIFF
--- a/modules/services/tag2Link.js
+++ b/modules/services/tag2Link.js
@@ -1,0 +1,25 @@
+// @ts-check
+import tag2linkRaw from 'tag2link';
+
+const RANKS = ['deprecated', 'normal', 'preferred'];
+
+/** @param {import('tag2link').Tag2Link[]} input */
+function convertSourceData(input) {
+  /** @type {Record<string, string>} */
+  const output = {};
+
+  const allKeys = new Set(input.map(item => item.key));
+
+  for (const key of allKeys) {
+    // find the item with the best rank
+    const bestDefinition = input
+      .filter(item => item.key === key)
+      .sort((a, b) => RANKS.indexOf(b.rank) - RANKS.indexOf(a.rank))[0];
+
+    output[key.replace('Key:', '')] = bestDefinition.url;
+  }
+
+  return output;
+}
+
+export const TAG2LINK = convertSourceData(tag2linkRaw);

--- a/modules/ui/sections/raw_tag_editor.js
+++ b/modules/ui/sections/raw_tag_editor.js
@@ -13,7 +13,16 @@ import { utilArrayDifference, utilArrayIdentical } from '../../util/array';
 import { utilGetSetValue, utilNoAuto, utilRebind, utilTagDiff } from '../../util';
 import { allowUpperCaseTagValues } from '../../osm/tags';
 import { fileFetcher } from '../../core';
+import { TAG2LINK } from '../../services/tag2Link';
 
+/** @param {string} key */
+export function getUrlHost(key) {
+    try {
+        return new URL(TAG2LINK[key]).host.replace(/^www\./, '');
+    } catch {
+        return undefined;
+    }
+}
 
 export function uiSectionRawTagEditor(id, context) {
 
@@ -199,6 +208,14 @@ export function uiSectionRawTagEditor(id, context) {
         innerWrap
             .append('button')
             .attr('tabindex', -1)
+            .attr('class', 'form-field-button foreignKey')
+            .attr('title', d => t('icons.view_on', { domain: getUrlHost(d.key) }))
+            .style('display', d => d.key in TAG2LINK ? 'block' : 'none')
+            .call(svgIcon('#iD-icon-out-link'));
+
+        innerWrap
+            .append('button')
+            .attr('tabindex', -1)
             .attr('class', 'form-field-button remove')
             .attr('title', t('icons.remove'))
             .call(svgIcon('#iD-operation-delete'));
@@ -238,6 +255,7 @@ export function uiSectionRawTagEditor(id, context) {
 
                 row.call(reference.body);
 
+                row.select('button.foreignKey'); // propagate bound data
                 row.select('button.remove');   // propagate bound data
             });
 
@@ -273,6 +291,18 @@ export function uiSectionRawTagEditor(id, context) {
                     return typeof d.value === 'string' ? d.value : '';
                 }, (_, newValue) => newValue !== null
             );
+
+        items.selectAll('button.foreignKey')
+            .on(('PointerEvent' in window ? 'pointer' : 'mouse') + 'down', // 'click' fires too late - #5878
+                (d3_event, d) => {
+                    if (d3_event.button !== 0) return;
+                    for (const value of d.value.split(';')) {
+                        const url = /^https?:\/\//i.test(value)
+                            ? value
+                            : TAG2LINK[d.key].replace(/\$1/g, value);
+                        window.open(url, '_blank');
+                    }
+                });
 
         items.selectAll('button.remove')
             .classed('disabled', d => d.key === '')  // disabled for blank tag line

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "pbf": "^4.0.1",
         "polygon-clipping": "~0.15.7",
         "rbush": "4.0.1",
+        "tag2link": "^2025.6.21",
         "vitest": "^3.2.4",
         "whatwg-fetch": "^3.6.20",
         "which-polygon": "2.2.1"
@@ -22615,6 +22616,12 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "devOptional": true
+    },
+    "node_modules/tag2link": {
+      "version": "2025.6.21",
+      "resolved": "https://registry.npmjs.org/tag2link/-/tag2link-2025.6.21.tgz",
+      "integrity": "sha512-EHsVq11iAFTr9bxkw59dXci6bPLGbXN3OY7RKvhM1Ld6nnhPCpbPjw9s7m1UuiLH92plaj7lOXWVPl1oVq8/hw==",
+      "license": "ISC"
     },
     "node_modules/text-hex": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "pbf": "^4.0.1",
     "polygon-clipping": "~0.15.7",
     "rbush": "4.0.1",
+    "tag2link": "^2025.6.21",
     "vitest": "^3.2.4",
     "whatwg-fetch": "^3.6.20",
     "which-polygon": "2.2.1"


### PR DESCRIPTION
There is a now a button next to foreign-key fields like `operator:wikidata`, `mapillary`, `gnis:feature_id`, which will open the feature in a new tab.

![image](https://github.com/openstreetmap/iD/assets/16009897/c474c259-cb9c-46b4-8674-c5d4f01b0182)

The URL templates are fetched from https://github.com/JOSM/tag2link, which gets its data from [`P1630`](https://www.wikidata.org/wiki/Property:P1630) on wikidata or [`P8`](https://osm.wiki/Property:P8) in the osm wiki.

Closes #5838, Closes #9804