### PR TITLE
remove `isHighwayIntersection` from osmEntity since it only applies to nodes

### DIFF
--- a/modules/osm/entity.js
+++ b/modules/osm/entity.js
@@ -182,10 +182,6 @@ osmEntity.prototype = {
         return Object.keys(this.tags).some(osmIsInterestingTag);
     },
 
-    isHighwayIntersection: function() {
-        return false;
-    },
-
     isDegenerate: function() {
         return true;
     },

--- a/modules/ui/inspector.js
+++ b/modules/ui/inspector.js
@@ -77,7 +77,7 @@ export function uiInspector(context) {
             if (context.validator().getEntityIssues(entityID).length) return false;
 
             // show turn restriction editor for junction vertices
-            if (entity.isHighwayIntersection(context.graph())) return false;
+            if (entity.type === 'node' && entity.isHighwayIntersection(context.graph())) return false;
 
             // otherwise show preset list for uninteresting vertices
             return true;

--- a/modules/ui/sections/preset_fields.js
+++ b/modules/ui/sections/preset_fields.js
@@ -78,7 +78,7 @@ export function uiSectionPresetFields(context) {
             });
 
             var singularEntity = _entityIDs.length === 1 && graph.hasEntity(_entityIDs[0]);
-            if (singularEntity && singularEntity.isHighwayIntersection(graph) && presetsManager.field('restrictions')) {
+            if (singularEntity && singularEntity.type === 'node' && singularEntity.isHighwayIntersection(graph) && presetsManager.field('restrictions')) {
                 _fieldsArr.push(
                     uiField(context, presetsManager.field('restrictions'), _entityIDs)
                 );

--- a/test/spec/osm/entity.js
+++ b/test/spec/osm/entity.js
@@ -298,12 +298,6 @@ describe('iD.osmEntity', function () {
         });
     });
 
-    describe('#isHighwayIntersection', function () {
-        it('returns false', function () {
-            expect(iD.osmEntity().isHighwayIntersection()).to.be.false;
-        });
-    });
-
     describe('#isDegenerate', function () {
         it('returns true', function () {
             expect(iD.osmEntity().isDegenerate()).to.be.true;


### PR DESCRIPTION
`osmEntity` is an abstract class extended by the node/way/relation classes, but also by `osmChangeset`. 

So it's a bit weird when you're debugging a changeset and you see a prototype method called `isHighwayIntersection`, since this only makes sense for nodes. 