### PR TITLE
Update address format for South Korea

### DIFF
--- a/data/address_formats.json
+++ b/data/address_formats.json
@@ -153,7 +153,8 @@
   {
     "countryCodes": ["kr"],
     "format": [
-      ["province", "city", "district"],
+      ["province", "city"],
+      ["district", "town", "subdistrict"],
       ["street", "housenumber", "unit"],
       ["postcode"]
     ]


### PR DESCRIPTION
fix KR address formats for detailed, formatted address

province(도/특별자치도), city(특별시/광역시/특별자치시/시/군)
district(구), town(읍/면), subdistrict(동/리)