### PR TITLE
Improve multilingual name fallback logic based on user locale

### DIFF
--- a/modules/core/localizer.js
+++ b/modules/core/localizer.js
@@ -6,6 +6,19 @@ import { utilStringQs } from '../util';
 import { utilArrayUniq } from '../util/array';
 import { presetsCdnUrl } from '../../config/id.js';
 
+const rematchCodes = {
+    // below is not needed, because it can be solved by split('-')[0].toLowerCase()
+    // 'ar-AA': 'ar',
+    // 'pt-BR': 'pt',
+    // 'pt': 'pt-PT',
+
+
+    'zh-CN': ['zh-Hans','zh'],
+    'zh-TW': ['zh-Hant','zh'],
+    'zh-HK': ['zh-Hant','zh'],
+    'ko-Hani': ['ko-Hani'],
+};
+
 let _mainLocalizer = coreLocalizer(); // singleton
 let _t = _mainLocalizer.t;
 
@@ -48,6 +61,7 @@ export function coreLocalizer() {
     // `_localeCodes` must contain `_localeCode` first, optionally followed by fallbacks
     let _localeCodes = ['en-US', 'en'];
     let _languageCode = 'en';
+    let _languageCodes= [];
     let _textDirection = 'ltr';
     let _usesMetric = false;
     let _languageNames = {};
@@ -57,6 +71,7 @@ export function coreLocalizer() {
     localizer.localeCode = () => _localeCode;
     localizer.localeCodes = () => _localeCodes;
     localizer.languageCode = () => _languageCode;
+    localizer.languageCodes = () => _languageCodes;
     localizer.textDirection = () => _textDirection;
     localizer.usesMetric = () => _usesMetric;
     localizer.languageNames = () => _languageNames;
@@ -169,6 +184,20 @@ export function coreLocalizer() {
 
     function updateForCurrentLocale() {
         if (!_localeCode) return;
+
+        for (let localeCode of _localeCodes) {
+            if (localeCode in rematchCodes) {
+                let languageCodeList = rematchCodes[localeCode];
+                for (let code of languageCodeList) {
+                    _languageCodes.push(code);
+                }
+            } else {
+                localeCode = localeCode.split('-')[0].toLowerCase();
+                _languageCodes.push(localeCode);
+            }
+        }
+
+        _languageCodes.push("en")
 
         _languageCode = _localeCode.split('-')[0];
 

--- a/modules/core/localizer.js
+++ b/modules/core/localizer.js
@@ -7,12 +7,6 @@ import { utilArrayUniq } from '../util/array';
 import { presetsCdnUrl } from '../../config/id.js';
 
 const rematchCodes = {
-    // below is not needed, because it can be solved by split('-')[0].toLowerCase()
-    // 'ar-AA': 'ar',
-    // 'pt-BR': 'pt',
-    // 'pt': 'pt-PT',
-
-
     'zh-CN': ['zh-Hans','zh'],
     'zh-TW': ['zh-Hant','zh'],
     'zh-HK': ['zh-Hant','zh'],

--- a/modules/util/util.js
+++ b/modules/util/util.js
@@ -187,8 +187,14 @@ export function utilGetAllNodes(ids, graph) {
  *                              it being shown twice (see PR #8707#discussion_r712658175)
  */
 export function utilDisplayName(entity, hideNetwork) {
-    var localizedNameKey = 'name:' + localizer.languageCode().toLowerCase();
-    var name = entity.tags[localizedNameKey] || entity.tags.name || '';
+    let languageCodes=localizer.languageCodes()
+    let name = languageCodes
+        .map(code => entity.tags['name:' + code])
+        .find(value => value !== undefined);
+
+    if (!name) {
+        name = entity.tags.name || '';
+    }
 
     var tags = {
         addr: entity.tags['addr:housenumber'] || entity.tags['addr:housename'],


### PR DESCRIPTION
## Introduction

This PR enhances the multilingual support for feature names in the map by allowing multiple fallback languages to be used when displaying `name:*` tags. This improves localization and ensures that users see names in their preferred or most appropriate language.

## Main Changes

- **Multiple language fallbacks for names:**  
Instead of checking only a single name:<lang> tag, the logic now iterates through a prioritized list of language codes based on the user's locale preferences. If no localized tag is found in any of the preferred languages, it falls back first to name:en, and if that is also not available, finally falls back to the general name tag.

- **Special handling for Chinese variants:**  
  Added remapping logic to better support Chinese language variants by mapping locale codes to appropriate language tags.