### PR TITLE
Preserve 'opening_hours' when matching with NSI

### DIFF
--- a/modules/services/nsi.js
+++ b/modules/services/nsi.js
@@ -581,7 +581,7 @@ function _upgradeTags(tags, loc) {
 
     // These tags can be toplevel tags -or- attributes - so we generally want to preserve existing values - #8615
     // We'll only _replace_ the tag value if this tag is the toplevel/defining tag for the matched item (`k`)
-    ['building', 'emergency', 'internet_access', 'takeaway'].forEach(osmkey => {
+    ['building', 'emergency', 'internet_access', 'opening_hours', 'takeaway'].forEach(osmkey => {
       if (k !== osmkey) preserveTags.push(`^${osmkey}$`);
     });
 


### PR DESCRIPTION
re: https://github.com/osmlab/name-suggestion-index/issues/10170#issuecomment-2508129832
re: https://github.com/facebook/Rapid/commit/b1f2c3f4d059663345f3d06d88aeca8139656eb0

These are tags that we want to leave alone (i.e. not offer an "upgrade") if they already have a value. We assume the mapper knows best.