### PR TITLE
Sort "more fields" dropdown items

### DIFF
--- a/modules/ui/form_fields.js
+++ b/modules/ui/form_fields.js
@@ -16,7 +16,8 @@ export function uiFormFields(context) {
     function formFields(selection) {
         var allowedFields = _fieldsArr.filter(function(field) { return field.isAllowed(); });
         var shown = allowedFields.filter(function(field) { return field.isShown(); });
-        var notShown = allowedFields.filter(function(field) { return !field.isShown(); });
+        var notShown = allowedFields.filter(function(field) { return !field.isShown(); })
+            .sort(function(a, b) { return (a.universal === b.universal ? 0 : a.universal ? 1 : -1); });
 
         var container = selection.selectAll('.form-fields-container')
             .data([0]);


### PR DESCRIPTION
The more fields combo dropdown offers 1) `moreFields` from the current preset and 2) all fields with `universal:true`. Currently they are all mixed together.

This PR sorts the dropdown so the moreFields are displayed first, and the universal below.

The idea is, that user would like to know which fields are relevant to the specific preset first, and not to look for them among all the universal ones.


###  Screenshot 

eg. for **train track** (w166662057)

| old | this PR |
| -- | -- |
| <img width="243" alt="image" src="https://github.com/openstreetmap/iD/assets/385047/4fe6de70-64c6-436c-82da-028f636685c1"> | <img width="234" alt="image" src="https://github.com/openstreetmap/iD/assets/385047/bf779e9e-da4c-4363-960c-8251beffdc85"> | 

