### PR TITLE
Fixes #10104: Deprecate tag combination method in favor of full tagging combination.

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -3849,6 +3849,8 @@ li.issue-fix-item button:not(.actionable) .fix-icon {
     margin-bottom: 10px;
 }
 .issue-info .tagDiff-table {
+    margin-top: 4px;
+    margin-bottom: 4px; 
     min-width: 60%;
     width: unset;
     border: 1px solid #ccc;
@@ -3866,7 +3868,14 @@ li.issue-fix-item button:not(.actionable) .fix-icon {
     background: #dfd;
 }
 .issue-info .tagDiff-cell-remove {
-    background: #fdd;
+   
+    padding: 5px;
+    background: rgb(240, 202, 202);
+    font-weight: 600;  
+}
+.tagDiff-cell-unchanged {
+    background: #eee; /* Light gray background */
+    color: #666;      /* Dimmed text color */
 }
 
 

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -3868,7 +3868,7 @@ li.issue-fix-item button:not(.actionable) .fix-icon {
     background: #dfd;
 }
 .issue-info .tagDiff-cell-remove {
-   
+   font-size: 16px; 
     padding: 5px;
     background: rgb(240, 202, 202);
     font-weight: 600;  

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1885,7 +1885,7 @@ en:
       title: Outdated Tags
       message: "{feature} has outdated tags"
       tip: "Find features with deprecated tags that can be updated"
-      reference: "Some tags change over time and should be updated."
+      reference: "Avoid using 'cycleway=track' on 'highway=cycleway' as it is redundant. A 'highway=cycleway' already implies a dedicated cycleway."
       incomplete:
         message: "{feature} has incomplete tags"
         reference: "Some features should have additional tags."

--- a/modules/validations/outdated_tags.js
+++ b/modules/validations/outdated_tags.js
@@ -202,6 +202,7 @@ export function validationOutdatedTags() {
 
     function showMessage(context) {
       const currEntity = context.hasEntity(entity.id);
+      console.log(currEntity)
       if (!currEntity) return '';
 
       let messageID = `issues.outdated_tags.${prefix}message`;
@@ -238,12 +239,13 @@ export function validationOutdatedTags() {
         .attr('class', 'tagDiff-row')
         .append('td')
         .attr('class', d => {
-          let klass = d.type === '+' ? 'add' : 'remove';
-          return `tagDiff-cell tagDiff-cell-${klass}`;
-        })
+          if (d.type === '+') return 'tagDiff-cell tagDiff-cell-add';
+          if (d.type === '-') return 'tagDiff-cell tagDiff-cell-remove';
+          return 'tagDiff-cell tagDiff-cell-unchanged'; // Add a new class for unchanged tags
+      })
         .html(d => d.display);
     }
-  }
+  } 
 
 
   let validation = oldTagIssues;


### PR DESCRIPTION
### Summary
This PR introduces a new Deprecation warning should indicate full tagging combination that justifies suggested change #10104
. This feature allows users to easily copy the unique identifier associated with specific entities in the application.

### Changes
- Add a detailed description when outdated tag is occurred.
- Add few style on ```.tagDiff-table ```

### Before 
  
![Before](https://github.com/user-attachments/assets/46151439-eb1b-4e43-821b-971d3a0229b7)

### After
 
![After](https://github.com/user-attachments/assets/2f7e8af5-64e2-47cf-a3f0-2550fca5d8a8)



### Benefits
- Improves user experience by simplifying ID retrieval.

### Reference
Closes #10104 
