### PR TITLE
Docs: Remove gif and debugbrowser reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,11 +20,10 @@ When reporting a bug:
 and browser extensions you have installed
 * Write steps to replicate the error: when did it happen? What did you expect to happen?
 What happened instead?
-* We love screenshots.  If you can take a picture of the issue, that is extra helpful.
-You can drag the image file onto the GitHub issue and it will be included with your bug report.
-* You can use a program like [LICEcap](http://www.cockos.com/licecap/) to record an animated gif.
+* We love screenshots. If you can take a picture of the issue, that is extra helpful.
+You can drag the image or video file onto the GitHub issue and it will be included with your bug report.
 * Please keep bug reports professional and straightforward: trust us, we share your dismay at software breaking.
-* If you can, [enable web developer extensions](http://debugbrowser.com/) and report the
+* If you can, enable web developer extensions and report the
 JavaScript error message.
 * When in doubt, over-describe the bug and how you discovered it.
 


### PR DESCRIPTION
- Gifs: Github now supports videos, which are the better way to share animations.
- `debugbrowser`: This side is not what is used to be anymore (open in private browsing…)