### PR TITLE
wmf-sitematrix v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,11 +43,18 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :white_check_mark: Validation
 #### :bug: Bugfixes
 #### :earth_asia: Localization
+
+* Update Sinitic languages in the Multilingual Names field ([#10488], thanks [@winstonsung])
+* Update the list of languages in the Wikipedia field ([#10489])
+
 #### :hourglass: Performance
 #### :mortar_board: Walkthrough / Help
 #### :rocket: Presets
 #### :hammer: Development
 
+[#10488]: https://github.com/openstreetmap/iD/pull/10488
+[#10489]: https://github.com/openstreetmap/iD/pull/10489
+[@winstonsung]: https://github.com/winstonsung/
 
 # 2.30.2
 ##### 2024-Aug-21

--- a/modules/core/file_fetcher.js
+++ b/modules/core/file_fetcher.js
@@ -39,7 +39,7 @@ export function coreFileFetcher() {
     'preset_defaults': presetsCdnUrl + 'dist/preset_defaults.min.json',
     'preset_fields': presetsCdnUrl + 'dist/fields.min.json',
     'preset_presets': presetsCdnUrl + 'dist/presets.min.json',
-    'wmf_sitematrix': wmfSitematrixCdnUrl.replace('{version}', '0.1') + 'wikipedia.min.json'
+    'wmf_sitematrix': wmfSitematrixCdnUrl.replace('{version}', '0.2') + 'data/wikipedia.min.json'
   };
 
   let _cachedData = {};


### PR DESCRIPTION
Upgraded to [wmf-sitematrix v0.2.0](https://github.com/osmlab/wmf-sitematrix/releases/tag/v0.2.0), which adds 34 new languages to the Wikipedia field. Also updated the changelog to mention the changes in #10488.