### PR TITLE
added-move nodes with touchscreen

### DIFF
--- a/modules/behavior/drag.js
+++ b/modules/behavior/drag.js
@@ -5,7 +5,6 @@ import {
     selection as d3_selection
 } from 'd3-selection';
 
-import { geoVecLength } from '../geo';
 import { osmNote } from '../osm';
 import { utilRebind } from '../util/rebind';
 import { utilFastMouse, utilPrefixCSSProperty, utilPrefixDOMProperty } from '../util';
@@ -29,10 +28,6 @@ import { utilFastMouse, utilPrefixCSSProperty, utilPrefixDOMProperty } from '../
 export function behaviorDrag() {
     var dispatch = d3_dispatch('start', 'move', 'end');
 
-    // see also behaviorSelect
-    var _tolerancePx = 1; // keep this low to facilitate pixel-perfect micromapping
-    var _penTolerancePx = 4; // styluses can be touchy so require greater movement - #1981
-
     var _origin = null;
     var _selector = '';
     var _targetNode;
@@ -55,11 +50,17 @@ export function behaviorDrag() {
 
 
     function pointerdown(d3_event) {
-
         if (_pointerId) return;
 
-        _pointerId = d3_event.pointerId || 'mouse';
+        // Explicitly handle touch events for mobile
+        if (d3_event.type === 'touchstart') {
+            // Ignore multi-touch scenarios
+            if (d3_event.touches.length > 1) return;
+            // Use the first touch point
+            d3_event = d3_event.touches[0];
+        }
 
+        _pointerId = d3_event.pointerId || 'touch';
         _targetNode = this;
 
         // only force reflow once per drag
@@ -70,9 +71,19 @@ export function behaviorDrag() {
         var started = false;
         var selectEnable = d3_event_userSelectSuppress();
 
+        // Track initial position to determine intentional drag
+        var initialPosition = {
+            x: d3_event.clientX,
+            y: d3_event.clientY
+        };
+
+        // Add touch event listeners for mobile
+        var moveEvent = d3_event.type === 'touchstart' ? 'touchmove' : (_pointerPrefix + 'move.drag');
+        var upEvent = d3_event.type === 'touchstart' ? 'touchend' : (_pointerPrefix + 'up.drag pointercancel.drag');
+
         d3_select(window)
-            .on(_pointerPrefix + 'move.drag', pointermove)
-            .on(_pointerPrefix + 'up.drag pointercancel.drag', pointerup, true);
+            .on(moveEvent + '.drag', pointermove)
+            .on(upEvent + '.drag', pointerup, true);
 
         if (_origin) {
             offset = _origin.call(_targetNode, _targetEntity);
@@ -83,52 +94,70 @@ export function behaviorDrag() {
 
         d3_event.stopPropagation();
 
-
         function pointermove(d3_event) {
-            if (_pointerId !== (d3_event.pointerId || 'mouse')) return;
+            // Handle touch events for mobile
+            if (d3_event.type === 'touchmove') {
+                // Ignore multi-touch scenarios
+                if (d3_event.touches.length > 1) return;
+                // Use the first touch point
+                d3_event = d3_event.touches[0];
+            }
+
+            if (_pointerId !== (d3_event.pointerId || 'touch')) return;
 
             var p = pointerLocGetter(d3_event);
 
-            if (!started) {
-                var dist = geoVecLength(startOrigin,  p);
-                var tolerance = d3_event.pointerType === 'pen' ? _penTolerancePx : _tolerancePx;
-                // don't start until the drag has actually moved somewhat
-                if (dist < tolerance) return;
+            // Determine if this is an intentional drag
+            var currentPosition = {
+                x: d3_event.clientX,
+                y: d3_event.clientY
+            };
 
+            var dragDistance = Math.sqrt(
+                Math.pow(currentPosition.x - initialPosition.x, 2) +
+                Math.pow(currentPosition.y - initialPosition.y, 2)
+            );
+
+            // Only start drag after minimal movement
+            if (!started && dragDistance > 5) {
                 started = true;
                 dispatch.call('start', this, d3_event, _targetEntity);
+            }
 
-            // Don't send a `move` event in the same cycle as `start` since dragging
-            // a midpoint will convert the target to a node.
-            } else {
+            if (started) {
+                // Precise delta calculation
+                var delta = [
+                    p[0] - startOrigin[0] - offset[0],
+                    p[1] - startOrigin[1] - offset[1]
+                ];
 
-                startOrigin = p;
-                d3_event.stopPropagation();
-                d3_event.preventDefault();
-
-                var dx = p[0] - startOrigin[0];
-                var dy = p[1] - startOrigin[1];
-                dispatch.call('move', this, d3_event, _targetEntity, [p[0] + offset[0],  p[1] + offset[1]], [dx, dy]);
+                dispatch.call('move', this, d3_event, _targetEntity, [
+                    p[0] - offset[0],
+                    p[1] - offset[1]
+                ], delta);
             }
         }
 
-
         function pointerup(d3_event) {
-            if (_pointerId !== (d3_event.pointerId || 'mouse')) return;
-
-            _pointerId = null;
-
-            if (started) {
-                dispatch.call('end', this, d3_event, _targetEntity);
-
-                d3_event.preventDefault();
+            // Handle touch events for mobile
+            if (d3_event.type === 'touchend') {
+                // Use the first touch point
+                d3_event = d3_event.changedTouches[0];
             }
+
+            if (_pointerId !== (d3_event.pointerId || 'touch')) return;
+
+            selectEnable();
 
             d3_select(window)
                 .on(_pointerPrefix + 'move.drag', null)
                 .on(_pointerPrefix + 'up.drag pointercancel.drag', null);
 
-            selectEnable();
+            if (started) {
+                dispatch.call('end', this, d3_event, _targetEntity);
+            }
+
+            _pointerId = null;
         }
     }
 

--- a/modules/modes/drag_node.js
+++ b/modules/modes/drag_node.js
@@ -208,7 +208,7 @@ export function modeDragNode(context) {
                 }
 
             } else if (targetNodes) {   // snap to way - a line target with `.nodes`
-                edge = geoChooseEdge(targetNodes, context.map().mouse(), context.projection, end.id);
+                edge = geoChooseEdge(targetNodes, context.map().mouse(), context.projection, entity.id);
                 if (edge) {
                     loc = edge.loc;
                 }
@@ -456,6 +456,26 @@ export function modeDragNode(context) {
 
 
     mode.enter = function() {
+        var selectedIDs = context.selectedIDs();
+        _restoreSelectedIDs = selectedIDs.slice();
+
+        // Ensure only one node is selected for dragging
+        if (selectedIDs.length !== 1) {
+            context.enter(modeBrowse(context));
+            return;
+        }
+
+        _activeEntity = context.entity(selectedIDs[0]);
+        _startLoc = _activeEntity.loc;
+        _lastLoc = _startLoc;
+        _wasMidpoint = _activeEntity.type === 'midpoint';
+        _isCancelled = false;
+
+        // Track initial touch/mouse state
+        var initialTouchPoint = null;
+        var isDragging = false;
+
+        // Install behaviors
         context.install(hover);
         context.install(edit);
 
@@ -463,8 +483,83 @@ export function modeDragNode(context) {
             .on('keydown.dragNode', keydown)
             .on('keyup.dragNode', keyup);
 
+
+        context.surface()
+            .on('pointerdown.drag', handlePointerDown)
+            .on('pointermove.drag', handlePointerMove)
+            .on('pointerup.drag pointercancel.drag', handlePointerUp);
+
+        function handlePointerDown(d3_event) {
+            // Ensure d3 is imported or available
+            var entity = window.d3.select(d3_event.target).datum();
+
+            // Ignore if not primary button or multiple touches
+            if (d3_event.button !== 0 || d3_event.type === 'touchstart' && d3_event.touches.length > 1) {
+                return;
+            }
+
+            // Prevent default only if directly on the node
+            if (!entity || entity.id !== _activeEntity.id) {
+                return;
+            }
+
+            // Track initial touch point
+            initialTouchPoint = {
+                x: d3_event.clientX,
+                y: d3_event.clientY
+            };
+
+            // Prevent text selection
+            d3_event.preventDefault();
+        }
+
+        function handlePointerMove(d3_event) {
+            // Require initial touch point and minimal movement
+            if (!initialTouchPoint) return;
+
+            var currentPoint = {
+                x: d3_event.clientX,
+                y: d3_event.clientY
+            };
+
+            // Define a small tolerance to distinguish between tap and drag
+            var tolerance = 5; // pixels
+            var distance = Math.sqrt(
+                Math.pow(currentPoint.x - initialTouchPoint.x, 2) +
+                Math.pow(currentPoint.y - initialTouchPoint.y, 2)
+            );
+
+            // Start dragging only after exceeding tolerance
+            if (!isDragging && distance > tolerance) {
+                isDragging = true;
+                d3_event.preventDefault();
+                d3_event.stopPropagation();
+            }
+
+            // Only proceed with node drag if definitely dragging
+            if (isDragging) {
+                // Remove unused point variable
+                var currPoint = context.mouse(d3_event);
+                move(d3_event, _activeEntity, currPoint);
+            }
+        }
+
+        function handlePointerUp(d3_event) {
+            if (isDragging) {
+                d3_event.preventDefault();
+                d3_event.stopPropagation();
+                end(d3_event, _activeEntity);
+            }
+
+            // Reset state
+            initialTouchPoint = null;
+            isDragging = false;
+        }
+
         context.history()
             .on('undone.drag-node', cancel);
+
+        context.enter(mode);
     };
 
 


### PR DESCRIPTION
# description
added the dragging of a node in touch screen 
# in drag.js file:
- Make dragging work smoothly on all devices (phone, tablet, computer)
- Let the screen scroll and pan naturally
- Start dragging only after moving a little bit (5 pixels)
- Handle touch and mouse events in the same way
- Remove complicated device-specific rules
- Make the code simpler and easier to understand
# in drag_node.js file:
- Help users drag map nodes (points) more precisely
- Work well on mobile and desktop
- Prevent accidental node movements
- Allow map panning while dragging nodes
- Make touch interactions feel natural
# solves:
https://github.com/openstreetmap/iD/issues/9451