### PR TITLE
make the imagery denylist RegExs case-insensitive

### DIFF
--- a/modules/services/osm.js
+++ b/modules/services/osm.js
@@ -1016,7 +1016,7 @@ export default {
                 var regexString = elements[i].getAttribute('regex');  // needs unencode?
                 if (regexString) {
                     try {
-                        var regex = new RegExp(regexString);
+                        var regex = new RegExp(regexString, 'i');
                         regexes.push(regex);
                     } catch {
                         /* noop */

--- a/test/spec/services/osm.js
+++ b/test/spec/services/osm.js
@@ -727,7 +727,7 @@ describe('iD.serviceOsm', function () {
 
                 await promisify(connection.status).call(connection);
                 var blocklists = connection.imageryBlocklists();
-                expect(blocklists).to.deep.equal([new RegExp('\.foo\.com'), new RegExp('\.bar\.org')]);
+                expect(blocklists).to.deep.equal([new RegExp('\.foo\.com', 'i'), new RegExp('\.bar\.org', 'i')]);
             });
         });
 


### PR DESCRIPTION
Currently you can just bypass the denylist by making one character uppercase...