### PR TITLE
Add shortcut to toggle overlay layer visibility

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -2413,6 +2413,7 @@ en:
         osm_data: "Toggle OpenStreetMap data"
         minimap: "Toggle minimap"
         highlight_edits: "Highlight unsaved edits"
+        overlays: "Toggle all overlays"
       selecting:
         title: "Selecting features"
         select_one: "Select a single feature"

--- a/data/shortcuts.json
+++ b/data/shortcuts.json
@@ -80,6 +80,11 @@
             "text": "shortcuts.browsing.enable.streetlevel"
           },
           {
+            "modifiers": ["⇧"],
+            "shortcuts": ["O"],
+            "text": "shortcuts.browsing.display_options.overlays"
+          },
+          {
             "shortcuts": ["background.minimap.key"],
             "text": "shortcuts.browsing.display_options.minimap"
           },

--- a/modules/ui/sections/overlay_list.js
+++ b/modules/ui/sections/overlay_list.js
@@ -10,6 +10,9 @@ import { uiSection } from '../section';
 
 export function uiSectionOverlayList(context) {
 
+    let _overlaysHidden = false;
+    let _savedOverlays = [];
+
     var section = uiSection('overlay-list', context)
         .label(() => t.append('background.overlays'))
         .disclosureContent(renderDisclosureContent);
@@ -37,6 +40,10 @@ export function uiSectionOverlayList(context) {
 
     function updateLayerSelections(selection) {
         function active(d) {
+            if (_overlaysHidden) {
+                // If overlays are hidden, ensure checkboxes remain checked on rerender
+                return _savedOverlays.includes(d);
+            }
             return context.background().showsLayer(d);
         }
 
@@ -111,6 +118,33 @@ export function uiSectionOverlayList(context) {
         _overlayList
             .call(drawListItems, 'checkbox', chooseOverlay, function(d) { return !d.isHidden() && d.overlay; });
     }
+
+    /**
+     * Toggles overlays on/off
+     */
+    function toggleAllOverlays(){
+        let overlays = context.background().overlayLayerSources();
+        let overlayContainer = d3_select('.disclosure-wrap-overlay_list');
+
+        if (!_overlaysHidden){
+            overlays.forEach(d => {
+                if (context.background().showsLayer(d)) {
+                    _savedOverlays.push(d);
+                    context.background().toggleOverlayLayer(d);
+                }
+            });
+            overlayContainer.classed('disabled-panel', true);
+        } else {
+            _savedOverlays.forEach(d => {
+                context.background().toggleOverlayLayer(d);
+            });
+            _savedOverlays = [];
+            overlayContainer.classed('disabled-panel', false);
+        }
+        _overlaysHidden = !_overlaysHidden;
+    };
+
+    context.keybinding().on('⇧O', toggleAllOverlays);
 
     context.map()
         .on('move.overlay_list',


### PR DESCRIPTION
Added a shortcut to toggle the visibility of all overlay layers to `Shift + O`. This follows the `Shift + <key>` pattern set by newer shortcuts (e.g., `Shift + P`) and, as far as I'm aware, does not conflict with any browser shortcuts. I chose O as the key as it is adjacent to the existing `Shift + P` shortcut on QWERTY keyboards, and is an intuitive letter for "Overlays" to be on.

I used essentially the same logic as `toggleStreetSide` for `toggleAllOverlays` with some modifications due to the differences in layer structure. Because the list of selectable overlays has a variable number of overlays, I also had to modify `updateLayerSelections` to stop them from unchecking on rerender.

Closes #10972 

Keybind in keyboard shortcuts:
<img width="336" height="379" alt="image" src="https://github.com/user-attachments/assets/96a80947-9675-426a-ab88-fcb9a8308026" />

Visibility on (default):
<img width="947" height="491" alt="image" src="https://github.com/user-attachments/assets/6a9507e7-d669-45bd-9e86-f12c7c0f8724" />

Visibility toggled:
<img width="953" height="497" alt="image" src="https://github.com/user-attachments/assets/696f8e3c-4eaf-47f9-89d9-a71782f2b193" />

