### PR TITLE
Add waterway=flowline to waterway tags representing directional water flows

### DIFF
--- a/modules/osm/tags.js
+++ b/modules/osm/tags.js
@@ -167,6 +167,7 @@ export var osmOneWayTags = {
         'ditch': true,
         'drain': true,
         'fish_pass': true,
+        'flowline': true,
         'pressurised': true,
         'river': true,
         'spillway': true,
@@ -245,7 +246,7 @@ export var osmRailwayTrackTagValues = {
 
 // "waterway" tag values for line features representing water flow
 export var osmFlowingWaterwayTagValues = {
-    canal: true, ditch: true, drain: true, fish_pass: true, river: true, stream: true, tidal_channel: true
+    canal: true, ditch: true, drain: true, fish_pass: true, flowline: true, river: true, stream: true, tidal_channel: true
 };
 
 // Tags which values should be considered case sensitive when offering tag suggestions


### PR DESCRIPTION
Currently, lines with `waterway=flowline` are represented as generic waterway features, and don't get the arrows pointing in the water flow direction along their length (as is the case with rivers, streams, canals, etc.). This change adds the tag so the representation is consistent with the other flowing waterway tags.
