### PR TITLE
Fix visible grid around tiles

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -4369,9 +4369,9 @@ img.tile {
 }
 
 /* Workaround to remove visible grid around tile borders on Chrome */
-/* with 3 exceptions for 110%, 80% and 67% browser zoom */
+/* with exceptions for 110%, 90%, 80% and 67% browser zoom */
 /* https://issues.chromium.org/issues/40084005  https://github.com/Leaflet/Leaflet/pull/8891  https://github.com/openstreetmap/iD/pull/10594 */
-@media not ((1.09 < -webkit-device-pixel-ratio < 1.11) or (0.79 < -webkit-device-pixel-ratio < 0.81) or (0.66 < -webkit-device-pixel-ratio < 0.68)) {
+@media not ((1.09 < -webkit-device-pixel-ratio < 1.11) or (0.89 < -webkit-device-pixel-ratio < 0.91) or (0.79 < -webkit-device-pixel-ratio < 0.81) or (0.66 < -webkit-device-pixel-ratio < 0.68)) {
     .layer-background img.tile {
         mix-blend-mode: plus-lighter;
     }

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -4367,12 +4367,16 @@ img.tile {
     opacity: 1;
     transition: opacity 120ms linear;
 }
-/* Fix visible grid around tiles borders on Chrome */
+
+/* Workaround to remove visible grid around tile borders on Chrome */
+/* with 3 exceptions for 110%, 80% and 67% browser zoom */
+/* https://issues.chromium.org/issues/40084005  https://github.com/Leaflet/Leaflet/pull/8891  https://github.com/openstreetmap/iD/pull/10594 */
 @media not ((1.09 < -webkit-device-pixel-ratio < 1.11) or (0.79 < -webkit-device-pixel-ratio < 0.81) or (0.66 < -webkit-device-pixel-ratio < 0.68)) {
     .layer-background img.tile {
         mix-blend-mode: plus-lighter;
     }
 }
+
 img.tile-removing {
     opacity: 0;
     z-index: 1;

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -4367,7 +4367,10 @@ img.tile {
     opacity: 1;
     transition: opacity 120ms linear;
 }
-
+.layer-background img.tile {
+    /* Fix visible grid around tiles borders on Chrome */
+    mix-blend-mode: plus-lighter;
+}
 img.tile-removing {
     opacity: 0;
     z-index: 1;

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -4369,9 +4369,13 @@ img.tile {
 }
 
 /* Workaround to remove visible grid around tile borders on Chrome */
-/* with exceptions for 110%, 90%, 80% and 67% browser zoom */
-/* https://issues.chromium.org/issues/40084005  https://github.com/Leaflet/Leaflet/pull/8891  https://github.com/openstreetmap/iD/pull/10594 */
-@media not ((1.09 < -webkit-device-pixel-ratio < 1.11) or (0.89 < -webkit-device-pixel-ratio < 0.91) or (0.79 < -webkit-device-pixel-ratio < 0.81) or (0.66 < -webkit-device-pixel-ratio < 0.68)) {
+/* Only works with browser zoom multiple of 25 (75%, 100%, 125%...) */
+/* Should be removed when https://issues.chromium.org/issues/40084005 is resolved */
+@media (-webkit-device-pixel-ratio = 1) or (-webkit-device-pixel-ratio = 1.25) or (-webkit-device-pixel-ratio = 1.5) or (-webkit-device-pixel-ratio = 1.75)
+    or (-webkit-device-pixel-ratio = 2) or (-webkit-device-pixel-ratio = 2.25) or (-webkit-device-pixel-ratio = 2.5) or (-webkit-device-pixel-ratio = 2.75)
+    or (-webkit-device-pixel-ratio = 3) or (-webkit-device-pixel-ratio = 3.25) or (-webkit-device-pixel-ratio = 3.5) or (-webkit-device-pixel-ratio = 3.75)
+    or (-webkit-device-pixel-ratio = 4) or (-webkit-device-pixel-ratio = 4.25) or (-webkit-device-pixel-ratio = 4.5) or (-webkit-device-pixel-ratio = 4.75) 
+    or (-webkit-device-pixel-ratio = 5) or (-webkit-device-pixel-ratio = 0.25) or (-webkit-device-pixel-ratio = 0.5) or (-webkit-device-pixel-ratio = 0.75) {
     .layer-background img.tile {
         mix-blend-mode: plus-lighter;
     }

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -4368,9 +4368,10 @@ img.tile {
     transition: opacity 120ms linear;
 }
 
-/* Workaround to remove visible grid around tile borders on Chrome */
-/* Only works with browser zoom multiple of 25 (75%, 100%, 125%...) */
-/* Should be removed when https://issues.chromium.org/issues/40084005 is resolved */
+/* Workaround to remove visible grid around tile borders on Chrome
+   Only works with browser zoom multiple of 25 (75%, 100%, 125%...) 
+   Should be removed when https://issues.chromium.org/issues/40084005 is resolved.
+   See https://github.com/openstreetmap/iD/pull/10594 */
 @media (-webkit-device-pixel-ratio = 1) or (-webkit-device-pixel-ratio = 1.25) or (-webkit-device-pixel-ratio = 1.5) or (-webkit-device-pixel-ratio = 1.75)
     or (-webkit-device-pixel-ratio = 2) or (-webkit-device-pixel-ratio = 2.25) or (-webkit-device-pixel-ratio = 2.5) or (-webkit-device-pixel-ratio = 2.75)
     or (-webkit-device-pixel-ratio = 3) or (-webkit-device-pixel-ratio = 3.25) or (-webkit-device-pixel-ratio = 3.5) or (-webkit-device-pixel-ratio = 3.75)

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -4367,9 +4367,11 @@ img.tile {
     opacity: 1;
     transition: opacity 120ms linear;
 }
-.layer-background img.tile {
-    /* Fix visible grid around tiles borders on Chrome */
-    mix-blend-mode: plus-lighter;
+/* Fix visible grid around tiles borders on Chrome */
+@media not ((1.09 < -webkit-device-pixel-ratio < 1.11) or (0.79 < -webkit-device-pixel-ratio < 0.81) or (0.66 < -webkit-device-pixel-ratio < 0.68)) {
+    .layer-background img.tile {
+        mix-blend-mode: plus-lighter;
+    }
 }
 img.tile-removing {
     opacity: 0;

--- a/modules/renderer/tile_layer.js
+++ b/modules/renderer/tile_layer.js
@@ -19,6 +19,7 @@ export function rendererTileLayer(context) {
 
     // Workaround to remove visible grid around tile borders on Chrome with dynamic epsilon for specific browser zoom levels
     // Should be removed when https://issues.chromium.org/issues/40084005 is resolved
+    // See https://github.com/openstreetmap/iD/pull/10594
     if (window.chrome) {
         updateEpsilon();
         window.addEventListener('resize', updateEpsilon);

--- a/modules/renderer/tile_layer.js
+++ b/modules/renderer/tile_layer.js
@@ -15,10 +15,33 @@ export function rendererTileLayer(context) {
     var _tileOrigin;
     var _zoom;
     var _source;
+    var _epsilon = 0;
 
+    // Workaround to remove visible grid around tile borders on Chrome with dynamic epsilon for specific browser zoom levels
+    // Should be removed when https://issues.chromium.org/issues/40084005 is resolved, https://github.com/openstreetmap/iD/pull/10594
+    if (window.chrome) {
+        updateEpsilon();
+        window.addEventListener('resize', updateEpsilon);
+    }
+    function updateEpsilon() {
+        switch (Math.round(window.devicePixelRatio * 100)) {
+            case 110:
+                _epsilon = 0.002;
+                break;
+            case 90:
+                _epsilon = 0.005;
+                break;
+            case 80:
+            case 67:
+                _epsilon = 0.003;
+                break;
+            default:
+                _epsilon = 0;
+        }
+    }
 
     function tileSizeAtZoom(d, z) {
-        return ((d.tileSize * Math.pow(2, z - d[2])) / d.tileSize);
+        return ((d.tileSize * Math.pow(2, z - d[2])) / d.tileSize) + _epsilon;
     }
 
 

--- a/modules/renderer/tile_layer.js
+++ b/modules/renderer/tile_layer.js
@@ -18,8 +18,7 @@ export function rendererTileLayer(context) {
 
 
     function tileSizeAtZoom(d, z) {
-        var EPSILON = 0.002;    // close seams
-        return ((d.tileSize * Math.pow(2, z - d[2])) / d.tileSize) + EPSILON;
+        return ((d.tileSize * Math.pow(2, z - d[2])) / d.tileSize);
     }
 
 

--- a/modules/renderer/tile_layer.js
+++ b/modules/renderer/tile_layer.js
@@ -18,25 +18,21 @@ export function rendererTileLayer(context) {
     var _epsilon = 0;
 
     // Workaround to remove visible grid around tile borders on Chrome with dynamic epsilon for specific browser zoom levels
-    // Should be removed when https://issues.chromium.org/issues/40084005 is resolved, https://github.com/openstreetmap/iD/pull/10594
+    // Should be removed when https://issues.chromium.org/issues/40084005 is resolved
     if (window.chrome) {
         updateEpsilon();
         window.addEventListener('resize', updateEpsilon);
     }
     function updateEpsilon() {
-        switch (Math.round(window.devicePixelRatio * 100)) {
-            case 110:
-                _epsilon = 0.002;
-                break;
-            case 90:
-                _epsilon = 0.005;
-                break;
-            case 80:
-            case 67:
-                _epsilon = 0.003;
-                break;
-            default:
-                _epsilon = 0;
+        const pageZoom = Math.round(window.devicePixelRatio * 100);
+        if (pageZoom % 25 === 0) {
+            _epsilon = 0; // uses mix-blend-mode: plus-lighter
+        } else if (pageZoom === 90) {
+            _epsilon = 0.005;
+        } else if (pageZoom === 110) {
+            _epsilon = 0.002;
+        } else {
+            _epsilon = 0.003;
         }
     }
 


### PR DESCRIPTION
This properly fixes #10589 by removing the tile overlap that was causing white borders with transparent tiles.

The tile overlap was added as a dirty fix to #3053, it doesn't even fully resolved the issue anyway.
This fix uses the CSS rule `mix-blend-mode: plus-lighter`, applied only to the background layer and is only needed to fix [this bug](https://issues.chromium.org/issues/40084005) in Chrome.
A future version of Chrome might make this CSS rule unnecessary (but leaving it shouldn't cause the borders to reappear).

Tested on Chrome and Firefox with normal and fractional zoom levels, with regular and transparent layers.
Not tested on macOS Safari or mobile.