### PR TITLE
Introduce governance documentation and co-maintainers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -317,6 +317,8 @@ We like when people get involved! iD is a busy project, so it helps if you first
 open an issue to ask whether an idea makes sense,
 instead of surprising us with a pull request.
 
+The [GOVERNANCE doc](./GOVERNANCE.md) goes into details on roles, people and processes.
+
 ### JavaScript
 
 iD code was initially written with ES5 syntax, however we do now develop using ES6 syntax.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -35,7 +35,7 @@ Github shows a `(Collaborator)` label next to users with any permission on this 
 
 ### Triage Role
 
-(No one has the triage role at the moment. Please reach out if you want to help.)
+- [nickrsan](https://github.com/nickrsan) contributes to this project as a volunteer.
 
 The triage role includes:
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,95 @@
+# Roles, People, and Processes for Maintaining iD
+
+This document outlines how this project is maintained.
+
+## Roles & People
+
+### Maintainer Role
+
+[Martin](https://github.com/tyrasd) maintains this project.
+
+The maintainer role includes:
+
+- Having the final say in decisions for the project.
+- Creating releases.
+- Updating dependencies.
+- Assign roles.
+
+and all the following roles.
+
+Github shows a `(Member)` label next to users with full access to this repository and the organisation.
+
+### Co-Maintainer Role
+
+- [Kyle](https://github.com/k-yle) contributes to this project as a volunteer.
+- [Tobias](https://github.com/tordans) contributes to this project as a volunteer.
+
+The co-maintainer role includes:
+
+- Reviewing PRs.
+- Merging "clear-cut" PRs by others.
+
+and all the following roles.
+
+Github shows a `(Collaborator)` label next to users with any permission on this repository.
+
+### Triage Role
+
+(No one has the triage role at the moment. Please reach out if you want to help.)
+
+The triage role includes:
+
+- Proactively helping to clarify issues and PRs.
+- Closing issues as duplicates or not planned.
+- Assigning labels to issues and PRs.
+
+Github shows a `(Collaborator)` label next to users with any permission on this repository.
+
+### Contributors
+
+To all contributors, thank you so much for your support! ❤ Especially for:
+
+- Suggesting new features or report bugs.
+- Researching and helping with issues and PRs.
+- Translating the project.
+
+Code contributions: [Check this complete list of contributors on GitHub](https://github.com/openstreetmap/id/graphs/contributors).
+
+Github shows a `(Contributor)` label next to users that previously committed to this repository.
+
+## Processes
+
+### PR Reviews and Merges
+
+- PRs need approval from two people: the author and one or more (co-)maintainers before being merged.
+- Non-"clear-cut" changes need to be merged by the maintainer.
+- We might revert merges later if necessary.
+
+**What is a clear-cut change?**
+
+- No or minimal controversial discussion on the change.
+- Coding and contribution [contribution guidelines](./CONTRIBUTING.md) are met.
+
+**How to merge…**
+
+- Usually squash merge PRs to make the history simpler
+- Give the merge a meaningful description of the change
+- Add labels to the PR to simplify creating the changelog. [Learn more…](CONTRIBUTING.md#issue-labels)
+
+### Releases
+
+There is no set release schedule at the moment, but releases usually occur every other month.
+
+### Assigning roles
+
+- Co-maintainer and triage roles are assigned by the current maintainer of this project.
+
+## Previous Maintainers
+
+Many thanks to all previous maintainers! ❤
+
+- [Milos](https://github.com/mbrzakovic)
+- [Quincy](https://github.com/quincylvania)
+- [Bryan](https://github.com/bhousel)
+- [Tom MacWright](https://github.com/tmcw)
+- [John Firebaugh](https://github.com/jfirebaugh)

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -15,7 +15,7 @@ The maintainer role includes:
 - Updating dependencies.
 - Assign roles.
 
-and all the following roles.
+and all responsibilities of the following roles.
 
 Github shows a `(Member)` label next to users with full access to this repository and the organisation.
 
@@ -29,7 +29,7 @@ The co-maintainer role includes:
 - Reviewing PRs.
 - Merging "clear-cut" PRs by others.
 
-and all the following roles.
+and all responsibilities of the following roles.
 
 Github shows a `(Collaborator)` label next to users with any permission on this repository.
 
@@ -50,6 +50,7 @@ Github shows a `(Collaborator)` label next to users with any permission on this 
 To all contributors, thank you so much for your support! ❤ Especially for:
 
 - Suggesting new features or report bugs.
+- Contributing bug fixes and features via PRs.
 - Researching and helping with issues and PRs.
 - Translating the project.
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 
 * Read the project [Code of Conduct](CODE_OF_CONDUCT.md) and remember to be nice to one another.
 * Read up on [Contributing and the code style of iD](CONTRIBUTING.md).
+* Learn about the [roles, people and processes](GOVERNANCE.md) that maintain iD.
 * See [open issues in the issue tracker](https://github.com/openstreetmap/iD/issues?state=open)
 if you're looking for something to do.
 * [Translate!](https://github.com/openstreetmap/iD/blob/develop/CONTRIBUTING.md#translating)


### PR DESCRIPTION
Recently, we added co-maintainers to the id-tagging-schema repo and used [a GOVERNANCE.md doc to describe roles, people and processed](https://github.com/openstreetmap/id-tagging-schema/blob/main/GOVERNANCE.md).

This change was [merged on 2024-08-07](https://github.com/openstreetmap/id-tagging-schema/pull/1230).

During the [iD Community Meeting on the same day](https://wiki.openstreetmap.org/wiki/ID/Community_Chats/2024-08-07) we discussed the extend this setup to iD and the schema builder repo as well.

Today I had a chat with @tyrasd during which we create the doc in this PR that adapts the document from the id-tagging-schema repo for this Project.

The plan we discussed during the community meetup is to have this PR open until after [SOTM Kenya](https://2024.stateofthemap.org/) to collect feedback.

The main goal of this change is, to introduce co-maintainers (@k-yle and myself) and describe the roles and processes that are used to maintain iD as a community project.