### PR TITLE
Fix hover inspector UI overflow & scrollbars

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -4232,9 +4232,12 @@ li.issue-fix-item button:not(.actionable) .fix-icon {
     border: 1px solid #ccc;
 }
 
-/* scrollbars only when necessary*/
+/* scrollbars only when necessary */
 .inspector-hover div {
     overflow-x: visible;
+    overflow-y: visible;
+}
+.inspector-hover .comment div {
     overflow-y: auto;
 }
 


### PR DESCRIPTION
This small CSS change fixes #10551, fixes #9910 and closes #9912
before & after
![overflow](https://github.com/user-attachments/assets/3b3b1a6c-45d8-467d-a05e-ffa6fba285b6) ![no overflow](https://github.com/user-attachments/assets/9160f39f-5eef-4c03-9ded-36f526c6d360)

These extra scrollbars were added by `overflow-y: auto;` in #9074 to fix #9070
I reverted it to its previous value of `visible` and made sure not to reintroduce the previous overflow issue in notes with [this](https://github.com/openstreetmap/iD/commit/42190dfb8d52f3127f3aa4b8267a898a9b7ffa54#diff-3f86fb5cebd04342575e756d440d18a0b6cfb131a3c26d7897ff1793f8b6d30bR4241)
You can test it here https://www.openstreetmap.org/edit#map=18/48.129455/7.827063