### PR TITLE
support `highway=ladder`

### DIFF
--- a/css/30_highways.css
+++ b/css/30_highways.css
@@ -253,6 +253,7 @@ path.line.shadow.tag-highway-footway,
 path.line.shadow.tag-highway-cycleway,
 path.line.shadow.tag-highway-bridleway,
 path.line.shadow.tag-highway-corridor,
+path.line.shadow.tag-highway-ladder,
 path.line.shadow.tag-highway-steps {
     stroke-width: 16;
 }
@@ -261,6 +262,7 @@ path.line.casing.tag-highway-footway,
 path.line.casing.tag-highway-cycleway,
 path.line.casing.tag-highway-bridleway,
 path.line.casing.tag-highway-corridor,
+path.line.casing.tag-highway-ladder,
 path.line.casing.tag-highway-steps {
     stroke-width: 5;
 }
@@ -269,6 +271,7 @@ path.line.stroke.tag-highway-footway,
 path.line.stroke.tag-highway-cycleway,
 path.line.stroke.tag-highway-bridleway,
 path.line.stroke.tag-highway-corridor,
+path.line.stroke.tag-highway-ladder,
 path.line.stroke.tag-highway-steps {
     stroke-width: 3;
 }
@@ -306,6 +309,7 @@ path.line.stroke.tag-highway-steps {
 .low-zoom path.line.shadow.tag-highway-cycleway,
 .low-zoom path.line.shadow.tag-highway-bridleway,
 .low-zoom path.line.shadow.tag-highway-corridor,
+.low-zoom path.line.shadow.tag-highway-ladder,
 .low-zoom path.line.shadow.tag-highway-steps {
     stroke-width: 12;
 }
@@ -314,6 +318,7 @@ path.line.stroke.tag-highway-steps {
 .low-zoom path.line.casing.tag-highway-cycleway,
 .low-zoom path.line.casing.tag-highway-bridleway,
 .low-zoom path.line.casing.tag-highway-corridor,
+.low-zoom path.line.casing.tag-highway-ladder,
 .low-zoom path.line.casing.tag-highway-steps {
     stroke-width: 3;
 }
@@ -322,6 +327,7 @@ path.line.stroke.tag-highway-steps {
 .low-zoom path.line.stroke.tag-highway-cycleway,
 .low-zoom path.line.stroke.tag-highway-bridleway,
 .low-zoom path.line.stroke.tag-highway-corridor,
+.low-zoom path.line.stroke.tag-highway-ladder,
 .low-zoom path.line.stroke.tag-highway-steps {
     stroke-width: 1;
 }
@@ -565,27 +571,34 @@ path.line.stroke.tag-leisure-track,
 }
 
 /* steps */
-.preset-icon .icon.tag-highway-steps {
+.preset-icon .icon.tag-highway-steps,
+.preset-icon .icon.tag-highway-ladder {
     color: #81d25c;
     fill: #fff;
 }
-path.line.stroke.tag-highway-steps {
+path.line.stroke.tag-highway-steps,
+path.line.stroke.tag-highway-ladder {
     stroke-linecap: butt;
     stroke-dasharray: 3, 3;
 }
-.low-zoom path.line.stroke.tag-highway-steps {
+.low-zoom path.line.stroke.tag-highway-steps,
+.low-zoom path.line.stroke.tag-highway-ladder {
     stroke-dasharray: 2, 2;
 }
-path.line.casing.tag-highway-steps {
+path.line.casing.tag-highway-steps,
+path.line.casing.tag-highway-ladder {
     stroke: #fff;
     stroke-linecap: round;
     stroke-dasharray: none;
 }
 path.line.stroke.tag-highway-steps,
-.preset-icon-container path.line.casing.tag-highway-steps {
+path.line.stroke.tag-highway-ladder,
+.preset-icon-container path.line.casing.tag-highway-steps,
+.preset-icon-container path.line.casing.tag-highway-ladder {
     stroke: #81d25c;
 }
-.preset-icon-container path.line.stroke.tag-highway-steps {
+.preset-icon-container path.line.stroke.tag-highway-steps,
+.preset-icon-container path.line.stroke.tag-highway-ladder {
     stroke: #fff;
 }
 
@@ -638,6 +651,7 @@ path.line.stroke.tag-highway.tag-footway-access_aisle {
 /* highway midpoints */
 g.midpoint.tag-highway-corridor .fill,
 g.midpoint.tag-highway-steps .fill,
+g.midpoint.tag-highway-ladder .fill,
 g.midpoint.tag-highway-path .fill,
 g.midpoint.tag-highway-footway .fill,
 g.midpoint.tag-highway-cycleway .fill,

--- a/css/50_misc.css
+++ b/css/50_misc.css
@@ -287,6 +287,7 @@ path.line.shadow.tag-highway-pedestrian.tag-bridge,
 path.line.shadow.tag-highway-service.tag-bridge,
 path.line.shadow.tag-highway-track.tag-bridge,
 path.line.shadow.tag-highway-steps.tag-bridge,
+path.line.shadow.tag-highway-ladder.tag-bridge,
 path.line.shadow.tag-highway-footway.tag-bridge,
 path.line.shadow.tag-highway-cycleway.tag-bridge,
 path.line.shadow.tag-highway-bridleway.tag-bridge {
@@ -300,6 +301,7 @@ path.line.casing.tag-highway-pedestrian.tag-bridge,
 path.line.casing.tag-highway-service.tag-bridge,
 path.line.casing.tag-highway-track.tag-bridge,
 path.line.casing.tag-highway-steps.tag-bridge,
+path.line.casing.tag-highway-ladder.tag-bridge,
 path.line.casing.tag-highway-footway.tag-bridge,
 path.line.casing.tag-highway-cycleway.tag-bridge,
 path.line.casing.tag-highway-bridleway.tag-bridge {
@@ -314,6 +316,7 @@ path.line.casing.tag-highway-bridleway.tag-bridge {
 .low-zoom path.line.shadow.tag-highway-service.tag-bridge,
 .low-zoom path.line.shadow.tag-highway-track.tag-bridge,
 .low-zoom path.line.shadow.tag-highway-steps.tag-bridge,
+.low-zoom path.line.shadow.tag-highway-ladder.tag-bridge,
 .low-zoom path.line.shadow.tag-highway-footway.tag-bridge,
 .low-zoom path.line.shadow.tag-highway-cycleway.tag-bridge,
 .low-zoom path.line.shadow.tag-highway-bridleway.tag-bridge {
@@ -327,6 +330,7 @@ path.line.casing.tag-highway-bridleway.tag-bridge {
 .low-zoom path.line.casing.tag-highway-service.tag-bridge,
 .low-zoom path.line.casing.tag-highway-track.tag-bridge,
 .low-zoom path.line.casing.tag-highway-steps.tag-bridge,
+.low-zoom path.line.casing.tag-highway-ladder.tag-bridge,
 .low-zoom path.line.casing.tag-highway-footway.tag-bridge,
 .low-zoom path.line.casing.tag-highway-cycleway.tag-bridge,
 .low-zoom path.line.casing.tag-highway-bridleway.tag-bridge {
@@ -455,14 +459,18 @@ path.line.shadow.tag-highway.tag-status.tag-status-construction.tag-construction
 path.line.shadow.tag-highway.tag-status.tag-status-construction.tag-construction-footway,
 path.line.shadow.tag-highway.tag-status.tag-status-construction.tag-construction-cycleway,
 path.line.shadow.tag-highway.tag-status.tag-status-construction.tag-construction-bridleway,
-path.line.shadow.tag-highway.tag-status.tag-status-construction.tag-construction-steps {
+path.line.shadow.tag-highway.tag-status.tag-status-construction.tag-construction-corridor,
+path.line.shadow.tag-highway.tag-status.tag-status-construction.tag-construction-steps,
+path.line.shadow.tag-highway.tag-status.tag-status-construction.tag-construction-ladder {
     stroke-width: 15;
 }
 path.line.casing.tag-highway.tag-status.tag-status-construction.tag-construction-path,
 path.line.casing.tag-highway.tag-status.tag-status-construction.tag-construction-footway,
 path.line.casing.tag-highway.tag-status.tag-status-construction.tag-construction-cycleway,
 path.line.casing.tag-highway.tag-status.tag-status-construction.tag-construction-bridleway,
-path.line.casing.tag-highway.tag-status.tag-status-construction.tag-construction-steps {
+path.line.casing.tag-highway.tag-status.tag-status-construction.tag-construction-corridor,
+path.line.casing.tag-highway.tag-status.tag-status-construction.tag-construction-steps,
+path.line.casing.tag-highway.tag-status.tag-status-construction.tag-construction-ladder {
     stroke-width: 5;
     stroke-linecap: butt;
     stroke-dasharray: none
@@ -471,7 +479,9 @@ path.line.stroke.tag-highway.tag-status.tag-status-construction.tag-construction
 path.line.stroke.tag-highway.tag-status.tag-status-construction.tag-construction-footway,
 path.line.stroke.tag-highway.tag-status.tag-status-construction.tag-construction-cycleway,
 path.line.stroke.tag-highway.tag-status.tag-status-construction.tag-construction-bridleway,
-path.line.stroke.tag-highway.tag-status.tag-status-construction.tag-construction-steps {
+path.line.stroke.tag-highway.tag-status.tag-status-construction.tag-construction-corridor,
+path.line.stroke.tag-highway.tag-status.tag-status-construction.tag-construction-steps,
+path.line.stroke.tag-highway.tag-status.tag-status-construction.tag-construction-ladder {
     stroke-width: 4;
     stroke-linecap: butt;
     stroke-dasharray: 10, 10;
@@ -482,28 +492,32 @@ path.line.shadow.tag-highway.tag-status.tag-status-proposed.tag-proposed-path,
 path.line.shadow.tag-highway.tag-status.tag-status-proposed.tag-proposed-footway,
 path.line.shadow.tag-highway.tag-status.tag-status-proposed.tag-proposed-cycleway,
 path.line.shadow.tag-highway.tag-status.tag-status-proposed.tag-proposed-bridleway,
-path.line.shadow.tag-highway.tag-status.tag-status-proposed.tag-proposed-steps {
+path.line.shadow.tag-highway.tag-status.tag-status-proposed.tag-proposed-steps,
+path.line.shadow.tag-highway.tag-status.tag-status-proposed.tag-proposed-ladder {
     stroke-width: 15;
 }
 path.line.casing.tag-highway.tag-status.tag-status-proposed.tag-proposed-path,
 path.line.casing.tag-highway.tag-status.tag-status-proposed.tag-proposed-footway,
 path.line.casing.tag-highway.tag-status.tag-status-proposed.tag-proposed-cycleway,
 path.line.casing.tag-highway.tag-status.tag-status-proposed.tag-proposed-bridleway,
-path.line.casing.tag-highway.tag-status.tag-status-proposed.tag-proposed-steps {
+path.line.casing.tag-highway.tag-status.tag-status-proposed.tag-proposed-steps,
+path.line.casing.tag-highway.tag-status.tag-status-proposed.tag-proposed-ladder {
     stroke-width: 4.5;
 }
 path.line.casing.tag-highway.tag-bridge.tag-status.tag-status-proposed.tag-proposed-path,
 path.line.casing.tag-highway.tag-bridge.tag-status.tag-status-proposed.tag-proposed-footway,
 path.line.casing.tag-highway.tag-bridge.tag-status.tag-status-proposed.tag-proposed-cycleway,
 path.line.casing.tag-highway.tag-bridge.tag-status.tag-status-proposed.tag-proposed-bridleway,
-path.line.casing.tag-highway.tag-bridge.tag-status.tag-status-proposed.tag-proposed-steps {
+path.line.casing.tag-highway.tag-bridge.tag-status.tag-status-proposed.tag-proposed-steps,
+path.line.casing.tag-highway.tag-bridge.tag-status.tag-status-proposed.tag-proposed-ladder {
     stroke-width: 10;
 }
 path.line.stroke.tag-highway.tag-status.tag-status-proposed.tag-proposed-path,
 path.line.stroke.tag-highway.tag-status.tag-status-proposed.tag-proposed-footway,
 path.line.stroke.tag-highway.tag-status.tag-status-proposed.tag-proposed-cycleway,
 path.line.stroke.tag-highway.tag-status.tag-status-proposed.tag-proposed-bridleway,
-path.line.stroke.tag-highway.tag-status.tag-status-proposed.tag-proposed-steps {
+path.line.stroke.tag-highway.tag-status.tag-status-proposed.tag-proposed-steps,
+path.line.stroke.tag-highway.tag-status.tag-status-proposed.tag-proposed-ladder {
     stroke-width: 3;
 }
 

--- a/modules/osm/tags.js
+++ b/modules/osm/tags.js
@@ -224,11 +224,11 @@ export var osmRoutableHighwayTagValues = {
     motorway: true, trunk: true, primary: true, secondary: true, tertiary: true, residential: true,
     motorway_link: true, trunk_link: true, primary_link: true, secondary_link: true, tertiary_link: true,
     unclassified: true, road: true, service: true, track: true, living_street: true, bus_guideway: true, busway: true,
-    path: true, footway: true, cycleway: true, bridleway: true, pedestrian: true, corridor: true, steps: true
+    path: true, footway: true, cycleway: true, bridleway: true, pedestrian: true, corridor: true, steps: true, ladder: true
 };
 // "highway" tag values that generally do not allow motor vehicles
 export var osmPathHighwayTagValues = {
-    path: true, footway: true, cycleway: true, bridleway: true, pedestrian: true, corridor: true, steps: true
+    path: true, footway: true, cycleway: true, bridleway: true, pedestrian: true, corridor: true, steps: true, ladder: true
 };
 
 // "railway" tag values representing existing railroad tracks (purposely does not include 'abandoned')

--- a/modules/osm/way.js
+++ b/modules/osm/way.js
@@ -111,7 +111,7 @@ Object.assign(osmWay.prototype, {
                 primary_link: 4, secondary_link: 4, tertiary_link: 4,
                 unclassified: 4, road: 4, living_street: 4, bus_guideway: 4, busway: 4, pedestrian: 4,
                 residential: 3.5, service: 3.5, track: 3, cycleway: 2.5,
-                bridleway: 2, corridor: 2, steps: 2, path: 1.5, footway: 1.5
+                bridleway: 2, corridor: 2, steps: 2, path: 1.5, footway: 1.5, ladder: 0.5,
             },
             railway: { // width includes ties and rail bed, not just track gauge
                 rail: 2.5, light_rail: 2.5, tram: 2.5, subway: 2.5,

--- a/modules/renderer/features.js
+++ b/modules/renderer/features.js
@@ -40,6 +40,7 @@ export function rendererFeatures(context) {
         'cycleway': true,
         'bridleway': true,
         'steps': true,
+        'ladder': true,
         'pedestrian': true
     };
 

--- a/modules/ui/fields/access.js
+++ b/modules/ui/fields/access.js
@@ -120,6 +120,12 @@ export function uiFieldAccess(field, context) {
                 bicycle: 'no',
                 horse: 'no'
             },
+            ladder: {
+                foot: 'yes',
+                motor_vehicle: 'no',
+                bicycle: 'no',
+                horse: 'no'
+            },
             pedestrian: {
                 foot: 'yes',
                 motor_vehicle: 'no'


### PR DESCRIPTION
 `highway=ladder` was recently approved, and iD recently added a preset for it (see openstreetmap/id-tagging-schema#1153).

However, it causes validation errors in iD, since it isn't registered as a routable highway type. It also looks quite strange; it's rendered much thicker than other paths.

This PR fixes both issues. It now renders the same as `highway=stairs`

<table>
<tr>
 <td><strong>Before
 <td><strong>After
<tr>
 <td><img src="https://github.com/openstreetmap/iD/assets/16009897/cbaebc95-339f-4021-9cf1-decc9f8ba8f3" />
 <td><img src="https://github.com/openstreetmap/iD/assets/16009897/4d9eb70a-5063-469c-91e9-4f448dcf6c8b" />
<tr>
 <td><img src="https://github.com/openstreetmap/iD/assets/16009897/c6f715ac-ef29-4a48-9ccf-64b119268f12" />
 <td><img src="https://github.com/openstreetmap/iD/assets/16009897/87a6f027-7d80-4c12-b68f-8227474129e2" />
</table>
