### PR TITLE
prevent pasting when map features are hidden

### DIFF
--- a/modules/behavior/paste.js
+++ b/modules/behavior/paste.js
@@ -11,6 +11,10 @@ export function behaviorPaste(context) {
         // prevent paste during low zoom selection
         if (!context.map().withinEditableZoom()) return;
 
+        // prevent paste if the pasted object would be invisible (see #10000)
+        const isOsmLayerEnabled = context.layers().layer('osm').enabled();
+        if (!isOsmLayerEnabled) return;
+
         d3_event.preventDefault();
 
         var baseGraph = context.graph();


### PR DESCRIPTION
Pressing <kbd>⌘</kbd> + <kbd>V</kbd> while the data layer is off (<kbd>⌥</kbd> + <kbd>W</kbd>) will still paste the feature, but you won't be able to see it. 

This causes confusion and can result in random features being accidentally created.

You can no longer paste when the data layer is off.