### PR TITLE
Render edit menu to the over-map layer. Fixes #10495

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :white_check_mark: Validation
 #### :bug: Bugfixes
 * Fix unsolvable validator error triggered by regional presets ([#10459])
+* Prevent edit menu from being covered up by street level imagery or other map overlay panels ([#10495])
 #### :earth_asia: Localization
 * Update Sinitic languages in the Multilingual Names field ([#10488], thanks [@winstonsung])
 * Update the list of languages in the Wikipedia field ([#10489])
@@ -58,6 +59,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#10459]: https://github.com/openstreetmap/iD/pull/10459
 [#10488]: https://github.com/openstreetmap/iD/pull/10488
 [#10489]: https://github.com/openstreetmap/iD/pull/10489
+[#10495]: https://github.com/openstreetmap/iD/issues/10495
 [@winstonsung]: https://github.com/winstonsung/
 
 

--- a/modules/ui/edit_menu.js
+++ b/modules/ui/edit_menu.js
@@ -36,7 +36,7 @@ export function uiEditMenu(context) {
 
     // offset the menu slightly from the target location
     var _menuSideMargin = 10;
-    
+
     // hardcoded values for repositioning the menu to account for the top menu height
     var _verticalOffset = 70;
 

--- a/modules/ui/edit_menu.js
+++ b/modules/ui/edit_menu.js
@@ -36,6 +36,9 @@ export function uiEditMenu(context) {
 
     // offset the menu slightly from the target location
     var _menuSideMargin = 10;
+    
+    // hardcoded values for repositioning the menu to account for the top menu height
+    var _verticalOffset = 70;
 
     var _tooltips = [];
 
@@ -226,7 +229,8 @@ export function uiEditMenu(context) {
         }
 
         var origin = geoVecAdd(anchorLoc, offset);
-
+        // adjusts for top menu height
+        origin[1] -= _verticalOffset;
         _menu
             .style('left', origin[0] + 'px')
             .style('top', origin[1] + 'px');

--- a/modules/ui/edit_menu.js
+++ b/modules/ui/edit_menu.js
@@ -6,6 +6,7 @@ import { localizer } from '../core/localizer';
 import { uiTooltip } from './tooltip';
 import { utilRebind } from '../util/rebind';
 import { utilHighlightEntities } from '../util/util';
+import { utilGetDimensions } from '../util/dimensions';
 import { svgIcon } from '../svg/icon';
 
 
@@ -36,9 +37,6 @@ export function uiEditMenu(context) {
 
     // offset the menu slightly from the target location
     var _menuSideMargin = 10;
-
-    // hardcoded values for repositioning the menu to account for the top menu height
-    var _verticalOffset = 70;
 
     var _tooltips = [];
 
@@ -229,8 +227,10 @@ export function uiEditMenu(context) {
         }
 
         var origin = geoVecAdd(anchorLoc, offset);
-        // adjusts for top menu height
+        // repositioning the menu to account for the top menu height
+        var _verticalOffset = parseFloat(utilGetDimensions(d3_select('.top-toolbar-wrap'))[1]);
         origin[1] -= _verticalOffset;
+
         _menu
             .style('left', origin[0] + 'px')
             .style('top', origin[1] + 'px');

--- a/modules/ui/init.js
+++ b/modules/ui/init.js
@@ -673,8 +673,9 @@ export function uiInit(context) {
 
     ui.closeEditMenu = function() {
         // remove any existing menu no matter how it was added
-       overMap
-            .select('.edit-menu').remove();
+        if (overMap !== undefined) {
+            overMap.select('.edit-menu').remove();
+        }
     };
 
 

--- a/modules/ui/init.js
+++ b/modules/ui/init.js
@@ -54,6 +54,7 @@ export function uiInit(context) {
 
     var _lastPointerType;
 
+    var overMap;
 
     function render(container) {
 
@@ -160,7 +161,7 @@ export function uiInit(context) {
             .attr('dir', 'ltr')
             .call(map);
 
-        var overMap = content
+        overMap = content
             .append('div')
             .attr('class', 'over-map');
 
@@ -665,13 +666,16 @@ export function uiInit(context) {
             .triggerType(triggerType)
             .operations(operations);
 
-        // render the menu
-        context.map().supersurface.call(_editMenu);
+        // render the menu onto the overmap
+        overMap
+            // .append('div')
+            // .attr('class', 'menu-topbar-offset')
+            .call(_editMenu);
     };
 
     ui.closeEditMenu = function() {
         // remove any existing menu no matter how it was added
-        context.map().supersurface
+       overMap
             .select('.edit-menu').remove();
     };
 

--- a/modules/ui/init.js
+++ b/modules/ui/init.js
@@ -668,8 +668,6 @@ export function uiInit(context) {
 
         // render the menu onto the overmap
         overMap
-            // .append('div')
-            // .attr('class', 'menu-topbar-offset')
             .call(_editMenu);
     };
 


### PR DESCRIPTION
This Fixes #10495 by rendering the menu to the `over-map` layer rather than the `supersurface`. I had to make a ref to `overMap` available which i'm not sure how to get around currently. If this is not ideal, please let me know if there are any tips on how to achieve this otherwise.

![image](https://github.com/user-attachments/assets/3a702fd9-ae29-480c-9822-a386e0b4751b)
