### PR TITLE
use LF line endings for .mjs files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@ trim_trailing_whitespace = true
 insert_final_newline = false
 
 
-[*.{js,json,css,html}]
+[*.{js,mjs,json,css,html}]
 indent_style = space
 indent_size = 4
 
@@ -13,7 +13,7 @@ indent_size = 4
 # EOL for ESLint
 # newline follows Airbnb style guide
 # mix of indent size between ES5 and ES6 syntax files
-[*.js]
+[*.{js,mjs}]
 end_of_line = lf
 insert_final_newline = true
 indent_size = tab_width

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 * text=auto
 *.bat eol=crlf
 *.js eol=lf
+*.mjs eol=lf


### PR DESCRIPTION
Closes #10628 

This is the same as #5744, but for `.mjs` files which weren't used back then. This helps windows users who have enabled [`autocrlf`](https://git-scm.com/book/be/v2/Customizing-Git-Git-Configuration#:~:text=core.autocrlf)