### PR TITLE
fix cyclic dependencies

### DIFF
--- a/modules/behavior/hash.js
+++ b/modules/behavior/hash.js
@@ -5,8 +5,9 @@ import { select as d3_select } from 'd3-selection';
 import { geoSphericalDistance } from '../geo';
 import { modeBrowse } from '../modes/browse';
 import { modeSelect, modeSelectNote } from '../modes';
-import { utilDisplayLabel, utilObjectOmit, utilQsString, utilStringQs } from '../util';
+import { utilObjectOmit, utilQsString, utilStringQs } from '../util';
 import { utilArrayIdentical } from '../util/array';
+import { utilDisplayLabel } from '../util/utilDisplayLabel';
 import { t } from '../core/localizer';
 import { prefs } from '../core/preferences';
 

--- a/modules/operations/paste.js
+++ b/modules/operations/paste.js
@@ -5,7 +5,7 @@ import { modeSelect } from '../modes/select';
 import { geoExtent, geoVecSubtract } from '../geo';
 import { t } from '../core/localizer';
 import { uiCmd } from '../ui/cmd';
-import { utilDisplayLabel } from '../util/util';
+import { utilDisplayLabel } from '../util/utilDisplayLabel';
 
 // see also `behaviorPaste`
 export function operationPaste(context) {

--- a/modules/util/index.js
+++ b/modules/util/index.js
@@ -19,7 +19,6 @@ export { utilDetect } from './detect';
 export { utilDisplayName } from './util';
 export { utilDisplayNameForPath } from './util';
 export { utilDisplayType } from './util';
-export { utilDisplayLabel } from './util';
 export { utilEntityRoot } from './util';
 export { utilEditDistance } from './util';
 export { utilEntityAndDeepMemberIDs } from './util';

--- a/modules/util/util.js
+++ b/modules/util/util.js
@@ -1,7 +1,6 @@
 import { remove as removeDiacritics } from 'diacritics';
 import { fixRTLTextForSvg, rtlRegex } from './svg_paths_rtl_fix';
 
-import { presetManager } from '../presets';
 import { t, localizer } from '../core/localizer';
 import { utilArrayUnion } from './array';
 import { utilDetect } from './detect';
@@ -241,32 +240,6 @@ export function utilDisplayType(id) {
         w: t('inspector.way'),
         r: t('inspector.relation')
     }[id.charAt(0)];
-}
-
-
-// `utilDisplayLabel`
-// Returns a string suitable for display
-// By default returns something like name/ref, fallback to preset type, fallback to OSM type
-//   "Main Street" or "Tertiary Road"
-// If `verbose=true`, include both preset name and feature name.
-//   "Tertiary Road Main Street"
-//
-export function utilDisplayLabel(entity, graphOrGeometry, verbose) {
-    var result;
-    var displayName = utilDisplayName(entity);
-    var preset = typeof graphOrGeometry === 'string' ?
-        presetManager.matchTags(entity.tags, graphOrGeometry) :
-        presetManager.match(entity, graphOrGeometry);
-    var presetName = preset && (preset.suggestion ? preset.subtitle() : preset.name());
-
-    if (verbose) {
-        result = [presetName, displayName].filter(Boolean).join(' ');
-    } else {
-        result = displayName || presetName;
-    }
-
-    // Fallback to the OSM type (node/way/relation)
-    return result || utilDisplayType(entity.id);
 }
 
 

--- a/modules/util/utilDisplayLabel.js
+++ b/modules/util/utilDisplayLabel.js
@@ -1,0 +1,33 @@
+import { presetManager } from '../presets';
+import { utilDisplayName, utilDisplayType } from './util';
+
+/**
+ * `utilDisplayLabel` returns a string suitable for display
+ *
+ * By default returns something like name/ref, fallback to preset type, fallback to OSM type
+ *   "Main Street" or "Tertiary Road"
+ *
+ * If `verbose=true`, include both preset name and feature name.
+ *    "Tertiary Road Main Street"
+ * @param {osmEntity} entity
+ * @param {string | unknown} graphOrGeometry
+ * @param {boolean} [verbose]
+ * @returns {string}
+ */
+export function utilDisplayLabel(entity, graphOrGeometry, verbose) {
+    var result;
+    var displayName = utilDisplayName(entity);
+    var preset = typeof graphOrGeometry === 'string' ?
+        presetManager.matchTags(entity.tags, graphOrGeometry) :
+        presetManager.match(entity, graphOrGeometry);
+    var presetName = preset && (preset.suggestion ? preset.subtitle() : preset.name());
+
+    if (verbose) {
+        result = [presetName, displayName].filter(Boolean).join(' ');
+    } else {
+        result = displayName || presetName;
+    }
+
+    // Fallback to the OSM type (node/way/relation)
+    return result || utilDisplayType(entity.id);
+}

--- a/modules/validations/almost_junction.js
+++ b/modules/validations/almost_junction.js
@@ -8,7 +8,7 @@ import { actionAddMidpoint } from '../actions/add_midpoint';
 import { actionChangeTags } from '../actions/change_tags';
 import { actionMergeNodes } from '../actions/merge_nodes';
 import { t } from '../core/localizer';
-import { utilDisplayLabel } from '../util';
+import { utilDisplayLabel } from '../util/utilDisplayLabel';
 import { osmRoutableHighwayTagValues } from '../osm/tags';
 import { validationIssue, validationIssueFix } from '../core/validation';
 import { services } from '../services';

--- a/modules/validations/close_nodes.js
+++ b/modules/validations/close_nodes.js
@@ -1,5 +1,5 @@
 import { actionMergeNodes } from '../actions/merge_nodes';
-import { utilDisplayLabel } from '../util';
+import { utilDisplayLabel } from '../util/utilDisplayLabel';
 import { t } from '../core/localizer';
 import { validationIssue, validationIssueFix } from '../core/validation';
 import { osmPathHighwayTagValues } from '../osm/tags';

--- a/modules/validations/crossing_ways.js
+++ b/modules/validations/crossing_ways.js
@@ -10,7 +10,7 @@ import { geoAngle, geoExtent, geoLatToMeters, geoLonToMeters, geoLineIntersectio
 import { osmNode } from '../osm/node';
 import { osmFlowingWaterwayTagValues, osmPathHighwayTagValues, osmRailwayTrackTagValues, osmRoutableHighwayTagValues } from '../osm/tags';
 import { t } from '../core/localizer';
-import { utilDisplayLabel } from '../util';
+import { utilDisplayLabel } from '../util/utilDisplayLabel';
 import { validationIssue, validationIssueFix } from '../core/validation';
 
 

--- a/modules/validations/disconnected_way.js
+++ b/modules/validations/disconnected_way.js
@@ -1,7 +1,7 @@
 import { t, localizer } from '../core/localizer';
 import { modeDrawLine } from '../modes/draw_line';
 import { operationDelete } from '../operations/delete';
-import { utilDisplayLabel } from '../util';
+import { utilDisplayLabel } from '../util/utilDisplayLabel';
 import { osmRoutableHighwayTagValues } from '../osm/tags';
 import { validationIssue, validationIssueFix } from '../core/validation';
 import { services } from '../services';

--- a/modules/validations/help_request.js
+++ b/modules/validations/help_request.js
@@ -1,5 +1,5 @@
 import { t } from '../core/localizer';
-import { utilDisplayLabel } from '../util';
+import { utilDisplayLabel } from '../util/utilDisplayLabel';
 import { validationIssue, validationIssueFix } from '../core/validation';
 
 

--- a/modules/validations/impossible_oneway.js
+++ b/modules/validations/impossible_oneway.js
@@ -1,7 +1,7 @@
 import { t, localizer } from '../core/localizer';
 import { modeDrawLine } from '../modes/draw_line';
 import { actionReverse } from '../actions/reverse';
-import { utilDisplayLabel } from '../util';
+import { utilDisplayLabel } from '../util/utilDisplayLabel';
 import { osmFlowingWaterwayTagValues, osmOneWayTags, osmRoutableHighwayTagValues } from '../osm/tags';
 import { validationIssue, validationIssueFix } from '../core/validation';
 import { services } from '../services';

--- a/modules/validations/incompatible_source.js
+++ b/modules/validations/incompatible_source.js
@@ -1,5 +1,5 @@
 import { t } from '../core/localizer';
-import { utilDisplayLabel } from '../util';
+import { utilDisplayLabel } from '../util/utilDisplayLabel';
 import { validationIssue, validationIssueFix } from '../core/validation';
 
 

--- a/modules/validations/invalid_format.js
+++ b/modules/validations/invalid_format.js
@@ -1,5 +1,5 @@
 import { t } from '../core/localizer';
-import { utilDisplayLabel } from '../util';
+import { utilDisplayLabel } from '../util/utilDisplayLabel';
 import { validationIssue } from '../core/validation';
 
 export function validationFormatting() {

--- a/modules/validations/mismatched_geometry.js
+++ b/modules/validations/mismatched_geometry.js
@@ -10,7 +10,8 @@ import { osmNodeGeometriesForTags, osmTagSuggestingArea } from '../osm/tags';
 import { presetManager } from '../presets';
 import { geoHasSelfIntersections, geoSphericalDistance } from '../geo';
 import { t } from '../core/localizer';
-import { utilDisplayLabel, utilTagText } from '../util';
+import { utilTagText } from '../util';
+import { utilDisplayLabel } from '../util/utilDisplayLabel';
 import { validationIssue, validationIssueFix } from '../core/validation';
 
 

--- a/modules/validations/missing_role.js
+++ b/modules/validations/missing_role.js
@@ -1,7 +1,7 @@
 import { actionChangeMember } from '../actions/change_member';
 import { actionDeleteMember } from '../actions/delete_member';
 import { t } from '../core/localizer';
-import { utilDisplayLabel } from '../util';
+import { utilDisplayLabel } from '../util/utilDisplayLabel';
 import { validationIssue, validationIssueFix } from '../core/validation';
 
 

--- a/modules/validations/missing_tag.js
+++ b/modules/validations/missing_tag.js
@@ -1,7 +1,7 @@
 import { operationDelete } from '../operations/delete';
 import { osmIsInterestingTag } from '../osm/tags';
 import { t } from '../core/localizer';
-import { utilDisplayLabel } from '../util';
+import { utilDisplayLabel } from '../util/utilDisplayLabel';
 import { validationIssue, validationIssueFix } from '../core/validation';
 
 

--- a/modules/validations/mutually_exclusive_tags.js
+++ b/modules/validations/mutually_exclusive_tags.js
@@ -1,6 +1,6 @@
 import { actionChangeTags } from '../actions/change_tags';
 import { t } from '../core/localizer';
-import { utilDisplayLabel } from '../util';
+import { utilDisplayLabel } from '../util/utilDisplayLabel';
 import { validationIssue, validationIssueFix } from '../core/validation';
 import { osmMutuallyExclusiveTagPairs } from '../osm/tags';
 

--- a/modules/validations/outdated_tags.js
+++ b/modules/validations/outdated_tags.js
@@ -6,7 +6,8 @@ import { actionUpgradeTags } from '../actions/upgrade_tags';
 import { fileFetcher } from '../core';
 import { presetManager } from '../presets';
 import { services } from '../services';
-import { utilDisplayLabel, utilHashcode, utilTagDiff } from '../util';
+import {  utilHashcode, utilTagDiff } from '../util';
+import { utilDisplayLabel } from '../util/utilDisplayLabel';
 import { validationIssue, validationIssueFix } from '../core/validation';
 
 

--- a/modules/validations/private_data.js
+++ b/modules/validations/private_data.js
@@ -1,6 +1,7 @@
 import { actionChangeTags } from '../actions/change_tags';
 import { t } from '../core/localizer';
-import { utilDisplayLabel, utilTagDiff } from '../util';
+import { utilTagDiff } from '../util';
+import { utilDisplayLabel } from '../util/utilDisplayLabel';
 import { validationIssue, validationIssueFix } from '../core/validation';
 
 

--- a/modules/validations/unsquare_way.js
+++ b/modules/validations/unsquare_way.js
@@ -3,7 +3,7 @@ import { t } from '../core/localizer';
 //import { actionChangeTags } from '../actions/change_tags';
 import { actionOrthogonalize } from '../actions/orthogonalize';
 import { geoOrthoCanOrthogonalize } from '../geo/ortho';
-import { utilDisplayLabel } from '../util';
+import { utilDisplayLabel } from '../util/utilDisplayLabel';
 import { validationIssue, validationIssueFix } from '../core/validation';
 import { services } from '../services';
 


### PR DESCRIPTION
`utilDisplayLabel` imports `presetManager` which imports `utils.js`, causing a dependency cycle.

This PR moves `utilDisplayLabel` into a separate file and updates the imports. 