### PR TITLE
fix `destination_sign` relations not updated when splitting a way

### DIFF
--- a/modules/actions/split.js
+++ b/modules/actions/split.js
@@ -172,7 +172,10 @@ export function actionSplit(nodeIds, newWayIds) {
             // 2. Splitting a VIA way - `wayB` remains in relation as a VIA way
             if (relation.hasFromViaTo()) {
                 var f = relation.memberByRole('from');
-                var v = relation.membersByRole('via');
+                var v = [
+                    ...relation.membersByRole('via'),
+                    ...relation.membersByRole('intersection'),
+                ];
                 var t = relation.memberByRole('to');
                 var i;
 
@@ -461,7 +464,10 @@ export function actionSplit(nodeIds, newWayIds) {
                 for (const parentRelation of parentRelations) {
                     if (parentRelation.hasFromViaTo()) {
                         // turn restrictions: via members must be loaded
-                        const vias = parentRelation.membersByRole('via');
+                        const vias = [
+                            ...parentRelation.membersByRole('via'),
+                            ...parentRelation.membersByRole('intersection'),
+                        ];
                         if (!vias.every(via => graph.hasEntity(via.id))) {
                             return 'parent_incomplete';
                         }

--- a/modules/osm/relation.js
+++ b/modules/osm/relation.js
@@ -259,7 +259,10 @@ Object.assign(osmRelation.prototype, {
     hasFromViaTo: function() {
         return (
             this.members.some(function(m) { return m.role === 'from'; }) &&
-            this.members.some(function(m) { return m.role === 'via'; }) &&
+            this.members.some((m) =>
+                m.role === 'via' ||
+                (m.role === 'intersection' && this.tags.type === 'destination_sign')
+            ) &&
             this.members.some(function(m) { return m.role === 'to'; })
         );
     },

--- a/test/spec/actions/split.js
+++ b/test/spec/actions/split.js
@@ -1653,7 +1653,9 @@ describe('iD.actionSplit', function () {
         });
 
 
-        ['restriction', 'restriction:bus', 'manoeuvre'].forEach(function (type) {
+        ['restriction', 'restriction:bus', 'manoeuvre', 'destination_sign'].forEach(function (type) {
+            const viaRole = type === 'destination_sign' ? 'intersection' : 'via';
+
             describe('type = ' + type, function () {
                 var a = iD.osmNode({id: 'a', loc: [0, 0]});
                 var b = iD.osmNode({id: 'b', loc: [1, 0]});
@@ -1674,7 +1676,7 @@ describe('iD.actionSplit', function () {
                     iD.osmRelation({id: 'r', tags: {type: type}, members: [
                         {id: '-', role: 'from', type: 'way'},
                         {id: '~', role: 'to', type: 'way'},
-                        {id: 'd', role: 'via', type: 'node'}
+                        {id: 'd', role: viaRole, type: 'node'}
                     ]})
                 ]);
 
@@ -1690,7 +1692,7 @@ describe('iD.actionSplit', function () {
                     iD.osmRelation({id: 'r', tags: {type: type}, members: [
                         {id: '~', role: 'from', type: 'way'},
                         {id: '-', role: 'to', type: 'way'},
-                        {id: 'd', role: 'via', type: 'node'}
+                        {id: 'd', role: viaRole, type: 'node'}
                     ]})
                 ]);
 
@@ -1706,7 +1708,7 @@ describe('iD.actionSplit', function () {
                     iD.osmRelation({id: 'r', tags: {type: type}, members: [
                         {id: '-', role: 'from', type: 'way'},
                         {id: '-', role: 'to', type: 'way'},
-                        {id: 'd', role: 'via', type: 'node'}
+                        {id: 'd', role: viaRole, type: 'node'}
                     ]})
                 ]);
 
@@ -1727,7 +1729,7 @@ describe('iD.actionSplit', function () {
                     iD.osmRelation({id: 'r', tags: {type: type}, members: [
                         {id: '-', role: 'from', type: 'way'},
                         {id: '~', role: 'to', type: 'way'},
-                        {id: '|', role: 'via', type: 'way'}
+                        {id: '|', role: viaRole, type: 'way'}
                     ]})
                 ]);
 
@@ -1748,7 +1750,7 @@ describe('iD.actionSplit', function () {
                     iD.osmRelation({id: 'r', tags: {type: type}, members: [
                         {id: '~', role: 'from', type: 'way'},
                         {id: '-', role: 'to', type: 'way'},
-                        {id: '|', role: 'via', type: 'way'}
+                        {id: '|', role: viaRole, type: 'way'}
                     ]})
                 ]);
 
@@ -1768,7 +1770,7 @@ describe('iD.actionSplit', function () {
                     iD.osmWay({id: '‖', nodes: ['f', 'd']}),
                     iD.osmRelation({id: 'r', tags: {type: type}, members: [
                         {id: '|', role: 'from', type: 'way'},
-                        {id: '-', role: 'via', type: 'way'},
+                        {id: '-', role: viaRole, type: 'way'},
                         {id: '‖', role: 'to', type: 'way'}
                     ]})
                 ]);
@@ -1785,7 +1787,7 @@ describe('iD.actionSplit', function () {
                     iD.osmRelation({id: 'r', tags: {type: type}, members: [
                         {id: '-', role: 'from', type: 'way'},
                         {id: '~', role: 'to', type: 'way'},
-                        {id: 'd', role: 'via', type: 'node'}
+                        {id: 'd', role: viaRole, type: 'node'}
                     ]})
                 ]);
 
@@ -1801,7 +1803,7 @@ describe('iD.actionSplit', function () {
                     expect(graph.entity('r').members).to.eql([
                         {id: '=', role: 'from', type: 'way'},
                         {id: '~', role: 'to', type: 'way'},
-                        {id: 'd', role: 'via', type: 'node'}
+                        {id: 'd', role: viaRole, type: 'node'}
                     ]);
                 });
 
@@ -1817,7 +1819,7 @@ describe('iD.actionSplit', function () {
                     expect(graph.entity('r').members).to.eql([
                         {id: '-', role: 'from', type: 'way'},
                         {id: '~', role: 'to', type: 'way'},
-                        {id: 'd', role: 'via', type: 'node'}
+                        {id: 'd', role: viaRole, type: 'node'}
                     ]);
                 });
 
@@ -1833,7 +1835,7 @@ describe('iD.actionSplit', function () {
                     expect(graph.entity('r').members).to.eql([
                         {id: '~', role: 'from', type: 'way'},
                         {id: '=', role: 'to', type: 'way'},
-                        {id: 'd', role: 'via', type: 'node'}
+                        {id: 'd', role: viaRole, type: 'node'}
                     ]);
                 });
 
@@ -1849,7 +1851,7 @@ describe('iD.actionSplit', function () {
                     expect(graph.entity('r').members).to.eql([
                         {id: '~', role: 'from', type: 'way'},
                         {id: '-', role: 'to', type: 'way'},
-                        {id: 'd', role: 'via', type: 'node'}
+                        {id: 'd', role: viaRole, type: 'node'}
                     ]);
                 });
 
@@ -1865,7 +1867,7 @@ describe('iD.actionSplit', function () {
                     expect(graph.entity('r').members).to.eql([
                         {id: '=', role: 'from', type: 'way'},
                         {id: '=', role: 'to', type: 'way'},
-                        {id: 'd', role: 'via', type: 'node'}
+                        {id: 'd', role: viaRole, type: 'node'}
                     ]);
                 });
 
@@ -1881,7 +1883,7 @@ describe('iD.actionSplit', function () {
                     expect(graph.entity('r').members).to.eql([
                         {id: '-', role: 'from', type: 'way'},
                         {id: '-', role: 'to', type: 'way'},
-                        {id: 'd', role: 'via', type: 'node'}
+                        {id: 'd', role: viaRole, type: 'node'}
                     ]);
                 });
 
@@ -1901,7 +1903,7 @@ describe('iD.actionSplit', function () {
                     expect(graph.entity('r').members).to.eql([
                         {id: '=', role: 'from', type: 'way'},
                         {id: '~', role: 'to', type: 'way'},
-                        {id: '|', role: 'via', type: 'way'}
+                        {id: '|', role: viaRole, type: 'way'}
                     ]);
                 });
 
@@ -1921,7 +1923,7 @@ describe('iD.actionSplit', function () {
                     expect(graph.entity('r').members).to.eql([
                         {id: '-', role: 'from', type: 'way'},
                         {id: '~', role: 'to', type: 'way'},
-                        {id: '|', role: 'via', type: 'way'}
+                        {id: '|', role: viaRole, type: 'way'}
                     ]);
                 });
 
@@ -1941,7 +1943,7 @@ describe('iD.actionSplit', function () {
                     expect(graph.entity('r').members).to.eql([
                         {id: '~', role: 'from', type: 'way'},
                         {id: '=', role: 'to', type: 'way'},
-                        {id: '|', role: 'via', type: 'way'}
+                        {id: '|', role: viaRole, type: 'way'}
                     ]);
                 });
 
@@ -1961,7 +1963,7 @@ describe('iD.actionSplit', function () {
                     expect(graph.entity('r').members).to.eql([
                         {id: '~', role: 'from', type: 'way'},
                         {id: '-', role: 'to', type: 'way'},
-                        {id: '|', role: 'via', type: 'way'}
+                        {id: '|', role: viaRole, type: 'way'}
                     ]);
                 });
 
@@ -1980,8 +1982,8 @@ describe('iD.actionSplit', function () {
 
                     expect(graph.entity('r').members).to.eql([
                         {id: '|', role: 'from', type: 'way'},
-                        {id: '-', role: 'via', type: 'way'},
-                        {id: '=', role: 'via', type: 'way'},
+                        {id: '-', role: viaRole, type: 'way'},
+                        {id: '=', role: viaRole, type: 'way'},
                         {id: '‖', role: 'to', type: 'way'}
                     ]);
                 });
@@ -2001,8 +2003,8 @@ describe('iD.actionSplit', function () {
 
                     expect(graph.entity('r').members).to.eql([
                         {id: '|', role: 'from', type: 'way'},
-                        {id: '-', role: 'via', type: 'way'},
-                        {id: '=', role: 'via', type: 'way'},
+                        {id: '-', role: viaRole, type: 'way'},
+                        {id: '=', role: viaRole, type: 'way'},
                         {id: '‖', role: 'to', type: 'way'}
                     ]);
                 });
@@ -2019,7 +2021,7 @@ describe('iD.actionSplit', function () {
                     expect(graph.entity('r').members).to.eql([
                         {id: '-', role: 'from', type: 'way'},
                         {id: '~', role: 'to', type: 'way'},
-                        {id: 'd', role: 'via', type: 'node'}
+                        {id: 'd', role: viaRole, type: 'node'}
                     ]);
                 });
 
@@ -2035,7 +2037,7 @@ describe('iD.actionSplit', function () {
                     expect(graph.entity('r').members).to.eql([
                         {id: '=', role: 'from', type: 'way'},
                         {id: '~', role: 'to', type: 'way'},
-                        {id: 'd', role: 'via', type: 'node'}
+                        {id: 'd', role: viaRole, type: 'node'}
                     ]);
                 });
             });

--- a/test/spec/osm/relation.js
+++ b/test/spec/osm/relation.js
@@ -262,6 +262,32 @@ describe('iD.osmRelation', function () {
             });
             expect(r.hasFromViaTo()).to.be.false;
         });
+
+        it('returns true if the `intersection` role is used instead of `via` for destination signs', () => {
+            const r = iD.osmRelation({
+                id: 'r',
+                tags: { type: 'destination_sign' },
+                members: [
+                    { role: 'from', id: 'f', type: 'way' },
+                    { role: 'intersection', id: 'v', type: 'node' },
+                    { role: 'to', id: 't', type: 'way' },
+                ]
+            });
+            expect(r.hasFromViaTo()).to.be.true;
+        });
+
+        it('returns false if the `intersection` role is used on anything other than a destination sign', () => {
+            const r = iD.osmRelation({
+                id: 'r',
+                tags: { type: 'restriction' },
+                members: [
+                    { role: 'from', id: 'f', type: 'way' },
+                    { role: 'intersection', id: 'v', type: 'node' },
+                    { role: 'to', id: 't', type: 'way' },
+                ]
+            });
+            expect(r.hasFromViaTo()).to.be.false;
+        });
     });
 
     describe('#isRestriction', function () {


### PR DESCRIPTION
Closes #9188

[`destination_sign`](https://osm.wiki/Relation:destination_sign) can use the `intersection` role instead of `via`. 

There are still valid cases `destination_sign` relations won't be split properly, such as if there is no `from` role. But this helps with the most common cases