### PR TITLE
fix double click bug in note comment

### DIFF
--- a/modules/ui/note_editor.js
+++ b/modules/ui/note_editor.js
@@ -371,7 +371,9 @@ export function uiNoteEditor(context) {
                 var andComment = (d.newComment ? '_comment' : '');
                 return t.html('note.' + action + andComment);
             })
-            .on('click.status', clickStatus);
+            .on('click.status', clickStatus)
+            .select('span')       // fix double click bug - #8994
+            .attr('style', 'pointer-events: none;');
 
         buttonSection.select('.comment-button')   // select and propagate data
             .attr('disabled', isSaveDisabled)

--- a/modules/ui/note_editor.js
+++ b/modules/ui/note_editor.js
@@ -370,10 +370,9 @@ export function uiNoteEditor(context) {
                 var action = (d.status === 'open' ? 'close' : 'open');
                 var andComment = (d.newComment ? '_comment' : '');
                 return t.html('note.' + action + andComment);
-            })
-            .on('click.status', clickStatus)
-            .select('span')       // fix double click bug - #8994
-            .attr('style', 'pointer-events: none;');
+            });
+        buttonSection.select('.status-button')
+            .on('click.status', clickStatus);
 
         buttonSection.select('.comment-button')   // select and propagate data
             .attr('disabled', isSaveDisabled)


### PR DESCRIPTION
fix: #8994 

I tested it, it should fixed , plz test

``` <button><span></span></button> ```
the bug is when you click span part it bug but if click button part it work, 
see: https://css-tricks.com/slightly-careful-sub-elements-clickable-things/ 

There are also has same``` <button><span></span></button> ```structure in context ,
maybe consider fix it 
