### PR TITLE
render addresses (housenumber/housename)

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -914,6 +914,9 @@ en:
     points:
       description: Points
       tooltip: "Points of Interest"
+    address_points:
+      description: Address Points
+      tooltip: "Addresses Mapped as Individual Points"
     traffic_roads:
       description: Traffic Roads
       tooltip: "Highways, Streets, etc."

--- a/modules/actions/merge_remote_changes.js
+++ b/modules/actions/merge_remote_changes.js
@@ -1,6 +1,6 @@
 import deepEqual from 'fast-deep-equal';
 import { diff3Merge } from 'node-diff3';
-import { escape } from 'lodash';
+import { escape } from 'lodash-es';
 
 import { t } from '../core/localizer';
 import { actionDeleteMultiple } from './delete_multiple';

--- a/modules/core/history.js
+++ b/modules/core/history.js
@@ -80,12 +80,12 @@ export function coreHistory(context) {
     // internal _overwrite with eased time
     function _overwrite(args, t) {
         var previous = _stack[_index].graph;
+        var actionResult = _act(args, t);
         if (_index > 0) {
             _index--;
             _stack.pop();
         }
         _stack = _stack.slice(0, _index + 1);
-        var actionResult = _act(args, t);
         _stack.push(actionResult);
         _index++;
         return change(previous);

--- a/modules/modes/move.js
+++ b/modules/modes/move.js
@@ -47,7 +47,7 @@ export function modeMove(context, entityIDs, baseGraph) {
 
     var _prevGraph;
     var _cache;
-    var _origin;
+    var _prevMouse;
     var _nudgeInterval;
 
     // use pointer events on supported platforms; fallback to mouse events
@@ -57,18 +57,18 @@ export function modeMove(context, entityIDs, baseGraph) {
     function doMove(nudge) {
         nudge = nudge || [0, 0];
 
-        var fn;
+        let fn;
         if (_prevGraph !== context.graph()) {
             _cache = {};
-            _origin = context.map().mouseCoordinates();
+            _prevMouse = context.map().mouse();
             fn = context.perform;
         } else {
             fn = context.overwrite;
         }
 
-        var currMouse = context.map().mouse();
-        var origMouse = context.projection(_origin);
-        var delta = geoVecSubtract(geoVecSubtract(currMouse, origMouse), nudge);
+        const currMouse = context.map().mouse();
+        const delta = geoVecSubtract(geoVecSubtract(currMouse, _prevMouse), nudge);
+        _prevMouse = currMouse;
 
         fn(actionMove(entityIDs, delta, context.projection, _cache));
         _prevGraph = context.graph();
@@ -129,7 +129,7 @@ export function modeMove(context, entityIDs, baseGraph) {
 
 
     mode.enter = function() {
-        _origin = context.map().mouseCoordinates();
+        _prevMouse = context.map().mouse();
         _prevGraph = null;
         _cache = {};
 

--- a/modules/osm/tags.js
+++ b/modules/osm/tags.js
@@ -1,13 +1,37 @@
 import { merge } from 'lodash-es';
 
+const uninterestingKeys = new Set([
+    'attribution',
+    'created_by',
+    'import_uuid',
+    'geobase:datasetName',
+    'geobase:uuid',
+    'KSJ2:curve_id',
+    'KSJ2:lat',
+    'KSJ2:long',
+    'lat',
+    'latitude',
+    'lon',
+    'longitude',
+    'source',
+    'source_ref',
+    'odbl',
+    'odbl:note'
+]);
+const uninterestingKeyRegex = /^(source(_ref)?|tiger):/;
+
+/**
+ * Returns whether the given OSM tag key is potentially "interesting".
+ * For example, some tags are deemed not interesting because the respective tag is
+ * considered "discardable".
+ *
+ * @param {string} key the key to test
+ * @returns {boolean}
+ */
 export function osmIsInterestingTag(key) {
-    return key !== 'attribution' &&
-        key !== 'created_by' &&
-        key !== 'source' &&
-        key !== 'odbl' &&
-        key.indexOf('source:') !== 0 &&
-        key.indexOf('source_ref') !== 0 && // purposely exclude colon
-        key.indexOf('tiger:') !== 0;
+    if (uninterestingKeys.has(key)) return false;
+    if (uninterestingKeyRegex.test(key))  return false;
+    return true;
 }
 
 export const osmLifecyclePrefixes = {

--- a/modules/osm/tags.js
+++ b/modules/osm/tags.js
@@ -296,7 +296,7 @@ export function isColourValid(value) {
 }
 
 // https://wiki.openstreetmap.org/wiki/Special:WhatLinksHere/Property:P44
-export var osmMutuallyExclusiveTagPairs = [
+export const osmMutuallyExclusiveTagPairs = [
     ['noname', 'name'],
     ['noref', 'ref'],
     ['nohousenumber', 'addr:housenumber'],

--- a/modules/presets/preset.js
+++ b/modules/presets/preset.js
@@ -1,4 +1,4 @@
-import { isEqual } from 'lodash';
+import { isEqual } from 'lodash-es';
 
 import { t } from '../core/localizer';
 import { osmAreaKeys, osmAreaKeysExceptions } from '../osm/tags';

--- a/modules/renderer/background_source.js
+++ b/modules/renderer/background_source.js
@@ -1,6 +1,6 @@
 import { geoArea as d3_geoArea, geoMercatorRaw as d3_geoMercatorRaw } from 'd3-geo';
 import { json as d3_json } from 'd3-fetch';
-import { escape } from 'lodash';
+import { escape } from 'lodash-es';
 
 import { t, localizer } from '../core/localizer';
 import { geoExtent, geoSphericalDistance } from '../geo';

--- a/modules/renderer/features.js
+++ b/modules/renderer/features.js
@@ -1,7 +1,7 @@
 import { dispatch as d3_dispatch } from 'd3-dispatch';
 
 import { prefs } from '../core/preferences';
-import { osmEntity, osmLifecyclePrefixes } from '../osm';
+import { osmEntity, osmIsInterestingTag, osmLifecyclePrefixes } from '../osm';
 import { utilRebind } from '../util/rebind';
 import { utilArrayGroupBy, utilArrayUnion, utilQsString, utilStringQs } from '../util';
 
@@ -103,9 +103,18 @@ export function rendererFeatures(context) {
         };
     }
 
+    function isAddressPoint(tags, geometry) {
+        const keys = Object.keys(tags);
+        return geometry === 'point' &&
+            keys.length > 0 &&
+            keys.every(key =>
+                key.startsWith('addr:') || !osmIsInterestingTag(key)
+            );
+    }
+    defineRule('address_points', isAddressPoint, 100);
 
     defineRule('points', function isPoint(tags, geometry) {
-        return geometry === 'point';
+        return geometry === 'point' && !isAddressPoint(tags, geometry);
     }, 200);
 
     defineRule('traffic_roads', function isTrafficRoad(tags) {

--- a/modules/renderer/map.js
+++ b/modules/renderer/map.js
@@ -393,8 +393,8 @@ export function rendererMap(context) {
             .call(drawLines, graph, data, filter)
             .call(drawAreas, graph, data, filter)
             .call(drawMidpoints, graph, data, filter, map.trimmedExtent())
-            .call(drawLabels, graph, data, filter, _dimensions, fullRedraw)
-            .call(drawPoints, graph, data, filter);
+            .call(drawPoints, graph, data, filter)
+            .call(drawLabels, graph, data, filter, _dimensions, fullRedraw);
 
         dispatch.call('drawn', this, {full: true});
     }

--- a/modules/renderer/map.js
+++ b/modules/renderer/map.js
@@ -17,7 +17,7 @@ import { utilGetDimensions } from '../util/dimensions';
 import { utilRebind } from '../util/rebind';
 import { utilZoomPan } from '../util/zoom_pan';
 import { utilDoubleUp } from '../util/double_up';
-import { isArray } from 'lodash-es';
+import { isArray, clamp } from 'lodash-es';
 
 // constants
 var TILESIZE = 256;
@@ -25,10 +25,6 @@ var minZoom = 2;
 var maxZoom = 24;
 var kMin = geoZoomToScale(minZoom, TILESIZE);
 var kMax = geoZoomToScale(maxZoom, TILESIZE);
-
-function clamp(num, min, max) {
-    return Math.max(min, Math.min(num, max));
-}
 
 
 export function rendererMap(context) {

--- a/modules/services/mapilio.js
+++ b/modules/services/mapilio.js
@@ -5,7 +5,7 @@ import { zoom as d3_zoom, zoomIdentity as d3_zoomIdentity } from 'd3-zoom';
 import Protobuf from 'pbf';
 import RBush from 'rbush';
 import { VectorTile } from '@mapbox/vector-tile';
-import { isEqual } from 'lodash';
+import { isEqual } from 'lodash-es';
 
 import { utilRebind, utilTiler, utilQsString, utilStringQs, utilSetTransform } from '../util';
 import {geoExtent, geoScaleToZoom} from '../geo';

--- a/modules/svg/labels.js
+++ b/modules/svg/labels.js
@@ -75,11 +75,6 @@ export function svgLabels(projection, context) {
     }
 
 
-    function get(array, prop) {
-        return function(d, i) { return array[i][prop]; };
-    }
-
-
     function drawLinePaths(selection, labels, filter, classes) {
         var paths = selection.selectAll('path:not(.debug)')
             .filter(d => filter(d.entity))
@@ -373,12 +368,6 @@ export function svgLabels(projection, context) {
                 });
         }
 
-
-        function isAddressPoint(tags) {
-            const keys = Object.keys(tags);
-            return keys.length > 0 && keys.every(key =>
-                key.startsWith('addr:') || !osmIsInterestingTag(key));
-        }
 
         function getPointLabel(entity, width, height, style) {
             var y = (style.geometry === 'point' ? -12 : 0);
@@ -775,7 +764,7 @@ export function svgLabels(projection, context) {
 }
 
 
-var _textWidthCache = {};
+const _textWidthCache = {};
 export function textWidth(text, size, container) {
     let c = _textWidthCache[size];
     if (!c) c = _textWidthCache[size] = {};
@@ -790,4 +779,24 @@ export function textWidth(text, size, container) {
     c[text] = elem.getComputedTextLength();
     elem.remove();
     return c[text];
+}
+
+
+const nonPrimaryKeys = new Set([
+    'check_date',
+    'fixme',
+    'layer',
+    'level',
+    'level:ref',
+    'note'
+]);
+const nonPrimaryKeysRegex = /^(ref|survey|note):/;
+export function isAddressPoint(tags) {
+    const keys = Object.keys(tags);
+    return keys.length > 0 && keys.every(key =>
+        key.startsWith('addr:') ||
+        !osmIsInterestingTag(key) ||
+        nonPrimaryKeys.has(key) ||
+        nonPrimaryKeysRegex.test(key)
+    );
 }

--- a/modules/svg/labels.js
+++ b/modules/svg/labels.js
@@ -81,7 +81,7 @@ export function svgLabels(projection, context) {
 
 
     function drawLinePaths(selection, labels, filter, classes) {
-        var paths = selection.selectAll('path')
+        var paths = selection.selectAll('path:not(.debug)')
             .filter(d => filter(d.entity))
             .data(labels, d => osmEntity.key(d.entity));
 

--- a/modules/svg/labels.js
+++ b/modules/svg/labels.js
@@ -321,7 +321,7 @@ export function svgLabels(projection, context) {
 
                 var getName = (geometry === 'line') ? utilDisplayNameForPath : utilDisplayName;
                 var name = getName(entity);
-                var width = name && textWidth(name, fontSize, selection.select('g.layer-osm.labels g.label').node());
+                var width = name && textWidth(name, fontSize, selection.select('g.layer-osm.labels').node());
                 var p = null;
 
                 if (geometry === 'point' || geometry === 'vertex') {
@@ -332,7 +332,7 @@ export function svgLabels(projection, context) {
                     if (renderAs.geometry === 'vertex' && zoom < 17) continue;
                     while (renderAs.isAddr && width > 36) {
                         name = `${name.substring(0, name.replace(/…$/, '').length - 1)}…`;
-                        width = textWidth(name, fontSize, selection.select('g.layer-osm.labels g.label').node());
+                        width = textWidth(name, fontSize, selection.select('g.layer-osm.labels').node());
                     }
 
                     p = getPointLabel(entity, width, fontSize, renderAs);

--- a/modules/svg/points.js
+++ b/modules/svg/points.js
@@ -2,32 +2,26 @@ import deepEqual from 'fast-deep-equal';
 import { clamp } from 'lodash-es';
 
 import { geoScaleToZoom } from '../geo';
-import { osmEntity, osmIsInterestingTag } from '../osm';
+import { osmEntity } from '../osm';
 import { svgPointTransform } from './helpers';
 import { svgTagClasses } from './tag_classes';
 import { presetManager } from '../presets';
-import { textWidth } from './labels';
+import { textWidth, isAddressPoint } from './labels';
 
 export function svgPoints(projection, context) {
 
     function markerPath(selection, klass) {
-        const isHousenumber = d => {
-            const tagKeys = Object.keys(d.tags);
-            if (tagKeys.length === 0) return false;
-            return Object.keys(d.tags).every(key =>
-                key.startsWith('addr:') || !osmIsInterestingTag(key));
-        };
         const addressShieldWidth = d => {
             const width = textWidth(d.tags['addr:housenumber'] || d.tags['addr:housename'] || '', 10, selection.node().parentElement);
             return clamp(width, 10, 34) + 8;
         };
         selection
             .attr('class', klass)
-            .attr('transform', d => isHousenumber(d)
+            .attr('transform', d => isAddressPoint(d.tags)
                 ? `translate(-${addressShieldWidth(d)/2}, -8)`
                 : 'translate(-8, -23)')
             .attr('d', d => {
-                if (!isHousenumber(d)) {
+                if (!isAddressPoint(d.tags)) {
                     return 'M 17,8 C 17,13 11,21 8.5,23.5 C 6,21 0,13 0,8 C 0,4 4,-0.5 8.5,-0.5 C 13,-0.5 17,4 17,8 z';
                 }
                 const shieldWidth = addressShieldWidth(d);

--- a/modules/svg/points.js
+++ b/modules/svg/points.js
@@ -1,4 +1,6 @@
 import deepEqual from 'fast-deep-equal';
+import { clamp } from 'lodash-es';
+
 import { geoScaleToZoom } from '../geo';
 import { osmEntity, osmIsInterestingTag } from '../osm';
 import { svgPointTransform } from './helpers';

--- a/modules/svg/points.js
+++ b/modules/svg/points.js
@@ -6,6 +6,7 @@ import { osmEntity, osmIsInterestingTag } from '../osm';
 import { svgPointTransform } from './helpers';
 import { svgTagClasses } from './tag_classes';
 import { presetManager } from '../presets';
+import { textWidth } from './labels';
 
 export function svgPoints(projection, context) {
 
@@ -13,12 +14,12 @@ export function svgPoints(projection, context) {
         const isHousenumber = d => {
             const tagKeys = Object.keys(d.tags);
             if (tagKeys.length === 0) return false;
-            //return d.tags['addr:housenumber'] &&
             return Object.keys(d.tags).every(key =>
                 key.startsWith('addr:') || !osmIsInterestingTag(key));
         };
         const addressShieldWidth = d => {
-                return Math.min(6, Math.max(2, (d.tags['addr:housenumber'] || d.tags['addr:housename'] || '').length)) * 6 + 6;
+            const width = textWidth(d.tags['addr:housenumber'] || d.tags['addr:housename'] || '', 10, selection.node().parentElement);
+            return clamp(width, 10, 34) + 8;
         };
         selection
             .attr('class', klass)

--- a/modules/ui/entity_editor.js
+++ b/modules/ui/entity_editor.js
@@ -202,8 +202,8 @@ export function uiEntityEditor(context) {
                 context.overwrite(combinedAction, annotation);
             } else {
                 context.perform(combinedAction, annotation);
-                _coalesceChanges = !!onInput;
             }
+            _coalesceChanges = !!onInput;
         }
 
         // if leaving field (blur event), rerun validation
@@ -259,7 +259,6 @@ export function uiEntityEditor(context) {
                 context.overwrite(combinedAction, annotation);
             } else {
                 context.perform(combinedAction, annotation);
-                _coalesceChanges = false;
             }
         }
 

--- a/modules/ui/fields/address.js
+++ b/modules/ui/fields/address.js
@@ -338,11 +338,9 @@ export function uiFieldAddress(field, context) {
         }
 
         _wrap.selectAll('input')
+            .on('input', change(true))
             .on('blur', change())
             .on('change', change());
-
-        _wrap.selectAll('input:not(.combobox-input)')
-            .on('input', change(true));
 
         if (_tags) updateTags(_tags);
     }

--- a/modules/ui/photoviewer.js
+++ b/modules/ui/photoviewer.js
@@ -1,6 +1,7 @@
 import {
     select as d3_select
 } from 'd3-selection';
+import { clamp } from 'lodash-es';
 
 import { t } from '../core/localizer';
 import { dispatch as d3_dispatch } from 'd3-dispatch';
@@ -245,10 +246,6 @@ export function uiPhotoviewer(context) {
                 }
 
                 dispatch.call(eventName, target, subtractPadding(utilGetDimensions(target, true), target));
-            }
-
-            function clamp(num, min, max) {
-                return Math.max(min, Math.min(num, max));
             }
 
             function stopResize(d3_event) {

--- a/modules/ui/sections/background_display_options.js
+++ b/modules/ui/sections/background_display_options.js
@@ -1,6 +1,7 @@
 import {
     select as d3_select
 } from 'd3-selection';
+import { clamp } from 'lodash-es';
 
 import { prefs } from '../../core/preferences';
 import { t, localizer } from '../../core/localizer';
@@ -26,10 +27,6 @@ export function uiSectionBackgroundDisplayOptions(context) {
         saturation: 1,
         sharpness: 1
     };
-
-    function clamp(x, min, max) {
-        return Math.max(min, Math.min(x, max));
-    }
 
     function updateValue(d, val) {
         val = clamp(val, _minVal, _maxVal);

--- a/modules/util/tiler.js
+++ b/modules/util/tiler.js
@@ -1,4 +1,6 @@
 import { range as d3_range } from 'd3-array';
+import { clamp } from 'lodash-es';
+
 import { geoExtent, geoScaleToZoom } from '../geo';
 
 
@@ -10,11 +12,6 @@ export function utilTiler() {
     var _translate = [_size[0] / 2, _size[1] / 2];
     var _margin = 0;
     var _skipNullIsland = false;
-
-
-    function clamp(num, min, max) {
-        return Math.max(min, Math.min(num, max));
-    }
 
 
     function nearNullIsland(tile) {

--- a/modules/util/units.js
+++ b/modules/util/units.js
@@ -1,3 +1,5 @@
+import { clamp } from 'lodash-es';
+
 import { t, localizer } from '../core/localizer';
 
 var OSM_PRECISION = 7;
@@ -100,10 +102,6 @@ export function displayArea(m2, isImperial) {
 function wrap(x, min, max) {
     var d = max - min;
     return ((x - min) % d + d) % d + min;
-}
-
-function clamp(x, min, max) {
-    return Math.max(min, Math.min(x, max));
 }
 
 function roundToDecimal (target, decimalPlace) {

--- a/modules/util/util.js
+++ b/modules/util/util.js
@@ -191,6 +191,7 @@ export function utilDisplayName(entity, hideNetwork) {
     var name = entity.tags[localizedNameKey] || entity.tags.name || '';
 
     var tags = {
+        addr: entity.tags['addr:housenumber'] || entity.tags['addr:housename'],
         direction: entity.tags.direction,
         from: entity.tags.from,
         name,
@@ -209,6 +210,10 @@ export function utilDisplayName(entity, hideNetwork) {
     // Non-routes tend to be labeled in many places besides the relation lists, such as the map, where brevity is important.
     if (!entity.tags.route && name) {
         return name;
+    }
+    // unnamed buildings or address nodes: show housenumber/housename
+    if (tags.addr) {
+        return tags.addr;
     }
 
     var keyComponents = [];

--- a/modules/validations/crossing_ways.js
+++ b/modules/validations/crossing_ways.js
@@ -447,8 +447,8 @@ export function validationCrossingWays(context) {
                 var entity1 = graph.hasEntity(this.entityIds[0]),
                     entity2 = graph.hasEntity(this.entityIds[1]);
                 return (entity1 && entity2) ? t.append('issues.crossing_ways.message', {
-                    feature: utilDisplayLabel(entity1, graph),
-                    feature2: utilDisplayLabel(entity2, graph)
+                    feature: utilDisplayLabel(entity1, graph, featureType1 === 'building'),
+                    feature2: utilDisplayLabel(entity2, graph, featureType2 === 'building')
                 }) : '';
             },
             reference: showReference,

--- a/modules/validations/crossing_ways.js
+++ b/modules/validations/crossing_ways.js
@@ -1,4 +1,4 @@
-import { isEqual } from 'lodash';
+import { isEqual } from 'lodash-es';
 
 import { actionAddMidpoint } from '../actions/add_midpoint';
 import { actionChangeTags } from '../actions/change_tags';


### PR DESCRIPTION
Various improvements regarding addresses:

* add feature type "address points" for addresses mapped as nodes, allows to hide these, e.g. in regions with extremely high density of such nodes. fixes #10315
* render the housenumber or housename of address points as dedicated points with a "number plate" outline (compared to the "pin" outline for regular POIs)
* render the housenumber or housename of buildings (and other areas) like the `name` (when there is no `name`)

Remaining todos / open questions:
* [x] add to changelog / release notes
* should in case when there are both `addr:housenumber` and `addr:housename`, also both be rendered?
* fully document all changes. There are some minor changes e.g. in the labeling code or the address field input handling, but there is one especially "deep" change in `history.js`: it should be fine (i.e. the intended way this was always supposed to work), but needs some double-checking for potential side-effects
  * [x] fix _move_ operation which is now glitchy probably because of the above mentioned change to the `overwrite` method
* [x] fix bbox of touch targets (`g.layer-touch > rect`)

Below are a few example screenshots for different situations of mapped addresses:

1. `addr:housename` tagged as nodes:
  ![](https://github.com/user-attachments/assets/5d8c0090-d7b9-41aa-a2ef-ffd091b71340)
2. `addr:housename` tagged on buildings:
  ![](https://github.com/user-attachments/assets/0086884a-d2b7-4bc7-845b-70d204e5e285)
3. mixture of address points addresses tagged on buildings with relatively long housenumbers
  ![](https://github.com/user-attachments/assets/62bf3710-73da-4e36-8904-a8beaa474be1)
4. mostly addresses on buildings
  ![](https://github.com/user-attachments/assets/06390df8-b948-42b0-b9c8-52efc1077494)
5. housenumbers on building vertices (not tagged as `entrance`)
  ![](https://github.com/user-attachments/assets/7d22a281-77ce-42ca-bc91-e8a3effb26f9)
6. housenumbers on building vertices, tagged as `entrance`
  ![](https://github.com/user-attachments/assets/a4eb8014-df7e-42f2-95e6-caf85db12042)
7. addresses as separate points (often more than one housenumber per house)
  ![](https://github.com/user-attachments/assets/81121109-9cd1-4456-9af7-19f88d5f2a1c)
