### PR TITLE
Prevent direction rendering on outbound one-ways from all-way stop signs

### DIFF
--- a/modules/osm/node.js
+++ b/modules/osm/node.js
@@ -120,7 +120,13 @@ const prototype = {
 
             var nodeIds = {};
             resolver.parentWays(this)
-                .filter(way => osmShouldRenderDirection(this.tags, way.tags))
+                .filter(way => {
+                    // check for outbound one-way ways from stop signs
+                    const isOutbound = way.tags.oneway === 'yes' && way.nodes[0] === this.id;
+                    const isStopSign = this.tags.highway === 'stop';
+                    if (isOutbound && isStopSign) return false;
+                    return osmShouldRenderDirection(this.tags, way.tags);
+                })
                 .forEach(function(parent) {
                     var nodes = parent.nodes;
                     for (i = 0; i < nodes.length; i++) {

--- a/modules/osm/node.js
+++ b/modules/osm/node.js
@@ -1,7 +1,7 @@
 import { osmEntity } from './entity';
 import { geoAngle, geoExtent } from '../geo';
 import { utilArrayUniq } from '../util';
-import { osmShouldRenderDirection } from './tags';
+import { osmShouldRenderDirection, hasPartialOneway } from './tags';
 
 export const cardinal = {
     north: 0,               n: 0,
@@ -120,17 +120,27 @@ const prototype = {
 
             var nodeIds = {};
             resolver.parentWays(this)
-                .filter(way => {
-                    // check for outbound one-way ways from stop signs
-                    const isOutbound = way.tags.oneway === 'yes' && way.nodes[0] === this.id;
-                    const isStopSign = this.tags.highway === 'stop';
-                    if (isOutbound && isStopSign) return false;
-                    return osmShouldRenderDirection(this.tags, way.tags);
-                })
+                .filter(way => osmShouldRenderDirection(this.tags, way.tags))
                 .forEach(function(parent) {
                     var nodes = parent.nodes;
                     for (i = 0; i < nodes.length; i++) {
                         if (nodes[i] === this.id) {  // match current entity
+                            const isStopOrSignal = (this.tags.highway === 'stop' && this.tags.stop === 'all') || this.tags.highway === 'traffic_signals';
+                            // handle outbound one-way ways
+                            if (isStopOrSignal && parent.isOneWay() && !hasPartialOneway(parent)) {
+                                // forward one-way, inbound is from previous node
+                                if (parent.isOneWayForwards() && i > 0) {
+                                    nodeIds[nodes[i - 1]] = true;
+                                }
+                                // backward one-way, inbound is from next node
+                                if (parent.isOneWayBackwards() && i < nodes.length - 1) {
+                                    nodeIds[nodes[i + 1]] = true;
+                                }
+                                // ignore outbound
+                                continue;
+                            }
+
+                            // default rendering logic for all nodes
                             if (lookForward && i > 0) {
                                 nodeIds[nodes[i - 1]] = true;  // look back to prev node
                             }

--- a/modules/osm/tags.js
+++ b/modules/osm/tags.js
@@ -347,6 +347,29 @@ export function osmShouldRenderDirection(vertexTags, wayTags) {
     return true;
 }
 
+/**
+ * Checks if a way has partial oneway tags that invalidate strict one-way behavior.
+ * @param {Object} way The way to check.
+ * @returns {boolean} True if the way has partial oneway tags, false otherwise.
+ */
+
+export function hasPartialOneway(way) {
+    // iterate over all tags in the way
+    for (const key in way.tags) {
+        if (key.startsWith('oneway:')) {
+            const value = way.tags[key].toLowerCase();
+
+            // Functionally two way traffic
+            if (value === 'no') return true;
+            // Reverse one-way
+            if (value === '-1' && way.isOneWayForwards()) return true;
+            // Backward one-way
+            if (value === 'yes' && way.isOneWayBackwards()) return true;
+        }
+    }
+    return false;
+}
+
 export var osmSummableTags = new Set([
     'step_count',
     'parking:both:capacity',


### PR DESCRIPTION
Fixes #9879

Description:
All-way stop signs were incorrectly showing direction cones on outbound one-way roads, which implied incoming traffic where none would be coming from.

Changes:
Updated the `.filter()` logic in the `osmNode.directions()` method to skip outbound one-way roads when the current node has the `highway=stop` tag.

Notes:
This is scoped specifically to stop signs to match the original issue, but this logic could be extended to other node types through a list of node types to check or by removing the stop sign check entirely (which would make every node have this logic). 

I implemented this within `.filter()` instead of `osmShouldRenderDirection()` because I was checking the first node in the one-way to determine if it was outbound or not, and accessing that value within `osmShouldRenderDirection()` would require refactoring the function. If there is another way to check if it is outbound, or if refactoring the `osmShouldRenderDirection()` would be more desirable, then I'd be happy to try another approach!

Original issue:
<img width="199" height="194" alt="image" src="https://github.com/user-attachments/assets/46a1983c-74c8-4517-bbf6-cf317b5f4a5b" />

Fix:
<img width="199" height="199" alt="image" src="https://github.com/user-attachments/assets/6e7d94fe-53ad-4654-be14-7bd959bd484b" />
