### PR TITLE
Feature: Persist edit highlights across sessions

### DIFF
--- a/modules/core/history.js
+++ b/modules/core/history.js
@@ -29,6 +29,7 @@ export function coreHistory(context) {
     var _stack;
     var _index;
     var _tree;
+    var _surface = d3_select(null);
 
 
     // internal _act, accepts list of actions and eased time
@@ -699,6 +700,7 @@ export function coreHistory(context) {
                 _hasUnresolvedRestorableChanges = false;
                 var json = this.savedHistoryJSON();
                 if (json) history.fromJSON(json, true);
+                _surface.classed('highlight-edited', (prefs('edit-highlight-toggle')=== 'true'));
             }
         },
 

--- a/modules/renderer/map.js
+++ b/modules/renderer/map.js
@@ -407,10 +407,8 @@ export function rendererMap(context) {
         drawAreas = svgAreas(projection, context);
         drawMidpoints = svgMidpoints(projection, context);
         drawLabels = svgLabels(projection, context);
-        if (prefs('edit-highlight-toggle') === 'true'){
+        if (prefs('edit-highlight-toggle')){
             surface.classed('highlight-edited', prefs('edit-highlight-toggle') === 'true');
-            map.pan([0,0]);  // trigger a redraw
-            dispatch.call('changeHighlighting', this);
         }
     };
 
@@ -1084,8 +1082,8 @@ export function rendererMap(context) {
 
     map.toggleHighlightEdited = function() {
         const lastEditHighlightToggle = prefs('edit-highlight-toggle');
-        surface.classed('highlight-edited', !(lastEditHighlightToggle === 'true'));
-        prefs('edit-highlight-toggle', !(lastEditHighlightToggle === 'true'));
+        prefs('edit-highlight-toggle', (lastEditHighlightToggle === 'true') ? 'false' : 'true');
+        surface.classed('highlight-edited', (prefs('edit-highlight-toggle') === 'true'));
         map.pan([0,0]);  // trigger a redraw
         dispatch.call('changeHighlighting', this);
     };

--- a/modules/renderer/map.js
+++ b/modules/renderer/map.js
@@ -407,6 +407,11 @@ export function rendererMap(context) {
         drawAreas = svgAreas(projection, context);
         drawMidpoints = svgMidpoints(projection, context);
         drawLabels = svgLabels(projection, context);
+        if (prefs('edit-highlight-toggle') === 'true'){
+            surface.classed('highlight-edited', prefs('edit-highlight-toggle') === 'true');
+            map.pan([0,0]);  // trigger a redraw
+            dispatch.call('changeHighlighting', this);
+        }
     };
 
     function editOff() {
@@ -1078,7 +1083,9 @@ export function rendererMap(context) {
 
 
     map.toggleHighlightEdited = function() {
-        surface.classed('highlight-edited', !surface.classed('highlight-edited'));
+        const lastEditHighlightToggle = prefs('edit-highlight-toggle');
+        surface.classed('highlight-edited', !(lastEditHighlightToggle === 'true'));
+        prefs('edit-highlight-toggle', !(lastEditHighlightToggle === 'true'));
         map.pan([0,0]);  // trigger a redraw
         dispatch.call('changeHighlighting', this);
     };

--- a/modules/ui/sections/map_style_options.js
+++ b/modules/ui/sections/map_style_options.js
@@ -1,6 +1,7 @@
 import { t } from '../../core/localizer';
 import { uiTooltip } from '../tooltip';
 import { uiSection } from '../section';
+import { prefs } from '../../core';
 
 export function uiSectionMapStyleOptions(context) {
 
@@ -27,7 +28,7 @@ export function uiSectionMapStyleOptions(context) {
             .attr('class', 'layer-list layer-visual-diff-list')
             .merge(container2)
             .call(drawListItems, ['highlight_edits'], 'checkbox', 'visual_diff', toggleHighlightEdited, function() {
-                return context.surface().classed('highlight-edited');
+                return prefs('edit-highlight-toggle') === 'true';
             });
     }
 


### PR DESCRIPTION
## What does this PR do: 

- Add 'edit-highlight-toggle' field into preferences 
- modify `map.toggleHighlightEdited` function to act as a single source of truth to read/write the `edit-highlight-toggle` field in preferences. 

Closes: #10870 
