### PR TITLE
Update help panel navigation buttons

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -4184,12 +4184,6 @@ li.issue-fix-item button:not(.actionable) .fix-icon {
     width: 100%;
 }
 
-.ideditor .help-pane .nav::after {
-    content: '';
-    display: table;
-    clear: both;
-}
-
 .help-pane .nav a {
     flex: 0 0 50%;
     text-align: center;

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -4179,11 +4179,19 @@ li.issue-fix-item button:not(.actionable) .fix-icon {
 .help-pane .nav {
     position: relative;
     padding-bottom: 30px;
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+}
+
+.ideditor .help-pane .nav::after {
+    content: '';
+    display: table;
+    clear: both;
 }
 
 .help-pane .nav a {
-    float: left;
-    width: 50%;
+    flex: 0 0 50%;
     text-align: center;
 }
 
@@ -4197,7 +4205,7 @@ li.issue-fix-item button:not(.actionable) .fix-icon {
 }
 
 .help-pane .nav a:only-child {
-    width: 100%;
+    flex: 0 0 100%;
     border-radius: 4px;
 }
 


### PR DESCRIPTION
Fixes #10573  where the empty nav button for 'next' was overlapping the keyboard shortcuts button when the user was currently view the Quality Assurance page.