### PR TITLE
Filter underground

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -929,6 +929,9 @@ en:
     past_future:
       description: Past/Future Features
       tooltip: "Proposed, Construction, Abandoned, Demolished, etc."
+    underground:
+      description: Unterground
+      tooltip: "Unterground features or negative level"
     others:
       description: Other Features
       tooltip: "Everything Else"

--- a/modules/core/preferences.js
+++ b/modules/core/preferences.js
@@ -20,7 +20,7 @@ const _listeners = {};
 //
 /**
  * @param {string} k
- * @param {string?} v
+ * @param {string?} [v]
  * @returns {boolean} true if the action succeeded
  */
 function corePreferences(k, v) {

--- a/modules/renderer/features.js
+++ b/modules/renderer/features.js
@@ -138,6 +138,13 @@ export function rendererFeatures(context) {
         return !!tags.indoor;
     });
 
+    defineRule('underground', function isUnterground(tags) {
+        // console.log('xx', tags, tags?.layer?.startsWith('-'), tags?.location === 'underground')
+        if (tags?.layer?.startsWith('-')) return true;
+        if (tags?.location === 'underground') return true;
+        return false;
+    });
+
     defineRule('landuse', function isLanduse(tags, geometry) {
         return geometry === 'area' && (
             !!tags.landuse ||
@@ -197,7 +204,7 @@ export function rendererFeatures(context) {
     });
 
     defineRule('pistes', function isPiste(tags) {
-        return tags['piste:type'];
+        return !!tags['piste:type'];
     });
 
     defineRule('aerialways', function isAerialways(tags) {

--- a/modules/renderer/features.js
+++ b/modules/renderer/features.js
@@ -72,9 +72,16 @@ export function rendererFeatures(context) {
 
 
     /**
+     * @callback FilterFunction
+     * @param {Record<string, string>} tags
+     * @param {string} [geometry]
+     * @returns {boolean}
+     */
+
+    /**
      * @param {string} k
-     * @param {(tags: Record<string, string>, geometry: string) => boolean} filter
-     * @param {?number} max
+     * @param {FilterFunction} filter
+     * @param {number} [max]
      */
     function defineRule(k, filter, max) {
         var isEnabled = true;
@@ -124,11 +131,11 @@ export function rendererFeatures(context) {
     }, 250);
 
     defineRule('building_parts', function isBuildingPart(tags) {
-        return tags['building:part'];
+        return !!tags['building:part'];
     });
 
     defineRule('indoor', function isIndoor(tags) {
-        return tags.indoor;
+        return !!tags.indoor;
     });
 
     defineRule('landuse', function isLanduse(tags, geometry) {
@@ -194,9 +201,7 @@ export function rendererFeatures(context) {
     });
 
     defineRule('aerialways', function isAerialways(tags) {
-        return tags.aerialway &&
-            tags.aerialway !== 'yes' &&
-            tags.aerialway !== 'station';
+        return tags?.aerialway !== 'yes' && tags?.aerialway !== 'station';
     });
 
     defineRule('power', function isPower(tags) {
@@ -260,7 +265,7 @@ export function rendererFeatures(context) {
         if (!arguments.length) {
             return _keys.filter(function(k) { return _rules[k].hidden(); });
         }
-        return _rules[k] && _rules[k].hidden();
+        return _rules[k]?.hidden();
     };
 
 

--- a/test/spec/renderer/features.js
+++ b/test/spec/renderer/features.js
@@ -17,7 +17,7 @@ describe('iD.rendererFeatures', function() {
             expect(keys).to.include(
                 'points', 'traffic_roads', 'service_roads', 'paths',
                 'buildings', 'landuse', 'boundaries', 'water', 'rail',
-                'power', 'past_future', 'others'
+                'power', 'past_future', 'underground', 'others'
             );
         });
     });
@@ -57,7 +57,7 @@ describe('iD.rendererFeatures', function() {
                 iD.osmNode({id: 'point_bar', tags: {amenity: 'bar'}, version: 1}),
                 iD.osmNode({id: 'point_dock', tags: {waterway: 'dock'}, version: 1}),
                 iD.osmNode({id: 'point_rail_station', tags: {railway: 'station'}, version: 1}),
-                iD.osmNode({id: 'point_generator', tags: {power: 'generator'}, version: 1}),
+                iD.osmNode({id: 'point_generator', tags: {power: 'generator', layer: '-2'}, version: 1}),
                 iD.osmNode({id: 'point_old_rail_station', tags: {railway: 'station', disused: 'yes'}, version: 1}),
                 iD.osmWay({id: 'motorway', tags: {highway: 'motorway'}, version: 1}),
                 iD.osmWay({id: 'building_yes', tags: {area: 'yes', amenity: 'school', building: 'yes'}, version: 1}),
@@ -77,6 +77,7 @@ describe('iD.rendererFeatures', function() {
             expect(stats.service_roads).to.eql(0);
             expect(stats.others).to.eql(1);
             expect(stats.past_future).to.eql(1);
+            expect(stats.underground).to.eql(1);
             expect(stats.paths).to.eql(0);
             expect(stats.points).to.eql(5);
             expect(stats.power).to.eql(1);


### PR DESCRIPTION
Attempt at fixing ~~https://github.com/openstreetmap/iD/issues/10322~~ #7261 by adding another filter.

However, this does not work ATM. It looks like a feature is only hidden when all filters hide it?
In my example
- http://127.0.0.1:8080/#background=Berlin-2023&disable_features=traffic_roads,underground,boundaries&id=n-1&map=21.41/52.51124/13.40554
- https://www.openstreetmap.org/edit?way=199847350#map=20/52.51122/13.40564

… the way is still visible, because it is also handled by the railway filter.

Is there a way around this? Like telling the `defineRule` to overwrite other rules @tyrasd?


---

Links: 
- https://wiki.openstreetmap.org/wiki/DE:Tag:location%3Dunderground