### PR TITLE
issues:11120 -automated id extraction from a pasted url in tags ( only for contacts)

### DIFF
--- a/modules/ui/sections/raw_tag_editor.js
+++ b/modules/ui/sections/raw_tag_editor.js
@@ -194,7 +194,29 @@ export function uiSectionRawTagEditor(id, context) {
             .call(utilNoAuto)
             .on('focus', interacted)
             .on('blur', valueChange)
-            .on('change', valueChange);
+            .on('change', valueChange)
+            .on('paste', function(event, d) {
+                const key = d.key || '';
+                const valueInput = this;
+                // Only  for contact:* keys
+                if (/^contact:/i.test(key)) {
+                    setTimeout(() => {
+                        let pasted = valueInput.value.trim();
+                        try {
+                            pasted = pasted.replace(/[?#].*$/, '');
+                            pasted = pasted.replace(/\/+$/, '');
+                            const match = pasted.match(/([^\/]+)$/);
+                            if (match) {
+                                valueInput.value = match[1];
+                                valueInput.dispatchEvent(new Event('change', { bubbles: true }));
+                            }
+                        } catch {
+                            //console.log('Error processing pasted value:', e);
+                            valueInput.value = pasted; 
+                        }
+                    }, 0);
+                }
+            });
 
         innerWrap
             .append('button')


### PR DESCRIPTION


as the issue  #11120 says , "It would be idea, if pasting the URL transparently returned just the id (username, etc) from the URL. And if rendering it reversed this process when generating the link so it could be edited."

the linkification part was done and PR is also there [(comment)](https://github.com/openstreetmap/iD/issues/11120#issuecomment-2964956960), 

in this PR i have pushed the code , to auto extract the ids from url in tags(contacts) .