### PR TITLE
Ensure correct this context for addMembership function to call the blur method correctly. Fixes #10555

### DIFF
--- a/modules/ui/sections/raw_membership_editor.js
+++ b/modules/ui/sections/raw_membership_editor.js
@@ -170,8 +170,10 @@ export function uiSectionRawMembershipEditor(context) {
     }
 
 
-    function addMembership(d, role) {
-        this.blur();           // avoid keeping focus on the button
+    function addMembership(d, role, domElement) {
+        if (domElement && typeof domElement.blur === 'function')   {
+            domElement.blur(); // avoid keeping focus on the button
+        }
         _showBlank = false;
 
         function actionAddMembers(relationId, ids, role) {
@@ -557,7 +559,7 @@ export function uiSectionRawMembershipEditor(context) {
             if (d.relation) utilHighlightEntities([d.relation.id], false, context);
 
             var role = context.cleanRelationRole(list.selectAll('.member-row-new .member-role').property('value'));
-            addMembership(d, role);
+            addMembership(d, role, this);
         }
 
 

--- a/modules/ui/sections/raw_membership_editor.js
+++ b/modules/ui/sections/raw_membership_editor.js
@@ -170,10 +170,7 @@ export function uiSectionRawMembershipEditor(context) {
     }
 
 
-    function addMembership(d, role, domElement) {
-        if (domElement && typeof domElement.blur === 'function')   {
-            domElement.blur(); // avoid keeping focus on the button
-        }
+    function addMembership(d, role) {
         _showBlank = false;
 
         function actionAddMembers(relationId, ids, role) {
@@ -504,7 +501,10 @@ export function uiSectionRawMembershipEditor(context) {
         newMembership.selectAll('.member-entity-input')
             .on('blur', cancelEntity)   // if it wasn't accepted normally, cancel it
             .call(nearbyCombo
-                .on('accept', acceptEntity)
+                .on('accept', function(d) {
+                    this.blur(); //  always blurs the trigering element
+                    acceptEntity.call(this, d);
+                })
                 .on('cancel', cancelEntity)
             );
 
@@ -555,11 +555,12 @@ export function uiSectionRawMembershipEditor(context) {
                 cancelEntity();
                 return;
             }
+
             // remove hover-higlighting
             if (d.relation) utilHighlightEntities([d.relation.id], false, context);
 
             var role = context.cleanRelationRole(list.selectAll('.member-row-new .member-role').property('value'));
-            addMembership(d, role, this);
+            addMembership(d, role);
         }
 
 

--- a/modules/ui/sections/raw_membership_editor.js
+++ b/modules/ui/sections/raw_membership_editor.js
@@ -555,7 +555,6 @@ export function uiSectionRawMembershipEditor(context) {
                 cancelEntity();
                 return;
             }
-
             // remove hover-higlighting
             if (d.relation) utilHighlightEntities([d.relation.id], false, context);
 

--- a/modules/ui/sections/raw_membership_editor.js
+++ b/modules/ui/sections/raw_membership_editor.js
@@ -502,7 +502,7 @@ export function uiSectionRawMembershipEditor(context) {
             .on('blur', cancelEntity)   // if it wasn't accepted normally, cancel it
             .call(nearbyCombo
                 .on('accept', function(d) {
-                    this.blur(); //  always blurs the trigering element
+                    this.blur(); // always blurs the triggering element
                     acceptEntity.call(this, d);
                 })
                 .on('cancel', cancelEntity)


### PR DESCRIPTION
Fixes issue #10555 

- Pass the `this` reference explicitly to the `addMembership` function to ensure the correct context is available.
- Resolved an issue where `this` was undefined due to implicit context binding in event handlers.
- Updated `acceptEntity` to pass the triggering DOM element explicitly as a parameter.

![Screen Recording 2024-11-27 at 6 25 10 AM](https://github.com/user-attachments/assets/c01f5b5f-3690-49c9-a506-9ad1b52d3e7c)