### PR TITLE
Fix: Remove Disambiguators from Relation Names in Membership Editor. Fixes #8759

### DIFF
--- a/modules/ui/sections/raw_member_editor.js
+++ b/modules/ui/sections/raw_member_editor.js
@@ -193,7 +193,12 @@ export function uiSectionRawMemberEditor(context) {
                         .attr('class', 'member-entity-type')
                         .text(function(d) {
                             var matched = presetManager.match(d.member, context.graph());
-                            return (matched && matched.name()) || utilDisplayType(d.member.id);
+
+                            var fullName = (matched && matched.name()) || utilDisplayType(d.member.id);
+
+                            // Remove the disambiguator (text in parentheses) from the full name
+                            var simplifiedName = fullName.replace(/\s*\(.*?\)$/, ''); // Removes " (…)" at the end
+                            return simplifiedName;
                         });
 
                     labelLink

--- a/modules/ui/sections/raw_membership_editor.js
+++ b/modules/ui/sections/raw_membership_editor.js
@@ -377,7 +377,11 @@ export function uiSectionRawMembershipEditor(context) {
             .attr('class', 'member-entity-type')
             .text(function(d) {
                 var matched = presetManager.match(d.relation, context.graph());
-                return (matched && matched.name()) || t.html('inspector.relation');
+                var fullName = (matched && matched.name()) || t('inspector.relation');
+
+                // Remove the disambiguator (text in parentheses) from the full name
+                var simplifiedName = fullName.replace(/\s*\(.*?\)$/, ''); // Removes " (…)" at the end
+                return simplifiedName;
             });
 
         labelLink


### PR DESCRIPTION
This fixes #8759 

This PR improves the usability of the raw member/membership editor by removing disambiguators (text in parentheses, e.g., (Santa Clara Valley Transportation Authority)) from relation names. The change simplifies the display, making it less cluttered and more focused on relevant information like the relation's ref and primary name.