### PR TITLE
Modified combo.js file to change restrictTagValueSpelling function to prevent lowercasing the hashtags #10038

### DIFF
--- a/modules/ui/fields/combo.js
+++ b/modules/ui/fields/combo.js
@@ -91,7 +91,7 @@ export function uiFieldCombo(field, context) {
         }
 
         if (!field.caseSensitive) {
-            dval = dval.toLowerCase();
+            dval = dval;
         }
 
         return dval;


### PR DESCRIPTION
Apparently, This function was changing tags according to their Casing,
Removing the toLowerCase() , makes the issue go away!
combo.js
line 94
inside restrictTagValueSpelling

Removed toLowerCase() function