### PR TITLE
fix crash when searching for coordinates

### DIFF
--- a/modules/ui/feature_list.js
+++ b/modules/ui/feature_list.js
@@ -334,11 +334,15 @@ export function uiFeatureList(context) {
 
 
         function mouseover(d3_event, d) {
+            if (d.id === -1) return;
+
             utilHighlightEntities([d.id], true, context);
         }
 
 
         function mouseout(d3_event, d) {
+            if (d.id === -1) return;
+
             utilHighlightEntities([d.id], false, context);
         }
 


### PR DESCRIPTION
Follow up to #10666 - there is now a crash when you search for coordiantes (such as `-36.601679,174.891183`), because that special list item has an id of `-1`:

https://github.com/openstreetmap/iD/blob/9cd1ed4ef0587a142e5dfe7865a5eaa956fc0089/modules/ui/feature_list.js#L129-L132

This causes the editor to be completely unusable, you can't even export your work as an osmChange file

<img width="560" alt="image" src="https://github.com/user-attachments/assets/80a7371f-c618-4c1c-afdd-f36d77e557ee" />
