### PR TITLE
Switch to new (undocumented) Bing Streetside bubble metadata URL

### DIFF
--- a/modules/services/streetside.js
+++ b/modules/services/streetside.js
@@ -7,7 +7,6 @@ import {
 
 import RBush from 'rbush';
 import { t, localizer } from '../core/localizer';
-import { jsonpRequest } from '../util/jsonp_request';
 
 import {
   geoExtent, geoMetersToLat, geoMetersToLon, geoPointInPolygon,
@@ -17,7 +16,7 @@ import {
 import { utilArrayUnion, utilQsString, utilRebind, utilStringQs, utilTiler, utilUniqueDomId } from '../util';
 
 
-const bubbleApi = 'https://dev.virtualearth.net/mapcontrol/HumanScaleServices/GetBubbles.ashx?';
+const bubbleApi = 'https://t.ssl.ak.tiles.virtualearth.net/tiles/cmd/StreetSideBubbleMetaData?';
 const streetsideImagesApi = 'https://t.ssl.ak.tiles.virtualearth.net/tiles/';
 const bubbleAppKey = 'AuftgJsO0Xs8Ts4M1xZUQJQXJNsvmh3IV8DkNieCiy3tCwCUMq76-WpkrBtNAuEm';
 const pannellumViewerCSS = 'pannellum/pannellum.css';
@@ -210,22 +209,33 @@ function connectSequences() {
 function getBubbles(url, tile, callback) {
   let rect = tile.extent.rectangle();
   let urlForRequest = url + utilQsString({
-    n: rect[3],
-    s: rect[1],
-    e: rect[2],
-    w: rect[0],
-    c: maxResults,
-    appkey: bubbleAppKey,
-    jsCallback: '{callback}'
+    north: rect[3],
+    south: rect[1],
+    east: rect[2],
+    west: rect[0],
+    count: maxResults,
+    key: bubbleAppKey
   });
 
-  return jsonpRequest(urlForRequest, (data) => {
-    if (!data || data.error) {
-      callback(null);
-    } else {
-      callback(data);
-    }
-  });
+  return loadData(urlForRequest, callback);
+}
+
+
+// Get data from the API
+function loadData(url, callback) {
+  return fetch(url, callback)
+    .then(function(response) {
+      if (!response.ok) {
+        throw new Error(response.status + ' ' + response.statusText);
+      }
+      return response.json();
+      })
+    .then(function(result) {
+      if (!result) {
+        callback(null);
+      }
+      return callback(result || []);
+   });
 }
 
 


### PR DESCRIPTION
Bing Streetside bubbles have often been missing recently, with the bubble metadata requests coming back with 401 errors. Occasionally, enabling the Streetside bubbles does work, but more often than not they don't show up.

This issue was first reported in the iD issue queue about two weeks ago (#10074) and also in the Rapid editor issue queue around the same time.

Per my comment in the issue, I noted that the Bing Maps website was now using a different URL, so I went poking around. I can't find either the old URL or the new URL documented anywhere, but switching to the new URL seems to work fine, and so far feels more reliable. The JSONP callback doesn't seem to be available with the new URL, so I dropped that and replaced it with a request method similar to the one in the Mapillary service.

Whether or not this is the right fix, I don't know. Probably needs discussing with someone at Microsoft?