### PR TITLE
automatically create pedestrian crossing line when joining sidewalk/road

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1950,6 +1950,7 @@ en:
         title: Connect the features
       connect_using_crossing:
         title: Connect using a crossing
+        annotation: Connected using a crossing.
       connect_using_ford:
         title: Connect using a ford
       continue_from_start:


### PR DESCRIPTION
Closes #7385

When a sidewalk crosses a road, the validator already adds a crossing node, but it does not split the sidewalk line.

This PR makes the validator automatically split the sidewalk and create a [`crossing`](https://osm.wiki/Tag:footway=crossing) line.

![image](https://github.com/user-attachments/assets/505bb63a-083d-40e5-85a4-50dbd501b947)

after clicking <kbd>Connect using a crossing</kbd>:
![image](https://github.com/user-attachments/assets/a8a231e9-6588-4855-bb03-830cc2fb8e43)


Most of the code is re-used from the <kbd>Connect using a bridge/tunnel</kbd> action. This means the length of the automatically-generated crossing also uses the existing code.