### PR TITLE
update temaki to v5.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "@mapbox/maki": "^8.0.1",
         "@openstreetmap/id-tagging-schema": "^6.8.1",
         "@rapideditor/mapillary_sprite_source": "^1.8.0",
-        "@rapideditor/temaki": "^5.9.0",
+        "@rapideditor/temaki": "^5.10.0",
         "@transifex/api": "^7.1.3",
         "@types/chai": "^4.3.17",
         "@types/d3": "^7.4.3",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@mapbox/maki": "^8.0.1",
     "@openstreetmap/id-tagging-schema": "^6.8.1",
     "@rapideditor/mapillary_sprite_source": "^1.8.0",
-    "@rapideditor/temaki": "^5.9.0",
+    "@rapideditor/temaki": "^5.10.0",
     "@transifex/api": "^7.1.3",
     "@types/chai": "^4.3.17",
     "@types/d3": "^7.4.3",


### PR DESCRIPTION
Bump the `@rapideditor/temaki` dependency version to `^5.10.0`. This version of temaki has a new icon in it that I made, indended for a preset that I'm currently [working on adding to id-tagging-schema](https://github.com/openstreetmap/id-tagging-schema/pull/1352). 🙂 