### PR TITLE
fix conversion of callback-style test runner to promisified one

### DIFF
--- a/test/spec_helpers.mts
+++ b/test/spec_helpers.mts
@@ -40,15 +40,21 @@ Reflect.set(
   global,
   'it',
   Object.assign(
-    (msg: string, fn: (done?: () => void) => void | Promise<void>) => {
+    (msg: string, fn: (done?: (err?: any) => void) => void | Promise<void>) => {
       _it(msg, () => {
         if (fn.length) {
           // there is a done callback -> return a promise instead
-          return new Promise<void>((done) => fn(done));
+          return new Promise<void>((resolve, reject) => fn(err => {
+            if (err) {
+              reject(err);
+            } else {
+              resolve();
+            }
+          }));
+        } else {
+          // no done callback -> normal behaviour
+          return fn();
         }
-
-        // no done callback -> normal behaviour
-        return fn();
       });
     },
     { todo: _it.todo, skip: _it.skip, only: _it.only, each: _it.each },


### PR DESCRIPTION
AFAICT, the current override/workaround to make the old asynchronous tests (that use the callback-style `done` parameter) does not properly detect some failing tests: try running the test below – it should fail, but doesn't. 

```js
describe('sanity checks', function () {
    it('should fail if done is called with error', function(done) {
        Promise.resolve().then(() => {
            expect(true).to.eql(false);
            done();
        }).catch(err => done(err));
    });
});
```

this style of test is used in a few places, see e.g. _validate returns a promise, fulfilled when the validation has completed_ 