### PR TITLE
Fix roadheight field width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Upgrade closed ways with `traffic_calming=island` to `area:highway=traffic_calming` ([id-tagging-schema#1162])
 #### :bug: Bugfixes
 * Prevent (route) relations from getting corrupted while splitting their way members in certain conditions ([#7653], [#8415])
+* Fix overflowing UI input elements of maxheight field when in imperial units mode on Firefox ([#10175], thanks [@1ec5]) 
 #### :earth_asia: Localization
 #### :hourglass: Performance
 #### :mortar_board: Walkthrough / Help
@@ -62,6 +63,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#9439]: https://github.com/openstreetmap/iD/issues/9439
 [#10135]: https://github.com/openstreetmap/iD/issues/10135
 [#10145]: https://github.com/openstreetmap/iD/issues/10145
+[#10175]: https://github.com/openstreetmap/iD/pull/10175
 [id-tagging-schema#1162]: https://github.com/openstreetmap/id-tagging-schema/issues/1162
 [@Sushil642]: https://github.com/Sushil642
 [@mattiapezzotti]: https://github.com/mattiapezzotti

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -2055,6 +2055,7 @@ input.date-selector {
 .form-field-input-roadheight input.roadheight-secondary-number,
 .form-field-input-roadspeed input.roadspeed-number {
     flex-basis: 0;
+    width: 0;
 }
 .form-field-input-roadheight input.roadheight-unit,
 .form-field-input-roadheight input.roadheight-secondary-unit {


### PR DESCRIPTION
Recent versions of Firefox give input fields a greater intrinsic width that causes `roadheight` fields to overflow the container. Constrain these input fields to an initial width of zero; they’ll grow proportionally as part of the flexbox.

<img src="https://github.com/openstreetmap/iD/assets/1231218/4e3876cb-fe76-4aa6-be60-4fe150fa40f5" width="399" alt="The four text fields that make up the Road Height field no longer overflow horizontally.">

Fixes #10174.