### PR TITLE
set the locale of the login popup

### DIFF
--- a/modules/services/osm.js
+++ b/modules/services/osm.js
@@ -9,6 +9,7 @@ import { JXON } from '../util/jxon';
 import { geoExtent, geoRawMercator, geoVecAdd, geoZoomToScale } from '../geo';
 import { osmEntity, osmNode, osmNote, osmRelation, osmWay } from '../osm';
 import { utilArrayChunk, utilArrayGroupBy, utilArrayUniq, utilObjectOmit, utilRebind, utilTiler, utilQsString } from '../util';
+import { localizer } from '../core/localizer.js';
 
 import { osmApiConnections } from '../../config/id.js';
 
@@ -1437,6 +1438,12 @@ export default {
             if (callback) callback(err, res);
             that.userChangesets(function() {});  // eagerly load user details/changesets
         }
+
+        // ensure the locale is correctly set before opening the popup
+        oauth.options({
+            ...oauth.options(),
+            locale: localizer.localeCode(),
+        });
 
         oauth.authenticate(done);
     },


### PR DESCRIPTION
Closes #3595

We now send the locale code that iD is using to the OAuth popup, so that the user always sees their preferred language. Same idea as #9501

This will have no effect until https://github.com/osmlab/osm-auth/pull/130 is merged and released