### PR TITLE
Use up-to-date NSI when staging

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -32,9 +32,9 @@ jobs:
       - run: npm run dist
         working-directory: './id-tagging-schema'
       - run: mkdir dist/id-tagging-schema && mv id-tagging-schema/dist dist/id-tagging-schema/dist
-      # build iD using freshest version of presets and ELI
+      # build iD using freshest version of presets, ELI and NSI
       - run: npm clean-install
-      - run: npm install editor-layer-index
+      - run: npm install editor-layer-index name-suggestion-index
       - run: mkdir dist/data
       - run: npm run imagery
       - run: npm run all


### PR DESCRIPTION
This updates NSI when staging (like it's already done for ELI) as otherwise the version from `2024-10-14` is used which is quite old.
https://github.com/openstreetmap/iD/blob/c277bd0b765af53789cbf50e16c10ca8e9a5d8f8/package-lock.json#L5848