### PR TITLE
Restrict direction cones to matching parent ways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :white_check_mark: Validation
 #### :bug: Bugfixes
 * Fix unsolvable validator error triggered by regional presets ([#10459])
+* Render highway direction cones only on matching parent ways ([#9013])
 #### :earth_asia: Localization
 * Update Sinitic languages in the Multilingual Names field ([#10488], thanks [@winstonsung])
 * Update the list of languages in the Wikipedia field ([#10489])
@@ -54,6 +55,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :hammer: Development
 * Migrate unit tests from karma to vitest ([#10452])
 
+[#9013]: https://github.com/openstreetmap/iD/issues/9013
 [#10452]: https://github.com/openstreetmap/iD/pull/10452
 [#10459]: https://github.com/openstreetmap/iD/pull/10459
 [#10488]: https://github.com/openstreetmap/iD/pull/10488

--- a/modules/osm/node.js
+++ b/modules/osm/node.js
@@ -114,19 +114,23 @@ Object.assign(osmNode.prototype, {
             if (!lookForward && !lookBackward) return;
 
             var nodeIds = {};
-            resolver.parentWays(this).forEach(function(parent) {
-                var nodes = parent.nodes;
-                for (i = 0; i < nodes.length; i++) {
-                    if (nodes[i] === this.id) {  // match current entity
-                        if (lookForward && i > 0) {
-                            nodeIds[nodes[i - 1]] = true;  // look back to prev node
-                        }
-                        if (lookBackward && i < nodes.length - 1) {
-                            nodeIds[nodes[i + 1]] = true;  // look ahead to next node
+            resolver.parentWays(this)
+                .filter(p => (this.tags.highway || this.tags.traffic_sign || this.tags.traffic_calming || this.tags.barrier || this.tags.cycleway) ? p.tags.highway : true)
+                .filter(p => (this.tags.railway) ? p.tags.railway : true)
+                .filter(p => (this.tags.waterway) ? p.tags.waterway : true)
+                .forEach(function(parent) {
+                    var nodes = parent.nodes;
+                    for (i = 0; i < nodes.length; i++) {
+                        if (nodes[i] === this.id) {  // match current entity
+                            if (lookForward && i > 0) {
+                                nodeIds[nodes[i - 1]] = true;  // look back to prev node
+                            }
+                            if (lookBackward && i < nodes.length - 1) {
+                                nodeIds[nodes[i + 1]] = true;  // look ahead to next node
+                            }
                         }
                     }
-                }
-            }, this);
+                }, this);
 
             Object.keys(nodeIds).forEach(function(nodeId) {
                 // +90 because geoAngle returns angle from X axis, not Y (north)


### PR DESCRIPTION
Fixes #9013: For certain vertex features, only look at matching parent ways when determining where to draw direction cones:

* highway related points (e.g. `highway=stop/yield/…`, traffic calming, `cycleway=asl`, traffic signs, barriers): only look at parent ways with `highway=*`
* railway related points (e.g. `railway=milestone`): only look at parent ways with `railway=*`
* waterway related points (e.g. `waterway=milestone`): only look at parent ways with `waterway=*`

These cases cover all presets in iD that currently use the `direction_vertex` field. Are there any further feature combinations to consider?