### PR TITLE
[recreated] fix the turn restriction editor not supporting bidirectional roads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :bug: Bugfixes
 * Prevent degenerate ways caused by deleting a corner of a triangle ([#10003], thanks [@k-yle])
 * Fix briefly disappearing data layer during background layer tile layer switching transition ([#10748])
+* Fix the turn restriction editor not supporting bidirectional roads ([#10731], thanks [@k-yle])
 * Preserve imagery offset during tile layer switching transition ([#10748])
 * Fix the relation membership list using a non-deterministic order ([#10648], thanks [@k-yle])
 * Fix over-saturated map tiles near the border of the tile service's coverage area ([#10747], thanks [@hlfan])
@@ -87,6 +88,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#10720]: https://github.com/openstreetmap/iD/issues/10720
 [#10722]: https://github.com/openstreetmap/iD/pull/10722
 [#10727]: https://github.com/openstreetmap/iD/issues/10727
+[#10731]: https://github.com/openstreetmap/iD/pull/10731
 [#10737]: https://github.com/openstreetmap/iD/pull/10737
 [#10747]: https://github.com/openstreetmap/iD/issues/10747
 [#10748]: https://github.com/openstreetmap/iD/issues/10748

--- a/modules/osm/intersection.js
+++ b/modules/osm/intersection.js
@@ -211,7 +211,8 @@ export function osmIntersection(graph, startVertexId, maxDistance) {
     // walking the intersection graph later and rendering turn arrows.
 
     function withMetadata(way, vertexIds) {
-        var __oneWay = way.isOneWay();
+        // bidirectional ways are two-way from an intersection's perspective
+        var __oneWay = way.isOneWay() && !way.isBiDirectional();
 
         // which affixes are key vertices?
         var __first = (vertexIds.indexOf(way.first()) !== -1);


### PR DESCRIPTION
GitHub didn't [automatically](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches#working-with-branches) change the base branch, so #10731 wasn't merged into `develop`. Recreated that PR.

Closes #8321