### PR TITLE
Search OSM notes by ID

### DIFF
--- a/modules/core/context.js
+++ b/modules/core/context.js
@@ -176,6 +176,13 @@ export function coreContext() {
       _connection.loadEntityRelations(entityID, afterLoad(cid, callback));
     }
   };
+  // Download single note
+  context.loadNote = (entityID, callback) => {
+    if (_connection) {
+      const cid = _connection.getConnectionId();
+      _connection.loadEntityNote(entityID, afterLoad(cid, callback));
+    }
+  };
 
   context.zoomToEntity = (entityID, zoomTo) => {
 

--- a/modules/services/osm.js
+++ b/modules/services/osm.js
@@ -732,8 +732,6 @@ export default {
     // Load a single note by id , XML format
     // GET /api/0.6/notes/#id
     loadEntityNote: function(id, callback) {
-        // var type = osmEntity.id.type(id);
-        // var osmID = osmEntity.id.toOSM(id);
         var options = { skipSeen: false };
         this.loadFromAPI(
             '/api/0.6/notes/' + id ,

--- a/modules/services/osm.js
+++ b/modules/services/osm.js
@@ -729,6 +729,21 @@ export default {
         );
     },
 
+    // Load a single note by id , XML format
+    // GET /api/0.6/notes/#id
+    loadEntityNote: function(id, callback) {
+        // var type = osmEntity.id.type(id);
+        // var osmID = osmEntity.id.toOSM(id);
+        var options = { skipSeen: false };
+        this.loadFromAPI(
+            '/api/0.6/notes/' + id ,
+            function(err, entities) {
+                if (callback) callback(err, { data: entities });
+            },
+            options
+        );
+    },
+
 
     // Load a single entity with a specific version
     // GET /api/0.6/[node|way|relation]/#id/#version

--- a/modules/ui/feature_list.js
+++ b/modules/ui/feature_list.js
@@ -139,15 +139,15 @@ export function uiFeatureList(context) {
             }
 
             // A location search takes priority over an ID search
-            var idMatch = !locationMatch && q.match(/(?:^|\W)(node|way|relation|[nwr])\W{0,2}0*([1-9]\d*)(?:\W|$)/i);
+            var idMatch = !locationMatch && q.match(/(?:^|\W)(node|way|relation|note|[nwr])\W{0,2}0*([1-9]\d*)(?:\W|$)/i);
 
             if (idMatch) {
-                var elemType = idMatch[1].charAt(0);
+                var elemType = idMatch[1] === 'note' ? idMatch[1] : idMatch[1].charAt(0);
                 var elemId = idMatch[2];
                 result.push({
                     id: elemType + elemId,
-                    geometry: elemType === 'n' ? 'point' : elemType === 'w' ? 'line' : 'relation',
-                    type: elemType === 'n' ? t('inspector.node') : elemType === 'w' ? t('inspector.way') : t('inspector.relation'),
+                    geometry: elemType === 'n' ? 'point' : elemType === 'w' ? 'line' : elemType === 'note' ? 'note' : 'relation',
+                    type: elemType === 'n' ? t('inspector.node') : elemType === 'w' ? t('inspector.way') : elemType === 'note' ? t('note.note') : t('inspector.relation'),
                     name: elemId
                 });
             }

--- a/modules/ui/feature_list.js
+++ b/modules/ui/feature_list.js
@@ -360,7 +360,7 @@ export function uiFeatureList(context) {
                 context.enter(modeSelect(context, [d.entity.id]));
                 context.map().zoomToEase(d.entity);
 
-            } else if (d.geometry  === 'note'){
+            } else if (d.geometry  === 'note') {
                 // note
                 // get number part 'note12345'
                 const noteId = d.id.replace(/\D/g, '');


### PR DESCRIPTION
Closes #7618

only support number without prefix,
I wonder if needed to treat note as osmEntity, and support one letter shortcut,
but 'n' is taken by node.

![noteSearchId](https://github.com/openstreetmap/iD/assets/109860906/f84d0d2e-1e2b-43c4-a1a6-01dc67bed6bf)
