### PR TITLE
fix relation role dropdown not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Fix flickering of imagery metadata information in background panel ([#9754])
 * Immediately update raw tag key/value inputs when spaces have been trimmed ([#11206])
 * Fix duplicate values deleted when editing `destination:*` tags ([#10639], thanks [@k-yle])
+* Fix the relation role dropdown not opening on click ([#10645], thanks [@k-yle])
 #### :earth_asia: Localization
 #### :hourglass: Performance
 #### :rocket: Presets
@@ -60,6 +61,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#9588]: https://github.com/openstreetmap/iD/pull/9588
 [#9754]: https://github.com/openstreetmap/iD/issues/9754
 [#10639]: https://github.com/openstreetmap/iD/pull/10639
+[#10645]: https://github.com/openstreetmap/iD/pull/10645
 [#11206]: https://github.com/openstreetmap/iD/issues/11206
 [#11211]: https://github.com/openstreetmap/iD/issues/11211
 [@bhavyaKhatri2703]: https://github.com/bhavyaKhatri2703
@@ -288,6 +290,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#9636]: https://github.com/openstreetmap/iD/pull/9636
 [#10003]: https://github.com/openstreetmap/iD/pull/10003
 [#10618]: https://github.com/openstreetmap/iD/pull/10618
+[#10645]: https://github.com/openstreetmap/iD/pull/10645
 [#10646]: https://github.com/openstreetmap/iD/pull/10646
 [#10648]: https://github.com/openstreetmap/iD/pull/10648
 [#10720]: https://github.com/openstreetmap/iD/issues/10720

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -2866,6 +2866,10 @@ img.tag-reference-wiki-image {
     margin: 0;
     padding-bottom: 10px;
 }
+/* only the raw-member-editor is reorederable, not the raw-membership-editor */
+.section-raw-member-editor .member-row .label-text { cursor: grab; }
+.section-raw-member-editor .member-row .label-text:active { cursor: grabbing; }
+
 .section-raw-member-editor .member-row .member-entity-name,
 .section-raw-membership-editor .member-row .member-entity-name {
     font-weight: normal;

--- a/modules/ui/combobox.js
+++ b/modules/ui/combobox.js
@@ -84,6 +84,9 @@ export function uiCombobox(context, klass) {
             if (input.classed('disabled')) return;
             _tDown = +new Date();
 
+            // mousedown should never bubble up (see #10481)
+            d3_event.stopPropagation();
+
             // clear selection
             var start = input.property('selectionStart');
             var end = input.property('selectionEnd');


### PR DESCRIPTION
Closes #10481 

Left-clicking on the input field should open up the dropdown, just like does in the _Membership_ (cf _Member_) section.

<img width="299" alt="image" src="https://github.com/user-attachments/assets/2c44aa1f-73a8-47e9-9acd-2afac715e9d3" />

The reason for the inconsistency is that _Member_ section is reorderable using drag-and-drop, while the _Membership_ section is not, so `d3-drag` is not involved.