### PR TITLE
Fix for issue #4090: cmd.js line 20-26 replaced with OS-specific keyboard shortcut mappings with localization.

### DIFF
--- a/modules/ui/cmd.js
+++ b/modules/ui/cmd.js
@@ -17,11 +17,11 @@ export var uiCmd = function (code) {
     var mac = (detected.os === 'mac');
     var result = '',
         replacements = {
-            '⌘': mac ?  t('shortcuts.key.cmd')    : t('shortcuts.key.ctrl'),
-            '⇧': mac ? t('shortcuts.key.shift')  : t('shortcuts.key.shift'),
-            '⌥': mac ?  t('shortcuts.key.option') : t('shortcuts.key.alt'),
-            '⌫': mac ?  t('shortcuts.key.delete') : t('shortcuts.key.backspace'),
-            '⌦': mac ?  t('shortcuts.key.del')    : t('shortcuts.key.del'),
+            '⌘': mac ? '⌘ '  : t('shortcuts.key.ctrl'),
+            '⇧': mac ? '⇧ '  : t('shortcuts.key.shift'),
+            '⌥': mac ? '⌥ '  : t('shortcuts.key.alt'),
+            '⌫': mac ? '⌫ '  : t('shortcuts.key.backspace'),
+            '⌦': mac ? '⌦ '  : t('shortcuts.key.del'),
         };
 
     for (var i = 0; i < code.length; i++) {

--- a/modules/ui/cmd.js
+++ b/modules/ui/cmd.js
@@ -14,14 +14,15 @@ export var uiCmd = function (code) {
     if (detected.os === 'win') {
         if (code === '⌘⇧Z') return 'Ctrl+Y';
     }
-
+    var mac = (detected.os === 'mac');
     var result = '',
         replacements = {
-            '⌘': 'Ctrl',
-            '⇧': 'Shift',
-            '⌥': 'Alt',
-            '⌫': 'Backspace',
-            '⌦': 'Delete'
+            '⌘': mac ? '⌘ ' + t('shortcuts.key.cmd')    : t('shortcuts.key.ctrl'),
+            '⇧': mac ? '⇧ ' + t('shortcuts.key.shift')  : t('shortcuts.key.shift'),
+            '⌥': mac ? '⌥ ' + t('shortcuts.key.option') : t('shortcuts.key.alt'),
+            '⌃': mac ? '⌃ ' + t('shortcuts.key.ctrl')   : t('shortcuts.key.ctrl'),
+            '⌫': mac ? '⌫ ' + t('shortcuts.key.delete') : t('shortcuts.key.backspace'),
+            '⌦': mac ? '⌦ ' + t('shortcuts.key.del')    : t('shortcuts.key.del'),
         };
 
     for (var i = 0; i < code.length; i++) {
@@ -36,12 +37,14 @@ export var uiCmd = function (code) {
 };
 
 
+
 // return a display-focused string for a given keyboard code
 uiCmd.display = function(code) {
     if (code.length !== 1) return code;
 
     var detected = utilDetect();
     var mac = (detected.os === 'mac');
+    
     var replacements = {
         '⌘': mac ? '⌘ ' + t('shortcuts.key.cmd')    : t('shortcuts.key.ctrl'),
         '⇧': mac ? '⇧ ' + t('shortcuts.key.shift')  : t('shortcuts.key.shift'),

--- a/modules/ui/cmd.js
+++ b/modules/ui/cmd.js
@@ -17,12 +17,11 @@ export var uiCmd = function (code) {
     var mac = (detected.os === 'mac');
     var result = '',
         replacements = {
-            '⌘': mac ? '⌘ ' + t('shortcuts.key.cmd')    : t('shortcuts.key.ctrl'),
-            '⇧': mac ? '⇧ ' + t('shortcuts.key.shift')  : t('shortcuts.key.shift'),
-            '⌥': mac ? '⌥ ' + t('shortcuts.key.option') : t('shortcuts.key.alt'),
-            '⌃': mac ? '⌃ ' + t('shortcuts.key.ctrl')   : t('shortcuts.key.ctrl'),
-            '⌫': mac ? '⌫ ' + t('shortcuts.key.delete') : t('shortcuts.key.backspace'),
-            '⌦': mac ? '⌦ ' + t('shortcuts.key.del')    : t('shortcuts.key.del'),
+            '⌘': mac ?  t('shortcuts.key.cmd')    : t('shortcuts.key.ctrl'),
+            '⇧': mac ? t('shortcuts.key.shift')  : t('shortcuts.key.shift'),
+            '⌥': mac ?  t('shortcuts.key.option') : t('shortcuts.key.alt'),
+            '⌫': mac ?  t('shortcuts.key.delete') : t('shortcuts.key.backspace'),
+            '⌦': mac ?  t('shortcuts.key.del')    : t('shortcuts.key.del'),
         };
 
     for (var i = 0; i < code.length; i++) {
@@ -44,7 +43,7 @@ uiCmd.display = function(code) {
 
     var detected = utilDetect();
     var mac = (detected.os === 'mac');
-    
+
     var replacements = {
         '⌘': mac ? '⌘ ' + t('shortcuts.key.cmd')    : t('shortcuts.key.ctrl'),
         '⇧': mac ? '⇧ ' + t('shortcuts.key.shift')  : t('shortcuts.key.shift'),

--- a/modules/ui/sections/data_layers.js
+++ b/modules/ui/sections/data_layers.js
@@ -405,6 +405,7 @@ export function uiSectionDataLayers(context) {
                 .placement('top')
             );
 
+
         historyPanelLabelEnter
             .append('input')
             .attr('type', 'checkbox')


### PR DESCRIPTION
Description of Code Change
The proposed change enhances keyboard shortcut mappings to dynamically adapt based on the operating system.

Original Code

The replacements object statically maps symbols (e.g., ⌘, ⇧) to generic labels (e.g., Ctrl, Shift), with no differentiation for macOS.

<img width="1325" alt="image" src="https://github.com/user-attachments/assets/802479f2-9eb7-4e77-b7ec-b44f50a94dcd">

This shows CTRL + Shift + C on German language.

---

Proposed Change :

OS Detection
Introduces a mac variable to determine if the operating system is macOS (detected.os === 'mac').

Dynamic Mapping
For macOS:
Uses macOS-specific symbols and labels (e.g., ⌘ Cmd, ⇧ Shift).
Prepends symbols to enhance clarity.

For Others:
Defaults to generic labels like Ctrl, Alt, and Shift.

Localization:
Integrates t() to fetch OS-specific, human-readable labels, supporting multiple languages.

<img width="1325" alt="image" src="https://github.com/user-attachments/assets/77f7602c-a7d2-4340-b7f2-6fd63abe5457">

This newly proposed shows STRG + Umschalt + C on German language.

