### PR TITLE
refresh numeric fields on blur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,12 +43,14 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :camera: Street-Level
 #### :white_check_mark: Validation
 #### :bug: Bugfixes
+* Refresh numeric input fields after leaving focus with the value that is stored in the tag ([#11027])
 #### :earth_asia: Localization
 #### :hourglass: Performance
 #### :mortar_board: Walkthrough / Help
 #### :hammer: Development
 
 [#10970]: https://github.com/openstreetmap/iD/pull/10970
+[#11027]: https://github.com/openstreetmap/iD/pull/11027
 
 
 # v2.34.0


### PR DESCRIPTION
addresses #10018: after leaving the input field, the numeric value will be always updated (printed in the user's locale number format). This specifically re-formats any "misplaced" thousands separators, e.g. in the case where a user with English locale typed in `0,1` which results in the tag value to be set to `1`. :arrow_right:  this is now reflected in the UI fields appropriately, and the user can correct their mistake if they had intended to enter `0.1`. Similarly, if a user writes `12,3445` the thousands separator will be updated to the "correct" position (i.e. `123,445`), making the user aware that they might typed a digit too many.

Example behavior:

English locale:

https://github.com/user-attachments/assets/95ec4395-9f15-44fa-921e-96ffd68ea078

German locale (`,` used as decimal separator / `.` used as thousands separator[^1]):

https://github.com/user-attachments/assets/4c1625be-eda7-4d5e-a5ce-43ae9a68064f

[^1]:  note that `.` can also always be used for input in "raw number format", i.e. `<digits>.<digits>` (no thousands separator allowed)
