### PR TITLE
Refactor Address Suggestion Logic to Improve Readability and Align with Addressing Standards. Fixes #10541

### DIFF
--- a/modules/ui/fields/address.js
+++ b/modules/ui/fields/address.js
@@ -55,7 +55,14 @@ export function uiFieldAddress(field, context) {
                     dist = geoSphericalDistance(choice.loc, l);
                 }
 
-                const value = resultProp && d.tags[resultProp] ? d.tags[resultProp] : d.tags.name;
+                const value = resultProp && d.tags[resultProp]
+                    ? d.tags[resultProp]
+                    : d.tags['name:en']
+                        ? d.tags['name:en'] // Fallback to English name
+                        : d.tags.name
+                            ? d.tags.name.split(';')[0].trim() // Use the first part of name (split by delimiter `;`)
+                            : null; // Default to null if no valid value exists
+
                 let title = value;
                 if (type === 'street') {
                     title = `${addrField.t('placeholders.street')}: ${title}`;


### PR DESCRIPTION
Fixes #10541 

This PR refactors the logic for determining address suggestions to improve readability and ensure compliance with addressing standards. The updated logic falls back to `name:en` for English names, and truncates multi-value name tags at the first delimiter (;) to handle dual names appropriately. 

![Screenshot 2024-11-27 at 10 24 44 AM](https://github.com/user-attachments/assets/03ed86f3-cae3-4f6f-a17f-bf5fbafdb545)
