### PR TITLE
fix wikidata styling not applying to vertices

### DIFF
--- a/css/20_map.css
+++ b/css/20_map.css
@@ -294,12 +294,14 @@ text.point {
 
 
 /* Wikidata-tagged */
-g.point.tag-wikidata path.stroke {
+g.point.tag-wikidata path.stroke,
+g.vertex.tag-wikidata circle.stroke {
     stroke-width: 2px;
     stroke: #666;
     fill: #eee;
 }
-g.point.tag-wikidata .icon {
+g.point.tag-wikidata .icon,
+g.vertex.tag-wikidata .icon {
     color: #666;
 }
 

--- a/modules/svg/vertices.js
+++ b/modules/svg/vertices.js
@@ -5,6 +5,7 @@ import { presetManager } from '../presets';
 import { geoScaleToZoom } from '../geo';
 import { osmEntity } from '../osm';
 import { svgPassiveVertex, svgPointTransform } from './helpers';
+import { svgTagClasses } from './tag_classes';
 
 export function svgVertices(projection, context) {
     var radiuses = {
@@ -140,6 +141,7 @@ export function svgVertices(projection, context) {
             .classed('retagged', function(d) {
                 return base.entities[d.id] && !deepEqual(graph.entities[d.id].tags, base.entities[d.id].tags);
             })
+            .call(svgTagClasses())
             .call(updateAttributes);
 
         // Vertices with icons get a `use`.


### PR DESCRIPTION
Nodes with a `*:wikidata` tag normally render in a special grey colour. However, this does not work for vertices.

This PR fixes the bug.

<table>
<tr>
 <td><strong>Before
 <td><strong>After
<tr>
 <td><img src="https://github.com/openstreetmap/iD/assets/16009897/0908f09f-a2ef-451a-ab56-db6486509e83" />
 <td><img src="https://github.com/openstreetmap/iD/assets/16009897/c02841c8-c873-4778-90b6-feaa381d99c3" />
</table>
only the bottom left example has changed
