### PR TITLE
Fix mapillary mouse symbol issue (#9992)

### DIFF
--- a/modules/ui/fields/input.js
+++ b/modules/ui/fields/input.js
@@ -171,11 +171,11 @@ export function uiFieldText(field, context) {
         } else if (field.type === 'identifier' && field.urlFormat && field.pattern) {
 
             input.attr('type', 'text');
-
+            const foreignId = utilGetSetValue(input);
             outlinkButton = wrap.selectAll('.foreign-id-permalink')
                 .data([0]);
-
-            outlinkButton.enter()
+            
+            outlinkButton = outlinkButton.enter()
                 .append('button')
                 .call(svgIcon('#iD-icon-out-link'))
                 .attr('class', 'form-field-button foreign-id-permalink')
@@ -187,9 +187,10 @@ export function uiFieldText(field, context) {
                     }
                     return '';
                 })
+                .merge(outlinkButton);
+                outlinkButton
                 .on('click', function(d3_event) {
                     d3_event.preventDefault();
-
                     var value = validIdentifierValueForLink();
                     if (value) {
                         var url = field.urlFormat.replace(/{value}/, encodeURIComponent(value));

--- a/modules/ui/fields/input.js
+++ b/modules/ui/fields/input.js
@@ -171,7 +171,6 @@ export function uiFieldText(field, context) {
         } else if (field.type === 'identifier' && field.urlFormat && field.pattern) {
 
             input.attr('type', 'text');
-            const foreignId = utilGetSetValue(input);
             outlinkButton = wrap.selectAll('.foreign-id-permalink')
                 .data([0]);
             


### PR DESCRIPTION
FIX #9992 

This commit adds support for the foreign-id field type. The issue was related to
the default disabled state of buttons with the 'foreign-id-permalink' class.
The issue is resolved by properly handling the disabled class for these buttons.