### PR TITLE
fix erroneous `mismatched_geometry` warning for preset-less tags

### DIFF
--- a/modules/validations/mismatched_geometry.js
+++ b/modules/validations/mismatched_geometry.js
@@ -34,6 +34,12 @@ export function validationMismatchedGeometry() {
             return null;
         }
 
+        if (asLine.isFallback() && asArea.isFallback() && !deepEqual(tagSuggestingArea, { area: 'yes' })) {
+            // if the entity matches the fallback preset, regardless of the
+            // geometry, then changing the geometry will not help.
+            return null;
+        }
+
         return tagSuggestingArea;
     }
 

--- a/test/spec/validations/mismatched_geometry.js
+++ b/test/spec/validations/mismatched_geometry.js
@@ -5,6 +5,9 @@ describe('iD.validations.mismatched_geometry', function () {
         _savedAreaKeys = iD.osmAreaKeys;
         context = iD.coreContext().init();
         iD.fileFetcher.cache().preset_presets = {
+            'Line': { geometry: ['line'], fallback: true, tags: {} },
+            'Area': { geometry: ['area'], fallback: true, tags: { area: 'yes' } },
+            'Building': { geometry: ['area'], tags: { building: '*' } },
             library: {
                 tags: { amenity: 'library' },
                 geometry: ['point', 'vertex', 'line', 'area'],
@@ -98,7 +101,8 @@ describe('iD.validations.mismatched_geometry', function () {
         expect(issues).to.have.lengthOf(0);
     });
 
-    it('flags open way with area tag', function() {
+    it('flags open way with area tag', async () => {
+        await iD.presetManager.ensureLoaded(true);
         iD.osmSetAreaKeys({ building: {} });
         createOpenWay({ building: 'yes' });
         var issues = validate();
@@ -121,6 +125,18 @@ describe('iD.validations.mismatched_geometry', function () {
         expect(issue.severity).to.eql('warning');
         expect(issue.entityIds).to.have.lengthOf(1);
         expect(issue.entityIds[0]).to.eql('w-1');
+    });
+
+    it('does not flag cases whether the entity matches the generic preset, regardless of geometry', async () => {
+        // in this test case, waterway=dam is allowed as an area,
+        // and there is no preset for waterway=security_lock, so it
+        // uses to the fallback preset for all geometries.
+        await iD.presetManager.ensureLoaded(true);
+        iD.osmSetAreaKeys({ waterway: { dam: true } });
+
+        createOpenWay({ 'disused:waterway': 'security_lock' });
+        const issues = validate();
+        expect(issues).to.have.lengthOf(0);
     });
 
     it('does not error if the best preset is limited to certain regions', async () => {


### PR DESCRIPTION
Closes #10522

There is no preset for `disused:waterway=security_lock`, so it matches the fallback presets (called ["`Line`"](https://github.com/openstreetmap/id-tagging-schema/blob/main/data/presets/line.json) and ["`Area`"](https://github.com/openstreetmap/id-tagging-schema/blob/main/data/presets/area.json)). But these two presets have different tags ([`{}`](https://github.com/openstreetmap/id-tagging-schema/blob/bf95421/data/presets/line.json#L8) vs [`{ area: 'yes' }`](https://github.com/openstreetmap/id-tagging-schema/blob/bf95421/data/presets/area.json#L8-L10)) which caused the bug.

This edge-case only occurs when the tag has a lifecycle prefix, because the preset for `waterway=*` does not affect features with a lifecycle preset.