### PR TITLE
Improve combobox dropdown styling to give labels more room and readability

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -2354,9 +2354,8 @@ div.combobox {
     display: block;
     padding: 5px 10px;
     border-top: 1px solid #ccc;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    overflow: hidden;
+    line-height: 0.95rem;
+    break: all;
 }
 
 .combobox a.selected,

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -1585,7 +1585,6 @@ input.date-selector {
     display: flex;
     flex-flow: row nowrap;
 }
-.form-field ul.rows li.labeled-input > span,
 .form-field ul.rows li.labeled-input > div {
     flex: 1 1 auto;
     width: 100%;

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -1589,6 +1589,7 @@ input.date-selector {
     flex: 1 1 auto;
     width: 100%;
     border-radius: 0;
+    line-height: 0.95rem;
 }
 .form-field ul.rows li input {
     border-radius: 0;
@@ -1605,6 +1606,28 @@ input.date-selector {
 .ideditor[dir='rtl'] .form-field ul.rows li.labeled-input input,
 .ideditor[dir='rtl'] .form-field ul.rows li button {
     border-right-width: 1px;
+}
+
+/* Field - lists with labeled input items as table
+------------------------------------------------------- */
+.form-field ul.rows.rows-table {
+    display: table;
+    width: 100%;
+}
+.form-field ul.rows.rows-table li.labeled-input {
+    display: table-row;
+}
+.form-field ul.rows.rows-table li.labeled-input > div:first-child {
+    display: table-cell;
+    width: auto;
+    max-width: 170px;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+}
+.form-field ul.rows.rows-table li.labeled-input > div:nth-child(2) {
+    display: table-cell;
+    width: auto;
 }
 
 

--- a/modules/ui/fields/access.js
+++ b/modules/ui/fields/access.js
@@ -37,7 +37,7 @@ export function uiFieldAccess(field, context) {
             .attr('class', function(d) { return 'labeled-input preset-access-' + d; });
 
         enter
-            .append('span')
+            .append('div')
             .attr('class', 'label preset-label-access')
             .attr('for', function(d) { return 'preset-input-access-' + d; })
             .html(function(d) { return field.t.html('types.' + d); });

--- a/modules/ui/fields/directional_combo.js
+++ b/modules/ui/fields/directional_combo.js
@@ -54,7 +54,7 @@ export function uiFieldDirectionalCombo(field, context) {
             .attr('class', function(d) { return 'labeled-input preset-directionalcombo-' + stripcolon(d); });
 
         enter
-            .append('span')
+            .append('div')
             .attr('class', 'label preset-label-directionalcombo')
             .attr('for', function(d) { return 'preset-input-directionalcombo-' + stripcolon(d); })
             .html(function(d) { return field.t.html('types.' + d); });

--- a/modules/ui/fields/directional_combo.js
+++ b/modules/ui/fields/directional_combo.js
@@ -43,7 +43,7 @@ export function uiFieldDirectionalCombo(field, context) {
 
         div = div.enter()
             .append('ul')
-            .attr('class', 'rows')
+            .attr('class', 'rows rows-table')
             .merge(div);
 
         items = div.selectAll('li')

--- a/modules/ui/fields/radio.js
+++ b/modules/ui/fields/radio.js
@@ -127,7 +127,7 @@ export function uiFieldRadio(field, context) {
             .attr('class', 'labeled-input structure-type-item');
 
         typeEnter
-            .append('span')
+            .append('div')
             .attr('class', 'label structure-label-type')
             .attr('for', 'preset-input-' + selected)
             .call(t.append('inspector.radio.structure.type'));
@@ -172,7 +172,7 @@ export function uiFieldRadio(field, context) {
             .attr('class', 'labeled-input structure-layer-item');
 
         layerEnter
-            .append('span')
+            .append('div')
             .attr('class', 'label structure-label-layer')
             .attr('for', 'preset-input-layer')
             .call(t.append('inspector.radio.structure.layer'));


### PR DESCRIPTION
**[Local test URL](http://localhost:8080/#background=Bing&disable_features=boundaries&id=w294999169&locale=de&map=16.26/52.38819/13.01081)**

A few screenshots:

* <img width="362" alt="image" src="https://github.com/openstreetmap/iD/assets/111561/86ff29be-927c-42a6-9070-cae12c8fa6da">
* <img width="365" alt="image" src="https://github.com/openstreetmap/iD/assets/111561/0afee515-1aa7-41aa-946a-fb183ab087ce">

