### PR TITLE
fix unsolvable validator error for presets with locationSet

### DIFF
--- a/modules/presets/index.js
+++ b/modules/presets/index.js
@@ -56,8 +56,9 @@ export function presetIndex() {
   let _loadPromise;
 
 
-  _this.ensureLoaded = () => {
-    if (_loadPromise) return _loadPromise;
+  /** @param {boolean=} bypassCache - used by unit tests */
+  _this.ensureLoaded = (bypassCache) => {
+    if (_loadPromise && !bypassCache) return _loadPromise;
 
     return _loadPromise = Promise.all([
         fileFetcher.get('preset_categories'),

--- a/modules/validations/mismatched_geometry.js
+++ b/modules/validations/mismatched_geometry.js
@@ -244,7 +244,11 @@ export function validationMismatchedGeometry() {
         var asSource = presetManager.match(entity, graph);
 
         var targetGeom = targetGeoms.find(nodeGeom => {
-            var asTarget = presetManager.matchTags(entity.tags, nodeGeom);
+            const asTarget = presetManager.matchTags(
+                entity.tags,
+                nodeGeom,
+                entity.extent(graph).center(),
+            );
             if (!asSource || !asTarget ||
                 asSource === asTarget ||
                 // sometimes there are two presets with the same tags for different geometries

--- a/test/spec/validations/mismatched_geometry.js
+++ b/test/spec/validations/mismatched_geometry.js
@@ -4,6 +4,17 @@ describe('iD.validations.mismatched_geometry', function () {
     beforeEach(function() {
         _savedAreaKeys = iD.osmAreaKeys;
         context = iD.coreContext().init();
+        iD.fileFetcher.cache().preset_presets = {
+            library: {
+                tags: { amenity: 'library' },
+                geometry: ['point', 'vertex', 'line', 'area'],
+                locationSet: { include: ['NU'] }
+            },
+            generic_amenity: {
+                tags: { amenity: '*' },
+                geometry: ['point', 'vertex', 'line', 'area']
+            },
+        };
     });
 
     afterEach(function() {
@@ -112,4 +123,11 @@ describe('iD.validations.mismatched_geometry', function () {
         expect(issue.entityIds[0]).to.eql('w-1');
     });
 
+    it('does not error if the best preset is limited to certain regions', async () => {
+        await iD.presetManager.ensureLoaded(true);
+
+        createClosedWay({ amenity: 'library' });
+        const issues = validate();
+        expect(issues).to.have.lengthOf(0);
+    });
 });


### PR DESCRIPTION
This was observed in https://github.com/openstreetmap/id-tagging-schema/pull/1335#pullrequestreview-2279573101

`presetManager.matchTags(...)` did not consider the `locationSet` of each preset, so it produced an error which was impossible to fix.

<img src="https://github.com/user-attachments/assets/8e80241a-3c2d-4a5e-a54c-77b779f8d522" width=300 />
<img src="https://github.com/user-attachments/assets/9f9a5d3b-b4e9-48b5-be94-cee7da57137a" width=300 />

Regardless of whether https://github.com/openstreetmap/id-tagging-schema/pull/1335 is accepted, this PR should be merged to prevent errors in other situations (for example, [this node](https://osm.org/edit?node=7503247785))