### PR TITLE
show date/time for georeferenced photos

### DIFF
--- a/css/60_photos.css
+++ b/css/60_photos.css
@@ -85,6 +85,10 @@
     padding: 4px 2px;
     z-index: 10;
 }
+.photo-attribution-dual {
+    display: flex;
+    justify-content: space-between;
+}
 
 .photo-attribution a,
 .photo-attribution a:visited,

--- a/modules/svg/local_photos.js
+++ b/modules/svg/local_photos.js
@@ -64,7 +64,7 @@ export function svgLocalPhotos(projection, context, dispatch) {
 
         viewerEnter
             .append('div')
-            .attr('class', 'photo-attribution fillD');
+            .attr('class', 'photo-attribution photo-attribution-dual fillD');
 
         return planePhotoFrame.init(context, viewerEnter)
             .then(planePhotoFrame => {
@@ -84,6 +84,11 @@ export function svgLocalPhotos(projection, context, dispatch) {
 
             const attribution = viewerWrap.selectAll('.photo-attribution').text('');
 
+            if (image.date) {
+                attribution
+                    .append('span')
+                    .text(image.date.toLocaleString());
+            }
             if (image.name) {
                 attribution
                     .append('span')
@@ -233,7 +238,8 @@ export function svgLocalPhotos(projection, context, dispatch) {
                     getSrc: () => readFileAsDataURL(file),
                     file: file,
                     loc: [exifData.longitude, exifData.latitude],
-                    direction: exifData.GPSImgDirection
+                    direction: exifData.GPSImgDirection,
+                    date: exifData.CreateDate || exifData.DateTimeOriginal || exifData.ModifyDate,
                 };
                 loaded.push(photo);
                 const sameName = _photos.filter(i => i.name === photo.name);


### PR DESCRIPTION
The new georeferenced photos feature is pretty cool, but the popup only shows the filename, which is often auto-generated by the camera and not very meaningful. 

This PR updates the popup to also show the date & time of the photo, which is a lot more helpful when you have similar photos.

![image](https://github.com/openstreetmap/iD/assets/16009897/c91aa396-5ddc-45d0-bd93-691467b8bc24)
