### PR TITLE
Enable dependabot for GitHub Actions dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,9 @@ updates:
       - "chore-dependabot"
     ignore:
       - dependency-name: "sinon"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "chore-dependabot"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,9 +21,9 @@ jobs:
         node-version: ['20', '22']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.2.2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v4.4.0
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm clean-install

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -11,8 +11,8 @@ jobs:
     name: Check for spelling errors
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: codespell-project/actions-codespell@v2
+      - uses: actions/checkout@v4.2.2
+      - uses: codespell-project/actions-codespell@v2.1
         with:
           check_filenames: true
           skip: ./.git,./data/territory_languages.json,./data/imagery.json,./data/languages.json,./data/address_formats.json,./dist/locales,./docs/img,./dist/img,./css,package.json,package-lock.json,scripts,docs

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     environment: workflows
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v4.2.2
+      - uses: actions/setup-node@v4.4.0
         with:
           node-version-file: '.nvmrc'
       # install and build development version of id-tagging-schema
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           repository: openstreetmap/id-tagging-schema
           path: './id-tagging-schema'

--- a/.github/workflows/transifex.yml
+++ b/.github/workflows/transifex.yml
@@ -19,7 +19,7 @@ jobs:
     environment: workflows
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.2.2
     - name: Install Transifex client
       run: |
         curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash


### PR DESCRIPTION
This PR adds the following:

- Dependabot configuration for GitHub Actions
- Explicit version pinning for GitHub Actions, to improve Depdendabot alerting