### PR TITLE
Stop password managers from autofilling address fields

### DIFF
--- a/modules/util/util.js
+++ b/modules/util/util.js
@@ -509,6 +509,10 @@ export function utilNoAuto(selection) {
         .attr('autocomplete', 'new-password')
         .attr('autocorrect', 'off')
         .attr('autocapitalize', 'off')
+        .attr('data-1p-ignore', 'true')  // 1Password
+        .attr('data-bwignore', 'true')   // Bitwarden
+        .attr('data-form-type', 'other') // Dashlane
+        .attr('data-lpignore', 'true')   // LastPass
         .attr('spellcheck', isText ? 'true' : 'false');
 }
 


### PR DESCRIPTION
I am a 1Password user (and employee). Whenever I am editing a local business's details in iD, I am frustrated that the 1Password browser extension offers to fill out my personal address instead of the business's address.

| **Before** | **After** |
|--------|--------|
| ![Screenshot 2024-10-18 at 12 16 32](https://github.com/user-attachments/assets/a4919e85-8e47-46d9-a0a0-2741c9755a7c)  |  ![Screenshot 2024-10-18 at 12 17 24](https://github.com/user-attachments/assets/7e6ea766-74be-4ff5-b48d-682932131f70) | 

I don't work on our browser extension, I could not tell you why every password manager has their own custom data attribute
when `autocomplete=off` exists. But, for fairness, I am including other major password managers' custom data attributes to stop them as well from autofilling address fields:

- [1Password](https://developer.1password.com/docs/web/compatible-website-design/)
- [Bitwarden](https://bitwarden.com/help/releasenotes/#2021-06-29)
- [Dashlane](https://www.dashlane.com/blog/dashlane-integration-forms#h-other-miscellaneous-musings)
- [LastPass](https://support.lastpass.com/s/document-item?language=en_US&bundleId=lastpass&topicId=LastPass/c_lp_prevent_fields_from_being_filled_automatically.html&_LANG=enus)

Fixes #10507