### PR TITLE
fix: deduplicate postcode suggested

### DIFF
--- a/modules/ui/fields/address.js
+++ b/modules/ui/fields/address.js
@@ -114,9 +114,10 @@ export function uiFieldAddress(field, context) {
     }
 
     function getNearPostcodes() {
-        return [... new Set([]
+        const postcodes = []
             .concat(getNearValues('postcode'))
-            .concat(getNear(d => d.tags.postal_code, 'postcode', 200, 'postal_code')))];
+            .concat(getNear(d => d.tags.postal_code, 'postcode', 200, 'postal_code'));
+        return utilArrayUniqBy(postcodes, item => item.value);
     }
 
     function getNearValues(key) {


### PR DESCRIPTION
#### Impact
- Eliminates duplicate postcode suggestions, improving user experience in the Address editor.
- Tested locally with nearby features having identical `addr:postcode` and `postal_code` values; dropdown now shows each postcode only once.

#### Related Issue
Fixes [#10845](https://github.com/openstreetmap/iD/issues/10845)

@tyrasd @tordans @k-yle 