### PR TITLE
Field: fix wikiURL by URL encoding it - and slight refactors

### DIFF
--- a/modules/ui/fields/wikipedia.js
+++ b/modules/ui/fields/wikipedia.js
@@ -308,9 +308,9 @@ export function uiFieldWikipedia(field, context) {
   }
 
   function updateEncodedWikiUrl(tagLang, tagArticleTitle, anchor) {
-    const underscored = tagArticleTitle.replace(/ /g, '_');
+    const underscoredUrlEncodedTitle = encodeURIComponent(tagArticleTitle.replace(/ /g, '_'));
     const urlAnchored = toUrlAnchor(anchor);
-    _wikiURL = encodeURI(`${scheme}${tagLang}.${domain}/wiki/${underscored}${urlAnchored}`);
+    _wikiURL = `${scheme}${tagLang}.${domain}/wiki/${underscoredUrlEncodedTitle}${urlAnchored}`;
   }
 
   function toUrlAnchor(anchor) {

--- a/modules/ui/fields/wikipedia.js
+++ b/modules/ui/fields/wikipedia.js
@@ -11,6 +11,8 @@ import { utilGetSetValue, utilNoAuto, utilRebind } from '../../util';
 
 
 export function uiFieldWikipedia(field, context) {
+  const scheme = 'https://';
+  const domain = 'wikipedia.org';
   const dispatch = d3_dispatch('change');
   const wikipedia = services.wikipedia;
   const wikidata = services.wikidata;
@@ -132,7 +134,7 @@ export function uiFieldWikipedia(field, context) {
     link = link.enter()
       .append('button')
       .attr('class', 'form-field-button wiki-link')
-      .attr('title', t('icons.view_on', { domain: 'wikipedia.org' }))
+      .attr('title', t('icons.view_on', { domain }))
       .call(svgIcon('#iD-icon-out-link'))
       .merge(link);
 
@@ -279,7 +281,7 @@ export function uiFieldWikipedia(field, context) {
     if (tagLangInfo) {
       const nativeLangName = tagLangInfo[1];
       utilGetSetValue(_langInput, nativeLangName);
-      utilGetSetValue(_titleInput, tagArticleTitle + (anchor ? ('#' + anchor) : ''));
+      utilGetSetValue(_titleInput, tagArticleTitle + toUrlAnchor(anchor));
       if (anchor) {
         try {
           // Best-effort `anchorencode:` implementation
@@ -288,8 +290,7 @@ export function uiFieldWikipedia(field, context) {
           anchor = anchor.replace(/ /g, '_');
         }
       }
-      _wikiURL = 'https://' + tagLang + '.wikipedia.org/wiki/' +
-        tagArticleTitle.replace(/ /g, '_') + (anchor ? ('#' + anchor) : '');
+      updateEncodedWikiUrl(tagLang, tagArticleTitle, anchor);
 
     // unrecognized value format
     } else {
@@ -297,7 +298,7 @@ export function uiFieldWikipedia(field, context) {
       if (value && value !== '') {
         utilGetSetValue(_langInput, '');
         const defaultLangInfo = defaultLanguageInfo();
-        _wikiURL = `https://${defaultLangInfo[2]}.wikipedia.org/w/index.php?fulltext=1&search=${value}`;
+        _wikiURL = `${scheme}${defaultLangInfo[2]}.${domain}/w/index.php?fulltext=1&search=${value}`;
       } else {
         const shownOrDefaultLangInfo = language(true /* skipEnglishFallback */);
         utilGetSetValue(_langInput, shownOrDefaultLangInfo[1]);
@@ -306,6 +307,15 @@ export function uiFieldWikipedia(field, context) {
     }
   }
 
+  function updateEncodedWikiUrl(tagLang, tagArticleTitle, anchor) {
+    const underscored = tagArticleTitle.replace(/ /g, '_');
+    const urlAnchored = toUrlAnchor(anchor);
+    _wikiURL = encodeURI(`${scheme}${tagLang}.${domain}/wiki/${underscored}${urlAnchored}`);
+  }
+
+  function toUrlAnchor(anchor) {
+    return anchor ? '#' + anchor : '';
+  }
 
   wiki.entityIDs = (val) => {
     if (!arguments.length) return _entityIDs;

--- a/modules/ui/fields/wikipedia.js
+++ b/modules/ui/fields/wikipedia.js
@@ -299,22 +299,15 @@ export function uiFieldWikipedia(field, context) {
 
   wiki.encodePath = (tagArticleTitle, anchor) => {
     const underscoredTitle = tagArticleTitle.replace(/ /g, '_');
-    return `${encodeURIComponent(underscoredTitle)}${anchor ? '#' + encodeURIComponent(wiki.anchorFragment(anchor)): ''}`;
+    const uriEncodedUnderscoredTitle = encodeURIComponent(underscoredTitle);
+    const uriEncodedAnchorFragment = wiki.encodeURIAnchorFragment(anchor);
+    return `${uriEncodedUnderscoredTitle}${uriEncodedAnchorFragment}`;
   };
 
-  wiki.anchorFragment = (anchor) => {
-    if (!anchor) {
-      return '';
-    }
-
-    try {
-      // Best-effort `anchorencode:` implementation
-      anchor = anchor.replace(/ /g, '_').replace(/%/g, '.');
-    } catch (e) {
-      anchor = anchor.replace(/ /g, '_');
-    }
-
-    return anchor;
+  wiki.encodeURIAnchorFragment = (anchor) => {
+    if (!anchor) return '';
+    const underscoredAnchor = anchor.replace(/ /g, '_');
+    return '#' + encodeURIComponent(underscoredAnchor);
   };
 
   wiki.entityIDs = (val) => {

--- a/modules/ui/fields/wikipedia.js
+++ b/modules/ui/fields/wikipedia.js
@@ -281,18 +281,8 @@ export function uiFieldWikipedia(field, context) {
     if (tagLangInfo) {
       const nativeLangName = tagLangInfo[1];
       utilGetSetValue(_langInput, nativeLangName);
-      utilGetSetValue(_titleInput, tagArticleTitle + toUrlAnchor(anchor));
-      if (anchor) {
-        try {
-          // Best-effort `anchorencode:` implementation
-          anchor = encodeURIComponent(anchor.replace(/ /g, '_')).replace(/%/g, '.');
-        } catch (e) {
-          anchor = anchor.replace(/ /g, '_');
-        }
-      }
-      updateEncodedWikiUrl(tagLang, tagArticleTitle, anchor);
-
-    // unrecognized value format
+      utilGetSetValue(_titleInput, tagArticleTitle + (anchor ? ('#' + anchor) : ''));
+      _wikiURL = `${scheme}${tagLang}.${domain}/wiki/${wiki.encodePath(tagArticleTitle, anchor)}`;
     } else {
       utilGetSetValue(_titleInput, value);
       if (value && value !== '') {
@@ -307,15 +297,25 @@ export function uiFieldWikipedia(field, context) {
     }
   }
 
-  function updateEncodedWikiUrl(tagLang, tagArticleTitle, anchor) {
-    const underscoredUrlEncodedTitle = encodeURIComponent(tagArticleTitle.replace(/ /g, '_'));
-    const urlAnchored = toUrlAnchor(anchor);
-    _wikiURL = `${scheme}${tagLang}.${domain}/wiki/${underscoredUrlEncodedTitle}${urlAnchored}`;
-  }
+  wiki.encodePath = (tagArticleTitle, anchor) => {
+    const underscoredTitle = tagArticleTitle.replace(/ /g, '_');
+    return `${encodeURIComponent(underscoredTitle)}${anchor ? '#' + encodeURIComponent(wiki.anchorFragment(anchor)): ''}`;
+  };
 
-  function toUrlAnchor(anchor) {
-    return anchor ? '#' + anchor : '';
-  }
+  wiki.anchorFragment = (anchor) => {
+    if (!anchor) {
+      return '';
+    }
+
+    try {
+      // Best-effort `anchorencode:` implementation
+      anchor = anchor.replace(/ /g, '_').replace(/%/g, '.');
+    } catch (e) {
+      anchor = anchor.replace(/ /g, '_');
+    }
+
+    return anchor;
+  };
 
   wiki.entityIDs = (val) => {
     if (!arguments.length) return _entityIDs;

--- a/test/spec/ui/fields/wikipedia.js
+++ b/test/spec/ui/fields/wikipedia.js
@@ -113,6 +113,24 @@ describe('iD.uiFieldWikipedia', function() {
         }, 20);
     });
 
+    it('sets encoded wiki URLs', function(done) {
+        var wikipedia = iD.uiFieldWikipedia(field, context).entityIDs([entity.id]);
+
+        window.setTimeout(function() {   // async, so data will be available
+            wikipedia.on('change', changeTags);
+            selection.call(wikipedia);
+
+            iD.utilGetSetValue(selection.selectAll('.wiki-title'), '? (film)');
+            happen.once(selection.selectAll('.wiki-title').node(), { type: 'change' });
+
+            expect(context.entity(entity.id).tags.wikipedia).to.equal('en:? (film)');
+            
+            // TODO assert wikiURL is correct
+
+            done();
+        }, 20);
+    });
+
     // note - currently skipping the tests that use `options` to delay responses
     it('preserves existing language', function(done) {
         var wikipedia1 = iD.uiFieldWikipedia(field, context);

--- a/test/spec/ui/fields/wikipedia.js
+++ b/test/spec/ui/fields/wikipedia.js
@@ -113,22 +113,11 @@ describe('iD.uiFieldWikipedia', function() {
         }, 20);
     });
 
-    it('sets encoded wiki URLs', function(done) {
+    it('has an encodePath function that returns an encoded URI component that contains the title and optional anchor', function(done) {
         var wikipedia = iD.uiFieldWikipedia(field, context).entityIDs([entity.id]);
-
-        window.setTimeout(function() {   // async, so data will be available
-            wikipedia.on('change', changeTags);
-            selection.call(wikipedia);
-
-            iD.utilGetSetValue(selection.selectAll('.wiki-title'), '? (film)');
-            happen.once(selection.selectAll('.wiki-title').node(), { type: 'change' });
-
-            expect(context.entity(entity.id).tags.wikipedia).to.equal('en:? (film)');
-            
-            // TODO assert wikiURL is correct
-
-            done();
-        }, 20);
+        expect(wikipedia.encodePath('? (film)', undefined)).to.equal('%3F_(film)');
+        expect(wikipedia.encodePath('? (film)', 'Themes and style')).to.equal('%3F_(film)#Themes_and_style');
+        done();
     });
 
     // note - currently skipping the tests that use `options` to delay responses

--- a/test/spec/ui/fields/wikipedia.js
+++ b/test/spec/ui/fields/wikipedia.js
@@ -113,11 +113,46 @@ describe('iD.uiFieldWikipedia', function() {
         }, 20);
     });
 
-    it('has an encodePath function that returns an encoded URI component that contains the title and optional anchor', function(done) {
-        var wikipedia = iD.uiFieldWikipedia(field, context).entityIDs([entity.id]);
-        expect(wikipedia.encodePath('? (film)', undefined)).to.equal('%3F_(film)');
-        expect(wikipedia.encodePath('? (film)', 'Themes and style')).to.equal('%3F_(film)#Themes_and_style');
-        done();
+    describe('encodePath', function() {
+        it('returns an encoded URI component that contains the title with spaces replaced by underscores', function(done) {
+            var wikipedia = iD.uiFieldWikipedia(field, context).entityIDs([entity.id]);
+            expect(wikipedia.encodePath('? (film)', undefined)).to.equal('%3F_(film)');
+            done();
+        });
+
+        it('returns an encoded URI component that includes an anchor fragment', function(done) {
+            var wikipedia = iD.uiFieldWikipedia(field, context).entityIDs([entity.id]);
+            // this can be tested manually by entering '? (film)#Themes and style in the search box before focusing out'
+            expect(wikipedia.encodePath('? (film)', 'Themes and style')).to.equal('%3F_(film)#Themes_and_style');
+            done();
+        });
+    });
+
+    describe('encodeURIAnchorFragment', function() {
+        it('returns an encoded URI anchor fragment', function(done) {
+            var wikipedia = iD.uiFieldWikipedia(field, context).entityIDs([entity.id]);
+            // this can be similarily tested by entering 'Section#Arts, entertainment and media' in the search box before focusing out'
+            expect(wikipedia.encodeURIAnchorFragment('Theme?')).to.equal('#Theme%3F');
+            done();
+        });
+
+        it('replaces all whitespace characters with underscore', function(done) {
+            var wikipedia = iD.uiFieldWikipedia(field, context).entityIDs([entity.id]);
+            expect(wikipedia.encodeURIAnchorFragment('Themes And Styles')).to.equal('#Themes_And_Styles');
+            done();
+        });
+
+        it('encodes % characters, does not replace them with a dot', function(done) {
+            var wikipedia = iD.uiFieldWikipedia(field, context).entityIDs([entity.id]);
+            expect(wikipedia.encodeURIAnchorFragment('Is%this_100% correct')).to.equal('#Is%25this_100%25_correct');
+            done();
+        });
+
+        it('encodes characters that are URI encoded characters', function (done) {
+            var wikipedia = iD.uiFieldWikipedia(field, context).entityIDs([entity.id]);
+            expect(wikipedia.encodeURIAnchorFragment('Section %20%25')).to.equal('#Section_%2520%2525');
+            done();
+        });
     });
 
     // note - currently skipping the tests that use `options` to delay responses


### PR DESCRIPTION
### Description 

closes #10065 by 

-  URL encoding wikiURL tag on change

#### Refacrtor

- Define wikipedia domain URL and scheme for reuse
- Extract toUrlAnchor as its own function for reuse 

### How was this tested?

- Executed the full unit test suite
- Added a unit tests to cover my changes
- ~Would do with complete assertion on the unit test to check the set wikiURL but was unable to expose it to test suite~
- Verified by running the application locally and auto filling various wikipedia URLs containing characters requiring URL encoding, such as `https://en.wikipedia.org/wiki/%3F_(film)` _and followed by some section header as anchor, directly_.
