### PR TITLE
create a random phone number if the local phone format is not specified in the ID

### DIFF
--- a/modules/ui/fields/input.js
+++ b/modules/ui/fields/input.js
@@ -345,13 +345,34 @@ export function uiFieldText(field, context) {
         }
     }
 
+    function generateRandomPhoneNumber() {
+        // Generate a random country code between +1 and +999
+        const countryCode = `+${Math.floor(Math.random() * 99) + 1}`;
+
+        // Generate a random phone number with 10 or 11 digits
+        const phoneNumberLength = Math.floor(Math.random() * 2) + 10 - (countryCode.length - 1);
+        let phoneNumber = '';
+
+        for (let i = 0; i < phoneNumberLength; i++) {
+            phoneNumber += Math.floor(Math.random() * 10);
+        }
+
+        // Format the number with spaces every 3 or 4 digits
+        const formattedNumber = phoneNumber.replace(/(\d{3})(?=\d{4,7})/g, '$1 ');
+
+        return `${countryCode} ${formattedNumber}`;
+    }
+
 
     function updatePhonePlaceholder() {
         if (input.empty() || !Object.keys(_phoneFormats).length) return;
 
         var extent = combinedEntityExtent();
         var countryCode = extent && countryCoder.iso1A2Code(extent.center());
-        var format = countryCode && _phoneFormats[countryCode.toLowerCase()];
+        var format;
+
+        if (countryCode && !_phoneFormats[countryCode.toLowerCase()]) format = generateRandomPhoneNumber(); // if the phone format is not listed
+        else format = (countryCode && _phoneFormats[countryCode.toLowerCase()]); // if the phone format is listed
         if (format) input.attr('placeholder', format);
     }
 


### PR DESCRIPTION
While discussing #10916  @tyrasd suggested that he make a random phone number, as we did not find any number registered in our phone number format list

now I have created a new function that does the following:
1. **Generates a Random Country Code**  
   - Creates a country code between **`+1` and `+99`**.  
   - Example: `+45`, `+83`, `+9`  
2. **Determines a Random Phone Number Length**  
   - The total number (including the country code) is **10 or 11 digits**.  
   - Adjusts the phone number length based on the country code length.  
3. **Generates a Random Phone Number**  
   - Fills the number with random digits (`0-9`).  
4. **Formats the Phone Number with Spaces**  
   - Inserts a space **every 3 digits**, except for the last **4 digits** which remain grouped.  
   - Example format: `+45 123 456 7890`  
5. **Returns a Complete Formatted Phone Number**  
   - Example outputs:  
     - `+5 123 456 7890`  
     - `+78 987 654 321`  
     - `+99 543 210 9876`