### PR TITLE
Sanitize Amazon CloudFront signature in imagery_used

### DIFF
--- a/modules/renderer/background_source.js
+++ b/modules/renderer/background_source.js
@@ -583,7 +583,7 @@ rendererBackgroundSource.Custom = function(template) {
             var parts = cleaned.split('?', 2);
             var qs = utilStringQs(parts[1]);
 
-            ['access_token', 'connectId', 'token'].forEach(function(param) {
+            ['access_token', 'connectId', 'token', 'Signature'].forEach(function(param) {
                 if (qs[param]) {
                     qs[param] = '{apikey}';
                 }

--- a/test/spec/renderer/background_source.js
+++ b/test/spec/renderer/background_source.js
@@ -92,6 +92,10 @@ describe('iD.rendererBackgroundSource.Custom', function() {
             var source = iD.rendererBackgroundSource.Custom('http://example.com?token=MYTOKEN');
             expect(source.imageryUsed()).to.eql('Custom (http://example.com?token={apikey} )');
         });
+        it('sanitizes `Signature` for CloudFront', function() {
+            var source = iD.rendererBackgroundSource.Custom('https://example.com/?Key-Pair-Id=foo&Policy=bar&Signature=baz');
+            expect(source.imageryUsed()).to.eql('Custom (https://example.com/?Key-Pair-Id=foo&Policy=bar&Signature={apikey} )');
+        });
         it('sanitizes wms path `token`', function() {
             var source = iD.rendererBackgroundSource.Custom('http://example.com/wms/v1/token/MYTOKEN/1.0.0/layer');
             expect(source.imageryUsed()).to.eql('Custom (http://example.com/wms/v1/token/{apikey}/1.0.0/layer )');


### PR DESCRIPTION
Similar to https://github.com/openstreetmap/iD/commit/47aaec0db6e73f56d4bb14447155de1b4abd400b and https://github.com/openstreetmap/iD/pull/8976, this removes Amazon CloudFront signatures from the URL in `imagery_used`. This comes up when using the [Strava global heatmap](https://wiki.openstreetmap.org/wiki/Strava#Global_Heatmap_in_High_Resolution) in iD.