### PR TITLE
Light flashbang when switching loaded imageries

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -4384,7 +4384,7 @@ img.tile {
     or (-webkit-device-pixel-ratio = 5) or (-webkit-device-pixel-ratio = 0.25) or (-webkit-device-pixel-ratio = 0.5) or (-webkit-device-pixel-ratio = 0.75) {
     .layer-background img.tile,
     .map-in-map-background img.tile {
-        mix-blend-mode: plus-lighter;
+        mix-blend-mode: normal;
     }
 }
 


### PR DESCRIPTION
# description
added mix blend mode from plus lighter to normal 
# solves:
https://github.com/openstreetmap/iD/issues/10738
