### PR TITLE
Enhancement: Streetlevel layers: keyboard shortcuts for previous/next photo

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -2408,8 +2408,8 @@ en:
         zoom_to: "Zoom to selected features"
       vertex_selected:
         title: "With node selected"
-        previous: "Jump to previous node"
-        next: "Jump to next node"
+        previous: "Jump to previous node / photo"
+        next: "Jump to next node / photo"
         first: "Jump to first node"
         last: "Jump to last node"
         parent: "Select parent way"

--- a/modules/services/mapilio.js
+++ b/modules/services/mapilio.js
@@ -7,7 +7,7 @@ import RBush from 'rbush';
 import { VectorTile } from '@mapbox/vector-tile';
 import { isEqual } from 'lodash';
 
-import { utilRebind, utilTiler, utilQsString, utilStringQs, utilSetTransform } from '../util';
+import { utilRebind, utilTiler, utilQsString, utilStringQs, utilSetTransform, utilKeybinding } from '../util';
 import {geoExtent, geoScaleToZoom} from '../geo';
 import {localizer} from '../core/localizer';
 
@@ -42,6 +42,7 @@ let _sceneOptions = {
 };
 let _currScene = 0;
 
+let keybinding = utilKeybinding('phoneviewer-mapillio');
 
 // Partition viewport into higher zoom tiles
 function partitionViewport(projection) {
@@ -488,6 +489,12 @@ export default {
             .on('click.forward', step(1))
             .text('►');
 
+        keybinding
+            .on(['[', 'pgup'], handlePreviousPhoto)
+            .on([']', 'pgdown'], handleNextPhoto);
+
+        d3_select(document).call(keybinding);
+
         wrapEnter
             .append('div')
             .attr('id', 'ideditor-viewer-mapilio-pnlm');
@@ -549,6 +556,38 @@ export default {
             .catch(function() {
                 _loadViewerPromise = null;
             });
+
+            function handleNextPhoto(d3_event) {
+                d3_event.preventDefault();
+
+                const selectedIDs = context.selectedIDs();
+
+                if (selectedIDs.length > 0) {
+                    const entity = context.entity(selectedIDs[0]);
+                    const entityType = entity.geometry(context.graph());
+                    if (entityType === 'vertex') {
+                        return;
+                    }
+                }
+
+                step(1)();
+            }
+
+            function handlePreviousPhoto(d3_event) {
+                d3_event.preventDefault();
+
+                const selectedIDs = context.selectedIDs();
+
+                if (selectedIDs.length > 0) {
+                    const entity = context.entity(selectedIDs[0]);
+                    const entityType = entity.geometry(context.graph());
+                    if (entityType === 'vertex') {
+                        return;
+                    }
+                }
+
+                step(-1)();
+            }
 
         function step(stepBy) {
             return function () {
@@ -612,6 +651,9 @@ export default {
             .classed('currentView', false);
 
         this.setActiveImage();
+
+        d3_select(document)
+            .call(keybinding.unbind);
 
         return this.setStyles(context, null);
     },

--- a/modules/services/panoramax.js
+++ b/modules/services/panoramax.js
@@ -1,10 +1,11 @@
 import { dispatch as d3_dispatch } from 'd3-dispatch';
+import { select as d3_select } from 'd3-selection';
 
 import Protobuf from 'pbf';
 import RBush from 'rbush';
 import { VectorTile } from '@mapbox/vector-tile';
 
-import { utilRebind, utilTiler, utilQsString, utilStringQs, utilUniqueDomId} from '../util';
+import { utilRebind, utilTiler, utilQsString, utilStringQs, utilUniqueDomId, utilKeybinding} from '../util';
 import { geoExtent, geoScaleToZoom } from '../geo';
 import { t, localizer } from '../core/localizer';
 import pannellumPhotoFrame from './pannellum_photo';
@@ -46,7 +47,7 @@ let _currentScene = {
 };
 
 let _activeImage;
-
+let keybinding = utilKeybinding('phoneviewer-panoramax');
 
 // Partition viewport into higher zoom tiles
 function partitionViewport(projection) {
@@ -594,6 +595,44 @@ export default {
             _planeFrame.event.on('viewerChanged', () => dispatch.call('viewerChanged'));
           });
 
+    keybinding
+            .on(['[', 'pgup'], handlePreviousPhoto)
+            .on([']', 'pgdown'], handleNextPhoto);
+
+        d3_select(document).call(keybinding);
+
+        function handleNextPhoto(d3_event) {
+            d3_event.preventDefault();
+
+            const selectedIDs = context.selectedIDs();
+
+            if (selectedIDs.length > 0) {
+                const entity = context.entity(selectedIDs[0]);
+                const entityType = entity.geometry(context.graph());
+                if (entityType === 'vertex') {
+                    return;
+                }
+            }
+
+            step(1)();
+        }
+
+        function handlePreviousPhoto(d3_event) {
+            d3_event.preventDefault();
+
+            const selectedIDs = context.selectedIDs();
+
+            if (selectedIDs.length > 0) {
+                const entity = context.entity(selectedIDs[0]);
+                const entityType = entity.geometry(context.graph());
+                if (entityType === 'vertex') {
+                    return;
+                }
+            }
+
+            step(-1)();
+        }
+
         function step(stepBy) {
             return function () {
                 if (!_currentScene.currentImage) return;
@@ -642,6 +681,10 @@ export default {
         context.container().selectAll('.viewfield-group, .sequence, .icon-sign')
             .classed('currentView', false);
         this.setActiveImage();
+
+        d3_select(document)
+            .call(keybinding.unbind);
+
         return this.setStyles(context, null);
     },
 

--- a/modules/services/streetside.js
+++ b/modules/services/streetside.js
@@ -13,7 +13,7 @@ import {
   geoRotate, geoScaleToZoom, geoVecLength
 } from '../geo';
 
-import { utilAesDecrypt, utilArrayUnion, utilQsString, utilRebind, utilStringQs, utilTiler, utilUniqueDomId } from '../util';
+import { utilAesDecrypt, utilArrayUnion, utilKeybinding, utilQsString, utilRebind, utilStringQs, utilTiler, utilUniqueDomId } from '../util';
 
 
 const streetsideApi = 'https://dev.virtualearth.net/REST/v1/Imagery/MetaData/Streetside?mapArea={bbox}&key={key}&count={count}&uriScheme=https';
@@ -46,6 +46,7 @@ let _sceneOptions = {
 };
 let _loadViewerPromise;
 
+let keybinding = utilKeybinding('phoneviewer-streetside');
 
 /**
  * abortRequest().
@@ -503,6 +504,11 @@ export default {
       .on('click.forward', step(1))
       .text('►');
 
+      keybinding
+        .on(['[', 'pgup'], handlePreviousPhoto)
+        .on([']', 'pgdown'], handleNextPhoto);
+
+      d3_select(document).call(keybinding);
 
     // create working canvas for stitching together images
     wrap = wrap
@@ -559,6 +565,38 @@ export default {
       });
 
     return _loadViewerPromise;
+
+    function handleNextPhoto(d3_event) {
+      d3_event.preventDefault();
+
+      const selectedIDs = context.selectedIDs();
+
+      if (selectedIDs.length > 0) {
+        const entity = context.entity(selectedIDs[0]);
+        const entityType = entity.geometry(context.graph());
+        if (entityType === 'vertex') {
+          return;
+        }
+      }
+
+      step(1)();
+    }
+
+    function handlePreviousPhoto(d3_event) {
+      d3_event.preventDefault();
+
+      const selectedIDs = context.selectedIDs();
+
+      if (selectedIDs.length > 0) {
+        const entity = context.entity(selectedIDs[0]);
+        const entityType = entity.geometry(context.graph());
+        if (entityType === 'vertex') {
+          return;
+        }
+      }
+
+      step(-1)();
+    }
 
     function step(stepBy) {
       return () => {
@@ -679,6 +717,9 @@ export default {
       .classed('currentView', false);
 
     this.updateUrlImage(null);
+
+    d3_select(document)
+      .call(keybinding.unbind);
 
     return this.setStyles(context, null, true);
   },


### PR DESCRIPTION
### Changes:
- Update `shortcuts.browsing.vertex_selected.next` and `shortcuts.browsing.vertex_selected.previews` 
- Use `keybinding` at Panoramax service to implement feature functionality

### video

https://github.com/user-attachments/assets/05f038a8-e8e4-4f66-b9d4-4cf167e5b1e0


### Related issue
#10370 