### PR TITLE
try to make NSI suggestion message less misleading

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1909,7 +1909,7 @@ en:
       noncanonical_brand:
         message: "{feature} may be matching one of known brands"
         message_incomplete: "{feature} may be matching one of known brands"
-        reference: " Some features, for example retail chains or post offices, are expected to have certain tags in common. This set of suggested tags is based on comparing the name and other existing tags to a database of major chains. If this is merely a coincidence, select “Tag as not the same.”"
+        reference: "Some features, for example retail chains or post offices, are expected to have certain tags in common. This set of suggested tags is based on comparing the name and other existing tags to a database of major chains. If this is merely a coincidence, select “Tag as not the same.”"
     point_as_area:
       message: '{feature} should be a point, not an area'
     point_as_line:

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1907,9 +1907,9 @@ en:
         message: "{feature} has incomplete tags"
         reference: "Some features should have additional tags."
       noncanonical_brand:
-        message: "{feature} may or may not benefit from changing this tags"
-        message_incomplete: "{feature} may or may not benefit from adding this tags"
-        reference: "Some features, for example retail chains or post offices, are expected to have certain tags in common."
+        message: "{feature} may be matching one of known brands"
+        message_incomplete: "{feature} may be matching one of known brands"
+        reference: " Some features, for example retail chains or post offices, are expected to have certain tags in common. This set of suggested tags is based on comparing the name and other existing tags to a database of major chains. If this is merely a coincidence, select “Tag as not the same.”"
     point_as_area:
       message: '{feature} should be a point, not an area'
     point_as_line:

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1907,7 +1907,7 @@ en:
         message: "{feature} has incomplete tags"
         reference: "Some features should have additional tags."
       noncanonical_brand:
-        message: "{feature} may or may not benefit from chaning this tags"
+        message: "{feature} may or may not benefit from changing this tags"
         message_incomplete: "{feature} may or may not benefit from adding this tags"
         reference: "Some features, for example retail chains or post offices, are expected to have certain tags in common."
     point_as_area:

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1907,8 +1907,8 @@ en:
         message: "{feature} has incomplete tags"
         reference: "Some features should have additional tags."
       noncanonical_brand:
-        message: "{feature} looks like a common feature with nonstandard tags"
-        message_incomplete: "{feature} looks like a common feature with incomplete tags"
+        message: "{feature} may or may not benefit from chaning this tags"
+        message_incomplete: "{feature} may or may not benefit from adding this tags"
         reference: "Some features, for example retail chains or post offices, are expected to have certain tags in common."
     point_as_area:
       message: '{feature} should be a point, not an area'

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1907,8 +1907,8 @@ en:
         message: "{feature} has incomplete tags"
         reference: "Some features should have additional tags."
       noncanonical_brand:
-        message: "{feature} may be matching one of known brands"
-        message_incomplete: "{feature} may be matching one of known brands"
+        message: "{feature} was automatically matched to one of templates"
+        message_incomplete: "{feature} was automatically matched to one of templates"
         reference: "This change is automatically guessed based on similarity to other branded features. If this guess is wrong, select “Tag as not the same.”"
     point_as_area:
       message: '{feature} should be a point, not an area'

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1909,7 +1909,7 @@ en:
       noncanonical_brand:
         message: "{feature} may be matching one of known brands"
         message_incomplete: "{feature} may be matching one of known brands"
-        reference: "Some features, for example retail chains or post offices, are expected to have certain tags in common. This set of suggested tags is based on comparing the name and other existing tags to a database of major chains. If this is merely a coincidence, select “Tag as not the same.”"
+        reference: "This change is automatically guessed based on similarity to other branded features. If this guess is wrong, select “Tag as not the same.”"
     point_as_area:
       message: '{feature} should be a point, not an area'
     point_as_line:


### PR DESCRIPTION
fixes #9529
fixes #6517
fixes #9592
fixes #9528

NSI may be wrong or incomplete which may result in wrong suggestions

some mappers are unaware that QA suggestions in iD are not always correct, sometimes resulting in "upgrading" thousands of objects without real benefit and damaging data

this is an attempt to make people more aware that brain must be engaged while doing QA

disclaimer: I am not a native speaker