### PR TITLE
fix relation membership list using a non-deterministic order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Prevent degenerate ways caused by deleting a corner of a triangle ([#10003], thanks [@k-yle])
 * Fix briefly disappearing data layer during background layer tile layer switching transition ([#10748])
 * Preserve imagery offset during tile layer switching transition ([#10748])
+* Fix the relation membership list using a non-deterministic order ([#10648], thanks [@k-yle])
 * Fix over-saturated map tiles near the border of the tile service's coverage area ([#10747], thanks [@hlfan])
 * Fix too dim markers of selected/hovered photo of some street level imagery layers ([#10755], thanks [@draunger])
 #### :earth_asia: Localization
@@ -59,6 +60,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 
 [#7381]: https://github.com/openstreetmap/iD/issues/7381
 [#10003]: https://github.com/openstreetmap/iD/pull/10003
+[#10648]: https://github.com/openstreetmap/iD/pull/10648
 [#10720]: https://github.com/openstreetmap/iD/issues/10720
 [#10747]: https://github.com/openstreetmap/iD/issues/10747
 [#10748]: https://github.com/openstreetmap/iD/issues/10748

--- a/modules/actions/join.js
+++ b/modules/actions/join.js
@@ -133,7 +133,7 @@ export function actionJoin(ids) {
         var sortedParentRelations = function (id) {
             return graph.parentRelations(graph.entity(id))
                 .filter((rel) => !rel.isRestriction() && !rel.isConnectivity())
-                .sort((a, b) => a.id - b.id);
+                .sort((a, b) => a.id.localeCompare(b.id));
         };
         var relsA = sortedParentRelations(ids[0]);
         for (i = 1; i < ids.length; i++) {


### PR DESCRIPTION
When selecting a way, the list of relations uses an unpredictable order. 

This is annoying, but more importantly, it causes a rare bug: You can't merge ways if the relations were added in a different order. 

For example, merging these ways:..

<table>
<tr>
<td><img width="354" alt="image" src="https://github.com/user-attachments/assets/01e98eb9-e532-4170-840b-b23a1bd96668" /></td>
<td><img width="350" alt="image" src="https://github.com/user-attachments/assets/d32f77dc-52b5-4b53-b4d6-2eeba8705633" /></td>
</tr>
</table>

...will cause an unexpected error:

<img width="482" alt="image" src="https://github.com/user-attachments/assets/47a78182-0fdd-4357-a936-b8a78025194b" />