### PR TITLE
Don't treat closed `waterway=dam` as area without `area=yes`

### DIFF
--- a/modules/osm/tags.js
+++ b/modules/osm/tags.js
@@ -63,9 +63,6 @@ export var osmAreaKeysExceptions = {
         wash: true,
         ventilation_shaft: true
     },
-    waterway: {
-        dam: true
-    },
     amenity: {
         bicycle_parking: true
     }


### PR DESCRIPTION
`waterway=dam` can be mapped as either a line or an area, and consumers like renderers will want to treat the two cases differently. Generally if a tag can be applied to either geometry, and `area=yes` tag is required to differentiate them. However, iD currently has a hardcoded exception to this for dams, meaning the `area=yes` tag is missing for many dams-as-areas in OSM. This means that data consumers will need to manually add the same exception in order to handle these properly, which isn't great. Removing the exception will help encourage unambiguous mapping, making it easier to parse the data.