### PR TITLE
Include route number in label of named route relations

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -763,6 +763,8 @@ en:
     lock:
       suggestion: 'The "{label}" field is locked because there is a Wikidata tag. You can delete it or edit the tags in the "Tags" section.'
     display_name:
+      network_ref_name: "{network} {ref}: {name}"
+      ref_name: "{ref}: {name}"
       direction: "{direction}"
       network: "{network}"
       from_to: "from {from} to {to}"

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -763,8 +763,6 @@ en:
     lock:
       suggestion: 'The "{label}" field is locked because there is a Wikidata tag. You can delete it or edit the tags in the "Tags" section.'
     display_name:
-      network_ref_name: "{network} {ref}: {name}"
-      ref_name: "{ref}: {name}"
       direction: "{direction}"
       network: "{network}"
       from_to: "from {from} to {to}"
@@ -780,6 +778,22 @@ en:
       network_ref_direction: "{network} {ref} {direction}"
       network_ref_from_to: "{network} {ref} from {from} to {to}"
       network_ref_from_to_via: "{network} {ref} from {from} to {to} via {via}"
+      name_direction: "{name} {direction}"
+      network_name: "{network} {name}"
+      name_from_to: "{name} from {from} to {to}"
+      name_from_to_via: "{name} from {from} to {to} via {via}"
+      network_name_direction: "{network} {name} {direction}"
+      network_name_from_to: "{network} {name} from {from} to {to}"
+      network_name_from_to_via: "{network} {name} from {from} to {to} via {via}"
+      name: "{name}"
+      ref_name: "{ref}: {name}"
+      ref_name_direction: "{ref}: {name} {direction}"
+      ref_name_from_to: "{ref}: {name} from {from} to {to}"
+      ref_name_from_to_via: "{ref}: {name} from {from} to {to} via {via}"
+      network_ref_name: "{network} {ref}: {name}"
+      network_ref_name_direction: "{network} {ref}: {name} {direction}"
+      network_ref_name_from_to: "{network} {ref}: {name} from {from} to {to}"
+      network_ref_name_from_to_via: "{network} {ref}: {name} from {from} to {to} via {via}"
     speed_unit: "Speed unit"
     roadheight:
       # symbol for meters

--- a/modules/ui/sections/raw_membership_editor.js
+++ b/modules/ui/sections/raw_membership_editor.js
@@ -386,7 +386,11 @@ export function uiSectionRawMembershipEditor(context) {
             .attr('class', 'member-entity-name')
             .classed('has-colour', d => d.relation.tags.colour && isColourValid(d.relation.tags.colour))
             .style('border-color', d => d.relation.tags.colour)
-            .text(function(d) { return utilDisplayName(d.relation); });
+            .html(function(d) {
+                const matched = presetManager.match(d.relation, context.graph());
+                // hide the network from the name if there is NSI match
+                return utilDisplayName(d.relation, matched.suggestion);
+            });
 
         labelEnter
             .append('button')

--- a/modules/util/util.js
+++ b/modules/util/util.js
@@ -197,9 +197,14 @@ export function utilDisplayName(entity, hideNetwork) {
 
     // for routes, prefer `network+ref+name` or `ref+name` over `name`
     if (name && tags.ref && entity.tags.route) {
-        return tags.network
-            ? t('inspector.display_name.network_ref_name', tags)
-            : t('inspector.display_name.ref_name', tags);
+        // A right arrow likely indicates a formulaic “name” as specified by the Public Transport v2 schema.
+        // This name format already contains enough details to disambiguate the feature; avoid duplicating these details.
+        var nameIsPTv2 = name.match(/→|[-=]>/);
+        if (!nameIsPTv2) {
+            return tags.network
+                ? t('inspector.display_name.network_ref_name', tags)
+                : t('inspector.display_name.ref_name', tags);
+        }
     }
     if (name) return name;
 

--- a/modules/util/util.js
+++ b/modules/util/util.js
@@ -177,20 +177,32 @@ export function utilGetAllNodes(ids, graph) {
     }
 }
 
-
-export function utilDisplayName(entity) {
+/**
+ * @param {boolean} hideNetwork If true, the `network` tag will not be used in the name to prevent
+ *                              it being shown twice (see PR #8707#discussion_r712658175)
+ */
+export function utilDisplayName(entity, hideNetwork) {
     var localizedNameKey = 'name:' + localizer.languageCode().toLowerCase();
     var name = entity.tags[localizedNameKey] || entity.tags.name || '';
-    if (name) return name;
 
     var tags = {
+        name,
         direction: entity.tags.direction,
         from: entity.tags.from,
-        network: entity.tags.cycle_network || entity.tags.network,
+        network: hideNetwork ? undefined : (entity.tags.cycle_network || entity.tags.network),
         ref: entity.tags.ref,
         to: entity.tags.to,
         via: entity.tags.via
     };
+
+    // for routes, prefer `network+ref+name` or `ref+name` over `name`
+    if (name && tags.ref && entity.tags.route) {
+        return tags.network
+            ? t('inspector.display_name.network_ref_name', tags)
+            : t('inspector.display_name.ref_name', tags);
+    }
+    if (name) return name;
+
     var keyComponents = [];
 
     if (tags.network) {

--- a/modules/util/util.js
+++ b/modules/util/util.js
@@ -186,27 +186,25 @@ export function utilDisplayName(entity, hideNetwork) {
     var name = entity.tags[localizedNameKey] || entity.tags.name || '';
 
     var tags = {
-        name,
         direction: entity.tags.direction,
         from: entity.tags.from,
+        name,
         network: hideNetwork ? undefined : (entity.tags.cycle_network || entity.tags.network),
         ref: entity.tags.ref,
         to: entity.tags.to,
         via: entity.tags.via
     };
 
-    // for routes, prefer `network+ref+name` or `ref+name` over `name`
-    if (name && tags.ref && entity.tags.route) {
-        // A right arrow likely indicates a formulaic “name” as specified by the Public Transport v2 schema.
-        // This name format already contains enough details to disambiguate the feature; avoid duplicating these details.
-        var nameIsPTv2 = name.match(/→|[-=]>/);
-        if (!nameIsPTv2) {
-            return tags.network
-                ? t('inspector.display_name.network_ref_name', tags)
-                : t('inspector.display_name.ref_name', tags);
-        }
+    // A right or left-right arrow likely indicates a formulaic “name” as specified by the Public Transport v2 schema.
+    // This name format already contains enough details to disambiguate the feature; avoid duplicating these details.
+    if (entity.tags.route && entity.tags.name && entity.tags.name.match(/[→⇒↔⇔]|[-=]>/)) {
+        return entity.tags.name;
     }
-    if (name) return name;
+
+    // Non-routes tend to be labeled in many places besides the relation lists, such as the map, where brevity is important.
+    if (!entity.tags.route && name) {
+        return name;
+    }
 
     var keyComponents = [];
 
@@ -215,6 +213,9 @@ export function utilDisplayName(entity, hideNetwork) {
     }
     if (tags.ref) {
         keyComponents.push('ref');
+    }
+    if (tags.name) {
+        keyComponents.push('name');
     }
 
     // Routes may need more disambiguation based on direction or destination

--- a/test/spec/util/util.js
+++ b/test/spec/util/util.js
@@ -262,6 +262,20 @@ describe('iD.util', function() {
         it('returns the name if tagged with a name', function() {
             expect(iD.utilDisplayName({tags: {name: 'East Coast Greenway'}})).to.eql('East Coast Greenway');
         });
+        it('returns just the name for non-routes', function() {
+            expect(iD.utilDisplayName({tags: { name: 'Abyssinian Room', ref: '260-115' }})).to.eql('Abyssinian Room');
+        });
+        it('returns the name and the ref for routes', function() {
+            expect(iD.utilDisplayName({tags: { name: 'Lynfield Express', ref: '25L', route: 'bus' }})).to.eql('25L: Lynfield Express');
+            expect(iD.utilDisplayName({tags: { name: 'Kāpiti Expressway', ref: 'SH1', route: 'road' }})).to.eql('SH1: Kāpiti Expressway');
+        });
+        it('returns the name, ref, and network for routes', function() {
+            expect(iD.utilDisplayName({tags: { name: 'Lynfield Express', ref: '25L', network: 'AT', route: 'bus' }})).to.eql('AT 25L: Lynfield Express');
+        });
+        it('does not use the network tag if the hideNetwork argument is true', function() {
+            expect(iD.utilDisplayName({tags: { name: 'Lynfield Express', ref: '25L', network: 'AT', route: 'bus' }}, true)).to.eql('25L: Lynfield Express');
+            expect(iD.utilDisplayName({tags: { network: 'SORTA', ref: '3X' }}, true)).to.eql('3X');
+        });
         it('distinguishes unnamed features by ref', function() {
             expect(iD.utilDisplayName({tags: {ref: '66'}})).to.eql('66');
         });

--- a/test/spec/util/util.js
+++ b/test/spec/util/util.js
@@ -265,6 +265,11 @@ describe('iD.util', function() {
         it('returns just the name for non-routes', function() {
             expect(iD.utilDisplayName({tags: { name: 'Abyssinian Room', ref: '260-115' }})).to.eql('Abyssinian Room');
         });
+        it('returns just the name for route with PTv2-formatted names', function() {
+            expect(iD.utilDisplayName({tags: { name: 'NORTA 2: French Market → Canal at Bourbon', network: 'NORTA', ref: '2', from: 'French Market', to: 'Canal at Bourbon'}})).to.eql('NORTA 2: French Market → Canal at Bourbon');
+            expect(iD.utilDisplayName({tags: { name: 'VTA 64A: McKee & White => San Jose Diridon => Ohlone/Chynoweth', network: 'VTA', ref: '64A', from: 'McKee & White', to: 'Ohlone/Chynoweth', via: 'San Jose Diridon'}})).to.eql('VTA 64A: McKee & White => San Jose Diridon => Ohlone/Chynoweth');
+            expect(iD.utilDisplayName({tags: { name: 'Bus 224: Downtown Garland Station -> Lake Ray Hubbard TC -> Downtown Dallas', route: 'bus', ref: '224', from: 'Downtown Garland Station', to: 'Downtown Dallas', via: 'Lake Ray Hubbard TC'}})).to.eql('Bus 224: Downtown Garland Station -> Lake Ray Hubbard TC -> Downtown Dallas');
+        });
         it('returns the name and the ref for routes', function() {
             expect(iD.utilDisplayName({tags: { name: 'Lynfield Express', ref: '25L', route: 'bus' }})).to.eql('25L: Lynfield Express');
             expect(iD.utilDisplayName({tags: { name: 'Kāpiti Expressway', ref: 'SH1', route: 'road' }})).to.eql('SH1: Kāpiti Expressway');

--- a/test/spec/util/util.js
+++ b/test/spec/util/util.js
@@ -270,16 +270,10 @@ describe('iD.util', function() {
             expect(iD.utilDisplayName({tags: { name: 'VTA 64A: McKee & White => San Jose Diridon => Ohlone/Chynoweth', network: 'VTA', ref: '64A', from: 'McKee & White', to: 'Ohlone/Chynoweth', via: 'San Jose Diridon'}})).to.eql('VTA 64A: McKee & White => San Jose Diridon => Ohlone/Chynoweth');
             expect(iD.utilDisplayName({tags: { name: 'Bus 224: Downtown Garland Station -> Lake Ray Hubbard TC -> Downtown Dallas', route: 'bus', ref: '224', from: 'Downtown Garland Station', to: 'Downtown Dallas', via: 'Lake Ray Hubbard TC'}})).to.eql('Bus 224: Downtown Garland Station -> Lake Ray Hubbard TC -> Downtown Dallas');
         });
-        it('returns the name and the ref for routes', function() {
-            expect(iD.utilDisplayName({tags: { name: 'Lynfield Express', ref: '25L', route: 'bus' }})).to.eql('25L: Lynfield Express');
-            expect(iD.utilDisplayName({tags: { name: 'Kāpiti Expressway', ref: 'SH1', route: 'road' }})).to.eql('SH1: Kāpiti Expressway');
-        });
-        it('returns the name, ref, and network for routes', function() {
-            expect(iD.utilDisplayName({tags: { name: 'Lynfield Express', ref: '25L', network: 'AT', route: 'bus' }})).to.eql('AT 25L: Lynfield Express');
-        });
-        it('does not use the network tag if the hideNetwork argument is true', function() {
+        it('suppresses the network tag if the hideNetwork argument is true', function() {
             expect(iD.utilDisplayName({tags: { name: 'Lynfield Express', ref: '25L', network: 'AT', route: 'bus' }}, true)).to.eql('25L: Lynfield Express');
             expect(iD.utilDisplayName({tags: { network: 'SORTA', ref: '3X' }}, true)).to.eql('3X');
+            expect(iD.utilDisplayName({tags: { name: 'Dallas North Tollway', network: 'US:TX:NTTA', route: 'road' }}, true)).to.eql('Dallas North Tollway');
         });
         it('distinguishes unnamed features by ref', function() {
             expect(iD.utilDisplayName({tags: {ref: '66'}})).to.eql('66');
@@ -301,6 +295,25 @@ describe('iD.util', function() {
             expect(iD.utilDisplayName({tags: {network: 'VTA', ref: 'Green', from: 'Old Ironsides', to: 'Winchester', route: 'bus'}})).to.eql('VTA Green from Old Ironsides to Winchester');
             // BART Yellow Line: Antioch => Pittsburg/Bay Point => SFO Airport => Millbrae
             expect(iD.utilDisplayName({tags: {network: 'BART', ref: 'Yellow', from: 'Antioch', to: 'Millbrae', via: 'Pittsburg/Bay Point;San Francisco International Airport', route: 'subway'}})).to.eql('BART Yellow from Antioch to Millbrae via Pittsburg/Bay Point;San Francisco International Airport');
+        });
+        it('distinguishes named features by name', function() {
+            expect(iD.utilDisplayName({tags: { name: 'Ohio Turnpike', route: 'road' }})).to.eql('Ohio Turnpike');
+            expect(iD.utilDisplayName({tags: { name: 'Lynfield Express', ref: '25L', route: 'bus' }})).to.eql('25L: Lynfield Express');
+            expect(iD.utilDisplayName({tags: { name: 'Kāpiti Expressway', ref: 'SH1', route: 'road' }})).to.eql('SH1: Kāpiti Expressway');
+            expect(iD.utilDisplayName({tags: { name: 'Lynfield Express', ref: '25L', network: 'AT', route: 'bus' }})).to.eql('AT 25L: Lynfield Express');
+        });
+        it('distinguishes named features by network or cycle_network', function() {
+            expect(iD.utilDisplayName({tags: { name: 'Dallas North Tollway', network: 'US:TX:NTTA', route: 'road' }})).to.eql('US:TX:NTTA Dallas North Tollway');
+        });
+        it('distinguishes named features by ref', function() {
+            expect(iD.utilDisplayName({tags: { name: 'Dallas North Tollway', network: 'US:TX:NTTA', ref: 'DNT', route: 'road' }})).to.eql('US:TX:NTTA DNT: Dallas North Tollway');
+        });
+        it('distinguishes named features by direction', function() {
+            expect(iD.utilDisplayName({tags: { name: 'Dallas North Tollway', network: 'US:TX:NTTA', direction: 'south', route: 'road' }})).to.eql('US:TX:NTTA Dallas North Tollway south');
+        });
+        it('distinguishes named features by waypoints', function() {
+            expect(iD.utilDisplayName({tags: { name: 'Kings Island Express', network: 'SORTA', ref: '71X', from: 'Sycamore & Court', to: 'Fields Ertel & Royal Point', route: 'bus' }})).to.eql('SORTA 71X: Kings Island Express from Sycamore & Court to Fields Ertel & Royal Point');
+            expect(iD.utilDisplayName({tags: { name: 'Local', network: 'Caltrain', from: 'San Francisco', to: 'Tamien', via: 'College Park', route: 'train' }})).to.eql('Caltrain Local from San Francisco to Tamien via College Park');
         });
     });
 


### PR DESCRIPTION
When labeling a route relation that has a `name=*`, include its `network=*` and route number (`ref=*`) for disambiguation. This is identical to 4856eef32b4b04ef40a86b64c98bb0e23cbb3305 by @k-yle. The only additional change is that we continue to show the `name=*` verbatim, without appending other details, if it looks like a [PTv2-formatted description](https://wiki.openstreetmap.org/wiki/Special:PermanentLink/2741977#cite_ref-name-description_1-0) of the route. This should address the criticisms in #8707.

Fixes #8559.