### PR TITLE
add support for panoramas from kartaview

### DIFF
--- a/modules/renderer/photos.js
+++ b/modules/renderer/photos.js
@@ -168,16 +168,23 @@ export function rendererPhotos(context) {
      * @returns If the Date Slider filter should be drawn
      */
     photos.shouldFilterDateBySlider = function(){
-        return showsLayer('mapillary') || showsLayer('kartaview') || showsLayer('mapilio')
-        || showsLayer('streetside') || showsLayer('vegbilder') || showsLayer('panoramax');
+        return showsLayer('mapillary')
+            || showsLayer('kartaview')
+            || showsLayer('mapilio')
+            || showsLayer('streetside')
+            || showsLayer('vegbilder')
+            || showsLayer('panoramax');
     };
 
     /**
      * @returns If the Photo Type filter should be drawn
      */
     photos.shouldFilterByPhotoType = function() {
-        return showsLayer('mapillary') ||
-            (showsLayer('streetside') && showsLayer('kartaview')) || showsLayer('vegbilder') || showsLayer('panoramax');
+        return showsLayer('mapillary')
+            || showsLayer('kartaview')
+            || showsLayer('streetside')
+            || showsLayer('vegbilder')
+            || showsLayer('panoramax');
     };
 
     /**

--- a/modules/services/kartaview.js
+++ b/modules/services/kartaview.js
@@ -109,7 +109,8 @@ function loadNextTilePage(which, currZoom, url, tile) {
                         captured_by: item.username,
                         imagePath: item.name,
                         sequence_id: item.sequence_id,
-                        sequence_index: +item.sequence_index
+                        sequence_index: +item.sequence_index,
+                        isPano: item.projection === 'SPHERE'
                     };
 
                     // cache sequence info
@@ -224,9 +225,10 @@ export default {
                         type: 'LineString',
                         coordinates: images.map(function (d) { return d.loc; }).filter(Boolean),
                         properties: {
-                            captured_at: images[0] ? images[0].captured_at: null,
-                            captured_by: images[0] ? images[0].captured_by: null,
-                            key: sequenceKey
+                            captured_at: images[0] ? images[0].captured_at : null,
+                            captured_by: images[0] ? images[0].captured_by : null,
+                            key: sequenceKey,
+                            isPano: images[0]?.isPano
                         }
                     });
                 }

--- a/modules/svg/kartaview_images.js
+++ b/modules/svg/kartaview_images.js
@@ -106,10 +106,18 @@ export function svgKartaviewImages(projection, context, dispatch) {
 
 
     function filterImages(images, skipDateFilter = false) {
-        var fromDate = context.photos().fromDate();
-        var toDate = context.photos().toDate();
-        var usernames = context.photos().usernames();
+        const showsPano = context.photos().showsPanoramic();
+        const showsFlat = context.photos().showsFlat();
+        const fromDate = context.photos().fromDate();
+        const toDate = context.photos().toDate();
+        const usernames = context.photos().usernames();
 
+        if (!showsPano || !showsFlat) {
+            images = images.filter(image => {
+                if (image.isPano) return showsPano;
+                return showsFlat;
+            });
+        }
         if (fromDate && !skipDateFilter) {
             var fromTimestamp = new Date(fromDate).getTime();
             images = images.filter(function(item) {
@@ -132,10 +140,18 @@ export function svgKartaviewImages(projection, context, dispatch) {
     }
 
     function filterSequences(sequences, skipDateFilter = false) {
-        var fromDate = context.photos().fromDate();
-        var toDate = context.photos().toDate();
-        var usernames = context.photos().usernames();
+        const showsPano = context.photos().showsPanoramic();
+        const showsFlat = context.photos().showsFlat();
+        const fromDate = context.photos().fromDate();
+        const toDate = context.photos().toDate();
+        const usernames = context.photos().usernames();
 
+        if (!showsPano || !showsFlat) {
+            sequences = sequences.filter(sequence => {
+                if (sequence.properties.isPano) return showsPano;
+                return showsFlat;
+            });
+        }
         if (fromDate && !skipDateFilter) {
             var fromTimestamp = new Date(fromDate).getTime();
             sequences = sequences.filter(function(sequence) {

--- a/modules/svg/panoramax_images.js
+++ b/modules/svg/panoramax_images.js
@@ -52,7 +52,7 @@ export function svgPanoramaxImages(projection, context, dispatch) {
         const service = getService();
 
         if (!showsPano || !showsFlat) {
-            images = images.filter(function(image) {
+            images = images.filter(image => {
                 if (image.isPano) return showsPano;
                 return showsFlat;
             });
@@ -103,9 +103,9 @@ export function svgPanoramaxImages(projection, context, dispatch) {
         const service = getService();
 
         if (!showsPano || !showsFlat) {
-            sequences = sequences.filter(function(sequence) {
-                    if (sequence.properties.type === 'equirectangular') return showsPano;
-                    return showsFlat;
+            sequences = sequences.filter(sequence => {
+                if (sequence.properties.type === 'equirectangular') return showsPano;
+                return showsFlat;
             });
         }
         if (fromDate && !skipDateFilter) {


### PR DESCRIPTION
Kartaview [now](https://youtu.be/N92rACDMRak?si=-DFs0h0o0c9Gy3Qh&t=761) also has panoramas (at least in certain selected regions [example](https://kartaview.org/details/11411513/520)). This adds support for panoramas from kartaview:

This PR is still work in progress:

* :white_check_mark: enable panoramic/flat filter when kartaview layer is active
* [ ] use panellum viewer when viewing a panorama from Kartaview
* [ ] (generally) upgrade API to [v2](https://kartaview.org/doc/photos)

Closes #8821, Closes kartaview/upload-scripts#120