### PR TITLE
fixed the overflowing combobox

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -2370,7 +2370,7 @@ div.combobox {
     z-index: 9999;
     display: none;
     box-shadow: 0 4px 10px 1px rgba(0,0,0,.2);
-    margin-top: -1px;
+    margin-top: -240px;
     background: #fff;
     max-height: 245px;
     overflow-y: auto;


### PR DESCRIPTION
Fixed: #10482
the current comboBox box css styles makes the content overflow out of the screen which creates a bad user experience .
Solved this by tweaking the marginTop of the comboBox
Previous 
![image](https://github.com/user-attachments/assets/30b5a697-b9f6-493a-bfa5-639e86df0595)
Modified
![image](https://github.com/user-attachments/assets/f7bbfb71-5ba5-4ded-a80a-1e374decc447)

