### PR TITLE
add New Zealand address format

### DIFF
--- a/data/address_formats.json
+++ b/data/address_formats.json
@@ -79,6 +79,14 @@
     ]
   },
   {
+    "countryCodes": ["nz"],
+    "format": [
+      ["housenumber", "street"],
+      ["suburb"],
+      ["city", "postcode"]
+    ]
+  },
+  {
     "countryCodes": ["br"],
     "format": [
       ["street+place"],


### PR DESCRIPTION
New Zealand uses `addr:suburb` for urban addresses[^1]

For historical reasons, rural addresses use `addr:hamlet` instead of `addr:suburb`. This is about 10% of the 2.2 million addresses. iD has no way of handling this weird situation, but this PR at least makes the address picker more useful for the 1.9 million urban addresses.

_Disclaimer:_ I currently maintain NZ's address import tool

[^1]: https://osm.wiki/Import/New_Zealand_Street_Addresses_(2021)