### PR TITLE
restore transitionable actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,16 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#11206]: https://github.com/openstreetmap/iD/issues/11206
 
 
+# v2.35.2
+##### 2025-07-17
+
+* Restore behavior of _reflect_ and _circularize_ operations, as well as fixing minor glitches in some other actions with transitions ([#11213])
+* Fix glitch while dragging the map during a _move_ operation ([#11217])
+
+[#11213]: https://github.com/openstreetmap/iD/issues/11213
+[#11217]: https://github.com/openstreetmap/iD/issues/11217
+
+
 # v2.35.1
 ##### 2025-07-14
 

--- a/modules/core/context.js
+++ b/modules/core/context.js
@@ -522,7 +522,6 @@ export function coreContext() {
       context.perform = withDebouncedSave(_history.perform);
       context.replace = withDebouncedSave(_history.replace);
       context.pop = withDebouncedSave(_history.pop);
-      context.overwrite = withDebouncedSave(_history.overwrite);
       context.undo = withDebouncedSave(_history.undo);
       context.redo = withDebouncedSave(_history.redo);
 

--- a/modules/core/history.js
+++ b/modules/core/history.js
@@ -172,14 +172,7 @@ export function coreHistory(context) {
 
         replace: function() {
             d3_select(document).interrupt('history.perform');
-            return _replace(arguments, 1);
-        },
-
-
-        // Same as calling pop and then perform
-        overwrite: function() {
-            d3_select(document).interrupt('history.perform');
-            return _overwrite(arguments, 1);
+            return _replace(arguments);
         },
 
 

--- a/modules/core/history.js
+++ b/modules/core/history.js
@@ -80,12 +80,12 @@ export function coreHistory(context) {
     // internal _overwrite with eased time
     function _overwrite(args, t) {
         var previous = _stack[_index].graph;
-        var actionResult = _act(args, t);
         if (_index > 0) {
             _index--;
             _stack.pop();
         }
         _stack = _stack.slice(0, _index + 1);
+        var actionResult = _act(args, t);
         _stack.push(actionResult);
         _index++;
         return change(previous);

--- a/modules/modes/move.js
+++ b/modules/modes/move.js
@@ -63,7 +63,7 @@ export function modeMove(context, entityIDs, baseGraph) {
             _prevMouse = context.map().mouse();
             fn = context.perform;
         } else {
-            fn = context.overwrite;
+            fn = context.replace;
         }
 
         const currMouse = context.map().mouse();

--- a/modules/modes/move.js
+++ b/modules/modes/move.js
@@ -47,7 +47,7 @@ export function modeMove(context, entityIDs, baseGraph) {
 
     var _prevGraph;
     var _cache;
-    var _prevMouse;
+    var _prevMouseCoords;
     var _nudgeInterval;
 
     // use pointer events on supported platforms; fallback to mouse events
@@ -60,15 +60,17 @@ export function modeMove(context, entityIDs, baseGraph) {
         let fn;
         if (_prevGraph !== context.graph()) {
             _cache = {};
-            _prevMouse = context.map().mouse();
+            _prevMouseCoords = context.map().mouseCoordinates();
             fn = context.perform;
         } else {
             fn = context.replace;
         }
 
-        const currMouse = context.map().mouse();
-        const delta = geoVecSubtract(geoVecSubtract(currMouse, _prevMouse), nudge);
-        _prevMouse = currMouse;
+        const currMouseCoords = context.map().mouseCoordinates();
+        const currMouse = context.projection(currMouseCoords);
+        const prevMouse = context.projection(_prevMouseCoords);
+        const delta = geoVecSubtract(geoVecSubtract(currMouse, prevMouse), nudge);
+        _prevMouseCoords = currMouseCoords;
 
         fn(actionMove(entityIDs, delta, context.projection, _cache));
         _prevGraph = context.graph();
@@ -129,7 +131,7 @@ export function modeMove(context, entityIDs, baseGraph) {
 
 
     mode.enter = function() {
-        _prevMouse = context.map().mouse();
+        _prevMouseCoords = context.map().mouseCoordinates();
         _prevGraph = null;
         _cache = {};
 

--- a/modules/ui/entity_editor.js
+++ b/modules/ui/entity_editor.js
@@ -199,7 +199,7 @@ export function uiEntityEditor(context) {
             var annotation = t('operations.change_tags.annotation');
 
             if (_coalesceChanges) {
-                context.overwrite(combinedAction, annotation);
+                context.replace(combinedAction, annotation);
             } else {
                 context.perform(combinedAction, annotation);
             }
@@ -256,7 +256,7 @@ export function uiEntityEditor(context) {
             var annotation = t('operations.change_tags.annotation');
 
             if (_coalesceChanges) {
-                context.overwrite(combinedAction, annotation);
+                context.replace(combinedAction, annotation);
             } else {
                 context.perform(combinedAction, annotation);
             }

--- a/modules/ui/fields/wikidata.js
+++ b/modules/ui/fields/wikidata.js
@@ -259,7 +259,7 @@ export function uiFieldWikidata(field, context) {
             if (!actions.length) return;
 
             // Coalesce the update of wikidata tag into the previous tag change
-            context.overwrite(
+            context.replace(
                 function actionUpdateWikipediaTags(graph) {
                     actions.forEach(function(action) {
                         graph = action(graph);

--- a/modules/ui/fields/wikipedia.js
+++ b/modules/ui/fields/wikipedia.js
@@ -246,7 +246,7 @@ export function uiFieldWikipedia(field, context) {
       if (!actions.length) return;
 
       // Coalesce the update of wikidata tag into the previous tag change
-      context.overwrite(
+      context.replace(
         function actionUpdateWikidataTags(graph) {
           actions.forEach(function(action) {
             graph = action(graph);

--- a/test/spec/core/history.js
+++ b/test/spec/core/history.js
@@ -165,49 +165,6 @@ describe('iD.coreHistory', function () {
         });
     });
 
-    describe('#overwrite', function () {
-        it('returns a difference', function () {
-            history.perform(actionNoop, 'annotation');
-            expect(history.overwrite(actionNoop).changes()).to.eql({});
-        });
-
-        it('updates the graph', function () {
-            history.perform(actionNoop, 'annotation');
-            var node = iD.osmNode();
-            history.overwrite(function (graph) { return graph.replace(node); });
-            expect(history.graph().entity(node.id)).to.equal(node);
-        });
-
-        it('replaces the undo annotation', function () {
-            history.perform(actionNoop, 'annotation1');
-            history.overwrite(actionNoop, 'annotation2');
-            expect(history.undoAnnotation()).to.equal('annotation2');
-        });
-
-        it('does not push the redo stack', function () {
-            history.perform(actionNoop, 'annotation');
-            history.overwrite(actionNoop, 'annotation2');
-            expect(history.redoAnnotation()).to.be.undefined;
-        });
-
-        it('emits a change event', function () {
-            history.perform(actionNoop, 'annotation');
-            history.on('change', spy);
-            var difference = history.overwrite(actionNoop, 'annotation2');
-            expect(spy).to.have.been.calledWith(difference);
-        });
-
-        it('performs multiple actions', function () {
-            var action1 = sinon.stub().returns(iD.coreGraph());
-            var action2 = sinon.stub().returns(iD.coreGraph());
-            history.perform(actionNoop, 'annotation');
-            history.overwrite(action1, action2, 'annotation2');
-            expect(action1).to.have.been.called;
-            expect(action2).to.have.been.called;
-            expect(history.undoAnnotation()).to.equal('annotation2');
-        });
-    });
-
     describe('#undo', function () {
         it('returns a difference', function () {
             expect(history.undo().changes()).to.eql({});
@@ -281,8 +238,6 @@ describe('iD.coreHistory', function () {
             history.perform(actionNoop, 'perform');
             expect(spy).to.have.not.been.called;
             history.replace(actionNoop, 'replace');
-            expect(spy).to.have.not.been.called;
-            history.overwrite(actionNoop, 'replace');
             expect(spy).to.have.not.been.called;
             history.undo();
             expect(spy).to.have.not.been.called;


### PR DESCRIPTION
fixes #11213, which is a regression in #10970:

* transitionable actions use `history`'s `_overwrite` under the hood, which expects the supplied graph to be the one of the original state when the action was started.
* the original approach in #10970 did change this method to instead supply the graph of the previous step of the transition or the previous call to `.overwrite`, such that objects get a new `v` version such that they are properly rerendered if necessary (e.g. in case a node changes from being an address node to a full POI node, or vice versa)
* this fix restores the `overwrite` implementation (to make transitioned action behave correctly), and elsewhere use `history.replace` where applicable to get proper entity updates

//edit: also fixes a related glitch in the move mode/operation, see #11217