### PR TITLE
Ref issue #10495: Viewer overlaps right click menu fixed.

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -5706,6 +5706,7 @@ li.hide + li.version .badge .tooltip .popover-arrow {
     flex-direction: column;
     background: #fff;
     border-radius: 4px;
+    flex-direction: row;
     /* padding is set in edit_menu.js */
 }
 


### PR DESCRIPTION

![Screenshot 2024-10-17 174659](https://github.com/user-attachments/assets/50b10b56-cea2-4400-acb2-23d22a8c3f14)

changed the orientation of the menu to appear horizontally.
