### PR TITLE
fixed:CTRL+SHIFT+I should not trigger CTRL+I

### DIFF
--- a/modules/ui/info.js
+++ b/modules/ui/info.js
@@ -123,6 +123,7 @@ export function uiInfo(context) {
 
         context.keybinding()
             .on(uiCmd('⌘' + t('info_panels.key')), function(d3_event) {
+                if(d3_event.shiftKey) return;
                 d3_event.stopImmediatePropagation();
                 d3_event.preventDefault();
                 info.toggle();

--- a/modules/ui/info.js
+++ b/modules/ui/info.js
@@ -123,7 +123,7 @@ export function uiInfo(context) {
 
         context.keybinding()
             .on(uiCmd('⌘' + t('info_panels.key')), function(d3_event) {
-                if(d3_event.shiftKey) return;
+                if (d3_event.shiftKey) return;
                 d3_event.stopImmediatePropagation();
                 d3_event.preventDefault();
                 info.toggle();


### PR DESCRIPTION
# description:
added the check condition if the key pressed contains shift or not 
# solves:
https://github.com/openstreetmap/iD/issues/10817