### PR TITLE
Fix duplicate values in the `source` field on the changeset page

### DIFF
--- a/modules/ui/changeset_editor.js
+++ b/modules/ui/changeset_editor.js
@@ -88,6 +88,7 @@ export function uiChangesetEditor(context) {
                     // based on the values used in recent changesets.
                     const recentSources = changesets
                         .flatMap((changeset) => changeset.tags.source?.split(';'))
+                        .filter(value => !sourceField.options.includes(value))
                         .filter(Boolean)
                         .map(title => ({ title, value: title, klass: 'raw-option' }));
 


### PR DESCRIPTION
Fixes a bug from #10764. Closes #10787