### PR TITLE
move enable/disable buttons to the top of the list

### DIFF
--- a/modules/ui/sections/map_features.js
+++ b/modules/ui/sections/map_features.js
@@ -20,31 +20,33 @@ export function uiSectionMapFeatures(context) {
             .append('div')
             .attr('class', 'layer-feature-list-container');
 
-                var footer = containerEnter
-            .append('div')
-            .attr('class', 'feature-list-links section-footer');
 
-        footer
-            .append('a')
-            .attr('class', 'feature-list-link')
-            .attr('role', 'button')
-            .attr('href', '#')
-            .call(t.append('issues.disable_all'))
-            .on('click', function(d3_event) {
-                d3_event.preventDefault();
-                context.features().disableAll();
-            });
+var footer = containerEnter
+    .append('div')
+    .attr('class', 'feature-list-links section-footer')
+    .style('margin-top', '-25px');
 
-        footer
-            .append('a')
-            .attr('class', 'feature-list-link')
-            .attr('role', 'button')
-            .attr('href', '#')
-            .call(t.append('issues.enable_all'))
-            .on('click', function(d3_event) {
-                d3_event.preventDefault();
-                context.features().enableAll();
-            });
+footer
+    .append('a')
+    .attr('class', 'feature-list-link')
+    .attr('role', 'button')
+    .attr('href', '#')
+    .call(t.append('issues.disable_all'))
+    .on('click', function(d3_event) {
+        d3_event.preventDefault();
+        context.features().disableAll();
+    });
+
+footer
+    .append('a')
+    .attr('class', 'feature-list-link')
+    .attr('role', 'button')
+    .attr('href', '#')
+    .call(t.append('issues.enable_all'))
+    .on('click', function(d3_event) {
+        d3_event.preventDefault();
+        context.features().enableAll();
+    });
 
         containerEnter
             .append('ul')

--- a/modules/ui/sections/map_features.js
+++ b/modules/ui/sections/map_features.js
@@ -20,11 +20,7 @@ export function uiSectionMapFeatures(context) {
             .append('div')
             .attr('class', 'layer-feature-list-container');
 
-        containerEnter
-            .append('ul')
-            .attr('class', 'layer-list layer-feature-list');
-
-        var footer = containerEnter
+                var footer = containerEnter
             .append('div')
             .attr('class', 'feature-list-links section-footer');
 
@@ -49,6 +45,12 @@ export function uiSectionMapFeatures(context) {
                 d3_event.preventDefault();
                 context.features().enableAll();
             });
+
+        containerEnter
+            .append('ul')
+            .attr('class', 'layer-list layer-feature-list');
+
+
 
         // Update
         container = container

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
         "netlify-cli": "^23.0.0",
         "nise": "^6.1.1",
         "npm-run-all": "^4.0.0",
-        "osm-community-index": "~5.9.2",
+        "osm-community-index": "5.9.2",
         "postcss": "^8.5.6",
         "postcss-prefix-selector": "^2.1.1",
         "serve-handler": "^6.1.6",


### PR DESCRIPTION
Moved the "Activate all" and "Deactivate all" options from the bottom to the top of the object selection list to improve visibility and accessibility.
This ensures users can easily discover and use these actions without needing to scroll through a long list.

Fixes: #8878
<img width="455" height="741" alt="image" src="https://github.com/user-attachments/assets/ec097725-abcb-4a3f-8ddb-29ff8953bd81" />

