### PR TITLE
Docs: Link to issue "choose" page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ everyone to feel comfortable contributing to iD.
 ## Submitting Issues
 
 We'd love to hear your feedback about iD. Please [search existing issues](https://github.com/search?l=&q=repo%3Aopenstreetmap%2FiD&type=Issues)
-before [opening a new one](https://github.com/openstreetmap/iD/issues/new). Many bugs and ideas have already been posted.
+before [opening a new one](https://github.com/openstreetmap/iD/issues/new/choose). Many bugs and ideas have already been posted.
 
 When reporting a bug:
 


### PR DESCRIPTION
The docs on new issues where written before we had the "choose issue type" page, which helps users to pick the right track for their issues.

This PR changes the link to the choose-page instead of right into the new issue form.