### PR TITLE
render shared bicycle/foot paths with a dedicated colour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 # Unreleased (2.40.0-dev)
 
 #### :sparkles: Usability & Accessibility
+* Render shared bicycle/foot paths with a dedicated colour ([#10256], thanks [@k-yle])
 #### :scissors: Operations
 * Correctly split a way on all selected vertices when three or more nodes are selected ([#12120])
 * Create fewer points when circularizing small features (and vice versa): the number of vertices in the resulting circle is now dynamic between a 12 and 32 depending on the radius of the circle (instead of always resulting in 19 nodes) ([#12139])
@@ -63,6 +64,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Add type annotations to `context.js` module ([#11589], thanks [@k-yle])
 
 [#9406]: https://github.com/openstreetmap/iD/issues/9406
+[#10256]: https://github.com/openstreetmap/iD/pull/10256
 [#11589]: https://github.com/openstreetmap/iD/pull/11589
 [#12010]: https://github.com/openstreetmap/iD/pull/12010
 [#12050]: https://github.com/openstreetmap/iD/issues/12050
@@ -75,6 +77,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#12110]: https://github.com/openstreetmap/iD/issues/12110
 [#12120]: https://github.com/openstreetmap/iD/issues/12120
 [#12139]: https://github.com/openstreetmap/iD/pull/12139
+
 
 
 # 2.39.5

--- a/css/30_highways.css
+++ b/css/30_highways.css
@@ -588,6 +588,27 @@ path.line.stroke.tag-highway-cycleway,
     stroke: #fff;
 }
 
+/* shared paths */
+path.line.casing.tag-highway-cycleway.tag-foot-designated:not(.tag-crossing),
+path.line.casing.tag-highway-path.tag-bicycle-designated.tag-foot-designated:not(.tag-crossing) {
+    stroke: #fff;
+}
+.preset-icon .icon.tag-highway-cycleway.tag-foot-designated,
+.preset-icon .icon.tag-highway-path.tag-bicycle-designated.tag-foot-designated {
+    color: #b458ed;
+    fill: #fff;
+}
+path.line.stroke.tag-highway-cycleway.tag-foot-designated,
+path.line.stroke.tag-highway-path.tag-bicycle-designated.tag-foot-designated,
+.preset-icon-container path.casing.tag-highway-cycleway.tag-foot-designated,
+.preset-icon-container path.casing.tag-highway-path.tag-bicycle-designated.tag-foot-designated {
+    stroke: #b458ed;
+}
+.preset-icon-container path.stroke.tag-highway-cycleway.tag-foot-designated:not(.tag-crossing),
+.preset-icon-container path.stroke.tag-highway-path.tag-bicycle-designated.tag-foot-designated:not(.tag-crossing) {
+    stroke: #fff;
+}
+
 /* bridleways */
 .preset-icon .icon.tag-route-horse,
 .preset-icon .icon.tag-highway-bridleway {

--- a/modules/svg/tag_classes.js
+++ b/modules/svg/tag_classes.js
@@ -14,7 +14,7 @@ export function svgTagClasses() {
         'oneway', 'bridge', 'tunnel', 'embankment', 'cutting', 'barrier',
         'surface', 'tracktype', 'footway', 'crossing', 'service', 'sport',
         'public_transport', 'location', 'parking', 'golf', 'type', 'leisure',
-        'man_made', 'indoor', 'construction', 'proposed'
+        'man_made', 'indoor', 'construction', 'proposed', 'bicycle', 'foot'
     ];
     var _tags = function(entity) { return entity.tags; };
 
@@ -61,15 +61,9 @@ export function svgTagClasses() {
 
         // pick at most one primary classification tag..
         for (i = 0; i < primaries.length; i++) {
-            k = primaries[i];
+            k = primaries[i].replace(':', '_');
             v = t[k];
             if (!v || v === 'no') continue;
-
-            if (k === 'piste:type') {  // avoid a ':' in the class name
-                k = 'piste';
-            } else if (k === 'building:part') {  // avoid a ':' in the class name
-                k = 'building_part';
-            }
 
             primary = k;
             if (statuses.indexOf(v) !== -1) {   // e.g. `railway=abandoned`


### PR DESCRIPTION
Closes #8485, Closes #10139, closes #2327

Currently, it's impossible to tell the difference between the `Cycleway` and `Cycle + Foot Path` presets.

There are [6 special countries](https://github.com/openstreetmap/id-tagging-schema/blob/e11a6d2c7468267ea4e579a8dc8a7e4487f34729/data/presets/highway/cycleway/bicycle_foot.json#L4-L9) that use a different preset, which is simiarly confusing, since it renders exactly the same as `crossing=*`.

This PR makes the styling consistent for `bicycle=designated` + `foot=designated`, regardless of whether you use `highway=path` or `highway=cycleway`

<table>
<tr>
 <td><strong>Before
 <td><img src="https://github.com/openstreetmap/iD/assets/16009897/ee2fb951-3725-4ca8-bcd8-68c65bcfdb57" />
<tr>
 <td><strong>After
 <td><img src="https://github.com/openstreetmap/iD/assets/16009897/b1f48323-dc90-4ba1-a192-c2837b2c5b99" /><br />(only the bottom 2 have changed)
</table>

