### PR TITLE
:memo: Update broken transifex links

### DIFF
--- a/.github/workflows/transifex.yml
+++ b/.github/workflows/transifex.yml
@@ -1,6 +1,6 @@
 # This workflow will push the iD source strings to transifex
 # - requires TX_TOKEN secret to be set on GitHub
-# - you can generate a token at https://www.transifex.com/user/settings/api/
+# - you can generate a token at https://app.transifex.com/user/settings/api/
 # - job does not run if no token provided
 
 name: transifex

--- a/ACCESSIBILITY.md
+++ b/ACCESSIBILITY.md
@@ -169,7 +169,7 @@ for more info.
 | ✅ | Locale URL parameters | `locale` and `rtl` can be used to manually set iD's locale preferences. See the [API](API.md#url-parameters) |
 | ❌ | Language selection in UI | The mapper should be able to view and change iD's language in the interface at any time. Useful for public computers with fixed browser languages | [#3120](https://github.com/openstreetmap/iD/issues/3120) |
 | 🟩 | Right-to-left layouts | The [`dir` HTML attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir) is properly set for languages like Hebrew and Arabic |
-| ✅ | [Language-specific plurals](https://docs.transifex.com/localization-tips-workflows/plurals-and-genders#how-pluralized-strings-are-handled-by-transifex) | English has two plural forms, but some languages need more to be grammatically correct | [#597](https://github.com/openstreetmap/iD/issues/597), [#7991](https://github.com/openstreetmap/iD/issues/7991) |
+| ✅ | [Language-specific plurals](https://help.transifex.com/en/articles/6231958-working-with-plurals-and-genders#h_51e09ec18a) | English has two plural forms, but some languages need more to be grammatically correct | [#597](https://github.com/openstreetmap/iD/issues/597), [#7991](https://github.com/openstreetmap/iD/issues/7991) |
 | ✅ | [Localized number formats](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat) | Most in-text numbers are localized, including numeric fields | [#8769](https://github.com/openstreetmap/iD/pull/8769), [#7993](https://github.com/openstreetmap/iD/issues/7993) |
 | 🟠 | Label icons | Icons should accompany text labels to illustrate the meaning of untranslated terms |
 
@@ -193,12 +193,12 @@ translated to one or more languages.
 | ✅ | OSM community index | | |
 | ✅ | iD validation issues | | |
 | ✅ | KeepRight issues | | |
-| ✅ | Osmose issues | Translated strings are [provided by Osmose](https://www.transifex.com/openstreetmap-france/osmose/) itself, not iD | |
+| ✅ | Osmose issues | Translated strings are [provided by Osmose](https://app.transifex.com/openstreetmap-france/osmose/) itself, not iD | |
 
 ### Language Coverage
 
 The completion percentages for iD translations constantly change, and so are not
-listed here. Visit the [Transifex project page](https://www.transifex.com/openstreetmap/id-editor/)
+listed here. Visit the [Transifex project page](https://app.transifex.com/openstreetmap/id-editor/)
 to see the latest numbers. Typically a few languages (German, Spanish, Japanese…)
 are kept close to 100% coverage, while most languages have less than 50% coverage.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6432,7 +6432,7 @@ _Check out the new imagery by opening the Background pane (shortcut <kbd>B</kbd>
 #### :tada: New Features
 
 * Update to Mapillary API v3, use traffic signs from Mapillary sprites ([#4050], thanks [@nickplesha])
-* iD editor translation project on Transifex has moved to the [OpenStreetMap organization](https://www.transifex.com/openstreetmap/)
+* iD editor translation project on Transifex has moved to the [OpenStreetMap organization](https://app.transifex.com/openstreetmap/)
 * New Keyboard Shortcuts help screen, press <kbd>?</kbd> to view ([#3791], [#1481], thanks [@ajithranka] and [@kepta])
 
 [#4050]: https://github.com/openstreetmap/iD/issues/4050

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -211,9 +211,9 @@ switch to the development database.
 ## Translating
 
 Translations are managed using the
-[Transifex](https://www.transifex.com/openstreetmap/id-editor/) platform. After
+[Transifex](https://app.transifex.com/openstreetmap/id-editor/) platform. After
 signing up, you can go to [iD's project
-page](https://www.transifex.com/openstreetmap/id-editor/), select a language and
+page](https://app.transifex.com/openstreetmap/id-editor/), select a language and
 click **Translate** to start translating. Translations are divided into
 separate resources:
 
@@ -235,11 +235,11 @@ For more information on translating the presets [please see this id-tagging-sche
 You can check your translations on the [development preview site](https://ideditor.netlify.app),
 which is updated every time we change the `develop` branch.
 
-[iD translation project on Transifex](https://www.transifex.com/openstreetmap/id-editor/)
+[iD translation project on Transifex](https://app.transifex.com/openstreetmap/id-editor/)
 
 To get notifications when translation source files change, click **Watch
 project** button near the bottom of the project page. You can edit your
-[notification settings](https://www.transifex.com/user/settings/notices/) if you're
+[notification settings](https://app.transifex.com/user/settings/notices/) if you're
 getting too many notifications.
 
 Translations are licensed under
@@ -262,7 +262,7 @@ These are separate translations for uniformity reasons and because some language
 
 **Why can't I find the Osmose QA layer translations?** The Osmose QA strings are
  pulled in from the external Osmose API. You can contribute to the
- [Osmose Transifex project](https://explore.transifex.com/openstreetmap-france/osmose/)
+ [Osmose Transifex project](https://app.transifex.com/openstreetmap-france/osmose/)
  and the results will be seen in iD once deployed.
 
 Note that if you want to add/update English translations in Osmose then you will

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,7 +213,7 @@ switch to the development database.
 Translations are managed using the
 [Transifex](https://app.transifex.com/openstreetmap/id-editor/) platform. After
 signing up, you can go to [iD's project
-page](https://app.transifex.com/openstreetmap/id-editor/), select a language and
+page](https://app.transifex.com/openstreetmap/id-editor/) and
 click **Translate** to start translating. Translations are divided into
 separate resources:
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,7 +1,7 @@
 ## Release Checklist
 
 ### Prerelease (several days prior)
-- [Notify translators](https://www.transifex.com/projects/p/id-editor/announcements/) of the impending release
+- [Notify translators](https://app.transifex.com/openstreetmap/communication/?q=project%3Aid-editor) of the impending release
 - Notify TomH
 
 ### Prep
@@ -13,7 +13,7 @@ on the iD project, and then create this file with contents like
   { "user":"api", "password": "<your-transifex-api-key>" }
   ````
 
-  where you insert your personal [transifex api token](https://www.transifex.com/user/settings/api/). This file is not version-controlled and will not be checked in.
+  where you insert your personal [transifex api token](https://app.transifex.com/user/settings/api/). This file is not version-controlled and will not be checked in.
 
 ### Update `iD`
 

--- a/scripts/update_locales.js
+++ b/scripts/update_locales.js
@@ -21,7 +21,7 @@ if (process.env.transifex_password) {
   transifexApi.setup({ auth: process.env.transifex_password });
 } else {
   // Credentials can be stored in transifex.auth as a json object. This file is gitignored.
-  // You must use an API token for authentication: You can generate one at https://www.transifex.com/user/settings/api/.
+  // You must use an API token for authentication: You can generate one at https://app.transifex.com/user/settings/api/.
   // {
   //   "password": "<api_key>"
   // }


### PR DESCRIPTION
Updates all `www.transifex.com` links to their `app.transifex.com` counterpart (will redirect to  `explore.transifex.com` if the user is not logged in) and also `docs.transifex.com` to `help.transifex.com`.