### PR TITLE
fix bug causing a spam of network requests

### DIFF
--- a/modules/core/file_fetcher.js
+++ b/modules/core/file_fetcher.js
@@ -67,7 +67,7 @@ export function coreFileFetcher() {
           return getUrl(url.replace('{presets_version}', presetsVersion), which);
         });
     } else {
-      return getUrl(url);
+      return getUrl(url, which);
     }
   };
 


### PR DESCRIPTION
Closes #9516

This bug meant that the cache was never used, so whenever you pan the map, several assets were constantly being re-requested