### PR TITLE
Add warning when road type is replaced with `highway=construction` without `construction=...` tag

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -2042,6 +2042,8 @@ en:
         title: Remove the name
       reposition_features:
         title: Reposition the features
+      restore_road_type:
+        title: Restore previous road type
       reverse_feature:
         title: Reverse this feature
       select_preset:

--- a/modules/validations/missing_tag.js
+++ b/modules/validations/missing_tag.js
@@ -62,26 +62,60 @@ export function validationMissingTag(context) {
         }
 
         // flag an unknown road even if it's a member of a relation
-        if (!subtype && isUnknownRoad(entity)) {
-            subtype = 'highway_classification';
+        if (!subtype) {
+            if (isUnknownRoad(entity)) {
+                subtype = 'highway_classification';
+            }
         }
 
         if (!subtype) return [];
 
-        var messageID = subtype === 'highway_classification' ? 'unknown_road' : 'missing_tag.' + subtype;
-        var referenceID = subtype === 'highway_classification' ? 'unknown_road' : 'missing_tag';
-
         // can always delete if the user created it in the first place..
-        var canDelete = (entity.version === undefined || entity.v !== undefined);
-        var severity = (canDelete && subtype !== 'highway_classification') ? 'error' : 'warning';
+        var userCreatedEntity = (entity.version === undefined || entity.v !== undefined);
+
+        // If tags are missing, display a warning with a dynamic fix offering to select a
+        // (new) preset.
+        let messageID = `issues.missing_tag.${subtype}.message`;
+        let referenceID = 'issues.missing_tag.reference';
+        let mainFixLabel = 'issues.fix.select_preset.title';
+        let mainFixAction = function(context) {
+            context.ui().sidebar.showPresetList();
+        };
+        let mainFixIcon = 'iD-icon-search';
+        let severity = 'warning';
+        // Whether the warning should contain a fix that will (attempt) to delete
+        // the entity with missing tags.
+        let offerDeletionFix = true;
+
+        switch (subtype) {
+            // An entity lacks tags to make it relevant, for example:
+            // - no tags at all (and not a way in a relation or a node in a way)
+            // - a node without tags that is not part of a way)
+            // - a relation without a type=... tag
+            case 'any':
+            case 'descriptive':
+            case 'relation_type':
+                if (userCreatedEntity) {
+                    severity = 'error';
+                }
+                break;
+            // A way tagged as highway=road (a more precise highway value should be
+            // used).
+            case 'highway_classification':
+                messageID = 'issues.unknown_road.message';
+                referenceID = 'issues.unknown_road.reference';
+                mainFixLabel = 'issues.fix.select_road_type.title';
+                break;
+        }
 
         return [new validationIssue({
             type: type,
             subtype: subtype,
             severity: severity,
+            // depends on messageID, t (localizer)
             message: function(context) {
                 var entity = context.hasEntity(this.entityIds[0]);
-                return entity ? t.append('issues.' + messageID + '.message', {
+                return entity ? t.append(messageID, {
                     feature: utilDisplayLabel(entity, context.graph())
                 }) : '';
             },
@@ -91,40 +125,36 @@ export function validationMissingTag(context) {
 
                 var fixes = [];
 
-                var selectFixType = subtype === 'highway_classification' ? 'select_road_type' : 'select_preset';
-
                 fixes.push(new validationIssueFix({
-                    icon: 'iD-icon-search',
-                    title: t.append('issues.fix.' + selectFixType + '.title'),
-                    onClick: function(context) {
-                        context.ui().sidebar.showPresetList();
-                    }
+                    icon: mainFixIcon,
+                    title: t.append(mainFixLabel),
+                    onClick: mainFixAction
                 }));
 
-                var deleteOnClick;
+                if (offerDeletionFix) {
+                    var deleteOnClick;
+                    var id = this.entityIds[0];
+                    var operation = operationDelete(context, [id]);
+                    var disabledReasonID = operation.disabled();
+                    if (!disabledReasonID) {
+                        deleteOnClick = function(context) {
+                            var id = this.issue.entityIds[0];
+                            var operation = operationDelete(context, [id]);
+                            if (!operation.disabled()) {
+                                operation();
+                            }
+                        };
+                    }
 
-                var id = this.entityIds[0];
-                var operation = operationDelete(context, [id]);
-                var disabledReasonID = operation.disabled();
-                if (!disabledReasonID) {
-                    deleteOnClick = function(context) {
-                        var id = this.issue.entityIds[0];
-                        var operation = operationDelete(context, [id]);
-                        if (!operation.disabled()) {
-                            operation();
-                        }
-                    };
+                    fixes.push(
+                        new validationIssueFix({
+                            icon: 'iD-operation-delete',
+                            title: t.append('issues.fix.delete_feature.title'),
+                            disabledReason: disabledReasonID ? t('operations.delete.' + disabledReasonID + '.single') : undefined,
+                            onClick: deleteOnClick
+                        })
+                    );
                 }
-
-                fixes.push(
-                    new validationIssueFix({
-                        icon: 'iD-operation-delete',
-                        title: t.append('issues.fix.delete_feature.title'),
-                        disabledReason: disabledReasonID ? t('operations.delete.' + disabledReasonID + '.single') : undefined,
-                        onClick: deleteOnClick
-                    })
-                );
-
                 return fixes;
             }
         })];
@@ -135,7 +165,7 @@ export function validationMissingTag(context) {
                 .enter()
                 .append('div')
                 .attr('class', 'issue-reference')
-                .call(t.append('issues.' + referenceID + '.reference'));
+                .call(t.append(referenceID));
         }
     };
 

--- a/modules/validations/missing_tag.js
+++ b/modules/validations/missing_tag.js
@@ -1,3 +1,4 @@
+import { actionChangeTags } from '../actions/change_tags';
 import { operationDelete } from '../operations/delete';
 import { osmIsInterestingTag } from '../osm/tags';
 import { t } from '../core/localizer';
@@ -34,6 +35,19 @@ export function validationMissingTag(context) {
         return entity.type === 'way' && entity.tags.highway === 'road';
     }
 
+    // There was a highway=<road_type> tag that was changed to highway=construction without
+    // adding a construction=<road_type> tag.
+    function hadRoadTypeChangedToConstruction(context, entity) {
+        let origGraph = context.history().base();
+        if (!origGraph.hasEntity(entity.id)) {
+            return false;
+        }
+        const origTags = origGraph.entity(entity.id).tags;
+        const wasKnownType = 'highway' in origTags && origTags.highway !== 'road' && origTags.highway !== 'construction';
+        const isUnknownType = entity.tags.highway === 'construction' && !('construction' in entity.tags);
+        return entity.type === 'way' && wasKnownType && isUnknownType;
+    }
+
     function isUntypedRelation(entity) {
         return entity.type === 'relation' && !entity.tags.type;
     }
@@ -65,6 +79,8 @@ export function validationMissingTag(context) {
         if (!subtype) {
             if (isUnknownRoad(entity)) {
                 subtype = 'highway_classification';
+            } else if (hadRoadTypeChangedToConstruction(context, entity)) {
+                subtype = 'highway_classification_construction';
             }
         }
 
@@ -106,13 +122,32 @@ export function validationMissingTag(context) {
                 referenceID = 'issues.unknown_road.reference';
                 mainFixLabel = 'issues.fix.select_road_type.title';
                 break;
+            // A way had a highway!=road tag, but it was changed to highway=construction
+            // without a a construction=... tag.
+            case 'highway_classification_construction':
+                messageID = 'issues.unknown_road.message';
+                referenceID = 'issues.unknown_road.reference';
+                mainFixLabel = 'issues.fix.restore_road_type.title';
+                mainFixIcon = 'iD-icon-undo';
+                offerDeletionFix = false;
+                mainFixAction = function(context) {
+                    // We checked in hadRoadTypeChangedToConstruction() that a highway tag
+                    // did exist before the edit and can thus just collect it here.
+                    const origRoadType = context.history().base().entity(entity.id).tags.highway;
+                    let newTags = Object.assign({}, entity.tags);   // shallow copy
+                    newTags.construction = origRoadType;
+                    context.perform(
+                        actionChangeTags(entity.id, newTags),
+                        t('operations.change_tags.annotation')
+                    );
+                };
+                break;
         }
 
         return [new validationIssue({
             type: type,
             subtype: subtype,
             severity: severity,
-            // depends on messageID, t (localizer)
             message: function(context) {
                 var entity = context.hasEntity(this.entityIds[0]);
                 return entity ? t.append(messageID, {

--- a/test/spec/validations/missing_tag.js
+++ b/test/spec/validations/missing_tag.js
@@ -122,4 +122,18 @@ describe('iD.validations.missing_tag', function () {
         expect(issue.entityIds[0]).to.eql('w-1');
     });
 
+    it('ignores highway=construction with construction key', function() {
+        createWay({ highway: 'construction', construction: 'primary' });
+        var issues = validate();
+        expect(issues).to.have.lengthOf(0);
+    });
+
+    // Arguably, this should be a warning in the future, but for now, just updated ways are flagged.
+    it('ignores newly created highway=construction without construction key', function() {
+        createWay({ highway: 'construction' });
+        var issues = validate();
+        expect(issues).to.have.lengthOf(0);
+    });
+
+    // TODO: Add test that updates an existing road and creates a warning
 });


### PR DESCRIPTION
## Summary

Add a warning when a `highway=<road_type>` is replaced with `highway=construction` without a `construction=<road_type>` tag. The warning comes with a fix that allows to restore the previous road type in the `construction` key. For now, the warning is only created when it can be fixed automatically, that is, when the unedited way had a `highway!=road` tag.

Possible follow-ups:
- Investigate whether the `construction=...` tag can be set when the "road under construction" preset is applied
- add a warning (perhaps a suggestion?) to set `construction=...` key for newly added ways

### Context

Context: This can happen when a user selects the "road under construction" preset or manually replaces the `highway` tag with `construction`. If the previous road type is not restored in the `construction=...` tag, the information which road type is being constructed is being lost in the tagging. From looking at affected changesets, it seems that typically, iD is used and it appears that the removal of the road type information was unintentional. Under these circumstances, iD should issue a warning. Data consumers shouldn't be expected to interpret tags based on the edit history.

To mitigate the consequences of removed road type information, mappers and data consumers would need to analyze the way history. For data consumers, such interpolations are often not feasible. StreetComplete for instance, will set `highway=road` in its "is this construction finished" quest if there is no `construction=...` key available (which is a reasonable default to assume based on exiting tags). 

There are many examples of `highway=road`s that were created as a result of a manual change `

| road type information lost (usually with iD) | Reset to `highway=road` (usually with SC) | Notes |
|--------------------------|-------------------------|-------------|
| https://www.openstreetmap.org/way/314491796/history/12 | https://www.openstreetmap.org/way/314491796/history/14 | `highway=secondary` before |
| https://www.openstreetmap.org/way/915874283/history/3 | https://www.openstreetmap.org/way/915874283/history/5 | `highway=footway` before |
| https://www.openstreetmap.org/way/375991058/history/13 | https://www.openstreetmap.org/way/375991058/history/14 | |

Overpass Link: https://overpass-turbo.eu/s/27Xa (`surface` filter helps to select roads that have a more rich history and are thus more likely to be true positives)

## Test Plan

Added some unit tests.

Until i figure out how to do this in tests, i manually verified that:

 - changing an existing `highway=xyz` to `highway=construction` triggers the warning and that the fix adds `construction=xyz`
 - no warning on existing `highway=construction` + `construction=xyz`
 - no warning for existing `highway=construction` without `construction`