### PR TITLE
simplify raw tag editor ui and logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 
 #### :sparkles: Usability & Accessibility
 * Render housenumbers (or housenames) of address points or buildings as dedicated labels on the map ([#10970])
+* Simplify raw tag editor and make it easier to use with keyboard-only input ([#10889])
 #### :scissors: Operations
 #### :camera: Street-Level
 #### :white_check_mark: Validation
@@ -48,6 +49,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :mortar_board: Walkthrough / Help
 #### :hammer: Development
 
+[#10889]: https://github.com/openstreetmap/iD/pull/10889
 [#10970]: https://github.com/openstreetmap/iD/pull/10970
 
 

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -359,6 +359,9 @@ button.disabled {
     color: rgba(0,0,0,.4);
     cursor: not-allowed;
 }
+button.disabled .icon {
+    fill: rgba(0,0,0,.4);
+}
 
 .joined > * {
     border-radius: 0;
@@ -4250,7 +4253,8 @@ li.issue-fix-item button:not(.actionable) .fix-icon {
 .inspector-hover .form-field-input-radio label,
 .inspector-hover .form-field-input-radio label span,
 .inspector-hover .form-field-input-radio label.remove .icon,
-.inspector-hover .add-row,
+.inspector-hover .tag-row button,
+.inspector-hover .tag-row.add-tag,
 .inspector-hover .section-entity-issues .issue-container .issue-fix-list,
 .inspector-hover .section-entity-issues .issue-container .issue-info-button {
     display: none;
@@ -4264,9 +4268,8 @@ li.issue-fix-item button:not(.actionable) .fix-icon {
 .inspector-hover .hide-toggle:before,
 .inspector-hover .more-fields,
 .inspector-hover .field-label button,
-.inspector-hover .tag-row button,
 .inspector-hover .footer * {
-    opacity: 0;
+    visibility: hidden;
 }
 
 /* Unstyle the active entity issue on hover */

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -713,7 +713,6 @@ en:
     features: Features
     title_count: "{title} ({count})"
     add_to_relation: Add to a relation
-    add_to_tag: Add a tag
     new_relation: New relation...
     choose_relation: Choose a parent relation
     role: Role

--- a/test/spec/ui/sections/raw_tag_editor.js
+++ b/test/spec/ui/sections/raw_tag_editor.js
@@ -1,5 +1,3 @@
-import { setTimeout } from 'node:timers/promises';
-
 describe('iD.uiSectionRawTagEditor', function() {
     var taglist, element, entity, context;
 
@@ -37,40 +35,22 @@ describe('iD.uiSectionRawTagEditor', function() {
     it('creates a pair of empty input elements if the entity has no tags', function () {
         element.remove();
         render({});
+        expect(element.selectAll('.tag-list li').nodes().length).to.eql(1);
         expect(element.select('.tag-list').selectAll('input.value').property('value')).to.be.empty;
         expect(element.select('.tag-list').selectAll('input.key').property('value')).to.be.empty;
     });
 
-    it('adds tags when clicking the add button', async () => {
-        happen.click(element.selectAll('button.add-tag').node());
-        await setTimeout(20);
-        expect(element.select('.tag-list').selectAll('input').nodes()[2].value).to.be.empty;
-        expect(element.select('.tag-list').selectAll('input').nodes()[3].value).to.be.empty;
-    });
-
-    it('removes tags when clicking the remove button', async () => {
-        iD.utilTriggerEvent(element.selectAll('button.remove'), 'mousedown', { button: 0 });
-        const tags = await new Promise(cb => {
-            taglist.on('change', (_, tags) => cb(tags));
-        });
-        expect(tags).to.eql({highway: undefined});
-    });
-
-    it('adds tags when pressing the TAB key on last input.value', async () => {
-        expect(element.selectAll('.tag-list li').nodes().length).to.eql(1);
-        var input = d3.select('.tag-list li:last-child input.value').nodes()[0];
-        happen.keydown(d3.select(input).node(), {keyCode: 9});
-        await setTimeout(20);
+    it('adds pair of empty input elements at end of list', () => {
         expect(element.selectAll('.tag-list li').nodes().length).to.eql(2);
         expect(element.select('.tag-list').selectAll('input').nodes()[2].value).to.be.empty;
         expect(element.select('.tag-list').selectAll('input').nodes()[3].value).to.be.empty;
     });
 
-    it('does not add a tag when pressing TAB while shift is pressed', async () => {
-        expect(element.selectAll('.tag-list li').nodes().length).to.eql(1);
-        var input = d3.select('.tag-list li:last-child input.value').nodes()[0];
-        happen.keydown(d3.select(input).node(), {keyCode: 9, shiftKey: true});
-        await setTimeout(20);
-        expect(element.selectAll('.tag-list li').nodes().length).to.eql(1);
+    it('removes tags when clicking the remove button', async () => {
+        const tags = new Promise(cb => {
+            taglist.on('change', (_, tags) => cb(tags));
+        });
+        iD.utilTriggerEvent(element.selectAll('button.remove'), 'mousedown', { button: 0 });
+        expect(await tags).to.eql({highway: undefined});
     });
 });


### PR DESCRIPTION
* always show empty line at bottom of the tag list to allow adding more tags (replaces `+` button and tab logic)
* disable delete and info buttons on empty tag
* replace deferring of tag change events and re-rendering with a simpler logic (to fix issues like #10871): only set input field values if the rendering event was triggered by an external event, or by a change of the respective field in the raw tag editor itself
* skip delete and tag info buttons while navigating using tab: makes it more quick to get to where one typically needs to, deleting a key using the keyboard only is possible by emptying the tag's key, and advanced users are not typically using the `i` button anyway

todo:
* thoroughly test if this does not introduce any old or new bugs (see also #6028, #4991, #5878, #5847)
* add changelog (after release v2.33 is out to avoid merge conflict)