### PR TITLE
Update development dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3718,8 +3718,10 @@
     },
     "node_modules/editor-layer-index": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/osmlab/editor-layer-index.git#3e15818cc1da3945a3e3747a9203942dde88a90a",
-      "dev": true
+      "resolved": "git+ssh://git@github.com/osmlab/editor-layer-index.git#87b6ab66b2a4dbf2407e33120e789b0526133ed1",
+      "integrity": "sha512-UtETrMxFgZHgOWuWcxHWIbaYaF3ZlhrPYFSaOw5SwPazgCZSm0sBqFViXD7LKCKGv+Rpuw0VQCxhY7BnldBwwA==",
+      "dev": true,
+      "license": "BSD"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.161",
@@ -5845,17 +5847,18 @@
       }
     },
     "node_modules/name-suggestion-index": {
-      "version": "6.0.20241014",
-      "resolved": "https://registry.npmjs.org/name-suggestion-index/-/name-suggestion-index-6.0.20241014.tgz",
-      "integrity": "sha512-7VLFk+GiHseFL1o8f8+T8gMuOzEryGmxIrFhGWCuG6McZaCjRkyZxB+p6Gzfc1L3cIw31i5/G0DB0r1dDv76bg==",
+      "version": "6.0.20250601",
+      "resolved": "https://registry.npmjs.org/name-suggestion-index/-/name-suggestion-index-6.0.20250601.tgz",
+      "integrity": "sha512-DzWZHo3ZqD8dIZOyO/gbKooZEN5uLS1cz6io5sBmdBYfGtAK83WYpQtcBC7xKkcyNIvIGrNjypIs8B9splC9Yw==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "diacritics": "^1.3.0",
         "run-s": "^0.0.0",
         "which-polygon": "^2.2.1"
       },
       "engines": {
-        "node": "^18.20 || >=20.10"
+        "node": ">=20.10"
       }
     },
     "node_modules/nanoid": {


### PR DESCRIPTION
Bumps the npm-dev-dependencies group with 2 updates in the / directory: [editor-layer-index](https://github.com/osmlab/editor-layer-index) and [name-suggestion-index](https://github.com/osmlab/name-suggestion-index).


Updates `editor-layer-index` from `3e15818` to `87b6ab6`
- [Commits](https://github.com/osmlab/editor-layer-index/compare/3e15818cc1da3945a3e3747a9203942dde88a90a...87b6ab66b2a4dbf2407e33120e789b0526133ed1)

Updates `name-suggestion-index` from 6.0.20241014 to 6.0.20250601
- [Changelog](https://github.com/osmlab/name-suggestion-index/blob/main/CHANGELOG.md)
- [Commits](https://github.com/osmlab/name-suggestion-index/compare/v6.0.20241014...v6.0.20250601)

---
updated-dependencies:
- dependency-name: editor-layer-index dependency-version: 87b6ab66b2a4dbf2407e33120e789b0526133ed1 dependency-type: direct:development dependency-group: npm-dev-dependencies
- dependency-name: name-suggestion-index dependency-version: 6.0.20250601 dependency-type: direct:development update-type: version-update:semver-patch dependency-group: npm-dev-dependencies ...