### PR TITLE
show more relevant presets when switching preset of an object

### DIFF
--- a/modules/ui/preset_list.js
+++ b/modules/ui/preset_list.js
@@ -149,7 +149,7 @@ export function uiPresetList(context) {
         var list = listWrap
             .append('div')
             .attr('class', 'preset-list')
-            .call(drawList, presetManager.defaults(entityGeometries()[0], 36, !context.inIntro(), _currLoc, entityPresets));
+            .call(drawList, presetManager.defaults(entityGeometries()[0], 36, context.inIntro() ? false : 'related-presets', _currLoc, entityPresets));
 
         context.features().on('change.preset-list', updateForFeatureHiddenState);
     }


### PR DESCRIPTION
When changing the preset of an existing object, the preset list currently contains a few of the recently used presets and a relatively long "default" list of presets which match the selected feature's geometry. Listing the completely context-less list of "defaults" is in general not very useful: it is pretty unlikely that one wants to change a `building` feature to something completely different like a park for example.[^1] Usually one wants to change an object's preset to either refine it (choosing to a more specific sub-preset, e.g. from a Doctor to a General Practitioner), or update the map by choosing a closely related preset (e.g. when switching from a `shop=shoes` to `shop=clothes` if a POI changed in reality or the POI was previously mapped incorrectly).

[^1]: There is a little bit of merit to not completely omit showing these defaults, tough: It teaches the mapper that there are many very different thing one can map in OSM: e.g. from natural features, landuse and water features, to points of interest, etc.

In this PR, the suggestions are based on the object's previous preset:
* if it was part of a category, show that category again (e.g. editing a `highway=primary` will offer the "Major Roads" category)
* if a preset has sub-presets: offer up to 5 of these (e.g. `barrier=kerb` will offer presets like Raised Curb, Lowered Curb, etc.)
* show the "partent" i.e. more generic preset if there is a matching one
* show up to 5 "sibling" presets

(currently this also increases the number of shown previously used presets from 4 to 5, see #9545)

Some unfinished business:
* [ ] should these be sorted differently, e.g. before the previously used presets)?
* [ ] should there be a visual separation between these suggestions, the recents and the defaults?
* [ ] investigate if a better sorting of candidates could be done when many siblings exist (e.g. `building=yes` might more likely be changed to a common building type like `building=house`, compared to something rare like `building=yurt` for example)
* [ ] add mechanism to offer more related presets (and/or more recently used presets)
* [ ] add test cases