### PR TITLE
create a new warning tier for low-severity suggestions

### DIFF
--- a/API.md
+++ b/API.md
@@ -59,6 +59,7 @@ of iD (e.g. `https://ideditor-release.netlify.app`), the following parameters ar
   _Example:_ `source=Bing%3BMapillary`
 * __`validationDisable`__ - The issues identified by these types/subtypes will be disabled (i.e. Issues will not be shown at all). Each parameter value should contain a comma-separated list of type/subtype match rules.  An asterisk `*` may be used as a wildcard.<br/>
   _Example:_ `validationDisable=crossing_ways/highway*,crossing_ways/tunnel*`
+* __`validationSuggestion`__ - The issues identified by these types/subtypes will be treated as suggestions (i.e. Issues will only be surfaced to the user while inspecting the feature, not during changeset upload). Each parameter value should contain a comma-separated list of type/subtype match rules.  An asterisk `*` may be used as a wildcard.<br/>
 * __`validationWarning`__ - The issues identified by these types/subtypes will be treated as warnings (i.e. Issues will be surfaced to the user but not block changeset upload). Each parameter value should contain a comma-separated list of type/subtype match rules.  An asterisk `*` may be used as a wildcard.<br/>
   _Example:_ `validationWarning=crossing_ways/highway*,crossing_ways/tunnel*`
 * __`validationError`__ - The issues identified by these types/subtypes will be treated as errors (i.e. Issues will be surfaced to the user but will block changeset upload). Each parameter value should contain a comma-separated list of type/subtype match rules.  An asterisk `*` may be used as a wildcard.<br/>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :scissors: Operations
 #### :camera: Street-Level
 #### :white_check_mark: Validation
+* Create a new warning tier for low-severity suggestions ([#11020], thanks [@k-yle])
 #### :bug: Bugfixes
 * Fix flickering of imagery metadata information in background panel ([#9754])
 * Immediately update raw tag key/value inputs when spaces have been trimmed ([#11206])
@@ -56,6 +57,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#9317]: https://github.com/openstreetmap/iD/issues/9317
 [#9511]: https://github.com/openstreetmap/iD/pull/9511
 [#9754]: https://github.com/openstreetmap/iD/issues/9754
+[#11020]: https://github.com/openstreetmap/iD/pull/11020
 [#11206]: https://github.com/openstreetmap/iD/issues/11206
 [#11211]: https://github.com/openstreetmap/iD/issues/11211
 [@bhavyaKhatri2703]: https://github.com/bhavyaKhatri2703

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -3598,6 +3598,57 @@ button.autofix.action.active {
     color: #fff;
 }
 
+/* suggestion styles */
+.suggestions-list,
+.suggestions-list *,
+.issue-container.active .issue.severity-suggestion,
+.issue-container.active .issue.severity-suggestion * {
+    border-color: #2f7eff;
+}
+.suggestions-list .issue.severity-suggestion .issue-label,
+.issue.severity-suggestion .issue-fix-list,
+.suggestion-section {
+    background: #e1effe;
+}
+
+.issue-container.active .issue.severity-suggestion .issue-label {
+    background: #e1effe;
+}
+
+.issue.severity-suggestion .issue-icon {
+    color: #49f;
+}
+
+.issue.severity-suggestion .issue-fix-item button.actionable,
+.issue-container.active .issue.severity-suggestion .issue-info-button {
+    color: #0066cc;
+    fill: #0066cc;
+}
+.suggestions-list .issue.severity-suggestion .issue-label:active,
+.suggestions-list .issue.severity-suggestion .issue-label:focus,
+.issue.severity-suggestion .issue-fix-item button.actionable:active,
+.issue.severity-suggestion .issue-fix-item button.actionable:focus {
+    background: #abd5ff;
+}
+.issue.severity-suggestion .issue-fix-item button.actionable:active,
+.issue.severity-suggestion .issue-fix-item button.actionable:focus,
+.issue-container.active .issue.severity-suggestion .issue-info-button:active,
+.issue-container.active .issue.severity-suggestion .issue-info-button:focus {
+    color: #0066cc;
+    fill: #1f4d82;
+}
+@media (hover: hover) {
+    .suggestions-list .issue.severity-suggestion .issue-label:hover,
+    .issue.severity-warning .issue-fix-item button.actionable:hover {
+        background: #bdf;
+    }
+    .issue.severity-suggestion .issue-fix-item button.actionable:hover,
+    .issue-container.active .issue.severity-suggestion .issue-info-button:hover {
+        color: #1f4d82;
+        fill: #1f4d82;
+    }
+}
+
 /* warning styles */
 .warnings-list,
 .warnings-list *,

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -613,6 +613,7 @@ en:
     download_changes: Download osmChange file
     errors: Errors
     warnings: Warnings
+    suggestions: Suggestions
     modified: Modified
     deleted: Deleted
     created: Created
@@ -1731,6 +1732,8 @@ en:
       list_title: "Errors"
     warnings:
       list_title: "Warnings"
+    suggestions:
+      list_title: "Suggestions"
     rules:
       title: Rules
     user_resolved_issues: Issues resolved by your edits

--- a/modules/core/validation/models.js
+++ b/modules/core/validation/models.js
@@ -4,7 +4,7 @@ import { t } from '../../core/localizer';
 export function validationIssue(attrs) {
     this.type = attrs.type;                // required - name of rule that created the issue (e.g. 'missing_tag')
     this.subtype = attrs.subtype;          // optional - category of the issue within the type (e.g. 'relation_type' under 'missing_tag')
-    this.severity = attrs.severity;        // required - 'warning' or 'error'
+    this.severity = attrs.severity;        // required - 'suggestion' or 'warning' or 'error'
     this.message = attrs.message;          // required - function returning localized string
     this.reference = attrs.reference;      // optional - function(selection) to render reference information
     this.entityIds = attrs.entityIds;      // optional - array of IDs of entities involved in the issue
@@ -63,7 +63,7 @@ export function validationIssue(attrs) {
         var fixes = this.dynamicFixes ? this.dynamicFixes(context) : [];
         var issue = this;
 
-        if (issue.severity === 'warning') {
+        if (issue.severity === 'warning' || issue.severity === 'suggestion') {
             // allow ignoring any issue that's not an error
             fixes.push(new validationIssueFix({
                 title: t.append('issues.fix.ignore_issue.title'),
@@ -87,6 +87,12 @@ export function validationIssue(attrs) {
     };
 
 }
+
+validationIssue.ICONS = {
+    suggestion: '#iD-icon-info',
+    warning: '#iD-icon-alert',
+    error: '#iD-icon-error'
+};
 
 
 export function validationIssueFix(attrs) {

--- a/modules/core/validator.js
+++ b/modules/core/validator.js
@@ -42,12 +42,13 @@ export function coreValidator(context) {
 
   const _errorOverrides = parseHashParam(context.initialHashParams.validationError);
   const _warningOverrides = parseHashParam(context.initialHashParams.validationWarning);
+  const _suggestionOverrides = parseHashParam(context.initialHashParams.validationSuggestion);
   const _disableOverrides = parseHashParam(context.initialHashParams.validationDisable);
 
   // `parseHashParam()`   (private)
   // Checks hash parameters for severity overrides
   // Arguments
-  //   `param` - a url hash parameter (`validationError`, `validationWarning`, or `validationDisable`)
+  //   `param` - a url hash parameter (`validationError`, `validationWarning`, `validationSuggestion`, or `validationDisable`)
   // Returns
   //   Array of Objects like { type: RegExp, subtype: RegExp }
   //
@@ -318,7 +319,7 @@ export function coreValidator(context) {
 
 
   // `getIssuesBySeverity()`
-  // Gets the issues then groups them by error/warning
+  // Gets the issues then groups them by error/warning/suggestion
   // (This just calls getIssues, then puts issues in groups)
   //
   // Arguments
@@ -327,13 +328,15 @@ export function coreValidator(context) {
   //   Object result like:
   //   {
   //     error:    Array of errors,
-  //     warning:  Array of warnings
+  //     warning:  Array of warnings,
+  //     suggestion:  Array of suggestions,
   //   }
   //
   validator.getIssuesBySeverity = (options) => {
     let groups = utilArrayGroupBy(validator.getIssues(options), 'severity');
     groups.error = groups.error || [];
     groups.warning = groups.warning || [];
+    groups.suggestion = groups.suggestion || [];
     return groups;
   };
 
@@ -639,6 +642,12 @@ export function coreValidator(context) {
         for (i = 0; i < _warningOverrides.length; i++) {
           if (_warningOverrides[i].type.test(type) && _warningOverrides[i].subtype.test(subtype)) {
             issue.severity = 'warning';
+            return true;
+          }
+        }
+        for (i = 0; i < _suggestionOverrides.length; i++) {
+          if (_suggestionOverrides[i].type.test(type) && _suggestionOverrides[i].subtype.test(subtype)) {
+            issue.severity = 'suggestion';
             return true;
           }
         }

--- a/modules/ui/commit_warnings.js
+++ b/modules/ui/commit_warnings.js
@@ -13,6 +13,9 @@ export function uiCommitWarnings(context) {
             .getIssuesBySeverity({ what: 'edited', where: 'all', includeDisabledRules: true });
 
         for (var severity in issuesBySeverity) {
+            // don't show suggestions on the changeset page
+            if (severity === 'suggestion') continue;
+
             var issues = issuesBySeverity[severity];
 
             if (severity !== 'error') {      // exclude 'fixme' and similar - #8603
@@ -34,7 +37,7 @@ export function uiCommitWarnings(context) {
 
             containerEnter
                 .append('h3')
-                .call(severity === 'warning' ? t.append('commit.warnings') : t.append('commit.errors'));
+                .call(t.append(`commit.${severity}s`));
 
             containerEnter
                 .append('ul')

--- a/modules/ui/issues_info.js
+++ b/modules/ui/issues_info.js
@@ -29,7 +29,8 @@ export function uiIssuesInfo(context) {
         var liveIssues = context.validator().getIssues({
             what: prefs('validate-what') || 'edited',
             where: prefs('validate-where') || 'all'
-        });
+        }).filter(issue => issue.severity !== 'suggestion');
+
         if (liveIssues.length) {
             warningsItem.count = liveIssues.length;
             shownItems.push(warningsItem);

--- a/modules/ui/panes/issues.js
+++ b/modules/ui/panes/issues.js
@@ -18,6 +18,7 @@ export function uiPaneIssues(context) {
             uiSectionValidationStatus(context),
             uiSectionValidationIssues('issues-errors', 'error', context),
             uiSectionValidationIssues('issues-warnings', 'warning', context),
+            uiSectionValidationIssues('issues-suggestions', 'suggestion', context),
             uiSectionValidationRules(context)
         ]);
 

--- a/modules/ui/sections/entity_issues.js
+++ b/modules/ui/sections/entity_issues.js
@@ -6,6 +6,7 @@ import { utilArrayIdentical } from '../../util/array';
 import { t } from '../../core/localizer';
 import { utilHighlightEntities } from '../../util';
 import { uiSection } from '../section';
+import { validationIssue } from '../../core/validation';
 
 
 export function uiSectionEntityIssues(context) {
@@ -104,9 +105,8 @@ export function uiSectionEntityIssues(context) {
 
         textEnter
             .each(function(d) {
-                var iconName = '#iD-icon-' + (d.severity === 'warning' ? 'alert' : 'error');
                 d3_select(this)
-                    .call(svgIcon(iconName, 'issue-icon'));
+                    .call(svgIcon(validationIssue.ICONS[d.severity], 'issue-icon'));
             });
 
         textEnter

--- a/modules/ui/sections/validation_issues.js
+++ b/modules/ui/sections/validation_issues.js
@@ -10,6 +10,7 @@ import { prefs } from '../../core/preferences';
 import { t } from '../../core/localizer';
 import { utilHighlightEntities } from '../../util';
 import { uiSection } from '../section';
+import { validationIssue } from '../../core/validation';
 
 export function uiSectionValidationIssues(id, severity, context) {
 
@@ -105,9 +106,8 @@ export function uiSectionValidationIssues(id, severity, context) {
             .append('span')
             .attr('class', 'issue-icon')
             .each(function(d) {
-                var iconName = '#iD-icon-' + (d.severity === 'warning' ? 'alert' : 'error');
                 d3_select(this)
-                    .call(svgIcon(iconName));
+                    .call(svgIcon(validationIssue.ICONS[d.severity]));
             });
 
         textEnter

--- a/modules/validations/unsquare_way.js
+++ b/modules/validations/unsquare_way.js
@@ -73,7 +73,7 @@ export function validationUnsquareWay(context) {
         return [new validationIssue({
             type: type,
             subtype: 'building',
-            severity: 'warning',
+            severity: 'suggestion',
             message: function(context) {
                 var entity = context.hasEntity(this.entityIds[0]);
                 return entity ? t.append('issues.unsquare_way.message', {


### PR DESCRIPTION
Closes #6101, Closes #10743

Created a new third tier for validation issues. `suggestion` (blue) is the lowest tier

<img width="379" alt="image" src="https://github.com/user-attachments/assets/c3d73fa7-77f2-411a-bf92-56d588b572f2" />

I've changed the 'Unsquare Corners' validator to this new low-severity type, since it's currently off by default[^1] so this change won't have any noticable impact. We can discuss where to use this tier in a followup issue, this PR is just the technical implementation.

Comparison of the severity tiers:

|  | `suggestion` |`warning` | `error` |
|-|--------|--------|--------|
| Prevents the changes from being uploaded |  |  | ✅ | 
| Shown on the changeset page | | ✅ | ✅ |
| Added to the changeset tags as `warning:*` | | ✅ | ✅ |
| Shown in the 'issues' panel | | ✅ | ✅ |
| Shown when a feature is selected | ✅  | ✅ | ✅ |

[^1]: I can't tell whether it's intentionally off by default, it actually seems to be a bug (#8477 ?)
