### PR TITLE
correct discord channel name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ if you're looking for something to do.
 
 Come on in, the water's lovely. More help? Ping `Martin Raifer`/`tyr_asd` or `bhousel` on:
 * [OpenStreetMap US Slack](https://slack.openstreetmap.us/) (`#id` channel)
-* [OpenStreetMap Discord](https://discord.com/invite/openstreetmap) (`#id` channel)
+* [OpenStreetMap Discord](https://discord.com/invite/openstreetmap) (`#id-and-rapid` channel)
 * [OpenStreetMap IRC](https://wiki.openstreetmap.org/wiki/IRC) (`irc.oftc.net`, in `#osm-dev`)
 * [OpenStreetMap `dev` mailing list](https://wiki.openstreetmap.org/wiki/Mailing_lists)
 


### PR DESCRIPTION
The README says `#id`, but [per this discussion](https://discord.com/channels/413070382636072960/782592770849505281/1333954062386856031) it's currently named `#id-and-rapid`.

