### PR TITLE
Enhance map data editing: toggle highlight state and persist settings

### DIFF
--- a/modules/ui/init.js
+++ b/modules/ui/init.js
@@ -425,8 +425,7 @@ export function uiInit(context) {
                 d3_event.preventDefault();
                 context.map().toggleHighlightEdited();
                 // save the last state of the highlightEdited
-                if (prefs('map_data.highlight_edits') === null) prefs('map_data.highlight_edits', 'true'); // if this is the firts ones, set it to true
-                else prefs('map_data.highlight_edits', prefs('map_data.highlight_edits') === 'true' ? 'false' : 'true'); // toggle the state, if it's already exist
+                prefs('map_data.highlight_edits', prefs('map_data.highlight_edits') === 'true' ? 'false' : 'true'); // Toggle the state. If it's the first time (value is null) or the value is (false), prefs change it to true and vice versa.
             });
 
         context

--- a/modules/ui/init.js
+++ b/modules/ui/init.js
@@ -373,6 +373,8 @@ export function uiInit(context) {
                 ui.onResize();
             });
 
+        // Reload the previous settings to highlight unsaved changes.
+        if (prefs('map_data.highlight_edits') === 'true') context.map().toggleHighlightEdited();
 
         var panPixels = 80;
         context.keybinding()
@@ -422,6 +424,9 @@ export function uiInit(context) {
             .on(t('map_data.highlight_edits.key'), function toggleHighlightEdited(d3_event) {
                 d3_event.preventDefault();
                 context.map().toggleHighlightEdited();
+                // save the last state of the highlightEdited
+                if (prefs('map_data.highlight_edits') === null) prefs('map_data.highlight_edits', 'true'); // if this is the firts ones, set it to true
+                else prefs('map_data.highlight_edits', prefs('map_data.highlight_edits') === 'true' ? 'false' : 'true'); // toggle the state, if it's already exist
             });
 
         context


### PR DESCRIPTION
This PR for the issue No. #10870 

I have saved the modified settings after the page update process.  

If the user presses the `G` button for the first time, it will save their settings and display an indicator of the last modification every time they refresh the page.  

If they press it again, the action will be reversed, as shown.