### PR TITLE
Field: Fix html tag type of wikidata label

### DIFF
--- a/modules/ui/fields/wikidata.js
+++ b/modules/ui/fields/wikidata.js
@@ -106,7 +106,7 @@ export function uiFieldWikidata(field, context) {
             .attr('class', function(d) { return 'labeled-input preset-wikidata-' + d; });
 
         enter
-            .append('span')
+            .append('div')
             .attr('class', 'label')
             .html(function(d) { return t.html('wikidata.' + d); });
 


### PR DESCRIPTION
The `span` need to be a `div` after https://github.com/openstreetmap/iD/pull/10127/files

Closes https://github.com/openstreetmap/iD/issues/10143

**Before**
<img width="591" alt="before" src="https://github.com/openstreetmap/iD/assets/111561/8e0e92ee-6e24-46a8-abac-a26bcc57a8c7">
**After**
<img width="545" alt="after" src="https://github.com/openstreetmap/iD/assets/111561/c3c9e9eb-1797-407a-a7d8-88aa924e782b">
