### PR TITLE
chore(tests): don't directly instantiate osmEntity in tests

### DIFF
--- a/test/spec/actions/add_entity.js
+++ b/test/spec/actions/add_entity.js
@@ -1,6 +1,6 @@
 describe('iD.actionAddEntity', function () {
     it('adds an entity to the graph', function () {
-        var entity = iD.osmEntity(),
+        var entity = iD.osmNode(),
             graph = iD.actionAddEntity(entity)(iD.coreGraph());
         expect(graph.entity(entity.id)).to.equal(entity);
     });

--- a/test/spec/actions/change_tags.js
+++ b/test/spec/actions/change_tags.js
@@ -1,6 +1,6 @@
 describe('iD.actionChangeTags', function () {
     it('changes an entity\'s tags', function () {
-        var entity = iD.osmEntity(),
+        var entity = iD.osmNode(),
             tags   = {foo: 'bar'},
             graph  = iD.actionChangeTags(entity.id, tags)(iD.coreGraph([entity]));
         expect(graph.entity(entity.id).tags).to.eql(tags);

--- a/test/spec/actions/upgrade_tags.js
+++ b/test/spec/actions/upgrade_tags.js
@@ -3,7 +3,7 @@ describe('iD.actionUpgradeTags', function () {
     it('upgrades a tag', function () {
         var oldTags = { amenity: 'swimming_pool' },
             newTags = { leisure: 'swimming_pool' },
-            entity = iD.osmEntity({ tags: { amenity: 'swimming_pool', name: 'Foo' }}),
+            entity = iD.osmNode({ tags: { amenity: 'swimming_pool', name: 'Foo' }}),
             graph  = iD.actionUpgradeTags(entity.id, oldTags, newTags)(iD.coreGraph([entity]));
         expect(graph.entity(entity.id).tags).to.eql({ leisure: 'swimming_pool', name: 'Foo' });
     });
@@ -11,7 +11,7 @@ describe('iD.actionUpgradeTags', function () {
     it('upgrades a tag combination', function () {
         var oldTags = { amenity: 'vending_machine', vending: 'news_papers' },
             newTags = { amenity: 'vending_machine', vending: 'newspapers' },
-            entity = iD.osmEntity({ tags: { amenity: 'vending_machine', vending: 'news_papers', name: 'Foo' }}),
+            entity = iD.osmNode({ tags: { amenity: 'vending_machine', vending: 'news_papers', name: 'Foo' }}),
             graph  = iD.actionUpgradeTags(entity.id, oldTags, newTags)(iD.coreGraph([entity]));
         expect(graph.entity(entity.id).tags).to.eql({ amenity: 'vending_machine', vending: 'newspapers', name: 'Foo' });
     });
@@ -19,7 +19,7 @@ describe('iD.actionUpgradeTags', function () {
     it('upgrades a tag with multiple replacement tags', function () {
         var oldTags = { natural: 'marsh' },
             newTags = { natural: 'wetland', wetland: 'marsh' },
-            entity = iD.osmEntity({ tags: { natural: 'marsh', name: 'Foo' }}),
+            entity = iD.osmNode({ tags: { natural: 'marsh', name: 'Foo' }}),
             graph  = iD.actionUpgradeTags(entity.id, oldTags, newTags)(iD.coreGraph([entity]));
         expect(graph.entity(entity.id).tags).to.eql({ natural: 'wetland', wetland: 'marsh', name: 'Foo' });
     });
@@ -27,7 +27,7 @@ describe('iD.actionUpgradeTags', function () {
     it('upgrades a tag and overrides an existing value', function () {
         var oldTags = { landuse: 'wood' },
             newTags = { natural: 'wood' },
-            entity = iD.osmEntity({ tags: { landuse: 'wood', natural: 'wetland', name: 'Foo' }}),
+            entity = iD.osmNode({ tags: { landuse: 'wood', natural: 'wetland', name: 'Foo' }}),
             graph  = iD.actionUpgradeTags(entity.id, oldTags, newTags)(iD.coreGraph([entity]));
         expect(graph.entity(entity.id).tags).to.eql({ natural: 'wood', name: 'Foo' });
     });
@@ -35,7 +35,7 @@ describe('iD.actionUpgradeTags', function () {
     it('upgrades a tag with no replacement tags', function () {
         var oldTags = { highway: 'no' },
             newTags,
-            entity = iD.osmEntity({ tags: { highway: 'no', name: 'Foo' }}),
+            entity = iD.osmNode({ tags: { highway: 'no', name: 'Foo' }}),
             graph  = iD.actionUpgradeTags(entity.id, oldTags, newTags)(iD.coreGraph([entity]));
         expect(graph.entity(entity.id).tags).to.eql({ name: 'Foo' });
     });
@@ -43,7 +43,7 @@ describe('iD.actionUpgradeTags', function () {
     it('upgrades a wildcard tag and moves the value', function () {
         var oldTags = { color: '*' },
             newTags = { colour: '$1' },
-            entity = iD.osmEntity({ tags: { color: 'red', name: 'Foo' }}),
+            entity = iD.osmNode({ tags: { color: 'red', name: 'Foo' }}),
             graph  = iD.actionUpgradeTags(entity.id, oldTags, newTags)(iD.coreGraph([entity]));
         expect(graph.entity(entity.id).tags).to.eql({ colour: 'red', name: 'Foo' });
     });
@@ -51,7 +51,7 @@ describe('iD.actionUpgradeTags', function () {
     it('upgrades a tag with a wildcard replacement and adds a default value', function () {
         var oldTags = { amenity: 'shop' },
             newTags = { shop: '*' },
-            entity = iD.osmEntity({ tags: { amenity: 'shop', name: 'Foo' }}),
+            entity = iD.osmNode({ tags: { amenity: 'shop', name: 'Foo' }}),
             graph  = iD.actionUpgradeTags(entity.id, oldTags, newTags)(iD.coreGraph([entity]));
         expect(graph.entity(entity.id).tags).to.eql({ shop: 'yes', name: 'Foo' });
     });
@@ -59,7 +59,7 @@ describe('iD.actionUpgradeTags', function () {
     it('upgrades a tag with a wildcard replacement and maintains the existing value', function () {
         var oldTags = { amenity: 'shop' },
             newTags = { shop: '*' },
-            entity = iD.osmEntity({ tags: { amenity: 'shop', shop: 'supermarket', name: 'Foo' }}),
+            entity = iD.osmNode({ tags: { amenity: 'shop', shop: 'supermarket', name: 'Foo' }}),
             graph  = iD.actionUpgradeTags(entity.id, oldTags, newTags)(iD.coreGraph([entity]));
         expect(graph.entity(entity.id).tags).to.eql({ shop: 'supermarket', name: 'Foo' });
     });
@@ -67,7 +67,7 @@ describe('iD.actionUpgradeTags', function () {
     it('upgrades a tag with a wildcard replacement and replaces the existing "no" value', function () {
         var oldTags = { amenity: 'shop' },
             newTags = { shop: '*' },
-            entity = iD.osmEntity({ tags: { amenity: 'shop', shop: 'no', name: 'Foo' }}),
+            entity = iD.osmNode({ tags: { amenity: 'shop', shop: 'no', name: 'Foo' }}),
             graph  = iD.actionUpgradeTags(entity.id, oldTags, newTags)(iD.coreGraph([entity]));
         expect(graph.entity(entity.id).tags).to.eql({ shop: 'yes', name: 'Foo' });
     });
@@ -75,7 +75,7 @@ describe('iD.actionUpgradeTags', function () {
     it('upgrades a tag from a semicolon-delimited list that has one other value', function () {
         var oldTags = { cuisine: 'vegan' },
             newTags = { 'diet:vegan': 'yes' },
-            entity = iD.osmEntity({ tags: { cuisine: 'italian;vegan', name: 'Foo' }}),
+            entity = iD.osmNode({ tags: { cuisine: 'italian;vegan', name: 'Foo' }}),
             graph  = iD.actionUpgradeTags(entity.id, oldTags, newTags)(iD.coreGraph([entity]));
         expect(graph.entity(entity.id).tags).to.eql({ cuisine: 'italian', 'diet:vegan': 'yes', name: 'Foo' });
     });
@@ -83,7 +83,7 @@ describe('iD.actionUpgradeTags', function () {
     it('upgrades a tag from a semicolon-delimited list that has many other values', function () {
         var oldTags = { cuisine: 'vegan' },
             newTags = { 'diet:vegan': 'yes' },
-            entity = iD.osmEntity({ tags: { cuisine: 'italian;vegan;regional;american', name: 'Foo' }}),
+            entity = iD.osmNode({ tags: { cuisine: 'italian;vegan;regional;american', name: 'Foo' }}),
             graph  = iD.actionUpgradeTags(entity.id, oldTags, newTags)(iD.coreGraph([entity]));
         expect(graph.entity(entity.id).tags).to.eql({ cuisine: 'italian;regional;american', 'diet:vegan': 'yes', name: 'Foo' });
     });
@@ -91,7 +91,7 @@ describe('iD.actionUpgradeTags', function () {
     it('upgrades a tag within a semicolon-delimited list without changing other values', function () {
         var oldTags = { leisure: 'ice_rink', sport: 'hockey' },
             newTags = { leisure: 'ice_rink', sport: 'ice_hockey' },
-            entity = iD.osmEntity({ tags: { leisure: 'ice_rink', sport: 'curling;hockey;multi', name: 'Foo' }}),
+            entity = iD.osmNode({ tags: { leisure: 'ice_rink', sport: 'curling;hockey;multi', name: 'Foo' }}),
             graph  = iD.actionUpgradeTags(entity.id, oldTags, newTags)(iD.coreGraph([entity]));
         expect(graph.entity(entity.id).tags).to.eql({ leisure: 'ice_rink', sport: 'curling;ice_hockey;multi', name: 'Foo' });
     });
@@ -99,7 +99,7 @@ describe('iD.actionUpgradeTags', function () {
     it('upgrades an entire semicolon-delimited tag value', function () {
         var oldTags = { vending: 'parcel_mail_in;parcel_pickup' },
             newTags = { vending: 'parcel_pickup;parcel_mail_in' },
-            entity = iD.osmEntity({ tags: { vending: 'parcel_mail_in;parcel_pickup', name: 'Foo' }}),
+            entity = iD.osmNode({ tags: { vending: 'parcel_mail_in;parcel_pickup', name: 'Foo' }}),
             graph  = iD.actionUpgradeTags(entity.id, oldTags, newTags)(iD.coreGraph([entity]));
         expect(graph.entity(entity.id).tags).to.eql({ vending: 'parcel_pickup;parcel_mail_in', name: 'Foo' });
     });

--- a/test/spec/core/graph.js
+++ b/test/spec/core/graph.js
@@ -1,19 +1,19 @@
 describe('iD.coreGraph', function() {
     describe('constructor', function () {
         it('accepts an entities Array', function () {
-            var entity = iD.osmEntity(),
+            var entity = iD.osmNode(),
                 graph = iD.coreGraph([entity]);
             expect(graph.entity(entity.id)).to.equal(entity);
         });
 
         it('accepts a Graph', function () {
-            var entity = iD.osmEntity(),
+            var entity = iD.osmNode(),
                 graph = iD.coreGraph(iD.coreGraph([entity]));
             expect(graph.entity(entity.id)).to.equal(entity);
         });
 
         it('copies other\'s entities', function () {
-            var entity = iD.osmEntity(),
+            var entity = iD.osmNode(),
                 base   = iD.coreGraph([entity]),
                 graph  = iD.coreGraph(base);
             expect(graph.entities).not.to.equal(base.entities);

--- a/test/spec/osm/entity.js
+++ b/test/spec/osm/entity.js
@@ -10,11 +10,11 @@ describe('iD.osmEntity', function () {
 
     if (iD.debug) {
         it('is frozen', function () {
-            expect(Object.isFrozen(iD.osmEntity({type: 'node'}))).to.be.true;
+            expect(Object.isFrozen(iD.osmNode())).to.be.true;
         });
 
         it('freezes tags', function () {
-            expect(Object.isFrozen(iD.osmEntity({type: 'node'}).tags)).to.be.true;
+            expect(Object.isFrozen(iD.osmNode().tags)).to.be.true;
         });
     }
 
@@ -43,14 +43,14 @@ describe('iD.osmEntity', function () {
 
     describe('#copy', function () {
         it('returns a new Entity', function () {
-            var n = iD.osmEntity({id: 'n'});
+            var n = iD.osmNode();
             var result = n.copy(null, {});
             expect(result).to.be.an.instanceof(iD.osmEntity);
             expect(result).not.to.equal(n);
         });
 
         it('adds the new Entity to input object', function () {
-            var n = iD.osmEntity({id: 'n'});
+            var n = iD.osmNode({id: 'n'});
             var copies = {};
             var result = n.copy(null, copies);
             expect(Object.keys(copies)).to.have.length(1);
@@ -58,7 +58,7 @@ describe('iD.osmEntity', function () {
         });
 
         it('returns an existing copy in input object', function () {
-            var n = iD.osmEntity({id: 'n'});
+            var n = iD.osmNode();
             var copies = {};
             var result1 = n.copy(null, copies);
             var result2 = n.copy(null, copies);
@@ -67,7 +67,7 @@ describe('iD.osmEntity', function () {
         });
 
         it('resets \'id\', \'user\', and \'version\' properties', function () {
-            var n = iD.osmEntity({id: 'n', version: 10, user: 'user'});
+            var n = iD.osmNode({id: 'n', version: 10, user: 'user'});
             var copies = {};
             n.copy(null, copies);
             expect(copies.n.isNew()).to.be.ok;
@@ -76,7 +76,7 @@ describe('iD.osmEntity', function () {
         });
 
         it('copies tags', function () {
-            var n = iD.osmEntity({id: 'n', tags: {foo: 'foo'}});
+            var n = iD.osmNode({id: 'n', tags: {foo: 'foo'}});
             var copies = {};
             n.copy(null, copies);
             expect(copies.n.tags).to.equal(n.tags);
@@ -85,7 +85,7 @@ describe('iD.osmEntity', function () {
 
     describe('#update', function () {
         it('returns a new Entity', function () {
-            var a = iD.osmEntity({type: 'node'});
+            var a = iD.osmNode();
             var b = a.update({});
             expect(b instanceof iD.osmEntity).to.be.true;
             expect(a).not.to.equal(b);
@@ -93,77 +93,77 @@ describe('iD.osmEntity', function () {
 
         it('updates the specified attributes', function () {
             var tags = {foo: 'bar'};
-            var e = iD.osmEntity({type: 'node'}).update({tags: tags});
+            var e = iD.osmNode().update({tags: tags});
             expect(e.tags).to.equal(tags);
         });
 
         it('preserves existing attributes', function () {
-            var e = iD.osmEntity({id: 'w1'}).update({});
+            var e = iD.osmWay({id: 'w1'}).update({});
             expect(e.id).to.equal('w1');
         });
 
         it('doesn\'t modify the input', function () {
             var attrs = {tags: {foo: 'bar'}};
-            iD.osmEntity({type: 'node'}).update(attrs);
+            iD.osmNode().update(attrs);
             expect(attrs).to.eql({tags: {foo: 'bar'}});
         });
 
         it('doesn\'t copy prototype properties', function () {
-            expect(iD.osmEntity({type: 'node'}).update({})).not.to.have.ownProperty('update');
+            expect(iD.osmNode().update({})).not.to.have.ownProperty('update');
         });
 
         it('sets v to 1 if previously undefined', function() {
-            expect(iD.osmEntity({type: 'node'}).update({}).v).to.equal(1);
+            expect(iD.osmNode().update({}).v).to.equal(1);
         });
 
         it('increments v', function() {
-            expect(iD.osmEntity({type: 'node',v: 1}).update({}).v).to.equal(2);
+            expect(iD.osmNode({v: 1}).update({}).v).to.equal(2);
         });
     });
 
     describe('#mergeTags', function () {
         it('returns self if unchanged', function () {
-            var a = iD.osmEntity({type: 'node',tags: {a: 'a'}});
+            var a = iD.osmNode({tags: {a: 'a'}});
             var b = a.mergeTags({a: 'a'});
             expect(a).to.equal(b);
         });
 
         it('returns a new Entity if changed', function () {
-            var a = iD.osmEntity({type: 'node',tags: {a: 'a'}});
+            var a = iD.osmNode({tags: {a: 'a'}});
             var b = a.mergeTags({a: 'b'});
             expect(b instanceof iD.osmEntity).to.be.true;
             expect(a).not.to.equal(b);
         });
 
         it('merges tags', function () {
-            var a = iD.osmEntity({type: 'node',tags: {a: 'a'}});
+            var a = iD.osmNode({tags: {a: 'a'}});
             var b = a.mergeTags({b: 'b'});
             expect(b.tags).to.eql({a: 'a', b: 'b'});
         });
 
         it('combines non-conflicting tags', function () {
-            var a = iD.osmEntity({type: 'node',tags: {a: 'a'}});
+            var a = iD.osmNode({tags: {a: 'a'}});
             var b = a.mergeTags({a: 'a'});
             expect(b.tags).to.eql({a: 'a'});
         });
 
         it('combines conflicting tags with semicolons', function () {
-            var a = iD.osmEntity({type: 'node',tags: {a: 'a'}});
+            var a = iD.osmNode({tags: {a: 'a'}});
             var b = a.mergeTags({a: 'b'});
             expect(b.tags).to.eql({a: 'a;b'});
         });
 
         it('combines combined tags', function () {
-            var a = iD.osmEntity({type: 'node',tags: {a: 'a;b'}});
-            var b = iD.osmEntity({type: 'node',tags: {a: 'b'}});
+            var a = iD.osmNode({tags: {a: 'a;b'}});
+            var b = iD.osmNode({tags: {a: 'b'}});
 
             expect(a.mergeTags(b.tags).tags).to.eql({a: 'a;b'});
             expect(b.mergeTags(a.tags).tags).to.eql({a: 'b;a'});
         });
 
         it('combines combined tags with whitespace', function () {
-            var a = iD.osmEntity({type: 'node',tags: {a: 'a; b'}});
-            var b = iD.osmEntity({type: 'node',tags: {a: 'b'}});
+            var a = iD.osmNode({tags: {a: 'a; b'}});
+            var b = iD.osmNode({tags: {a: 'b'}});
 
             expect(a.mergeTags(b.tags).tags).to.eql({a: 'a;b'});
             expect(b.mergeTags(a.tags).tags).to.eql({a: 'b;a'});
@@ -181,9 +181,9 @@ describe('iD.osmEntity', function () {
 
     describe('#osmId', function () {
         it('returns an OSM ID as a string', function () {
-            expect(iD.osmEntity({id: 'w1234'}).osmId()).to.eql('1234');
-            expect(iD.osmEntity({id: 'n1234'}).osmId()).to.eql('1234');
-            expect(iD.osmEntity({id: 'r1234'}).osmId()).to.eql('1234');
+            expect(iD.osmWay({id: 'w1234'}).osmId()).to.eql('1234');
+            expect(iD.osmNode({id: 'n1234'}).osmId()).to.eql('1234');
+            expect(iD.osmRelation({id: 'r1234'}).osmId()).to.eql('1234');
         });
     });
 
@@ -237,27 +237,27 @@ describe('iD.osmEntity', function () {
 
     describe('#hasInterestingTags', function () {
         it('returns false if the entity has no tags', function () {
-            expect(iD.osmEntity({ type: 'node' }).hasInterestingTags()).to.equal(false);
+            expect(iD.osmNode().hasInterestingTags()).to.equal(false);
         });
 
         it('returns true if the entity has tags other than \'attribution\', \'created_by\', \'source\', \'odbl\' and tiger tags', function () {
-            expect(iD.osmEntity({type: 'node',tags: {foo: 'bar'}}).hasInterestingTags()).to.equal(true);
+            expect(iD.osmNode({tags: {foo: 'bar'}}).hasInterestingTags()).to.equal(true);
         });
 
         it('return false if the entity has only uninteresting tags', function () {
-            expect(iD.osmEntity({type: 'node',tags: {source: 'Bing'}}).hasInterestingTags()).to.equal(false);
+            expect(iD.osmNode({tags: {source: 'Bing'}}).hasInterestingTags()).to.equal(false);
         });
 
         it('return false if the entity has only tiger tags', function () {
-            expect(iD.osmEntity({type: 'node',tags: {'tiger:source': 'blah', 'tiger:foo': 'bar'}}).hasInterestingTags()).to.equal(false);
+            expect(iD.osmNode({tags: {'tiger:source': 'blah', 'tiger:foo': 'bar'}}).hasInterestingTags()).to.equal(false);
         });
     });
 
     describe('#isDegenerate', function () {
         it('returns true', function () {
-            expect(iD.osmEntity({ type: 'node' }).isDegenerate()).to.be.true;
-            expect(iD.osmEntity({ type: 'way' }).isDegenerate()).to.be.true;
-            expect(iD.osmEntity({ type: 'relation' }).isDegenerate()).to.be.true;
+            expect(iD.osmNode().isDegenerate()).to.be.true;
+            expect(iD.osmWay().isDegenerate()).to.be.true;
+            expect(iD.osmRelation().isDegenerate()).to.be.true;
         });
     });
 

--- a/test/spec/osm/entity.js
+++ b/test/spec/osm/entity.js
@@ -10,11 +10,11 @@ describe('iD.osmEntity', function () {
 
     if (iD.debug) {
         it('is frozen', function () {
-            expect(Object.isFrozen(iD.osmEntity())).to.be.true;
+            expect(Object.isFrozen(iD.osmEntity({type: 'node'}))).to.be.true;
         });
 
         it('freezes tags', function () {
-            expect(Object.isFrozen(iD.osmEntity().tags)).to.be.true;
+            expect(Object.isFrozen(iD.osmEntity({type: 'node'}).tags)).to.be.true;
         });
     }
 
@@ -85,7 +85,7 @@ describe('iD.osmEntity', function () {
 
     describe('#update', function () {
         it('returns a new Entity', function () {
-            var a = iD.osmEntity();
+            var a = iD.osmEntity({type: 'node'});
             var b = a.update({});
             expect(b instanceof iD.osmEntity).to.be.true;
             expect(a).not.to.equal(b);
@@ -93,7 +93,7 @@ describe('iD.osmEntity', function () {
 
         it('updates the specified attributes', function () {
             var tags = {foo: 'bar'};
-            var e = iD.osmEntity().update({tags: tags});
+            var e = iD.osmEntity({type: 'node'}).update({tags: tags});
             expect(e.tags).to.equal(tags);
         });
 
@@ -104,66 +104,66 @@ describe('iD.osmEntity', function () {
 
         it('doesn\'t modify the input', function () {
             var attrs = {tags: {foo: 'bar'}};
-            iD.osmEntity().update(attrs);
+            iD.osmEntity({type: 'node'}).update(attrs);
             expect(attrs).to.eql({tags: {foo: 'bar'}});
         });
 
         it('doesn\'t copy prototype properties', function () {
-            expect(iD.osmEntity().update({})).not.to.have.ownProperty('update');
+            expect(iD.osmEntity({type: 'node'}).update({})).not.to.have.ownProperty('update');
         });
 
         it('sets v to 1 if previously undefined', function() {
-            expect(iD.osmEntity().update({}).v).to.equal(1);
+            expect(iD.osmEntity({type: 'node'}).update({}).v).to.equal(1);
         });
 
         it('increments v', function() {
-            expect(iD.osmEntity({v: 1}).update({}).v).to.equal(2);
+            expect(iD.osmEntity({type: 'node',v: 1}).update({}).v).to.equal(2);
         });
     });
 
     describe('#mergeTags', function () {
         it('returns self if unchanged', function () {
-            var a = iD.osmEntity({tags: {a: 'a'}});
+            var a = iD.osmEntity({type: 'node',tags: {a: 'a'}});
             var b = a.mergeTags({a: 'a'});
             expect(a).to.equal(b);
         });
 
         it('returns a new Entity if changed', function () {
-            var a = iD.osmEntity({tags: {a: 'a'}});
+            var a = iD.osmEntity({type: 'node',tags: {a: 'a'}});
             var b = a.mergeTags({a: 'b'});
             expect(b instanceof iD.osmEntity).to.be.true;
             expect(a).not.to.equal(b);
         });
 
         it('merges tags', function () {
-            var a = iD.osmEntity({tags: {a: 'a'}});
+            var a = iD.osmEntity({type: 'node',tags: {a: 'a'}});
             var b = a.mergeTags({b: 'b'});
             expect(b.tags).to.eql({a: 'a', b: 'b'});
         });
 
         it('combines non-conflicting tags', function () {
-            var a = iD.osmEntity({tags: {a: 'a'}});
+            var a = iD.osmEntity({type: 'node',tags: {a: 'a'}});
             var b = a.mergeTags({a: 'a'});
             expect(b.tags).to.eql({a: 'a'});
         });
 
         it('combines conflicting tags with semicolons', function () {
-            var a = iD.osmEntity({tags: {a: 'a'}});
+            var a = iD.osmEntity({type: 'node',tags: {a: 'a'}});
             var b = a.mergeTags({a: 'b'});
             expect(b.tags).to.eql({a: 'a;b'});
         });
 
         it('combines combined tags', function () {
-            var a = iD.osmEntity({tags: {a: 'a;b'}});
-            var b = iD.osmEntity({tags: {a: 'b'}});
+            var a = iD.osmEntity({type: 'node',tags: {a: 'a;b'}});
+            var b = iD.osmEntity({type: 'node',tags: {a: 'b'}});
 
             expect(a.mergeTags(b.tags).tags).to.eql({a: 'a;b'});
             expect(b.mergeTags(a.tags).tags).to.eql({a: 'b;a'});
         });
 
         it('combines combined tags with whitespace', function () {
-            var a = iD.osmEntity({tags: {a: 'a; b'}});
-            var b = iD.osmEntity({tags: {a: 'b'}});
+            var a = iD.osmEntity({type: 'node',tags: {a: 'a; b'}});
+            var b = iD.osmEntity({type: 'node',tags: {a: 'b'}});
 
             expect(a.mergeTags(b.tags).tags).to.eql({a: 'a;b'});
             expect(b.mergeTags(a.tags).tags).to.eql({a: 'b;a'});
@@ -237,25 +237,27 @@ describe('iD.osmEntity', function () {
 
     describe('#hasInterestingTags', function () {
         it('returns false if the entity has no tags', function () {
-            expect(iD.osmEntity().hasInterestingTags()).to.equal(false);
+            expect(iD.osmEntity({ type: 'node' }).hasInterestingTags()).to.equal(false);
         });
 
         it('returns true if the entity has tags other than \'attribution\', \'created_by\', \'source\', \'odbl\' and tiger tags', function () {
-            expect(iD.osmEntity({tags: {foo: 'bar'}}).hasInterestingTags()).to.equal(true);
+            expect(iD.osmEntity({type: 'node',tags: {foo: 'bar'}}).hasInterestingTags()).to.equal(true);
         });
 
         it('return false if the entity has only uninteresting tags', function () {
-            expect(iD.osmEntity({tags: {source: 'Bing'}}).hasInterestingTags()).to.equal(false);
+            expect(iD.osmEntity({type: 'node',tags: {source: 'Bing'}}).hasInterestingTags()).to.equal(false);
         });
 
         it('return false if the entity has only tiger tags', function () {
-            expect(iD.osmEntity({tags: {'tiger:source': 'blah', 'tiger:foo': 'bar'}}).hasInterestingTags()).to.equal(false);
+            expect(iD.osmEntity({type: 'node',tags: {'tiger:source': 'blah', 'tiger:foo': 'bar'}}).hasInterestingTags()).to.equal(false);
         });
     });
 
     describe('#isDegenerate', function () {
         it('returns true', function () {
-            expect(iD.osmEntity().isDegenerate()).to.be.true;
+            expect(iD.osmEntity({ type: 'node' }).isDegenerate()).to.be.true;
+            expect(iD.osmEntity({ type: 'way' }).isDegenerate()).to.be.true;
+            expect(iD.osmEntity({ type: 'relation' }).isDegenerate()).to.be.true;
         });
     });
 

--- a/test/spec/services/maprules.js
+++ b/test/spec/services/maprules.js
@@ -440,13 +440,13 @@ describe('maprules', function() {
                     }
                 ];
                 entities = [
-                    iD.osmEntity({ type: 'node', tags: { amenity: 'marketplace' }}),
+                    iD.osmNode({ tags: { amenity: 'marketplace' }}),
                     iD.osmWay({ tags: { building: 'house', amenity: 'clinic' }, nodes: [ 'a', 'b', 'c', 'a' ]}),
-                    iD.osmEntity({ type: 'node', tags: { man_made: 'tower', 'tower:type': 'communication', height: 5 }}),
-                    iD.osmEntity({ type: 'node', tags: { man_made: 'tower', height: 6 }}),
-                    iD.osmEntity({ type: 'node', tags: { man_made: 'tower', height: 9 }}),
-                    iD.osmEntity({ type: 'node', tags: { man_made: 'tower', height: 5 }}),
-                    iD.osmEntity({ type: 'node', tags: { man_made: 'tower', height: 10 }}),
+                    iD.osmNode({ tags: { man_made: 'tower', 'tower:type': 'communication', height: 5 }}),
+                    iD.osmNode({ tags: { man_made: 'tower', height: 6 }}),
+                    iD.osmNode({ tags: { man_made: 'tower', height: 9 }}),
+                    iD.osmNode({ tags: { man_made: 'tower', height: 5 }}),
+                    iD.osmNode({ tags: { man_made: 'tower', height: 10 }}),
                     iD.osmWay({ tags: { amenity: 'clinic', emergency: 'definitely' }, nodes: [ 'd', 'e', 'f', 'd' ]}),
                     iD.osmWay({ tags: { highway: 'residential', structure: 'bridge' }}),
                 ];
@@ -535,13 +535,13 @@ describe('maprules', function() {
                     }
                 ];
                 entities = [
-                    iD.osmEntity({ type: 'node', tags: { amenity: 'marketplace' }}),
+                    iD.osmNode({ tags: { amenity: 'marketplace' }}),
                     iD.osmWay({ tags: { building: 'house', amenity: 'clinic' }, nodes: [ 'a', 'b', 'c', 'a' ]}),
-                    iD.osmEntity({ type: 'node', tags: { man_made: 'tower', 'tower:type': 'communication', height: 5 }}),
-                    iD.osmEntity({ type: 'node', tags: { man_made: 'tower', height: 6 }}),
-                    iD.osmEntity({ type: 'node', tags: { man_made: 'tower', height: 9 }}),
-                    iD.osmEntity({ type: 'node', tags: { man_made: 'tower', height: 5 }}),
-                    iD.osmEntity({ type: 'node', tags: { man_made: 'tower', height: 10 }}),
+                    iD.osmNode({ tags: { man_made: 'tower', 'tower:type': 'communication', height: 5 }}),
+                    iD.osmNode({ tags: { man_made: 'tower', height: 6 }}),
+                    iD.osmNode({ tags: { man_made: 'tower', height: 9 }}),
+                    iD.osmNode({ tags: { man_made: 'tower', height: 5 }}),
+                    iD.osmNode({ tags: { man_made: 'tower', height: 10 }}),
                     iD.osmWay({ tags: { amenity: 'clinic', emergency: 'definitely' }, nodes: [ 'd', 'e', 'f', 'd' ]}),
                     iD.osmWay({ tags: { highway: 'residential', structure: 'bridge' }}),
                 ];

--- a/test/spec/svg/tag_classes.js
+++ b/test/spec/svg/tag_classes.js
@@ -7,169 +7,169 @@ describe('iD.svgTagClasses', function () {
 
     it('adds no classes to elements whose datum has no tags', function() {
         selection
-            .datum(iD.osmEntity())
+            .datum(iD.osmWay())
             .call(iD.svgTagClasses());
         expect(selection.attr('class')).to.equal(null);
     });
 
     it('adds classes for primary tag key and key-value', function() {
         selection
-            .datum(iD.osmEntity({tags: {building: 'residential'}}))
+            .datum(iD.osmWay({tags: {building: 'residential'}}))
             .call(iD.svgTagClasses());
         expect(selection.attr('class')).to.equal('tag-building tag-building-residential');
     });
 
     it('adds only one primary tag', function() {
         selection
-            .datum(iD.osmEntity({tags: {building: 'residential', railway: 'rail'}}))
+            .datum(iD.osmWay({tags: {building: 'residential', railway: 'rail'}}))
             .call(iD.svgTagClasses());
         expect(selection.attr('class')).to.equal('tag-building tag-building-residential');
     });
 
     it('orders primary tags', function() {
         selection
-            .datum(iD.osmEntity({tags: {railway: 'rail', building: 'residential'}}))
+            .datum(iD.osmWay({tags: {railway: 'rail', building: 'residential'}}))
             .call(iD.svgTagClasses());
         expect(selection.attr('class')).to.equal('tag-building tag-building-residential');
     });
 
     it('adds status tag when status in primary value (`railway=abandoned`)', function() {
         selection
-            .datum(iD.osmEntity({tags: {railway: 'abandoned'}}))
+            .datum(iD.osmWay({tags: {railway: 'abandoned'}}))
             .call(iD.svgTagClasses());
         expect(selection.attr('class')).to.equal('tag-railway tag-status tag-status-abandoned');
     });
 
     it('adds status tag when status in key and value matches "yes" (railway=rail + abandoned=yes)', function() {
         selection
-            .datum(iD.osmEntity({tags: {railway: 'rail', abandoned: 'yes'}}))
+            .datum(iD.osmWay({tags: {railway: 'rail', abandoned: 'yes'}}))
             .call(iD.svgTagClasses());
         expect(selection.attr('class')).to.equal('tag-railway tag-railway-rail tag-status tag-status-abandoned');
     });
 
     it('adds status tag when status in key and value matches primary (railway=rail + abandoned=railway)', function() {
         selection
-            .datum(iD.osmEntity({tags: {railway: 'rail', abandoned: 'railway'}}))
+            .datum(iD.osmWay({tags: {railway: 'rail', abandoned: 'railway'}}))
             .call(iD.svgTagClasses());
         expect(selection.attr('class')).to.equal('tag-railway tag-railway-rail tag-status tag-status-abandoned');
     });
 
     it('adds primary and status tag when status in key and no primary (abandoned=railway)', function() {
         selection
-            .datum(iD.osmEntity({tags: {abandoned: 'railway'}}))
+            .datum(iD.osmWay({tags: {abandoned: 'railway'}}))
             .call(iD.svgTagClasses());
         expect(selection.attr('class')).to.equal('tag-railway tag-status tag-status-abandoned');
     });
 
     it('does not add status tag for different primary tag (highway=path + abandoned=railway)', function() {
         selection
-            .datum(iD.osmEntity({tags: {highway: 'path', abandoned: 'railway'}}))
+            .datum(iD.osmWay({tags: {highway: 'path', abandoned: 'railway'}}))
             .call(iD.svgTagClasses());
         expect(selection.attr('class')).to.equal('tag-highway tag-highway-path');
     });
 
     it('adds secondary tags', function() {
         selection
-            .datum(iD.osmEntity({tags: {railway: 'rail', bridge: 'yes'}}))
+            .datum(iD.osmWay({tags: {railway: 'rail', bridge: 'yes'}}))
             .call(iD.svgTagClasses());
         expect(selection.attr('class')).to.equal('tag-railway tag-railway-rail tag-bridge tag-bridge-yes');
     });
 
     it('adds no bridge=no tags', function() {
         selection
-            .datum(iD.osmEntity({tags: {bridge: 'no'}}))
+            .datum(iD.osmWay({tags: {bridge: 'no'}}))
             .call(iD.svgTagClasses());
         expect(selection.attr('class')).to.equal(null);
     });
 
     it('adds tag-unpaved for highway=track with no surface tagging', function() {
         selection
-            .datum(iD.osmEntity({tags: {highway: 'track'}}))
+            .datum(iD.osmWay({tags: {highway: 'track'}}))
             .call(iD.svgTagClasses());
         expect(selection.classed('tag-unpaved')).to.be.true;
     });
 
     it('does not add tag-unpaved for highway=track with explicit paved surface tagging', function() {
         selection
-            .datum(iD.osmEntity({tags: {highway: 'track', surface: 'asphalt'}}))
+            .datum(iD.osmWay({tags: {highway: 'track', surface: 'asphalt'}}))
             .call(iD.svgTagClasses());
         expect(selection.classed('tag-unpaved')).to.be.false;
 
         selection
-            .datum(iD.osmEntity({tags: {highway: 'track', tracktype: 'grade1'}}))
+            .datum(iD.osmWay({tags: {highway: 'track', tracktype: 'grade1'}}))
             .call(iD.svgTagClasses());
         expect(selection.classed('tag-unpaved')).to.be.false;
     });
 
     it('adds tag-unpaved for highway=track with explicit unpaved surface tagging', function() {
         selection
-            .datum(iD.osmEntity({tags: {highway: 'track', surface: 'dirt'}}))
+            .datum(iD.osmWay({tags: {highway: 'track', surface: 'dirt'}}))
             .call(iD.svgTagClasses());
         expect(selection.classed('tag-unpaved')).to.be.true;
 
         selection
-            .datum(iD.osmEntity({tags: {highway: 'track', tracktype: 'grade3'}}))
+            .datum(iD.osmWay({tags: {highway: 'track', tracktype: 'grade3'}}))
             .call(iD.svgTagClasses());
         expect(selection.classed('tag-unpaved')).to.be.true;
     });
 
     it('does not add tag-unpaved for non-track highways with no surface tagging', function() {
         selection
-            .datum(iD.osmEntity({tags: {highway: 'tertiary'}}))
+            .datum(iD.osmWay({tags: {highway: 'tertiary'}}))
             .call(iD.svgTagClasses());
         expect(selection.classed('tag-unpaved')).to.be.false;
 
         selection
-            .datum(iD.osmEntity({tags: {highway: 'foo'}}))
+            .datum(iD.osmWay({tags: {highway: 'foo'}}))
             .call(iD.svgTagClasses());
         expect(selection.classed('tag-unpaved')).to.be.false;
     });
 
     it('does not add tag-unpaved for non-track highways with explicit paved surface tagging', function() {
         selection
-            .datum(iD.osmEntity({tags: {highway: 'tertiary', surface: 'asphalt'}}))
+            .datum(iD.osmWay({tags: {highway: 'tertiary', surface: 'asphalt'}}))
             .call(iD.svgTagClasses());
         expect(selection.classed('tag-unpaved')).to.be.false;
 
         selection
-            .datum(iD.osmEntity({tags: {highway: 'foo', tracktype: 'grade1'}}))
+            .datum(iD.osmWay({tags: {highway: 'foo', tracktype: 'grade1'}}))
             .call(iD.svgTagClasses());
         expect(selection.classed('tag-unpaved')).to.be.false;
     });
 
     it('does not add tag-unpaved for aeroways with explicit paved surface tagging', function() {
         selection
-            .datum(iD.osmEntity({tags: {aeroway: 'taxiway', surface: 'asphalt'}}))
+            .datum(iD.osmWay({tags: {aeroway: 'taxiway', surface: 'asphalt'}}))
             .call(iD.svgTagClasses());
         expect(selection.classed('tag-unpaved')).to.be.false;
 
         selection
-            .datum(iD.osmEntity({tags: {aeroway: 'runway', surface: 'paved'}}))
+            .datum(iD.osmWay({tags: {aeroway: 'runway', surface: 'paved'}}))
             .call(iD.svgTagClasses());
         expect(selection.classed('tag-unpaved')).to.be.false;
     });
 
     it('adds tag-unpaved for non-track highways with explicit unpaved surface tagging', function() {
         selection
-            .datum(iD.osmEntity({tags: {highway: 'tertiary', surface: 'dirt'}}))
+            .datum(iD.osmWay({tags: {highway: 'tertiary', surface: 'dirt'}}))
             .call(iD.svgTagClasses());
         expect(selection.classed('tag-unpaved')).to.be.true;
 
         selection
-            .datum(iD.osmEntity({tags: {highway: 'foo', tracktype: 'grade3'}}))
+            .datum(iD.osmWay({tags: {highway: 'foo', tracktype: 'grade3'}}))
             .call(iD.svgTagClasses());
         expect(selection.classed('tag-unpaved')).to.be.true;
     });
 
     it('adds tag-semipaved for non-track highways with explicit semipaved surface tagging', function() {
         selection
-            .datum(iD.osmEntity({tags: {highway: 'tertiary', surface: 'paving_stones'}}))
+            .datum(iD.osmWay({tags: {highway: 'tertiary', surface: 'paving_stones'}}))
             .call(iD.svgTagClasses());
         expect(selection.classed('tag-unpaved')).to.be.false;
         expect(selection.classed('tag-semipaved')).to.be.true;
 
         selection
-            .datum(iD.osmEntity({tags: {highway: 'foo', surface: 'wood'}}))
+            .datum(iD.osmWay({tags: {highway: 'foo', surface: 'wood'}}))
             .call(iD.svgTagClasses());
         expect(selection.classed('tag-unpaved')).to.be.false;
         expect(selection.classed('tag-semipaved')).to.be.true;
@@ -177,25 +177,25 @@ describe('iD.svgTagClasses', function () {
 
     it('adds tag-unpaved for aeroways with explicit unpaved surface tagging', function() {
         selection
-            .datum(iD.osmEntity({tags: {aeroway: 'taxiway', surface: 'dirt'}}))
+            .datum(iD.osmWay({tags: {aeroway: 'taxiway', surface: 'dirt'}}))
             .call(iD.svgTagClasses());
         expect(selection.classed('tag-unpaved')).to.be.true;
 
         selection
-            .datum(iD.osmEntity({tags: {aeroway: 'runway', surface: 'unpaved'}}))
+            .datum(iD.osmWay({tags: {aeroway: 'runway', surface: 'unpaved'}}))
             .call(iD.svgTagClasses());
         expect(selection.classed('tag-unpaved')).to.be.true;
     });
 
     it('adds tag-semipaved for aeroways with explicit semipaved surface tagging', function() {
         selection
-            .datum(iD.osmEntity({tags: {aeroway: 'taxiway', surface: 'paving_stones'}}))
+            .datum(iD.osmWay({tags: {aeroway: 'taxiway', surface: 'paving_stones'}}))
             .call(iD.svgTagClasses());
         expect(selection.classed('tag-unpaved')).to.be.false;
         expect(selection.classed('tag-semipaved')).to.be.true;
 
         selection
-            .datum(iD.osmEntity({tags: {aeroway: 'runway', surface: 'wood'}}))
+            .datum(iD.osmWay({tags: {aeroway: 'runway', surface: 'wood'}}))
             .call(iD.svgTagClasses());
         expect(selection.classed('tag-unpaved')).to.be.false;
         expect(selection.classed('tag-semipaved')).to.be.true;
@@ -203,33 +203,33 @@ describe('iD.svgTagClasses', function () {
 
     it('does not add tag-unpaved for non-highways/aeroways', function() {
         selection
-            .datum(iD.osmEntity({tags: {railway: 'abandoned', surface: 'gravel'}}))
+            .datum(iD.osmWay({tags: {railway: 'abandoned', surface: 'gravel'}}))
             .call(iD.svgTagClasses());
         expect(selection.classed('tag-unpaved')).to.be.false;
 
         selection
-            .datum(iD.osmEntity({tags: {amenity: 'parking', surface: 'dirt'}}))
+            .datum(iD.osmWay({tags: {amenity: 'parking', surface: 'dirt'}}))
             .call(iD.svgTagClasses());
         expect(selection.classed('tag-unpaved')).to.be.false;
     });
 
     it('does not add tag-wikidata if no wikidata tag', function() {
         selection
-            .datum(iD.osmEntity())
+            .datum(iD.osmWay())
             .call(iD.svgTagClasses());
         expect(selection.classed('tag-wikidata')).to.be.false;
     });
 
     it('adds tag-wikidata if entity has a wikidata tag', function() {
         selection
-            .datum(iD.osmEntity({ tags: { wikidata: 'Q18275868' } }))
+            .datum(iD.osmWay({ tags: { wikidata: 'Q18275868' } }))
             .call(iD.svgTagClasses());
         expect(selection.classed('tag-wikidata')).to.be.true;
     });
 
     it('adds tag-wikidata if entity has a brand:wikidata tag', function() {
         selection
-            .datum(iD.osmEntity({ tags: { 'brand:wikidata': 'Q18275868' } }))
+            .datum(iD.osmWay({ tags: { 'brand:wikidata': 'Q18275868' } }))
             .call(iD.svgTagClasses());
         expect(selection.classed('tag-wikidata')).to.be.true;
     });
@@ -237,7 +237,7 @@ describe('iD.svgTagClasses', function () {
     it('adds tags based on the result of the `tags` accessor', function() {
         var primary = function () { return { railway: 'rail'}; };
         selection
-            .datum(iD.osmEntity())
+            .datum(iD.osmWay())
             .call(iD.svgTagClasses().tags(primary));
         expect(selection.attr('class')).to.equal('tag-railway tag-railway-rail');
     });
@@ -245,7 +245,7 @@ describe('iD.svgTagClasses', function () {
     it('removes classes for tags that are no longer present', function() {
         selection
             .attr('class', 'tag-highway tag-highway-primary')
-            .datum(iD.osmEntity())
+            .datum(iD.osmWay())
             .call(iD.svgTagClasses());
         expect(selection.attr('class')).to.equal('');
     });
@@ -253,7 +253,7 @@ describe('iD.svgTagClasses', function () {
     it('preserves existing non-"tag-"-prefixed classes', function() {
         selection
             .attr('class', 'selected')
-            .datum(iD.osmEntity())
+            .datum(iD.osmWay())
             .call(iD.svgTagClasses());
         expect(selection.attr('class')).to.equal('selected');
     });
@@ -261,7 +261,7 @@ describe('iD.svgTagClasses', function () {
     it('stroke overrides: renders areas with barriers as lines', function() {
         selection
             .attr('class', 'way area stroke')
-            .datum(iD.osmEntity({tags: {landuse: 'residential', barrier: 'hedge'}}))
+            .datum(iD.osmWay({tags: {landuse: 'residential', barrier: 'hedge'}}))
             .call(iD.svgTagClasses());
         expect(selection.classed('area')).to.be.false;
         expect(selection.classed('line')).to.be.true;
@@ -270,7 +270,7 @@ describe('iD.svgTagClasses', function () {
     it('works on SVG elements', function() {
         selection = d3.select(document.createElementNS('http://www.w3.org/2000/svg', 'g'));
         selection
-            .datum(iD.osmEntity())
+            .datum(iD.osmWay())
             .call(iD.svgTagClasses());
         expect(selection.attr('class')).to.equal(null);
     });


### PR DESCRIPTION
minor refactor for unit tests only. [osmEntity](https://github.com/openstreetmap/iD/blob/f5b82d/modules/osm/entity.js) is effectively an abstract class, so it doesn't make sense to call `new osmEntity()` directly. 

`osmEntity` must be extended by a subclass like `osmNode` or `osmWay`.

* So, to avoid confusion, commit 1 replaces `new osmEntity()` with `new osmNode()`
* Commit 2 goes one step further and replaces `new osmEntity({id: 'n'})` with `new osmNode()`. Just to avoid [this magic](https://github.com/openstreetmap/iD/blob/f5b82daf24de0bbc01bea2f82bc7a55596403a97/modules/osm/entity.js#L11-L16) and make it marginally easier to understand