### PR TITLE
Enable territory-level address hints

### DIFF
--- a/modules/ui/fields/address.js
+++ b/modules/ui/fields/address.js
@@ -273,6 +273,7 @@ export function uiFieldAddress(field, context) {
                 countryCode = t('intro.graph.countrycode');
             } else {
                 var center = extent.center();
+                // even if we do not have data for this territory/country, the editor will generate a default format for us.
                 countryCode = countryCoder.iso1A2Code(center, { level: 'territory' });
             }
             if (countryCode) {

--- a/modules/ui/fields/address.js
+++ b/modules/ui/fields/address.js
@@ -273,7 +273,7 @@ export function uiFieldAddress(field, context) {
                 countryCode = t('intro.graph.countrycode');
             } else {
                 var center = extent.center();
-                countryCode = countryCoder.iso1A2Code(center);
+                countryCode = countryCoder.iso1A2Code(center, { level: 'territory' });
             }
             if (countryCode) {
                 _countryCode = countryCode.toLowerCase();


### PR DESCRIPTION
As guided by https://github.com/openstreetmap/iD/issues/10899#issuecomment-2745909687 , this PR enables the editor to look at the territory-level country code, and therefore fixes #10906.

Hopefully there are no unexpected side effects.

The major beneficiaries of this PR are most probably the Hong Kong and Macau mapping communities. However, for those communities, this PR is **blocked by #10907**, so at this stage it will exist as a draft. But still, feature-wise, this PR is complete, just need to wait for a good timing.

I see no need to rush this through before #10907 is done, but if there are other territory-level countries that also benefit from this PR but already has a well-defined address format, feel free to convert this from a draft to an actual PR (I think it is only me that can do the conversion?).