### PR TITLE
fix rendering of `service=*`

### DIFF
--- a/css/30_highways.css
+++ b/css/30_highways.css
@@ -418,11 +418,11 @@ path.line.casing.tag-highway-service {
 /* special service roads and bus guideways */
 /* with `service=* tag`  (e.g. parking_aisle, alley, drive-through) */
 path.line.stroke.tag-highway-bus_guideway,
-path.line.stroke.tag-highway-service.tag-service {
+path.line.stroke.tag-highway.tag-service {
     stroke: #dca;
 }
 path.line.casing.tag-highway-bus_guideway,
-path.line.casing.tag-highway-service.tag-service {
+path.line.casing.tag-highway.tag-service {
     stroke: #666;
 }
 


### PR DESCRIPTION
Follow up to 5227294, there are over 100,000 examples of `highway=*` + `highway≠service` + `service=*`, which are no longer rendered with the special casing.

This PR makes the rule slightly more lenient, it only checks for `highway=*`, not `highway=service`