### PR TITLE
fix foreign id link disabled on first load

### DIFF
--- a/modules/ui/fields/input.js
+++ b/modules/ui/fields/input.js
@@ -171,9 +171,10 @@ export function uiFieldText(field, context) {
         } else if (field.type === 'identifier' && field.urlFormat && field.pattern) {
 
             input.attr('type', 'text');
+            const foreignId = utilGetSetValue(input);
 
             outlinkButton = wrap.selectAll('.foreign-id-permalink')
-                .data([0]);
+                .data([foreignId]);
 
             outlinkButton.enter()
                 .append('button')


### PR DESCRIPTION
Closes #9992 

Fixes the foreign link disabled when the field first loads. See that issue for reproduction steps.