### PR TITLE
Added placeholder "Add key" for a new tag key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 # unreleased (v2.36.0-dev)
 
 #### :sparkles: Usability & Accessibility
+* Show "add new key" placeholder text for blank row in raw tag editor ([#11211], thanks [@bhavyaKhatri2703])
 #### :scissors: Operations
 #### :camera: Street-Level
 #### :white_check_mark: Validation
@@ -51,6 +52,8 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 
 [#9754]: https://github.com/openstreetmap/iD/issues/9754
 [#11206]: https://github.com/openstreetmap/iD/issues/11206
+[#11211]: https://github.com/openstreetmap/iD/issues/11211
+[@bhavyaKhatri2703]: https://github.com/bhavyaKhatri2703
 
 
 # v2.35.1

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -2954,6 +2954,10 @@ img.tag-reference-wiki-image {
 .add-tag {
     border-radius: 0 0 4px 4px;
 }
+.add-tag input.key {
+    border-bottom-left-radius: 4px;
+    font-weight: normal;
+}
 .add-relation {
     margin-top: 10px;
     border-radius: 4px;

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -715,6 +715,7 @@ en:
     features: Features
     title_count: "{title} ({count})"
     add_to_relation: Add to a relation
+    add_tag: Add new tag
     new_relation: New relation...
     choose_relation: Choose a parent relation
     role: Role

--- a/modules/ui/sections/raw_tag_editor.js
+++ b/modules/ui/sections/raw_tag_editor.js
@@ -234,7 +234,6 @@ export function uiSectionRawTagEditor(id, context) {
                     .call(reference.button)
                     .select('.tag-reference-button')
                     .attr('tabindex', -1)
-                    // disable button for "add new tag" row
                     .classed('disabled', d => d.key === '')
                     .attr('disabled', d => d.key === '' ? 'disabled' : null);
 
@@ -245,8 +244,7 @@ export function uiSectionRawTagEditor(id, context) {
 
         items.selectAll('input.key')
             .attr('title', function(d) { return d.key; })
-	    .attr('placeholder', function(d) {
-                // Show placeholder only for the blank row
+            .attr('placeholder', function(d) {
                 return d.key === '' ? t('inspector.add_tag') : null;
             })
             .attr('readonly', function(d) {
@@ -279,7 +277,7 @@ export function uiSectionRawTagEditor(id, context) {
             });
 
         items.selectAll('button.remove')
-            .classed('disabled', d => d.key === '') // disable button for "add new tag" row
+            .classed('disabled', d => d.key === '')
             .on(('PointerEvent' in window ? 'pointer' : 'mouse') + 'down', // 'click' fires too late - #5878
                 (d3_event, d) => {
                     if (d3_event.button !== 0) return;

--- a/modules/ui/sections/raw_tag_editor.js
+++ b/modules/ui/sections/raw_tag_editor.js
@@ -245,7 +245,7 @@ export function uiSectionRawTagEditor(id, context) {
             .attr('title', function(d) { return d.key; })
 	    .attr('placeholder', function(d) {
                 // Show placeholder only for the blank row
-                return d.key === '' ? 'Add key' : null;
+                return d.key === '' ? t('inspector.add_tag') : null;
             })
             .attr('readonly', function(d) {
                 return isReadOnly(d) || null;

--- a/modules/ui/sections/raw_tag_editor.js
+++ b/modules/ui/sections/raw_tag_editor.js
@@ -243,6 +243,10 @@ export function uiSectionRawTagEditor(id, context) {
 
         items.selectAll('input.key')
             .attr('title', function(d) { return d.key; })
+	    .attr('placeholder', function(d) {
+                // Show placeholder only for the blank row
+                return d.key === '' ? 'Add key' : null;
+            })
             .attr('readonly', function(d) {
                 return isReadOnly(d) || null;
             })

--- a/modules/ui/sections/raw_tag_editor.js
+++ b/modules/ui/sections/raw_tag_editor.js
@@ -234,7 +234,9 @@ export function uiSectionRawTagEditor(id, context) {
                     .call(reference.button)
                     .select('.tag-reference-button')
                     .attr('tabindex', -1)
-                    .classed('disabled', d => d.key === '');  // disabled for blank tag line
+                    // disable button for "add new tag" row
+                    .classed('disabled', d => d.key === '')
+                    .attr('disabled', d => d.key === '' ? 'disabled' : null);
 
                 row.call(reference.body);
 
@@ -277,7 +279,7 @@ export function uiSectionRawTagEditor(id, context) {
             });
 
         items.selectAll('button.remove')
-            .classed('disabled', d => d.key === '')  // disabled for blank tag line
+            .classed('disabled', d => d.key === '') // disable button for "add new tag" row
             .on(('PointerEvent' in window ? 'pointer' : 'mouse') + 'down', // 'click' fires too late - #5878
                 (d3_event, d) => {
                     if (d3_event.button !== 0) return;


### PR DESCRIPTION
This pr adds a placehoder text to the empty key field which is for adding a new tag
<img width="386" height="261" alt="image" src="https://github.com/user-attachments/assets/48b00998-f91f-4cd3-af32-27afb7fd5c58" />
Fix #11211
Pls let me know if need to make some other changes.