### PR TITLE
remove unused import utilArrayUnion from kartaview.js

### DIFF
--- a/modules/services/kartaview.js
+++ b/modules/services/kartaview.js
@@ -6,7 +6,7 @@ import RBush from 'rbush';
 
 import { localizer } from '../core/localizer';
 import { geoExtent, geoScaleToZoom } from '../geo';
-import { utilArrayUnion, utilQsString, utilRebind, utilSetTransform, utilStringQs, utilTiler } from '../util';
+import { utilQsString, utilRebind, utilSetTransform, utilStringQs, utilTiler } from '../util';
 
 
 var apibase = 'https://kartaview.org';


### PR DESCRIPTION
@tyrasd 

### Description
This pull request fixes the lint warning by removing the **unused** `utilArrayUnion` import from [`kartaview.js`](https://github.com/openstreetmap/iD/blob/develop/modules/services/kartaview.js). Since it’s not referenced anywhere in the file, removing it resolves the `no-unused-vars` warning.

### Related Issue
- Closes #[10667] (https://github.com/openstreetmap/iD/issues/10667))

### What Changed
- Deleted `utilArrayUnion` from the import statement in `kartaview.js`:
  ```diff
  - import { utilArrayUnion, utilQsString, utilRebind, utilSetTransform, utilStringQs, utilTiler } from '../util';
  + import { utilQsString, utilRebind, utilSetTransform, utilStringQs, utilTiler } from '../util';

### Actual Behavior
- The lint warning appears:
![image](https://github.com/user-attachments/assets/7e58f694-29d0-4200-8112-db370136a0cc)
