### PR TITLE
support `integer` preset fields

### DIFF
--- a/modules/presets/field.js
+++ b/modules/presets/field.js
@@ -51,7 +51,7 @@ export function presetField(fieldID, field, allFields) {
   _this.terms = () => _this.resolveReference('label').t('terms', { 'default': _this.originalTerms })
     .toLowerCase().trim().split(/\s*,+\s*/);
 
-  _this.increment = _this.type === 'number' ? (_this.increment || 1) : undefined;
+  _this.increment = (_this.type === 'number' || _this.type === 'integer') ? (_this.increment || 1) : undefined;
 
   return _this;
 }

--- a/modules/ui/fields/input.js
+++ b/modules/ui/fields/input.js
@@ -108,7 +108,7 @@ export function uiFieldText(field, context) {
         if (field.type === 'tel') {
             updatePhonePlaceholder();
 
-        } else if (field.type === 'number') {
+        } else if (field.type === 'number' || field.type === 'integer') {
             var rtl = (localizer.textDirection() === 'rtl');
 
             input.attr('type', 'text');
@@ -415,7 +415,7 @@ export function uiFieldText(field, context) {
             if (!val && getVals(_tags).size > 1) return;
 
             let displayVal = val;
-            if (field.type === 'number' && val) {
+            if ((field.type === 'number' || field.type === 'integer') && val) {
                 const numbers = val.split(';').map(v => {
                     if (likelyRawNumberFormat.test(v)) {
                         // input number likely in "raw" format
@@ -480,7 +480,7 @@ export function uiFieldText(field, context) {
         var val = vals.size === 1 ? [...vals][0] ?? '' : '';
         var shouldUpdate;
 
-        if (field.type === 'number' && val) {
+        if ((field.type === 'number' || field.type === 'integer') && val) {
             var numbers = val.split(';');
             var oriNumbers = utilGetSetValue(input).split(';');
             if (numbers.length !== oriNumbers.length) shouldUpdate = true;
@@ -522,7 +522,7 @@ export function uiFieldText(field, context) {
             .attr('placeholder', isMixed ? t('inspector.multiple_values') : (field.placeholder() || t('inspector.unknown')))
             .classed('mixed', isMixed);
 
-        if (field.type === 'number') {
+        if (field.type === 'number' || field.type === 'integer') {
             const buttons = wrap.selectAll('.increment, .decrement');
             if (isMixed) {
                 buttons.attr('disabled', 'disabled').classed('disabled', true);


### PR DESCRIPTION
This PR just adds support for https://github.com/ideditor/schema-builder/pull/217. There's no special logic yet, for now `number` and `interger` are exactly the same.

This allows https://github.com/openstreetmap/iD/issues/8607 to be solved in a future PR.