### PR TITLE
Fix geo-images UX issue #9918

### DIFF
--- a/css/60_photos.css
+++ b/css/60_photos.css
@@ -497,8 +497,8 @@ label.streetside-hires {
 
 .list-local-photos {
     max-height: 40vh;
-    overflow-y: scroll;
-    overflow-x: auto;
+    overflow-y: visible;
+    overflow-x: visible;
     /* workaround for something like "overflow-x: visible"
        see https://stackoverflow.com/a/39554003 */
     margin-left: -100px;
@@ -542,7 +542,7 @@ label.streetside-hires {
     border-bottom-right-radius: 4px;
 }
 .list-local-photos li.invalid span.filename {
-    color: #ccc;
+    color: #222222;
 }
 .list-local-photos li.invalid button.zoom-to-data {
     display: none;
@@ -552,6 +552,7 @@ label.streetside-hires {
 }
 .list-local-photos li.invalid button.no-geolocation {
     display: block;
+    color: red;
 }
 .list-local-photos .placeholder div {
     display: block;

--- a/css/60_photos.css
+++ b/css/60_photos.css
@@ -497,12 +497,15 @@ label.streetside-hires {
 
 .list-local-photos {
     max-height: 40vh;
-    overflow-y: visible;
-    overflow-x: visible;
+    overflow-y: scroll;
+    overflow-x: auto;
     /* workaround for something like "overflow-x: visible"
        see https://stackoverflow.com/a/39554003 */
     margin-left: -100px;
     padding-left: 100px;
+    margin-top: -20px;
+    padding-top: 20px;
+    min-height: 100px;
 }
 .list-local-photos::-webkit-scrollbar {
     border-left: none;
@@ -540,9 +543,6 @@ label.streetside-hires {
 }
 .list-local-photos li:last-child button.remove {
     border-bottom-right-radius: 4px;
-}
-.list-local-photos li.invalid span.filename {
-    color: #222222;
 }
 .list-local-photos li.invalid button.zoom-to-data {
     display: none;


### PR DESCRIPTION
This pull request addresses UX issues related to the georeferenced photos feature. The identified problems included:

- The image filename (IMG_etc) displaying in the same color as the frame.
- The alert icon being too easy to miss due to its light gray color.
- A warning message being cut off when hovering over the alert icon.


https://github.com/openstreetmap/iD/assets/142984776/4910b06b-3043-4e9f-9ec7-ada6ddec9a95





Closes #9918 