### PR TITLE
Add "dir=auto" to fields with potentially bidirectional text

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -243,6 +243,12 @@ textarea.mixed::placeholder {
     font-style: italic;
 }
 
+.ideditor[dir='rtl'] input:placeholder-shown[dir="auto"] {
+    /* hard-set rtl for placeholder texts in rtl locales, see
+       https://github.com/openstreetmap/iD/pull/11091#issuecomment-2936953197 */
+    direction: rtl;
+}
+
 /* keytraps need to be invisible yet not be display:none or visibility:hidden */
 .keytrap {
     width: 0;

--- a/modules/ui/fields/combo.js
+++ b/modules/ui/fields/combo.js
@@ -494,6 +494,7 @@ export function uiFieldCombo(field, context) {
         _input = _input.enter()
             .append('input')
             .attr('type', 'text')
+            .attr('dir', 'auto')
             .attr('id', field.domId)
             .call(utilNoAuto)
             .call(initCombo, _container)

--- a/modules/ui/fields/input.js
+++ b/modules/ui/fields/input.js
@@ -91,6 +91,7 @@ export function uiFieldText(field, context) {
         input = input.enter()
             .append('input')
             .attr('type', field.type === 'identifier' ? 'text' : field.type)
+            .attr('dir', 'auto')
             .attr('id', field.domId)
             .classed(field.type, true)
             .call(utilNoAuto)

--- a/modules/ui/fields/localized.js
+++ b/modules/ui/fields/localized.js
@@ -172,6 +172,7 @@ export function uiFieldLocalized(field, context) {
         input = input.enter()
             .append('input')
             .attr('type', 'text')
+            .attr('dir', 'auto')
             .attr('id', field.domId)
             .attr('class', 'localized-main')
             .call(utilNoAuto)
@@ -426,6 +427,7 @@ export function uiFieldLocalized(field, context) {
                 wrap
                     .append('input')
                     .attr('type', 'text')
+                    .attr('dir', 'auto')
                     .attr('class', 'localized-value')
                     .on('blur', changeValue)
                     .on('change', changeValue);

--- a/modules/ui/fields/textarea.js
+++ b/modules/ui/fields/textarea.js
@@ -33,6 +33,7 @@ export function uiFieldTextarea(field, context) {
 
         input = input.enter()
             .append('textarea')
+            .attr('dir', 'auto')
             .attr('id', field.domId)
             .call(utilNoAuto)
             .on('input', change(true))

--- a/modules/ui/fields/wikidata.js
+++ b/modules/ui/fields/wikidata.js
@@ -60,6 +60,7 @@ export function uiFieldWikidata(field, context) {
         searchRowEnter
             .append('input')
             .attr('type', 'text')
+            .attr('dir', 'auto')
             .attr('id', field.domId)
             .style('flex', '1')
             .call(utilNoAuto)
@@ -113,6 +114,7 @@ export function uiFieldWikidata(field, context) {
         enter
             .append('input')
             .attr('type', 'text')
+            .attr('dir', 'auto')
             .call(utilNoAuto)
             .classed('disabled', 'true')
             .attr('readonly', 'true');

--- a/modules/ui/fields/wikipedia.js
+++ b/modules/ui/fields/wikipedia.js
@@ -113,6 +113,7 @@ export function uiFieldWikipedia(field, context) {
     _titleInput = _titleInput.enter()
       .append('input')
       .attr('type', 'text')
+      .attr('dir', 'auto')
       .attr('class', 'wiki-title')
       .attr('id', field.domId)
       .call(utilNoAuto)

--- a/modules/ui/sections/raw_tag_editor.js
+++ b/modules/ui/sections/raw_tag_editor.js
@@ -135,6 +135,7 @@ export function uiSectionRawTagEditor(id, context) {
             .call(utilNoAuto)
             .attr('placeholder', t('inspector.key_value'))
             .attr('spellcheck', 'false')
+            .style('direction', 'ltr')
             .merge(textarea);
 
         textarea
@@ -190,6 +191,7 @@ export function uiSectionRawTagEditor(id, context) {
             .attr('class', 'value-wrap')
             .append('input')
             .property('type', 'text')
+            .attr('dir', 'auto')
             .attr('class', 'value')
             .call(utilNoAuto)
             .on('focus', interacted)


### PR DESCRIPTION
Addresses #11079 by setting `dir=auto` to all text input fields that potentially contain bi-directional text.

Unfortunately, this comes with a significant drawback: as the text _direction_ of an input field also affects the direction of the input field's _placeholder_ text,  `dir=auto` means that placeholders will always be rendered left to right. This is because the "value" of the input field itself is empty in the situation where the placeholder is to be shown, and an empty string apparently falls back to left to right. :shrug: 

<img src="https://github.com/user-attachments/assets/c183cab6-1b83-4201-b014-79e1e4f04c0f" width="360">


Apparently, this is the intended behavior of the [placeholders](http://www.w3.org/html/wg/drafts/html/master/forms.html#the-placeholder-attribute) of input fields, and it is not possible to set the placeholder's text direction independently from the input field itself, but there's a documented workaround: 

> In situations where the control's content has one directionality but the placeholder needs to have a different directionality, Unicode's bidirectional-algorithm formatting characters can be used in the attribute value


todo: 
* [ ] fix placeholders' orientation
* [ ] also include address field input elements