### PR TITLE
Authenticantion in 127.0.0.1 broken / blank screen

### DIFF
--- a/scripts/server.js
+++ b/scripts/server.js
@@ -12,6 +12,7 @@ gaze(['css/**/*.css'], (err, watcher) => {
 
 const server = http.createServer((request, response) => {
   return serve(request, response, {
+    cleanUrls: false,
     symlinks: true,
     headers: [{
       source: '**',


### PR DESCRIPTION
This fixes authentication with osm live server in 127.0.0.1.
There was a redirect being made and the code returned from oauth in querystring was being removed in the redirect 301 made by the server trying to remove `.html` from `land.html`, so the authentication failed.