### PR TITLE
support RegExs for `prerequisiteTag`s

### DIFF
--- a/modules/ui/field.js
+++ b/modules/ui/field.js
@@ -354,6 +354,9 @@ export function uiField(context, presetField, entityIDs, options) {
                         return prerequisiteTag.valueNot !== value;
                     }
                     if (prerequisiteTag.value) {
+                        if (prerequisiteTag.value.startsWith('/') && prerequisiteTag.value.endsWith('/')) {
+                            return new RegExp(prerequisiteTag.value.slice(1, -1)).test(value);
+                        }
                         return prerequisiteTag.value === value;
                     }
                 } else if (prerequisiteTag.keyNot) {


### PR DESCRIPTION
Split out of #9511. That PR had logic to support RegExs, which was added 2 years ago, but the more recent discussion hasn't considered this part. So I'm moving this into a seperate PR. 

The ~~only~~ fields that need this are [`seamark:*:colour_pattern`](https://taginfo.osm.org/keys/seamark:topmark:colour_pattern), which should only be shown if [`seamark:*:colour`](https://taginfo.osm.org/keys/seamark:topmark:colour) contains a `;`

_edit: ...and perhaps [`parking:SIDE:orientation=*`](https://github.com/openstreetmap/id-tagging-schema/blob/main/data/fields/parking/side/orientation.json), see https://github.com/openstreetmap/iD/pull/11182#issuecomment-3036050854_
