### PR TITLE
Change zoomToNote to moveToNote

### DIFF
--- a/modules/behavior/hash.js
+++ b/modules/behavior/hash.js
@@ -196,7 +196,7 @@ export function behaviorHash(context) {
             const selectIds = q.id.split(',');
             if (selectIds.length === 1 && selectIds[0].startsWith('note/')) {
                 const noteId = selectIds[0].split('/')[1];
-                context.zoomToNote(noteId, !q.map);
+                context.moveToNote(noteId, !q.map);
             } else {
                 context.zoomToEntities(
                     // convert ids to short form id: node/123 -> n123

--- a/modules/core/context.js
+++ b/modules/core/context.js
@@ -219,22 +219,21 @@ export function coreContext() {
     });
   };
 
-  context.zoomToNote = (noteId, zoomTo) => {
+  context.moveToNote = (noteId, moveTo) => {
     context.loadNote(noteId, (err, result) => {
       if (err) return;
       const entity = result.data.find(e => e.id === noteId);
-      if (entity) {
-        // zoom to, used note loc
-        const note = services.osm.getNote(noteId);
-        if (zoomTo !== false) {
-          context.map().centerZoom(note.loc,15);
-        }
-        // open note layer
-        const noteLayer = context.layers().layer('notes');
-        noteLayer.enabled(true);
-        // select the note
-        context.enter(modeSelectNote(context, noteId));
+      if (!entity) return;
+      // zoom to, used note loc
+      const note = services.osm.getNote(noteId);
+      if (moveTo !== false) {
+        context.map().center(note.loc);
       }
+      // open note layer
+      const noteLayer = context.layers().layer('notes');
+      noteLayer.enabled(true);
+      // select the note
+      context.enter(modeSelectNote(context, noteId));
     });
   };
 

--- a/modules/ui/feature_list.js
+++ b/modules/ui/feature_list.js
@@ -383,7 +383,7 @@ export function uiFeatureList(context) {
                 const noteId = d.id.replace(/\D/g, '');
 
                 // load note
-                context.zoomToNote(noteId);
+                context.moveToNote(noteId);
             } else {
                 // download, zoom to, and select the entity with the given ID
                 context.zoomToEntity(d.id);


### PR DESCRIPTION
Fixes #10807 by using map.center instead of map.centerZoom.
Also includes renames and a move to an early return.