### PR TITLE
fixed-when searching while hovering over a place search result, highlights become visually stuck

### DIFF
--- a/modules/ui/feature_list.js
+++ b/modules/ui/feature_list.js
@@ -243,8 +243,8 @@ export function uiFeatureList(context) {
             return result;
         }
 
-        var highlight_after_mouseout = false;
-        var id_on_mouseover =-1;
+        var highlightAfterMouseout = false;
+        let idOnMouseover = new Set();
         function drawList() {
             var value = search.property('value');
             var results = features();
@@ -279,9 +279,10 @@ export function uiFeatureList(context) {
                   .attr('class', 'entity-name')
                   .call(t.append('geocoder.search'));
             }
-
-            if ((!value || !results.length) && highlight_after_mouseout  && id_on_mouseover !== -1) {
-                utilHighlightEntities([id_on_mouseover], false, context);
+            if (highlightAfterMouseout) {
+                idOnMouseover.forEach((value) => {
+                utilHighlightEntities([value], false, context); 
+                });
             }    
             list.selectAll('.no-results-item')
                 .style('display', (value.length && !results.length) ? 'block' : 'none');
@@ -339,15 +340,15 @@ export function uiFeatureList(context) {
 
         function mouseover(d3_event, d) {
             if (d.id === -1) return;
-            highlight_after_mouseout=true;
-            id_on_mouseover =d.id;
+            highlightAfterMouseout=true;
+            idOnMouseover.add(d.id);
             utilHighlightEntities([d.id], true, context);
         }
 
 
         function mouseout(d3_event, d) {
             if (d.id === -1) return;
-            highlight_after_mouseout=false;
+            highlightAfterMouseout=false;
             utilHighlightEntities([d.id], false, context);
         }
 

--- a/modules/ui/feature_list.js
+++ b/modules/ui/feature_list.js
@@ -243,7 +243,8 @@ export function uiFeatureList(context) {
             return result;
         }
 
-
+        var highlight_after_mouseout = false;
+        var id_on_mouseover =-1;
         function drawList() {
             var value = search.property('value');
             var results = features();
@@ -279,6 +280,10 @@ export function uiFeatureList(context) {
                   .call(t.append('geocoder.search'));
             }
 
+            if((!value || !results.length) && highlight_after_mouseout  && id_on_mouseover!=-1){
+                utilHighlightEntities([id_on_mouseover], false, context);
+                }
+                
             list.selectAll('.no-results-item')
                 .style('display', (value.length && !results.length) ? 'block' : 'none');
 
@@ -335,14 +340,15 @@ export function uiFeatureList(context) {
 
         function mouseover(d3_event, d) {
             if (d.id === -1) return;
-
+            highlight_after_mouseout=true;
+            id_on_mouseover =d.id;
             utilHighlightEntities([d.id], true, context);
         }
 
 
         function mouseout(d3_event, d) {
             if (d.id === -1) return;
-
+            highlight_after_mouseout=false;
             utilHighlightEntities([d.id], false, context);
         }
 

--- a/modules/ui/feature_list.js
+++ b/modules/ui/feature_list.js
@@ -340,7 +340,7 @@ export function uiFeatureList(context) {
 
         function mouseover(d3_event, d) {
             if (d.id === -1) return;
-            highlightAfterMouseout=true;
+            highlightAfterMouseout = true;
             idOnMouseover.add(d.id);
             utilHighlightEntities([d.id], true, context);
         }
@@ -348,7 +348,7 @@ export function uiFeatureList(context) {
 
         function mouseout(d3_event, d) {
             if (d.id === -1) return;
-            highlightAfterMouseout=false;
+            highlightAfterMouseout = false;
             utilHighlightEntities([d.id], false, context);
         }
 

--- a/modules/ui/feature_list.js
+++ b/modules/ui/feature_list.js
@@ -280,10 +280,9 @@ export function uiFeatureList(context) {
                   .call(t.append('geocoder.search'));
             }
 
-            if((!value || !results.length) && highlight_after_mouseout  && id_on_mouseover!=-1){
+            if ((!value || !results.length) && highlight_after_mouseout  && id_on_mouseover !== -1) {
                 utilHighlightEntities([id_on_mouseover], false, context);
-                }
-                
+            }    
             list.selectAll('.no-results-item')
                 .style('display', (value.length && !results.length) ? 'block' : 'none');
 


### PR DESCRIPTION
# description
## problem before the fix:
- when we search the place by placing the cursor on the empty area initially ,
-  then after writing the place, the search result comes and as the cursor is on the item 
- it highlight that item on the map , so after changing the place by placing the cursor on the same position as before 
- the item is remain highlighted or if we change the place without changing the position of the cursor the item 
- which is hovered before is highlighted along with the new result 
-  here you can see in this video attached below:-

https://www.loom.com/share/3ff0436cf2854bed8f390df3710ad5f1?sid=97a6949d-10f5-46e5-8144-60158e730c18

as you can see in this video when we write "dek" then kish hospitality drive also highlighted along with dekalb...

## approach:
- Basically i used a set data structure and push every id of highlighted item 
- when we change the search label then the previous highlighted items get unhighlighted 
- i used this in if-condition and iterate in set data structure so that all the previous highlighted item get unhighlighted 
- here you can see in this video atttached below :

https://www.loom.com/share/a0eff1338e69448b8c16d2d020039528?sid=411b93af-545b-48e7-9e71-a0d10a9180f6

# attached issue : 
https://github.com/openstreetmap/iD/issues/10661