### PR TITLE
Add support  for multiple layers

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -965,6 +965,13 @@ en:
             switch: "`{switch:a,b,c}`: DNS server multiplexing"
             quadtile: "`{u}`: quadtile (Bing) scheme"
             scale_factor: "`{@2x}` or `{r}`: resolution scale factor"
+        multiple:
+          multiple_label: "Adding multiple layers"
+          steps:
+            step1: "Type or paste the URLs in the input field, each on a new line."
+            step2: "To include a layer, leave it without any prefix."
+            step3: "To exclude a layer, prefix it with `#`."
+            example_step: "In this case the 2nd layer i.e `https://example-2` will be selected"
         example: "Example:"
       template:
         placeholder: Enter a url template

--- a/modules/ui/settings/custom_background.js
+++ b/modules/ui/settings/custom_background.js
@@ -19,7 +19,7 @@ export function uiSettingsCustomBackground() {
             template: prefs('background-custom-template')
         };
 
-        var example = 'https://tile.openstreetmap.org/{zoom}/{x}/{y}.png';
+        var example = 'https://tile.openstreetmap.org/{zoom}/{x}/{y}.png';        
         var modal = uiConfirm(selection).okButton();
 
         modal
@@ -49,7 +49,16 @@ export function uiSettingsCustomBackground() {
             `* ${t.html('settings.custom_background.instructions.tms.tokens.scale_factor')}\n` +
             '\n' +
             `#### ${t.html('settings.custom_background.instructions.example')}\n` +
-            `\`${example}\``;
+            `\`${example}\`\n` +
+            `#### ${t.html('settings.custom_background.instructions.multiple.multiple_label')}\n` +
+            `* ${t.html('settings.custom_background.instructions.multiple.steps.step1')}\n` +
+            `* ${t.html('settings.custom_background.instructions.multiple.steps.step2')}\n` +
+            `* ${t.html('settings.custom_background.instructions.multiple.steps.step3')}\n` +
+            `#### ${t.html('settings.custom_background.instructions.example')}\n` +
+            `${t.html('settings.custom_background.instructions.multiple.steps.example_step1')}\n` +
+            `${t.html('settings.custom_background.instructions.multiple.steps.example_step2')}\n` +
+            `${t.html('settings.custom_background.instructions.multiple.steps.example_step3')}\n` +            
+            `* ${t.html('settings.custom_background.instructions.multiple.steps.example_step4')}`;           
 
         textSection
             .append('div')
@@ -94,10 +103,34 @@ export function uiSettingsCustomBackground() {
             modal.close();
         }
 
+        //function to parse the text box and select the correct template
+        function parseCustomTemplate() {
+            var tempString = textSection.select('.field-template').property('value');
+            var urls = tempString.split('\n'); // Split the input into an array of URLs
+            var selectedUrl;
+        
+            for (let i = 0; i < urls.length; i++) {
+                var currentUrl = urls[i].trim();
+
+                // Skip if url starts with #
+                if (currentUrl.startsWith('#')) {
+                    continue;
+                }        
+                // If no URL is selected yet, or if the current URL has a higher priority (lower index), update the selected URL
+                if (!selectedUrl || currentUrl.endsWith(selectedUrl.substring(selectedUrl.lastIndexOf('/') + 1))) {
+                    selectedUrl = currentUrl;
+                }
+            }
+
+            return selectedUrl;
+        }
+        
+
         // accept the current template
         function clickSave() {
-            _currSettings.template = textSection.select('.field-template').property('value');
-            prefs('background-custom-template', _currSettings.template);
+            var originalTemplate = textSection.select('.field-template').property('value');            
+            _currSettings.template = parseCustomTemplate();
+            prefs('background-custom-template', originalTemplate);
             this.blur();
             modal.close();
             dispatch.call('change', this, _currSettings);


### PR DESCRIPTION
Fixes #10055
How it works:

1. You have multiple layers in the custom background section
2. you can prefix the layer with '#' to not select it
3. if a layer does not have the '#' prefix then it is selected

Below I have demonstrated how it works.

[Screencast from 15-01-24 05:15:31 PM IST.webm](https://github.com/openstreetmap/iD/assets/130328580/770cd6f0-c4a1-4332-a317-6cc19d7aa918)

This way editors can quickly switch between layers rather than having to copy paste manually every time.

Also added instructions for the same.
![image](https://github.com/openstreetmap/iD/assets/130328580/4f2e8f96-5250-4c15-93e1-ac21816ed122)
