### PR TITLE
render oneway arrows for the `conveying` tag

### DIFF
--- a/modules/osm/tags.js
+++ b/modules/osm/tags.js
@@ -135,6 +135,11 @@ export var osmOneWayTags = {
         't-bar': true,
         'zip_line': true
     },
+    'conveying': {
+        'forward': true,
+        'backward': true,
+        'reversible': true,
+    },
     'highway': {
         'motorway': true
     },

--- a/modules/svg/lines.js
+++ b/modules/svg/lines.js
@@ -254,9 +254,18 @@ export function svgLines(projection, context) {
             var onewayArr = v.filter(function(d) { return d.isOneWay(); });
             var onewaySegments = svgMarkerSegments(
                 projection, graph, 35,
-                function shouldReverse(entity) { return entity.tags.oneway === '-1'; },
+                function shouldReverse(entity) {
+                    return (
+                        entity.tags.oneway === '-1'
+                        || entity.tags.conveying === 'backward'
+                    );
+                },
                 function bothDirections(entity) {
-                    return entity.tags.oneway === 'reversible' || entity.tags.oneway === 'alternating';
+                    return (
+                        entity.tags.oneway === 'alternating'
+                        || entity.tags.oneway === 'reversible'
+                        || entity.tags.conveying === 'reversible'
+                    );
                 }
             );
             onewaydata[k] = utilArrayFlatten(onewayArr.map(onewaySegments));


### PR DESCRIPTION
When mapping escalators, it's a bit confusing to figure out what 'forwards' and 'backwards' means. 

This PR makes it much easier to map escalators, by rendering oneway arrows for the `conveying` tag:

![image](https://github.com/openstreetmap/iD/assets/16009897/4d66cf2f-ebe5-4ce1-9d7d-f2a4459f3d0e)
