### PR TITLE
Thin scrollbars for Firefox

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -5774,9 +5774,6 @@ li.hide + li.version .badge .tooltip .popover-arrow {
         background-color: rgba(0,0,0,.05);
     }
 }
-body {
-    scrollbar-width: 10px;
-}
 /* Firefox */
 @-moz-document url-prefix() {
 	* {

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -5777,6 +5777,12 @@ li.hide + li.version .badge .tooltip .popover-arrow {
 body {
     scrollbar-width: 10px;
 }
+/* Firefox */
+@-moz-document url-prefix() {
+	* {
+	    scrollbar-width: thin;
+	}
+}
 
 
 /* Intro walkthrough


### PR DESCRIPTION
Since Firefox doesn't use `::-webkit-`, we should use `scrollbar-width: thin` to better match the style on Chrome. 
This doesn't override other `scrollbar-width: none`

Chrome scrollbars:
![image](https://github.com/user-attachments/assets/1b5bca26-063c-4e3c-a16e-5523c77511dd)
Firefox scrollbars:
![ff](https://github.com/user-attachments/assets/e903497c-b6a1-4a05-b46b-17fa278c4f3d)
Firefox with thin scrollbars:
![ff_](https://github.com/user-attachments/assets/6c1b1065-7a5d-495e-92e6-e852fa861390)

Also I’m quite sure the rule `body { scrollbar-width: 10px; }` doesn’t do anything because it’s unsupported and should be deleted.