### PR TITLE
Use distinct placeholder text for feature type search box

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -736,6 +736,7 @@ en:
     back_tooltip: Change feature type
     remove: Remove
     search: Search
+    search_feature_type: Search feature type
     unknown: Unknown
     incomplete: <not downloaded>
     feature_list: Search features

--- a/modules/ui/preset_list.js
+++ b/modules/ui/preset_list.js
@@ -123,7 +123,7 @@ export function uiPresetList(context) {
         var search = searchWrap
             .append('input')
             .attr('class', 'preset-search-input')
-            .attr('placeholder', t('inspector.search'))
+            .attr('placeholder', 'Search feature type')
             .attr('type', 'search')
             .call(utilNoAuto)
             .on('keydown', initialKeydown)

--- a/modules/ui/preset_list.js
+++ b/modules/ui/preset_list.js
@@ -123,7 +123,7 @@ export function uiPresetList(context) {
         var search = searchWrap
             .append('input')
             .attr('class', 'preset-search-input')
-            .attr('placeholder', 'Search feature type')
+            .attr('placeholder', t('inspector.search_feature_type'))
             .attr('type', 'search')
             .call(utilNoAuto)
             .on('keydown', initialKeydown)


### PR DESCRIPTION
# description
i have changed the placeholder for the search input box when we come on the section of select feature type 
# approach
change the placeholder attribute ..
# before the fix:
![image](https://github.com/user-attachments/assets/d735ba4f-ef62-4fcc-87d3-9777319a728e)
# after the fix:
![image](https://github.com/user-attachments/assets/093849c6-9cd3-4ad7-a679-7df295b986db)
# solves:
https://github.com/openstreetmap/iD/issues/10721