### PR TITLE
Change follow tool to follow lines with multiple same parents

### DIFF
--- a/modules/behavior/draw_way.js
+++ b/modules/behavior/draw_way.js
@@ -457,7 +457,11 @@ export function behaviorDrawWay(context, wayID, mode, startGraph) {
 
             const featureType = getFeatureType(lastNodesParents);
 
-            if (lastNodesParents.length !== 1 || secondLastNodesParents.length === 0) {
+            const sameAllParents =
+                lastNodesParents.length === secondLastNodesParents.length &&
+                lastNodesParents.every(w => secondLastNodesParents.some(n => n.id === w.id));
+
+            if (!sameAllParents && lastNodesParents.length !== 1 || secondLastNodesParents.length === 0) {
                 context.ui().flash
                     .duration(4000)
                     .iconName('#iD-icon-no')


### PR DESCRIPTION
When mapping a river tidal flat, if the river already has a coast and I want to add a second layer of tidal flat on top of the river feature, I cant use the `F` key to follow the coast of the river because there are 2 shared areas with the same line. I want to be able to follow for a third feature that shares the same linestring.

Just added a condition for that to work.

This is the feature working. The following node must be the pointed with the red arrow because both nodes share the same multiple parents.
(This cannot be made in current iD because the nodes have multiple parents, the follow tool only follows lines with one parent.)
![2025-03-08_01-24](https://github.com/user-attachments/assets/ab4a5129-49c0-4b38-be2e-8d4ee79dccfa)

This is where it stops, because there are multiple different alternatives to take for the following node to be chosen. (list of node parents are different)
![2025-03-08_01-26](https://github.com/user-attachments/assets/fd4c3a12-f0a2-41f0-82f0-b62e160f4eb3)

