### PR TITLE
fix backspace not working as a keyboard shortcut

### DIFF
--- a/modules/ui/init.js
+++ b/modules/ui/init.js
@@ -375,7 +375,6 @@ export function uiInit(context) {
 
         var panPixels = 80;
         context.keybinding()
-            .on('⌫', function(d3_event) { d3_event.preventDefault(); })
             .on([t('sidebar.key'), '`', '²', '@'], ui.sidebar.toggle)   // #5663, #6864 - common QWERTY, AZERTY
             .on('←', pan([panPixels, 0]))
             .on('↑', pan([0, panPixels]))


### PR DESCRIPTION
In many browsers, <kbd>⌫ Backspace</kbd> used to be a shortcut to navigate back to the previous page. Since this was very frustrating, an override was added to block <kbd>⌫ Backspace</kbd> 11 years ago (see #303).

However, this code prevents other iD operations from using <kbd>⌫ Backspace</kbd> as a keyboard shortcut (see #9994).


Luckily, all the major browsers removed the <kbd>⌫ Backspace</kbd> feature (Chrome in 2016<sup>[[1]](https://www.zdnet.com/article/firefox-to-block-backspace-key-from-working-as-back-button/)</sup>, Safari in 2019<sup>[[2]](https://forums.macrumors.com/threads/backspace-key-as-back-button-in-safari-12-and-above.2175062/)</sup>, Edge in 2019<sup>[[3]](http://edge://flags/#edge-backspace-key-navigate-page-back)</sup>, Firefox in 2021<sup>[[1]](https://www.zdnet.com/article/firefox-to-block-backspace-key-from-working-as-back-button/)</sup>), so we can now remove this override to fix #9994
