### PR TITLE
Docs: Remove reference to mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 * iD is a JavaScript [OpenStreetMap](https://www.openstreetmap.org/) editor.
 * It's intentionally simple. It lets you do the most basic tasks while not breaking other people's data.
-* It supports all popular modern desktop browsers: Chrome, Firefox, Safari and Edge.
+* It supports all popular modern desktop browsers: Chrome, Firefox, Safari, Opera, and Edge.
 * Data is rendered with [d3.js](https://d3js.org/).
 
 ## Participate!

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@
 
 * iD is a JavaScript [OpenStreetMap](https://www.openstreetmap.org/) editor.
 * It's intentionally simple. It lets you do the most basic tasks while not breaking other people's data.
-* It supports all popular modern desktop browsers: Chrome, Firefox, Safari, Opera, and Edge.
-* iD is not yet designed for mobile browsers, but this is something we hope to add!
+* It supports all popular modern desktop browsers: Chrome, Firefox, Safari and Edge.
 * Data is rendered with [d3.js](https://d3js.org/).
 
 ## Participate!


### PR DESCRIPTION
The readme has very prominent wording that makes it sound like iD is not usable one mobile at all. However, Quincy did a lot of work in this area a while back and IMO iD works well enough to look at data and make minor changes.

I suggest we remove this reference now, because it is not true anymore. At least not to this extent.