### PR TITLE
Improve CJK names with a lang atttribute on multilingual name fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Update the list of languages in the Wikipedia field ([#10489])
 * Add Ladin (language code `lld`) as an available option for multilingual names
 * Add 30 indigenous languages as dropdown options for multilingual names ([#10684], thanks [@k-yle])
+* Add `lang`uage attributes to input fields for multilingual names, as well as wikidata and wikipedia fields ([#10716], thanks [@mapmeld])
 #### :hourglass: Performance
 #### :mortar_board: Walkthrough / Help
 * Fix walkthrough from showing tooltips on wrong location under certain circumstances ([#10650], [#10624], [#10634])
@@ -79,6 +80,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#10653]: https://github.com/openstreetmap/iD/issues/10653
 [#10683]: https://github.com/openstreetmap/iD/issues/10683
 [#10684]: https://github.com/openstreetmap/iD/pull/10684
+[#10716]: https://github.com/openstreetmap/iD/pull/10716
 [@winstonsung]: https://github.com/winstonsung/
 [@Nekzuris]: https://github.com/Nekzuris
 [@michaelabon]: https://github.com/michaelabon

--- a/modules/ui/fields/localized.js
+++ b/modules/ui/fields/localized.js
@@ -427,6 +427,9 @@ export function uiFieldLocalized(field, context) {
                     .append('input')
                     .attr('type', 'text')
                     .attr('class', 'localized-value')
+                    .attr('lang', function (d) {
+                      return d.lang;
+                    })
                     .on('blur', changeValue)
                     .on('change', changeValue);
             });

--- a/modules/ui/fields/localized.js
+++ b/modules/ui/fields/localized.js
@@ -471,7 +471,6 @@ export function uiFieldLocalized(field, context) {
                 return Array.isArray(d.value) ? t('inspector.multiple_values') : t('translate.localized_translation_name');
             })
             .attr('lang', function (d) {
-                // for CJK and other display issues
                 return d.lang;
             })
             .classed('mixed', function(d) {

--- a/modules/ui/fields/localized.js
+++ b/modules/ui/fields/localized.js
@@ -427,9 +427,6 @@ export function uiFieldLocalized(field, context) {
                     .append('input')
                     .attr('type', 'text')
                     .attr('class', 'localized-value')
-                    .attr('lang', function (d) {
-                      return d.lang;
-                    })
                     .on('blur', changeValue)
                     .on('change', changeValue);
             });
@@ -472,6 +469,9 @@ export function uiFieldLocalized(field, context) {
             })
             .attr('placeholder', function(d) {
                 return Array.isArray(d.value) ? t('inspector.multiple_values') : t('translate.localized_translation_name');
+            })
+            .attr('lang', function (d) {
+                return d.lang;
             })
             .classed('mixed', function(d) {
                 return Array.isArray(d.value);

--- a/modules/ui/fields/localized.js
+++ b/modules/ui/fields/localized.js
@@ -471,6 +471,7 @@ export function uiFieldLocalized(field, context) {
                 return Array.isArray(d.value) ? t('inspector.multiple_values') : t('translate.localized_translation_name');
             })
             .attr('lang', function (d) {
+                // for CJK and other display issues
                 return d.lang;
             })
             .classed('mixed', function(d) {

--- a/modules/ui/fields/wikidata.js
+++ b/modules/ui/fields/wikidata.js
@@ -282,12 +282,10 @@ export function uiFieldWikidata(field, context) {
             label = entityPropertyForDisplay(_wikidataEntity, 'labels');
             if (label.value.length === 0) {
                 label.value = _wikidataEntity.id.toString();
-            } else {
-              // for CJK and other display issues
-              d3_select('.wikidata-search input').attr('lang', label.language);
             }
         }
-        utilGetSetValue(_searchInput, label.value);
+        utilGetSetValue(_searchInput, label.value)
+            .attr('lang', label.language);
     }
 
 
@@ -317,17 +315,18 @@ export function uiFieldWikidata(field, context) {
 
             setLabelForEntity();
 
-            var description = entityPropertyForDisplay(entity, 'descriptions').value;
+            var description = entityPropertyForDisplay(entity, 'descriptions');
 
             _selection.select('button.wiki-link')
                 .classed('disabled', false);
 
             _selection.select('.preset-wikidata-description')
                 .style('display', function(){
-                    return description.length > 0 ? 'flex' : 'none';
+                    return description.value.length > 0 ? 'flex' : 'none';
                 })
                 .select('input')
-                .attr('value', description);
+                .attr('value', description.value)
+                .attr('lang', description.language);
 
             _selection.select('.preset-wikidata-identifier')
                 .style('display', function(){
@@ -360,7 +359,7 @@ export function uiFieldWikidata(field, context) {
     };
 
     function entityPropertyForDisplay(wikidataEntity, propKey) {
-        var blankResponse = {value:''};
+        var blankResponse = { value: '' };
         if (!wikidataEntity[propKey]) return blankResponse;
         var propObj = wikidataEntity[propKey];
         var langKeys = Object.keys(propObj);

--- a/modules/ui/fields/wikidata.js
+++ b/modules/ui/fields/wikidata.js
@@ -275,14 +275,19 @@ export function uiFieldWikidata(field, context) {
     }
 
     function setLabelForEntity() {
-        var label = '';
+        var label = {
+          value: ''
+        };
         if (_wikidataEntity) {
             label = entityPropertyForDisplay(_wikidataEntity, 'labels');
-            if (label.length === 0) {
-                label = _wikidataEntity.id.toString();
+            if (label.value.length === 0) {
+                label.value = _wikidataEntity.id.toString();
+            } else {
+              // for CJK and other display issues
+              d3_select('.wikidata-search input').attr('lang', label.language);
             }
         }
-        utilGetSetValue(_searchInput, label);
+        utilGetSetValue(_searchInput, label.value);
     }
 
 
@@ -312,7 +317,7 @@ export function uiFieldWikidata(field, context) {
 
             setLabelForEntity();
 
-            var description = entityPropertyForDisplay(entity, 'descriptions');
+            var description = entityPropertyForDisplay(entity, 'descriptions').value;
 
             _selection.select('button.wiki-link')
                 .classed('disabled', false);
@@ -355,19 +360,20 @@ export function uiFieldWikidata(field, context) {
     };
 
     function entityPropertyForDisplay(wikidataEntity, propKey) {
-        if (!wikidataEntity[propKey]) return '';
+        var blankResponse = {value:''};
+        if (!wikidataEntity[propKey]) return blankResponse;
         var propObj = wikidataEntity[propKey];
         var langKeys = Object.keys(propObj);
-        if (langKeys.length === 0) return '';
+        if (langKeys.length === 0) return blankResponse;
         // sorted by priority, since we want to show the user's language first if possible
         var langs = wikidata.languagesToQuery();
         for (var i in langs) {
             var lang = langs[i];
             var valueObj = propObj[lang];
-            if (valueObj && valueObj.value && valueObj.value.length > 0) return valueObj.value;
+            if (valueObj && valueObj.value && valueObj.value.length > 0) return valueObj;
         }
         // default to any available value
-        return propObj[langKeys[0]].value;
+        return propObj[langKeys[0]];
     }
 
 

--- a/modules/ui/fields/wikipedia.js
+++ b/modules/ui/fields/wikipedia.js
@@ -281,6 +281,7 @@ export function uiFieldWikipedia(field, context) {
     if (tagLangInfo) {
       const nativeLangName = tagLangInfo[1];
       utilGetSetValue(_langInput, nativeLangName);
+      _titleInput.attr('lang', tagLangInfo[2]); // for CJK and other display issues
       utilGetSetValue(_titleInput, tagArticleTitle + (anchor ? ('#' + anchor) : ''));
       _wikiURL = `${scheme}${tagLang}.${domain}/wiki/${wiki.encodePath(tagArticleTitle, anchor)}`;
     } else {

--- a/modules/ui/fields/wikipedia.js
+++ b/modules/ui/fields/wikipedia.js
@@ -204,7 +204,8 @@ export function uiFieldWikipedia(field, context) {
         value += '#' + anchor.replace(/_/g, ' ');
       }
       value = value.slice(0, 1).toUpperCase() + value.slice(1);
-      utilGetSetValue(_langInput, nativeLangName);
+      utilGetSetValue(_langInput, nativeLangName)
+        .attr('lang', langInfo[2]);
       utilGetSetValue(_titleInput, value);
     }
 

--- a/test/spec/ui/fields/localized.js
+++ b/test/spec/ui/fields/localized.js
@@ -167,7 +167,7 @@ describe('iD.uiFieldLocalized', function() {
         }, 20);
     });
 
-    it('has a lang attribute on an existing name field value', function(done) {
+    it('has a lang attribute on an existing multilingual name field', function(done) {
       var localized = iD.uiFieldLocalized(field, context);
       localized.tags({'name:de': 'Value'});
       window.setTimeout(function() {

--- a/test/spec/ui/fields/localized.js
+++ b/test/spec/ui/fields/localized.js
@@ -166,4 +166,14 @@ describe('iD.uiFieldLocalized', function() {
             done();
         }, 20);
     });
+
+    it('has a lang attribute on an existing name field value', function(done) {
+      var localized = iD.uiFieldLocalized(field, context);
+      localized.tags({'name:de': 'Value'});
+      window.setTimeout(function() {
+        selection.call(localized);
+        expect(selection.selectAll('.localized-value').attr('lang')).to.eql('de');
+        done();
+      }, 20);
+    });
 });


### PR DESCRIPTION
While researching issues with Chinese characters in OSM tiles and Mapnik, I realized that a similar issue exists in iD's multilingual name UI and it could be improved with a small change

Unicode CJK Unified Ideographs represents characters such as 化 with one codepoint. If the language of the element is Traditional Chinese (`lang="zh-Hant"`), the text renderer will display the same text differently (<span lang="zh-Hant">化</span>). Luckily we already have the language code when we are setting multilingual names `name:zh=*`, `name:ja=`, etc.

<img width="523" alt="Screenshot 2025-01-29 at 12 51 35 AM" src="https://github.com/user-attachments/assets/57048064-6267-434e-a3a3-c52ce51ad90e" />

Possible issues:
- I set the lang tag when loading the object. I didn't know how to make changing the language dropdown update the input's lang attribute without reorganizing the UI code and callbacks. Open to suggestions on how to do this in D3.
- This doesn't change the appearance of the main `name=` tag since it can have any language(s)