### PR TITLE
Warn when saving incomplete features

### DIFF
--- a/modules/validations/missing_tag.js
+++ b/modules/validations/missing_tag.js
@@ -9,7 +9,7 @@ export function validationMissingTag(context) {
     var type = 'missing_tag';
 
     function hasDescriptiveTags(entity) {
-        var onlyAttributeKeys = ['description', 'name', 'note', 'start_date'];
+        var onlyAttributeKeys = ['description', 'name', 'note', 'start_date', 'oneway'];
         var entityDescriptiveKeys = Object.keys(entity.tags)
             .filter(function(k) {
                 if (k === 'area' || !osmIsInterestingTag(k)) return false;


### PR DESCRIPTION
Fixes #10471 by ensuring a warning is shown when a primary tag (e.g., highway=*) is removed, leaving only attributes.

Changes:
Improved validation to detect incomplete features.

Testing:
- [x] Removed highway=* while keeping oneway=* → warning displayed.
- [x] Kept highway=* → no warning.