### PR TITLE
consider language scripts when determining the locale to use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Make features clickable when "Full Fill" rendering style is selected
 * Fix calculation of access field placeholders for multi selections ([#9333])
 #### :earth_asia: Localization
+* Consider language scripts when determining the locale to use ([#10910], thanks [@k-yle])
 #### :hourglass: Performance
 #### :mortar_board: Walkthrough / Help
 #### :rocket: Presets
@@ -74,6 +75,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#10843]: https://github.com/openstreetmap/iD/pull/10843
 [#10852]: https://github.com/openstreetmap/iD/issues/10852
 [#10885]: https://github.com/openstreetmap/iD/issues/10885
+[#10910]: https://github.com/openstreetmap/iD/pull/10910
 [id-tagging-schema#609]: https://github.com/openstreetmap/id-tagging-schema/issues/609
 [@0xatulpatil]: https://github.com/0xatulpatil
 [@MohamedAli00949]: https://github.com/MohamedAli00949

--- a/test/spec/core/localizer.js
+++ b/test/spec/core/localizer.js
@@ -90,4 +90,29 @@ describe('iD.coreLocalizer', function() {
             expect(countDecimalPlaces('10')).to.eql(0);
         });
     });
+
+    describe('localesToUseFrom', () => {
+        const SUPPORTED_LANGS = {
+            en: true,
+            'en-AU': true,
+            fr: true,
+            zh: true,
+            'zh-CN': true,
+        };
+        it.each([
+            /* [requested, matching] */
+            [[], ['en']],
+            [['en'], ['en']],
+            [['en-AU'], ['en-AU', 'en']],
+            [['zh'], ['zh', 'en']],
+            [['zh-CN'], ['zh-CN', 'zh', 'en']],
+            [['zh-Hans-CN'], ['zh-CN', 'zh', 'en']],
+            [['zh-Hans'], ['zh', 'en']],
+            [['fr-Latn'], ['fr', 'en']],
+        ])('resolves %s to %s', (requested, matching) => {
+            const localiser = iD.coreLocalizer();
+            localiser.preferredLocaleCodes(requested);
+            expect(localiser.localesToUseFrom(SUPPORTED_LANGS)).toStrictEqual(matching);
+        });
+    });
 });


### PR DESCRIPTION
Part 1 of #10219

If your browser's locale is set to `zh-Hans-CN`, iD will correctly remove the _script_ (`-Hans-`), thereby setting the locale to `zh-CN`. This applies to any tag with a script, for example `sr-Latn` becomes `sr`.


This PR has no special logic for chinese. We could automatically do conversions like `zh-TW` -> `zh-Hant`, but it's probably better to discuss that in a separate PR.