### PR TITLE
adding Thailand to address_formats.json

### DIFF
--- a/data/address_formats.json
+++ b/data/address_formats.json
@@ -284,5 +284,14 @@
       ["postcode", "city"],
       ["street", "housenumber"]
     ]
+  },
+  {
+    "countryCodes": ["th"],
+    "format": [
+      ["housenumber", "place"],
+      ["street"],
+      ["subdistrict", "district"],
+      ["province", "postcode"]
+    ]
   }
 ]


### PR DESCRIPTION
based on local community consensus:

https://community.openstreetmap.org/t/correct-way-to-tag-a-thai-address-with-example/113105/30