### PR TITLE
remove empty line from drag_note.js

### DIFF
--- a/modules/actions/discard_tags.js
+++ b/modules/actions/discard_tags.js
@@ -1,4 +1,3 @@
-
 export function actionDiscardTags(difference, discardTags) {
   discardTags = discardTags || {};
 

--- a/modules/actions/extract.js
+++ b/modules/actions/extract.js
@@ -1,4 +1,3 @@
-
 import { geoPath as d3_geoPath } from 'd3-geo';
 
 import { osmNode } from '../osm/node';

--- a/modules/behavior/operation.js
+++ b/modules/behavior/operation.js
@@ -1,5 +1,3 @@
-
-
 /* Creates a keybinding behavior for an operation */
 export function behaviorOperation(context) {
     var _operation;

--- a/modules/core/preferences.js
+++ b/modules/core/preferences.js
@@ -1,4 +1,3 @@
-
 // https://github.com/openstreetmap/iD/issues/772
 // http://mathiasbynens.be/notes/localstorage-pattern#comment-9
 let _storage;

--- a/modules/modes/drag_note.js
+++ b/modules/modes/drag_note.js
@@ -1,4 +1,3 @@
-
 import { services } from '../services';
 import { actionNoop } from '../actions/noop';
 import { behaviorDrag } from '../behavior/drag';

--- a/modules/operations/paste.js
+++ b/modules/operations/paste.js
@@ -1,4 +1,3 @@
-
 import { actionCopyEntities } from '../actions/copy_entities';
 import { actionMove } from '../actions/move';
 import { modeSelect } from '../modes/select';

--- a/modules/osm/lanes.js
+++ b/modules/osm/lanes.js
@@ -1,4 +1,3 @@
-
 export function osmLanes(entity) {
     if (entity.type !== 'way') return null;
     if (!entity.tags.highway) return null;

--- a/modules/osm/qa_item.js
+++ b/modules/osm/qa_item.js
@@ -1,4 +1,3 @@
-
 export class QAItem {
   constructor(loc, service, itemType, id, props) {
     // Store required properties

--- a/modules/svg/debug.js
+++ b/modules/svg/debug.js
@@ -1,4 +1,3 @@
-
 import { fileFetcher } from '../core/file_fetcher';
 import { svgPath } from './helpers';
 

--- a/modules/svg/tag_pattern.js
+++ b/modules/svg/tag_pattern.js
@@ -1,4 +1,3 @@
-
 // Patterns only work in Firefox when set directly on element.
 // (This is not a bug: https://bugzilla.mozilla.org/show_bug.cgi?id=750632)
 var patterns = {

--- a/modules/ui/panes/background.js
+++ b/modules/ui/panes/background.js
@@ -1,4 +1,3 @@
-
 import { t } from '../../core/localizer';
 import { uiPane } from '../pane';
 

--- a/modules/ui/panes/issues.js
+++ b/modules/ui/panes/issues.js
@@ -1,4 +1,3 @@
-
 import { t } from '../../core/localizer';
 import { uiPane } from '../pane';
 

--- a/modules/ui/panes/map_data.js
+++ b/modules/ui/panes/map_data.js
@@ -1,4 +1,3 @@
-
 import { t } from '../../core/localizer';
 import { uiPane } from '../pane';
 

--- a/modules/ui/panes/preferences.js
+++ b/modules/ui/panes/preferences.js
@@ -1,4 +1,3 @@
-
 import { t } from '../../core/localizer';
 import { uiPane } from '../pane';
 import { uiSectionPrivacy } from '../sections/privacy';

--- a/modules/util/array.js
+++ b/modules/util/array.js
@@ -1,4 +1,3 @@
-
 // Returns true if a and b have the same elements at the same indices.
 export function utilArrayIdentical(a, b) {
     // an array is always identical to itself

--- a/modules/util/detect.js
+++ b/modules/util/detect.js
@@ -1,4 +1,3 @@
-
 let _detected;
 
 export function utilDetect(refresh) {

--- a/modules/util/object.js
+++ b/modules/util/object.js
@@ -1,4 +1,3 @@
-
 export function utilObjectOmit(obj, omitKeys) {
     return Object.keys(obj).reduce(function(result, key) {
         if (omitKeys.indexOf(key) === -1) {


### PR DESCRIPTION
It confuses some tools if a `*.js` file starts with an empty line.