### PR TITLE
Fix build script on Mac

### DIFF
--- a/config/esbuild.config.js
+++ b/config/esbuild.config.js
@@ -16,6 +16,7 @@ const context = await esbuild.context({
   metafile: true,
   outfile: 'dist/iD.js',
   target: browserslistToEsbuild(),
+  loader: { '.DS_Store' : 'empty' },
 });
 
 if (args.watch) {

--- a/config/esbuild.config.min.js
+++ b/config/esbuild.config.min.js
@@ -13,5 +13,6 @@ esbuild
     logLevel: 'info',
     outfile: 'dist/iD.min.js',
     target: browserslistToEsbuild(),
+    loader: { '.DS_Store' : 'empty' },
   })
   .catch(() => process.exit(1));

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     css: true,
     environment: 'jsdom',
     globals: true,
-    include: ['test/spec/**/*'],
+    include: ['test/spec/**/*.{js,ts}'],
     setupFiles: ['./test/spec_helpers.ts'],
   },
 });


### PR DESCRIPTION
When I ran `npm run all` or `npm run build:js` on a mac, I got those errors due to the mac's auto generated `.DS_Store` files:

```
> iD@2.36.0-dev build:js
> node config/esbuild.config.mjs

✘ [ERROR] No loader is configured for ".DS_Store" files: modules/core/.DS_Store

    modules/core/file_fetcher.js:74:54:
      74 │       _inflight[url] = prom = (window.VITEST ? import(`../${url}`) : fetch(url))
         ╵                                                       ~~~~~~~~~~~

✘ [ERROR] No loader is configured for ".DS_Store" files: modules/.DS_Store

    modules/core/file_fetcher.js:74:54:
      74 │       _inflight[url] = prom = (window.VITEST ? import(`../${url}`) : fetch(url))
         ╵                                                       ~~~~~~~~~~~

✘ [ERROR] No loader is configured for ".DS_Store" files: modules/ui/.DS_Store

    modules/core/file_fetcher.js:74:54:
      74 │       _inflight[url] = prom = (window.VITEST ? import(`../${url}`) : fetch(url))
         ╵                                                       ~~~~~~~~~~~

3 errors
/Users/fmc/Development/OSM/iD/node_modules/esbuild/lib/main.js:1467
  let error = new Error(text);
              ^

Error: Build failed with 3 errors:
modules/core/file_fetcher.js:74:54: ERROR: No loader is configured for ".DS_Store" files: modules/.DS_Store
modules/core/file_fetcher.js:74:54: ERROR: No loader is configured for ".DS_Store" files: modules/core/.DS_Store
modules/core/file_fetcher.js:74:54: ERROR: No loader is configured for ".DS_Store" files: modules/ui/.DS_Store
    at failureErrorWithLog (/Users/fmc/Development/OSM/iD/node_modules/esbuild/lib/main.js:1467:15)
    at /Users/fmc/Development/OSM/iD/node_modules/esbuild/lib/main.js:926:25
    at /Users/fmc/Development/OSM/iD/node_modules/esbuild/lib/main.js:878:52
    at buildResponseToResult (/Users/fmc/Development/OSM/iD/node_modules/esbuild/lib/main.js:924:7)
    at /Users/fmc/Development/OSM/iD/node_modules/esbuild/lib/main.js:936:9
    at new Promise (<anonymous>)
    at requestCallbacks.on-end (/Users/fmc/Development/OSM/iD/node_modules/esbuild/lib/main.js:935:54)
    at handleRequest (/Users/fmc/Development/OSM/iD/node_modules/esbuild/lib/main.js:628:17)
    at handleIncomingPacket (/Users/fmc/Development/OSM/iD/node_modules/esbuild/lib/main.js:653:7)
    at Socket.readFromStdout (/Users/fmc/Development/OSM/iD/node_modules/esbuild/lib/main.js:581:7) {
  errors: [Getter/Setter],
  warnings: [Getter/Setter]
}

Node.js v22.13.1
ERROR: "build:js" exited with 1.
ERROR: "build" exited with 1.
```

Cursor + ChatGPT-5 came up with the solution in the first commit.
Martin found a simpler solution in the second commit.

Another part of this 
> `window.VITEST` is defined as `false` in both configs to ensure the test-only dynamic import branch is not considered during production bundling. This is a safeguard; the core ignore still handles `.DS_Store` robustly.

Don't know if that is actually helpful or not.