### PR TITLE
Fix localized field hidden despite nonempty subkeys

### DIFF
--- a/modules/ui/field.js
+++ b/modules/ui/field.js
@@ -97,6 +97,15 @@ export function uiField(context, presetField, entityIDs, options) {
                 }
                 return false;
             }
+            if (field.type === 'localized') {
+                for (let tagKey in _tags) {
+                    // matches for field:<code>, where <code> is a BCP 47 locale code
+                    let match = tagKey.match(/^(.*):([a-z]{2,3}(?:-[A-Z][a-z]{3})?(?:-[A-Z]{2})?)$/);
+                    if (match && match[1] === field.key && match[2]) {
+                        return true;
+                    }
+                }
+            }
             return _tags[key] !== undefined;
         });
     }

--- a/modules/ui/field.js
+++ b/modules/ui/field.js
@@ -8,6 +8,7 @@ import { uiTooltip } from './tooltip';
 import { geoExtent } from '../geo/extent';
 import { uiFieldHelp } from './field_help';
 import { uiFields } from './fields';
+import { LANGUAGE_SUFFIX_REGEX } from './fields/localized';
 import { uiTagReference } from './tag_reference';
 import { utilRebind, utilUniqueDomId } from '../util';
 
@@ -100,7 +101,7 @@ export function uiField(context, presetField, entityIDs, options) {
             if (field.type === 'localized') {
                 for (let tagKey in _tags) {
                     // matches for field:<code>, where <code> is a BCP 47 locale code
-                    let match = tagKey.match(/^(.*):([a-z]{2,3}(?:-[A-Z][a-z]{3})?(?:-[A-Z]{2})?)$/);
+                    let match = tagKey.match(LANGUAGE_SUFFIX_REGEX);
                     if (match && match[1] === field.key && match[2]) {
                         return true;
                     }

--- a/modules/ui/fields/localized.js
+++ b/modules/ui/fields/localized.js
@@ -14,6 +14,7 @@ import { uiLengthIndicator } from '../length_indicator';
 
 var _languagesArray = [];
 
+export const LANGUAGE_SUFFIX_REGEX = /^(.*):([a-z]{2,3}(?:-[A-Z][a-z]{3})?(?:-[A-Z]{2})?)$/;
 
 export function uiFieldLocalized(field, context) {
     var dispatch = d3_dispatch('change', 'input');
@@ -127,7 +128,7 @@ export function uiFieldLocalized(field, context) {
             // matches for field:<code>, where <code> is a BCP 47 locale code
             // motivation is to avoid matching on similarly formatted tags that are
             // not for languages, e.g. name:left, name:source, etc.
-            var m = k.match(/^(.*):([a-z]{2,3}(?:-[A-Z][a-z]{3})?(?:-[A-Z]{2})?)$/);
+            var m = k.match(LANGUAGE_SUFFIX_REGEX);
             if (m && m[1] === field.key && m[2]) {
                 var item = { lang: m[2], value: tags[k] };
                 if (existingLangs.has(item.lang)) {


### PR DESCRIPTION
Fix https://github.com/openstreetmap/iD/issues/10323

- Add logic to show a field of type `localized` that has any key beginning with the field’s key and a colon
- Use the same regular expression added in https://github.com/openstreetmap/iD/pull/9124 to test whether the field would show the subkey


https://github.com/user-attachments/assets/1c8e6be9-ef55-4b80-9090-8f141b843825

