### PR TITLE
Fix tile edge blending

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -4382,8 +4382,8 @@ img.tile {
     transition: opacity 1ms linear;
 }
 
-.layer-background img.tile,
-.map-in-map-background img.tile {
+.layer-background,
+.map-in-map-background {
     filter: url(#alpha-slope5);
 }
 


### PR DESCRIPTION
Since I came across Leaflet's tiling discussion and 9e110cfda41787aeda5547d6b37e5fa56330587c again:

Currently, tiles later in the DOM spill over earlier ones with the extruded edges due to the increased opacity.
Actually, you'd want to tile the layer first and only apply the filter on everything together.
That way, the edges mix with a more correct proportion (still not perfect, but much better).

The impact is pretty difficult to spot; I've had to pick a [layer with very high local contrast](https://github.com/osmlab/editor-layer-index/blob/gh-pages/sources/europe/at/ViennaMehrzweckkarte-situation.geojson) and do A-B testing constantly to occasionally see an affected pixel.