### PR TITLE
Do not add ignore_issue if there are no other dynamic fixes, tries to fix #10614

### DIFF
--- a/modules/core/validation/models.js
+++ b/modules/core/validation/models.js
@@ -63,7 +63,7 @@ export function validationIssue(attrs) {
         var fixes = this.dynamicFixes ? this.dynamicFixes(context) : [];
         var issue = this;
 
-        if (issue.severity === 'warning') {
+        if (issue.severity === 'warning' && fixes.length > 0) {
             // allow ignoring any issue that's not an error
             fixes.push(new validationIssueFix({
                 title: t.append('issues.fix.ignore_issue.title'),


### PR DESCRIPTION
Tries to fix #10614

I have tried to solve the problem of the mapper getting mislead into thinking there is nothing else to fix by showing "ignore this issue" while adding a tunnel

I have added an extra check which prevents inserting the `ignore_issue` `validationIssueFix` if there are no other `dynamicFixes` in the context