### PR TITLE
refactor direction cone logic + fix case for railway tracks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,11 +42,13 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :camera: Street-Level
 #### :white_check_mark: Validation
 #### :bug: Bugfixes
+* fix some direction cones not appearing on railway tracks ([#10843], thanks [@k-yle])
 #### :earth_asia: Localization
 #### :hourglass: Performance
 #### :mortar_board: Walkthrough / Help
 #### :hammer: Development
 
+[#10843]: https://github.com/openstreetmap/iD/pull/10843
 
 # 2.32.0
 ##### 2025-03-05

--- a/modules/osm/node.js
+++ b/modules/osm/node.js
@@ -1,6 +1,7 @@
 import { osmEntity } from './entity';
 import { geoAngle, geoExtent } from '../geo';
 import { utilArrayUniq } from '../util';
+import { osmShouldRenderDirection } from './tags';
 
 export const cardinal = {
     north: 0,               n: 0,
@@ -119,9 +120,7 @@ const prototype = {
 
             var nodeIds = {};
             resolver.parentWays(this)
-                .filter(p => (this.tags.highway || this.tags.traffic_sign || this.tags.traffic_calming || this.tags.barrier || this.tags.cycleway) ? p.tags.highway : true)
-                .filter(p => (this.tags.railway) ? p.tags.railway : true)
-                .filter(p => (this.tags.waterway) ? p.tags.waterway : true)
+                .filter(way => osmShouldRenderDirection(this.tags, way.tags))
                 .forEach(function(parent) {
                     var nodes = parent.nodes;
                     for (i = 0; i < nodes.length; i++) {

--- a/modules/osm/tags.js
+++ b/modules/osm/tags.js
@@ -306,3 +306,19 @@ export var osmMutuallyExclusiveTagPairs = [
     ['addr:nostreet', 'addr:street']
 ];
 
+
+/**
+ * @param {Tags} vertexTags @param {Tags} wayTags
+ * returns true if iD should render the `direction` tag for
+ * this vertex+way combination.
+ */
+export function osmShouldRenderDirection(vertexTags, wayTags) {
+    if (vertexTags.highway || vertexTags.traffic_sign || vertexTags.traffic_calming || vertexTags.barrier) {
+        // allowed on roads and tramways
+        return !!(wayTags.highway || wayTags.railway);
+    }
+    if (vertexTags.railway) return !!wayTags.railway;
+    if (vertexTags.waterway) return !!wayTags.waterway;
+    if (vertexTags.cycleway === 'asl') return !!wayTags.highway;
+    return true;
+}


### PR DESCRIPTION
`highway=traffic_signals`, `traffic_sign=*`, etc. can be used on tram tracks (and [in rare cases](https://github.com/user-attachments/assets/ded66b4d-657c-458e-a558-76a732170aa2) for normal railways). Since #10582, the direction cones have just disappeared. 

Another edge case I noticed is `crane:mobile=rail` with (`railway=buffer_stop` + `direction=*`), not sure if we should support that one because it's rare and poorly undocumented.
