### PR TITLE
Fix SecurityError in cross-origin context

### DIFF
--- a/modules/util/detect.js
+++ b/modules/util/detect.js
@@ -113,5 +113,6 @@ export function utilDetect(refresh) {
 
   _detected.host = origin + loc.pathname;
 
+
   return _detected;
 }

--- a/modules/util/detect.js
+++ b/modules/util/detect.js
@@ -99,13 +99,22 @@ export function utilDetect(refresh) {
 
 
   /* Host */
-  const loc = window.top.location;
-  let origin = loc.origin;
+  let loc, origin, pathname;
+  try {
+    loc = window.top.location;
+    origin = loc.origin;
+    pathname = loc.pathname;
+  } catch {
+    loc = window.location;
+    origin = loc.origin;
+    pathname = loc.pathname;
+  }
+  
   if (!origin) {  // for unpatched IE11
     origin = loc.protocol + '//' + loc.hostname + (loc.port ? ':' + loc.port: '');
   }
 
-  _detected.host = origin + loc.pathname;
+  _detected.host = origin + pathname;
 
 
   return _detected;

--- a/modules/util/detect.js
+++ b/modules/util/detect.js
@@ -99,23 +99,19 @@ export function utilDetect(refresh) {
 
 
   /* Host */
-  let loc, origin, pathname;
+  let loc;
   try {
     loc = window.top.location;
-    origin = loc.origin;
-    pathname = loc.pathname;
   } catch {
     loc = window.location;
-    origin = loc.origin;
-    pathname = loc.pathname;
   }
-  
+  let origin = loc.origin;
+
   if (!origin) {  // for unpatched IE11
     origin = loc.protocol + '//' + loc.hostname + (loc.port ? ':' + loc.port: '');
   }
 
-  _detected.host = origin + pathname;
-
+  _detected.host = origin + loc.pathname;
 
   return _detected;
 }


### PR DESCRIPTION
Add fallback to window.location when window.top.location properties are inaccessible due to cross-origin restrictions.

E.g.

Uncaught SecurityError: Failed to read a named property 'origin' from 'Location': Blocked a frame with origin "..." from accessing a cross-origin frame.