### PR TITLE
feat: Persist highlight unsaved edits mode across sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :sparkles: Usability & Accessibility
 * Allow searching for coordinates in localized number format in search box ([#10805])
 * Improve visibility of oneway arrows for dashed line styles (such as railway lines, foot paths, etc.): they are now rendered such that the arrows seemlessly integrate into the line dashes ([#10849])
+* Persist "highlight unsaved edits" mode across editing sessions, so users don't need to re-enable it manually ([#10903])
 #### :scissors: Operations
 * Fix unexpected behavior of squaring operation on individual vertices ([#10401])
 #### :camera: Street-Level
@@ -74,6 +75,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#10843]: https://github.com/openstreetmap/iD/pull/10843
 [#10852]: https://github.com/openstreetmap/iD/issues/10852
 [#10885]: https://github.com/openstreetmap/iD/issues/10885
+[#10903]: https://github.com/openstreetmap/iD/pull/10903
 [id-tagging-schema#609]: https://github.com/openstreetmap/id-tagging-schema/issues/609
 [@0xatulpatil]: https://github.com/0xatulpatil
 [@MohamedAli00949]: https://github.com/MohamedAli00949

--- a/modules/ui/init.js
+++ b/modules/ui/init.js
@@ -348,6 +348,10 @@ export function uiInit(context) {
                 .call(uiAccount(context));
         }
 
+        if (prefs('highlight-edited')=='true'){
+            context.map().toggleHighlightEdited();
+        }
+
 
         // Setup map dimensions and move map to initial center/zoom.
         // This should happen after .main-content and toolbars exist.
@@ -422,6 +426,8 @@ export function uiInit(context) {
             .on(t('map_data.highlight_edits.key'), function toggleHighlightEdited(d3_event) {
                 d3_event.preventDefault();
                 context.map().toggleHighlightEdited();
+                var highlightEditedStatus=prefs('highlight-edited')=='true';
+                prefs('highlight-edited',highlightEditedStatus?'false':'true');
             });
 
         context

--- a/modules/ui/init.js
+++ b/modules/ui/init.js
@@ -348,7 +348,7 @@ export function uiInit(context) {
                 .call(uiAccount(context));
         }
 
-        if (prefs('highlight-edited')=='true'){
+        if (prefs('highlight-edited')==='true'){
             context.map().toggleHighlightEdited();
         }
 
@@ -426,7 +426,7 @@ export function uiInit(context) {
             .on(t('map_data.highlight_edits.key'), function toggleHighlightEdited(d3_event) {
                 d3_event.preventDefault();
                 context.map().toggleHighlightEdited();
-                var highlightEditedStatus=prefs('highlight-edited')=='true';
+                var highlightEditedStatus=prefs('highlight-edited')==='true';
                 prefs('highlight-edited',highlightEditedStatus?'false':'true');
             });
 


### PR DESCRIPTION
Changes:
- Updated ui/init.js to apply the saved preference during initialization.
- Make it so that a preference is saved when highlighting (pressing `g`)

Solves #10870 