### PR TITLE
Fix the confusion caused by the arrow next to the feature type selection panel.

### DIFF
--- a/modules/ui/preset_list.js
+++ b/modules/ui/preset_list.js
@@ -37,7 +37,7 @@ export function uiPresetList(context) {
             .append('h2')
             .call(t.append('inspector.choose'));
 
-        var direction = (localizer.textDirection() === 'rtl') ? 'backward' : 'forward';
+        var direction = 'close';
 
         messagewrap
             .append('button')

--- a/modules/ui/preset_list.js
+++ b/modules/ui/preset_list.js
@@ -37,14 +37,12 @@ export function uiPresetList(context) {
             .append('h2')
             .call(t.append('inspector.choose'));
 
-        var direction = 'close';
-
         messagewrap
             .append('button')
             .attr('class', 'preset-choose')
             .attr('title', _entityIDs.length === 1 ? t('inspector.edit') : t('inspector.edit_features'))
             .on('click', function() { dispatch.call('cancel', this); })
-            .call(svgIcon(`#iD-icon-${direction}`));
+            .call(svgIcon('#iD-icon-close'));
 
         function initialKeydown(d3_event) {
             // hack to let delete shortcut work when search is autofocused


### PR DESCRIPTION
Fixes [#10724](https://github.com/openstreetmap/iD/issues/10724)

This pull request is for the confusion caused by the arrow next to the feature type selection panel.


![image](https://github.com/user-attachments/assets/e27c5618-2966-40f0-9699-86d128a42dba)


