### PR TITLE
allow to enter strings with quote marks in raw tag editor's text mode

### DIFF
--- a/modules/ui/sections/raw_tag_editor.js
+++ b/modules/ui/sections/raw_tag_editor.js
@@ -332,7 +332,11 @@ export function uiSectionRawTagEditor(id, context) {
     function unstringify(s) {
         const isQuoted = s.length > 1 && s.charAt(0) === '"' && s.charAt(s.length - 1) === '"';
         if (isQuoted) {
-            return JSON.parse(s);
+            try {
+                return JSON.parse(s);
+            } catch {
+                return s;
+            }
         } else {
             return s;
         }

--- a/modules/ui/sections/raw_tag_editor.js
+++ b/modules/ui/sections/raw_tag_editor.js
@@ -321,21 +321,21 @@ export function uiSectionRawTagEditor(id, context) {
     }
 
     function stringify(s) {
-        return JSON.stringify(s).slice(1, -1);   // without leading/trailing "
+        const stringified = JSON.stringify(s).slice(1, -1);   // without leading/trailing "
+        if (stringified !== s) {
+            return `"${stringified}"`;
+        } else {
+            return s;
+        }
     }
 
     function unstringify(s) {
-        var leading = '';
-        var trailing = '';
-        if (s.length < 1 || s.charAt(0) !== '"') {
-            leading = '"';
+        const isQuoted = s.length > 1 && s.charAt(0) === '"' && s.charAt(s.length - 1) === '"';
+        if (isQuoted) {
+            return JSON.parse(`"${s}"`);
+        } else {
+            return s;
         }
-        if (s.length < 2 || s.charAt(s.length - 1) !== '"' ||
-            (s.charAt(s.length - 1) === '"' && s.charAt(s.length - 2) === '\\')
-        ) {
-            trailing = '"';
-        }
-        return JSON.parse(leading + s + trailing);
     }
 
     function rowsToText(rows) {

--- a/modules/ui/sections/raw_tag_editor.js
+++ b/modules/ui/sections/raw_tag_editor.js
@@ -332,7 +332,7 @@ export function uiSectionRawTagEditor(id, context) {
     function unstringify(s) {
         const isQuoted = s.length > 1 && s.charAt(0) === '"' && s.charAt(s.length - 1) === '"';
         if (isQuoted) {
-            return JSON.parse(`"${s}"`);
+            return JSON.parse(s);
         } else {
             return s;
         }


### PR DESCRIPTION
…and use fully quoted strings for cases which have characters that need to be encoded

old: `tag=foo\"bar\"` (or `tag="foo\"bar\""`) -> new: `tag=foo"bar"` or `tag="foo\"bar\""`
old: `tag=foo\nbar` (or `tag="foo\"bar\""`)   -> new: `tag="foo\nbar"`

closes #10369
