### PR TITLE
fix: hide city and postal code field in editor for french contribution

### DIFF
--- a/data/address_formats.json
+++ b/data/address_formats.json
@@ -67,8 +67,7 @@
   {
     "countryCodes": ["fr", "lu"],
     "format": [
-      ["housenumber", "street+place"],
-      ["postcode", "city"]
+      ["housenumber", "street+place"]
     ]
   },
   {

--- a/scripts/server.js
+++ b/scripts/server.js
@@ -4,7 +4,7 @@ const gaze = require('gaze');
 const serve = require('serve-handler');
 
 const buildCSS = require('./build_css.js');
-
+const port = 8080;
 
 gaze(['css/**/*.css'], (err, watcher) => {
   watcher.on('all', () => buildCSS());
@@ -23,7 +23,7 @@ const server = http.createServer((request, response) => {
   });
 });
 
-server.listen(8080, () => {
+server.listen(port, () => {
   /* eslint-disable no-console */
-  console.log(chalk.yellow(`Listening on ${server.port}`));
+  console.log(chalk.yellow(`Listening on ${port}`));
 });


### PR DESCRIPTION
I’ve removed the `postcode` and `city` fields for `fr` and `lu` as requested in #10836 to hide them from the iD editor. This reduces redundancy since boundary relations can infer these values.

![Screenshot 2025-03-06 070607](https://github.com/user-attachments/assets/533ee228-ebdb-41a9-9698-a3afaa72fffa)
![Screenshot 2025-03-06 070457](https://github.com/user-attachments/assets/04966c40-0e0f-48ed-a161-f220b06bcc62)

@tyrasd @k-yle @tordans 
