### PR TITLE
Fixed minimap rendering issue #10653

### DIFF
--- a/modules/renderer/tile_layer.js
+++ b/modules/renderer/tile_layer.js
@@ -16,6 +16,7 @@ export function rendererTileLayer(context) {
     var _zoom;
     var _source;
     var _epsilon = 0;
+    var _allowedUnderZoomAmount = 0;
 
     // Workaround to remove visible grid around tile borders on Chrome with dynamic epsilon for specific browser zoom levels
     // Should be removed when https://issues.chromium.org/issues/40084005 is resolved
@@ -82,7 +83,7 @@ export function rendererTileLayer(context) {
     }
 
 
-    // Update tiles based on current state of `projection`.
+    // Update tiles based on current state of projection.
     function background(selection) {
         _zoom = geoScaleToZoom(_projection.scale(), _tileSize);
 
@@ -115,14 +116,18 @@ export function rendererTileLayer(context) {
 
 
     // Derive the tiles onscreen, remove those offscreen and position them.
-    // Important that this part not depend on `_projection` because it's
+    // Important that this part not depend on _projection because it's
     // rentered when tiles load/error (see #644).
     function render(selection) {
         if (!_source) return;
         var requests = [];
         var showDebug = context.getDebug('tile') && !_source.overlay;
 
-        var clampedZoom = Math.max(_source.zoomExtent[0], Math.min(_zoom, _source.zoomExtent[1]));
+        var zoomLevel = Math.max(_source.zoomExtent[0], Math.min(_zoom, _source.zoomExtent[1]));
+        var effectiveZoom = Math.max(
+            _source.zoomExtent[0] - _allowedUnderZoomAmount,
+            Math.min(_zoom, _source.zoomExtent[1])
+        );
 
         tiler.skipNullIsland(!!_source.overlay);
 
@@ -160,8 +165,8 @@ export function rendererTileLayer(context) {
         }
 
         function imageTransform(d) {
-            var ts = d.tileSize * Math.pow(2, clampedZoom - d[2]);
-            var scale = tileSizeAtZoom(d, clampedZoom);
+            var ts = d.tileSize * Math.pow(2, effectiveZoom - d[2]);
+            var scale = tileSizeAtZoom(d, effectiveZoom);
             return 'translate(' +
                 ((d[0] * ts) * _tileSize / d.tileSize - _tileOrigin[0]
             ) + 'px,' +
@@ -304,6 +309,13 @@ export function rendererTileLayer(context) {
         _tileSize = _source.tileSize;
         _cache = {};
         tiler.tileSize(_source.tileSize).zoomExtent(_source.zoomExtent);
+        return background;
+    };
+
+
+    background.allowedUnderZoomAmount = function(val) {
+        if (!arguments.length) return _allowedUnderZoomAmount;
+        _allowedUnderZoomAmount = val;
         return background;
     };
 

--- a/modules/renderer/tile_layer.js
+++ b/modules/renderer/tile_layer.js
@@ -122,24 +122,25 @@ export function rendererTileLayer(context) {
         var requests = [];
         var showDebug = context.getDebug('tile') && !_source.overlay;
 
-        if (_source.validZoom(_zoom)) {
-            tiler.skipNullIsland(!!_source.overlay);
+        var clampedZoom = Math.max(_source.zoomExtent[0], Math.min(_zoom, _source.zoomExtent[1]));
 
-            tiler().forEach(function(d) {
-                addSource(d);
-                if (d.url === '') return;
-                if (typeof d.url !== 'string') return; // Workaround for #2295
-                requests.push(d);
-                if (_cache[d.url] === false && lookUp(d)) {
-                    requests.push(addSource(lookUp(d)));
-                }
-            });
+        tiler.skipNullIsland(!!_source.overlay);
 
-            requests = uniqueBy(requests, 'url').filter(function(r) {
-                // don't re-request tiles which have failed in the past
-                return _cache[r.url] !== false;
-            });
-        }
+        tiler().forEach(function(d) {
+            addSource(d);
+            if (d.url === '') return;
+            if (typeof d.url !== 'string') return; // Workaround for #2295
+            requests.push(d);
+            if (_cache[d.url] === false && lookUp(d)) {
+                requests.push(addSource(lookUp(d)));
+            }
+        });
+
+        requests = uniqueBy(requests, 'url').filter(function(r) {
+            // Don't re-request tiles which have failed in the past
+            return _cache[r.url] !== false;
+        });
+
 
         function load(d3_event, d) {
             _cache[d.url] = true;
@@ -159,8 +160,8 @@ export function rendererTileLayer(context) {
         }
 
         function imageTransform(d) {
-            var ts = d.tileSize * Math.pow(2, _zoom - d[2]);
-            var scale = tileSizeAtZoom(d, _zoom);
+            var ts = d.tileSize * Math.pow(2, clampedZoom - d[2]);
+            var scale = tileSizeAtZoom(d, clampedZoom);
             return 'translate(' +
                 ((d[0] * ts) * _tileSize / d.tileSize - _tileOrigin[0]
             ) + 'px,' +

--- a/modules/ui/map_in_map.js
+++ b/modules/ui/map_in_map.js
@@ -7,7 +7,7 @@ import { geoRawMercator, geoScaleToZoom, geoVecSubtract, geoVecScale, geoZoomToS
 import { rendererTileLayer } from '../renderer';
 import { svgDebug, svgData } from '../svg';
 import { utilSetTransform } from '../util';
-import { utilGetDimensions } from '../util/dimensions';
+// import { utilGetDimensions } from '../util/dimensions';
 
 
 export function uiMapInMap(context) {

--- a/modules/ui/map_in_map.js
+++ b/modules/ui/map_in_map.js
@@ -7,13 +7,14 @@ import { geoRawMercator, geoScaleToZoom, geoVecSubtract, geoVecScale, geoZoomToS
 import { rendererTileLayer } from '../renderer';
 import { svgDebug, svgData } from '../svg';
 import { utilSetTransform } from '../util';
-// import { utilGetDimensions } from '../util/dimensions';
+import { utilGetDimensions } from '../util/dimensions';
 
 
 export function uiMapInMap(context) {
 
     function mapInMap(selection) {
-        var backgroundLayer = rendererTileLayer(context);
+        var backgroundLayer = rendererTileLayer(context)
+            .allowedUnderZoomAmount(1);
         var overlayLayers = {};
         var projection = geoRawMercator();
         var dataLayer = svgData(projection, context).showLabels(false);


### PR DESCRIPTION
Introduced a new property _allowedUnderZoomAmount in tile_layer.js to manage zooming out beyond usual bounds effectively, resolving rendering issues with the minimap.


before
The minimap turned black when zoomed out of the usual bounds.

![image](https://github.com/user-attachments/assets/7a523426-67a7-47b7-b6a0-bcc81ed187f4)


after
The minimap now renders properly, even when zoomed out beyond usual bounds.

![image](https://github.com/user-attachments/assets/6b2def0d-f43f-4787-9555-06f713dee2d0)



changes that i made--
in modules/renderer/tile_layer.js

Added _allowedUnderZoomAmount property to handle zooming logic.
Modified zoom calculations in render and imageTransform functions to respect the new property.


in modules/ui/map_in_map.js

Updated the instantiation of rendererTileLayer to set _allowedUnderZoomAmount.

//cc @tyrasd see #10653