### PR TITLE
Add dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 
 # unreleased (v2.36.0-dev)
 
+#### :mega: Release Highlights
+* Add dark mode theme ([#8214], thanks [@hlfan]!)
 #### :sparkles: Usability & Accessibility
 * use `addr:` tags to label features with no name ([#8440], thanks [@k-yle])
 * The flip operation now works on nodes with no `direction` tag, to support quickly adding `direction` to features like traffic signs ([#9317], thanks [@k-yle])
@@ -76,6 +78,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Configure preview deployments for Pull Requests ([#11332], thanks [@k-yle])
 
 [#7629]: https://github.com/openstreetmap/iD/pull/7629
+[#8214]: https://github.com/openstreetmap/iD/issues/8214
 [#8440]: https://github.com/openstreetmap/iD/pull/8440
 [#9317]: https://github.com/openstreetmap/iD/issues/9317
 [#9511]: https://github.com/openstreetmap/iD/pull/9511

--- a/css/10_colors.css
+++ b/css/10_colors.css
@@ -1,0 +1,57 @@
+.ideditor {
+    --bg-color: #fff; /* ~Bootstrap .bg-body */
+    --bg-color-2: #f6f6f6; /* ~Bootstrap .bg-body-tertiary */
+    --bg-color-3: #ececec; /* ~Bootstrap .bg-body-secondary */
+    --active-bg-color: #f1f1f1; /* in the middle between --bg-color-2 and --bg-color-3 */
+    --border-color: #ccc; /* ~Bootstrap .border-secondary-subtle */
+    --transparent-border-color: #cccccc94; /* --border-color with alpha value to match rgba(0, 0, 0, .1) over --bg-color-2 */
+    --border-color-2: #ddd; /* mix 66% of --border-color with white */
+    --outset-color: #fcfcfc; /* brighter than --border-color with white */
+    --shadow-color: #bbb; /* mix 91.5% of --border-color with black */
+    --text-color: #333;
+    --muted-text-color: #aaa;
+    --passive-bg-color: #cccccc; /* = --border-color */
+    --passive-text-color: #888;
+    --widget-color: #222;
+    --widget-bg-color: #eee;
+    --nested-bg-color: #eff2f7;
+    --nested-highlight-color: #e3e8ef;
+    --nested-border-color: #ccd5e3;
+    --selected-bg-color: #e8ebff;
+    --warning-bg-color: #ffc; /* mix 60% of --warning-label-color with white */
+    --warning-label-color: #ffa;
+    --warning-highlight-color: #ff8; /* ~saturate(1.5) of --warning-label-color */
+    --warning-border-color: #fb2;
+    --warning-text-color: #b15500;
+    --warning-highlight-text-color: #7f3d00;
+    --warning-icon-color: #f90;
+}
+
+@media (prefers-color-scheme: dark) {
+    .ideditor {
+        --bg-color: #212529;
+        --bg-color-2: #2b3035;
+        --bg-color-3: #343a40;
+        --active-bg-color: #30353b;
+        --passive-bg-color: #41464b;
+        --border-color: #41464b;
+        --transparent-border-color: #41464b94;
+        --border-color-2: #2b2e32;
+        --outset-color: #54595d;
+        --shadow-color: #3b4045;
+        --text-color: #dee2e6;
+        --muted-text-color: #6e7276;
+        --widget-color: #e9ecef;
+        --widget-bg-color: #31373c;
+        --nested-bg-color: #2d2e33;
+        --nested-highlight-color: #33363b;
+        --nested-border-color: #3e434e;
+        --selected-bg-color: #3b3c49;
+        --warning-bg-color: #332701;
+        --warning-label-color: #554102;
+        --warning-highlight-color: #5f4100;
+        --warning-border-color: #7e3b00;
+        --warning-text-color: #e98c38;
+        --warning-highlight-text-color: #f0ac71;
+    }
+}

--- a/css/10_colors.css
+++ b/css/10_colors.css
@@ -1,4 +1,5 @@
 .ideditor {
+    color-scheme: light;
     --bg-color: #fff; /* ~Bootstrap .bg-body */
     --bg-color-2: #f6f6f6; /* ~Bootstrap .bg-body-tertiary */
     --bg-color-3: #ececec; /* ~Bootstrap .bg-body-secondary */
@@ -62,6 +63,7 @@
 
 @media (prefers-color-scheme: dark) {
     .ideditor {
+        color-scheme: dark;
         --bg-color: #212529;
         --bg-color-2: #2b3035;
         --bg-color-3: #343a40;

--- a/css/10_colors.css
+++ b/css/10_colors.css
@@ -3,6 +3,8 @@
     --bg-color-2: #f6f6f6; /* ~Bootstrap .bg-body-tertiary */
     --bg-color-3: #ececec; /* ~Bootstrap .bg-body-secondary */
     --active-bg-color: #f1f1f1; /* in the middle between --bg-color-2 and --bg-color-3 */
+    --transparent-bg-color: #fffc;
+    --transparent-button-color: #fff4;
     --border-color: #ccc; /* ~Bootstrap .border-secondary-subtle */
     --transparent-border-color: #cccccc94; /* --border-color with alpha value to match rgba(0, 0, 0, .1) over --bg-color-2 */
     --border-color-2: #ddd; /* mix 66% of --border-color with white */
@@ -10,6 +12,8 @@
     --shadow-color: #bbb; /* mix 91.5% of --border-color with black */
     --text-color: #333;
     --muted-text-color: #aaa;
+    --transparent-text-color: #2223;
+    --transparent-text-emphasis-color: #0007;
     --passive-bg-color: #cccccc; /* = --border-color */
     --passive-text-color: #888;
     --widget-color: #222;
@@ -18,6 +22,27 @@
     --nested-highlight-color: #e3e8ef;
     --nested-border-color: #ccd5e3;
     --selected-bg-color: #e8ebff;
+
+    --bg-filter: none;
+    --mix-blend-mode: normal;
+    --bg-blend-mode: normal;
+
+    --valid-bg-color: #cfc;
+    --valid-label-color: #afa;
+    --valid-highlight-color: #8f8;
+    --valid-border-color: #2f2;
+    --valid-text-color: #0b0;
+    --valid-highlight-text-color: #080;
+    --valid-icon-color: #0f0;
+
+    --suggestion-bg-color: #cef;
+    --suggestion-label-color: #adf;
+    --suggestion-highlight-color: #8cf;
+    --suggestion-border-color: #29f;
+    --suggestion-text-color: #05b;
+    --suggestion-highlight-text-color: #038;
+    --suggestion-icon-color: #07f;
+
     --warning-bg-color: #ffc; /* mix 60% of --warning-label-color with white */
     --warning-label-color: #ffa;
     --warning-highlight-color: #ff8; /* ~saturate(1.5) of --warning-label-color */
@@ -25,6 +50,14 @@
     --warning-text-color: #b15500;
     --warning-highlight-text-color: #7f3d00;
     --warning-icon-color: #f90;
+
+    --error-bg-color: #fcc;
+    --error-label-color: #faa;
+    --error-highlight-color: #f88;
+    --error-border-color: #f22;
+    --error-text-color: #a00;
+    --error-highlight-text-color: #800;
+    --error-icon-color: #f00;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -34,6 +67,8 @@
         --bg-color-3: #343a40;
         --active-bg-color: #30353b;
         --passive-bg-color: #41464b;
+        --transparent-bg-color: #111c;
+        --transparent-button-color: #3338;
         --border-color: #41464b;
         --transparent-border-color: #41464b94;
         --border-color-2: #2b2e32;
@@ -41,17 +76,45 @@
         --shadow-color: #3b4045;
         --text-color: #dee2e6;
         --muted-text-color: #6e7276;
+        --transparent-text-color: #eee3;
+        --transparent-text-emphasis-color: #fff7;
         --widget-color: #e9ecef;
         --widget-bg-color: #31373c;
         --nested-bg-color: #2d2e33;
         --nested-highlight-color: #33363b;
         --nested-border-color: #3e434e;
         --selected-bg-color: #3b3c49;
+
+        --bg-filter: invert();
+        --mix-blend-mode: screen;
+        --bg-blend-mode: difference;
+
+        --valid-bg-color: #030;
+        --valid-label-color: #050;
+        --valid-highlight-color: #060;
+        --valid-border-color: #080;
+        --valid-text-color: #3e3;
+        --valid-highlight-text-color: #6e6;
+
+        --suggestion-bg-color: #023;
+        --suggestion-label-color: #047;
+        --suggestion-highlight-color: #036;
+        --suggestion-border-color: #06d;
+        --suggestion-text-color: #38e;
+        --suggestion-highlight-text-color: #6ae;
+
         --warning-bg-color: #332701;
         --warning-label-color: #554102;
         --warning-highlight-color: #5f4100;
         --warning-border-color: #7e3b00;
         --warning-text-color: #e98c38;
         --warning-highlight-text-color: #f0ac71;
+
+        --error-bg-color: #300;
+        --error-label-color: #500;
+        --error-highlight-color: #600;
+        --error-border-color: #800;
+        --error-text-color: #e33;
+        --error-highlight-text-color: #e66;
     }
 }

--- a/css/10_colors.css
+++ b/css/10_colors.css
@@ -25,6 +25,8 @@
     --nested-highlight-color: #e3e8ef;
     --nested-border-color: #ccd5e3;
     --selected-bg-color: #e8ebff;
+    --dark-tooltip-text-color: #fff;
+    --dark-tooltip-bg-color: #444;
 
     --bg-filter: none;
     --mix-blend-mode: normal;
@@ -90,6 +92,8 @@
         --nested-highlight-color: #33363b;
         --nested-border-color: #3e434e;
         --selected-bg-color: #3b3c49;
+        --dark-tooltip-text-color: #ccc;
+        --dark-tooltip-bg-color: #000;
 
         --bg-filter: invert();
         --mix-blend-mode: screen;

--- a/css/10_colors.css
+++ b/css/10_colors.css
@@ -75,7 +75,7 @@
         --transparent-button-color: #3338;
         --border-color: #41464b;
         --transparent-border-color: #41464b94;
-        --border-color-2: #2b2e32;
+        --border-color-2: #32363b;
         --outset-color: #54595d;
         --shadow-color: #3b4045;
         --text-color: #dee2e6;

--- a/css/10_colors.css
+++ b/css/10_colors.css
@@ -12,6 +12,8 @@
     --outset-color: #fcfcfc; /* brighter than --border-color with white */
     --shadow-color: #bbb; /* mix 91.5% of --border-color with black */
     --text-color: #333;
+    --link-color: #7092ff;
+    --link-focus-color: #597be7;
     --muted-text-color: #aaa;
     --transparent-text-color: #2223;
     --transparent-text-emphasis-color: #0007;
@@ -77,6 +79,8 @@
         --outset-color: #54595d;
         --shadow-color: #3b4045;
         --text-color: #dee2e6;
+        --link-color: #7b92db;
+        --link-focus-color: #7e9cff;
         --muted-text-color: #6e7276;
         --transparent-text-color: #eee3;
         --transparent-text-emphasis-color: #fff7;

--- a/css/60_photos.css
+++ b/css/60_photos.css
@@ -25,7 +25,7 @@ li.list-item-photos.active:after {
     width: 330px;
     height: 250px;
     padding: 5px;
-    background-color: #fff;
+    background-color: var(--bg-color);
 }
 .ideditor[dir='ltr'] .photoviewer {
     margin-left: 10px;

--- a/css/60_photos.css
+++ b/css/60_photos.css
@@ -696,7 +696,7 @@ label.streetside-hires {
     filter: invert(1);
 }
 .local-photos label.button {
-    background: #7092ff;
+    background: var(--link-color);
     color: #fff;
     font-weight: bold;
     padding: 10px 25px;

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -5701,25 +5701,25 @@ button.conflicts-button {
 .map-pane .tooltip.top .popover-arrow,
 .sidebar .tooltip.top .popover-arrow,
 .modal .tooltip.top .popover-arrow {
-    border-top-color: #000;
+    border-top-color: var(--dark-tooltip-bg-color);
 }
 .tooltip.dark.bottom .popover-arrow,
 .map-pane .tooltip.bottom .popover-arrow,
 .sidebar .tooltip.bottom .popover-arrow,
 .modal .tooltip.bottom .popover-arrow {
-    border-bottom-color: #000;
+    border-bottom-color: var(--dark-tooltip-bg-color);
 }
 .tooltip.dark.left .popover-arrow,
 .map-pane .tooltip.left .popover-arrow,
 .sidebar .tooltip.left .popover-arrow,
 .modal .tooltip.left .popover-arrow {
-    border-left-color: #000;
+    border-left-color: var(--dark-tooltip-bg-color);
 }
 .tooltip.dark.right .popover-arrow,
 .map-pane .tooltip.right .popover-arrow,
 .sidebar .tooltip.right .popover-arrow,
 .modal .tooltip.right .popover-arrow {
-    border-right-color: #000;
+    border-right-color: var(--dark-tooltip-bg-color);
 }
 .tooltip.dark .popover-inner,
 .tooltip.dark .tooltip-heading,
@@ -5731,8 +5731,8 @@ button.conflicts-button {
 .sidebar .tooltip-heading,
 .sidebar .keyhint-wrap,
 .modal .popover-inner {
-    background: #000;
-    color: #ccc;
+    background: var(--dark-tooltip-bg-color);
+    color: var(--dark-tooltip-text-color);
 }
 .tooltip.dark kbd,
 .map-pane .tooltip kbd,

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -2509,11 +2509,10 @@ div.combobox {
     right: 20px;
     margin: 5px;
     padding: 8px;
-    border: 1px solid #ccc;
-    border-top: 0;
-    border-radius: 0 0 4px 4px;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
     z-index: 20;
-    background: rgba(255,255,255,0.95);
+    background: var(--transparent-bg-color);
     box-shadow: 0 0 30px 5px rgba(0,0,0,.4);
 }
 
@@ -2524,8 +2523,8 @@ div.combobox {
 }
 .field-help-title button {
     width: 45px;
-    height: 55px;
-    border-radius: 0;
+    height: 45px;
+    border-radius: 0 5px 0 0;
 }
 
 .field-help-nav {

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -1777,7 +1777,7 @@ input.date-selector {
     padding: 0px 5px 0px 5px;
     margin: 0;
     cursor: pointer;
-    color: #a6b4ce;
+    color: var(--muted-text-color);
     display: block;
     text-align: center;
     flex: 0 0 auto;
@@ -2317,7 +2317,6 @@ input.date-selector {
 
 .form-field-input-restrictions .restriction-container {
     position: relative;
-    color: #333;
     height: 370px;
 }
 /* zero width space, so container takes up space */
@@ -2536,7 +2535,7 @@ div.combobox {
     display: inline-block;
     padding: 5px 10px;
     cursor: pointer;
-    color: #666;
+    color: var(--text-color);
 }
 .field-help-nav-item.active {
     color: var(--link-color);

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -219,8 +219,8 @@ input:focus {
 
 textarea.disabled,
 input.disabled {
-    color: #777;
-    background-color: #eee;
+    color: var(--passive-text-color);
+    background-color: var(--bg-color-3);
     cursor: not-allowed;
 }
 
@@ -260,7 +260,7 @@ textarea.mixed::placeholder {
 
 /* tables */
 table {
-    background-color: #fff;
+    background-color: var(--bg-color);
     border-collapse: collapse;
     width: 100%;
     border-spacing: 0;
@@ -269,7 +269,7 @@ table th {
     text-align: left;
 }
 table.tags, table.tags td, table.tags th {
-    border: 1px solid #ccc;
+    border: 1px solid var(--border-color);
     padding: 4px;
 }
 
@@ -323,13 +323,15 @@ li.hide {
 }
 
 .deemphasize {
-    color: #a9a9a9;
+    color: var(--muted-text-color);
 }
 .content {
     box-shadow: 0 0 30px 0 rgba(0, 0, 0, 0.25);
 }
-.loading {
-    background: url(img/loader_bg.gif);
+.loading.loading {
+    background-color: #aaa;
+    background-blend-mode: var(--bg-blend-mode);
+    background-image: url(img/loader_bg.gif);
     background-size: 5px 5px;
 }
 
@@ -361,12 +363,12 @@ button.active {
     background: #7092ff;
 }
 button.disabled {
-    background-color: rgba(255,255,255,.25);
-    color: rgba(0,0,0,.4);
+    background-color: var(--transparent-button-color);
+    color: var(--transparent-text-emphasis-color);
     cursor: not-allowed;
 }
 button.disabled .icon {
-    fill: rgba(0,0,0,.4);
+    fill: var(--transparent-text-emphasis-color);
 }
 
 .joined > * {
@@ -379,7 +381,7 @@ button.disabled .icon {
 }
 
 .fillL .joined > * {
-    border-right: 1px solid #fff;
+    border-right: 1px solid var(--bg-color);
 }
 .joined > *:first-child {
     border-radius: 4px 0 0 4px;
@@ -452,13 +454,13 @@ button.secondary-action {
 }
 
 .icon.operation use {
-    fill: #222;
+    fill: var(--widget-color);
     color: #79f;
 }
 button.disabled .icon.operation use,
 .icon.operation.disabled use {
-    fill: rgba(32,32,32,.2);
-    color: rgba(40,40,40,.2);
+    fill: var(--transparent-text-color);
+    color: var(--transparent-text-color);
 }
 
 .icon.monochrome use {
@@ -636,7 +638,7 @@ button.add-note svg.icon {
     height: 15px;
     width: 15px;
     color: rgba(0,0,0,0.25);
-    stroke: #333;
+    stroke: var(--text-color);
     stroke-width: 60px;
     margin-top: 3px;
 }
@@ -770,8 +772,8 @@ button.add-note svg.icon {
     bottom: 0;
     margin: 0;
     padding: 0 15px;
-    border-top: 1px solid #ccc;
-    background-color: #f6f6f6;
+    border-top: 1px solid var(--border-color);
+    background-color: var(--bg-color-2);
     width: 100%;
     height: 2.5em;
     z-index: 1;
@@ -1020,7 +1022,7 @@ a.hide-toggle {
     }
 }
 .feature-list-item .entity-name {
-    color: #666;
+    color: var(--passive-text-color);
     padding-left: 10px;
 }
 .ideditor[dir='rtl'] .feature-list-item .entity-name {
@@ -1028,7 +1030,7 @@ a.hide-toggle {
     padding-right: 10px;
 }
 .section-selected-features .feature-list {
-    border: 1px solid #ccc;
+    border: 1px solid var(--border-color);
     border-radius: 4px;
     overflow: hidden;
     margin-top: 5px;
@@ -1081,7 +1083,7 @@ a.hide-toggle {
 }
 
 .preset-list.filtered .preset-list-item:first-child .preset-list-button {
-    background: #ececec;
+    background: var(--bg-color-3);
 }
 
 .preset-icon-container {
@@ -1174,8 +1176,8 @@ a.hide-toggle {
 
 .preset-icon-fill-vertex circle {
     stroke-width: 1.5px;
-    stroke: #333;
-    fill: #efefef;
+    stroke: var(--text-color);
+    fill: var(--bg-color-3);
     backface-visibility: hidden;
 }
 
@@ -1261,8 +1263,8 @@ button.preset-reset .label.flash-bg {
     animation: flash-bg 750ms;
 }
 @keyframes flash-bg {
-    0% { background-color: #fff; }
-    100% { background-color: #f6f6f6; }
+    0% { background-color: var(--bg-color); }
+    100% { background-color: var(--bg-color-2); }
 }
 
 .preset-list-button .label-inner {
@@ -1467,7 +1469,7 @@ button.preset-reset .label.flash-bg {
 }
 .field-label .icon {
     opacity: .5;
-
+    fill: var(--text-color);
 }
 
 .field-label .modified-icon,
@@ -1536,14 +1538,14 @@ button.preset-reset .label.flash-bg {
     }
 }
 .form-field-button .icon {
-    fill: #333;
+    fill: var(--text-color);
     opacity: .5;
 }
 .form-field-button.colour-preview {
     border-radius: 0 0 4px 0;
 }
 .form-field-button.colour-preview > div.colour-box {
-    border: 3px solid #fff;
+    border: 3px solid var(--bg-color);
     height: 100%;
     border-radius: 8px;
     cursor: pointer;
@@ -1552,15 +1554,15 @@ button.preset-reset .label.flash-bg {
     padding: 1px 0 0 1px;
 }
 .inspector-hover .form-field-button.colour-preview > div.colour-box {
-    border-color: #ececec;
+    border-color: var(--bg-color-3);
 }
 .form-field-button.colour-preview:active > div.colour-box,
 .form-field-button.colour-preview:focus > div.colour-box {
-    border-color: #f1f1f1;
+    border-color: var(--active-bg-color);
 }
 @media (hover: hover) {
     .form-field-button.colour-preview:hover > div.colour-box {
-        border-color: #f1f1f1;
+        border-color: var(--active-bg-color);
     }
 }
 input.colour-selector {
@@ -1723,8 +1725,8 @@ input.date-selector {
 }
 
 .form-field-input-multicombo li.chip {
-    background-color: #eff2f7;
-    border: 1px solid #ccd5e3;
+    background-color: var(--nested-bg-color);
+    border: 1px solid var(--nested-border-color);
     max-width: 100%;
     color: #7092ff;
 }
@@ -1752,11 +1754,11 @@ input.date-selector {
 }
 .form-field-input-multicombo li.chip.raw-value {
     font-family: monospace;
-    color: #333;
+    color: var(--text-color);
 }
 .form-field-input-multicombo li.mixed {
-    border-color: #eff2f7;
-    color: #888;
+    border-color: var(--nested-bg-color);
+    color: var(--passive-text-color);
     font-style: italic;
 }
 
@@ -1932,12 +1934,12 @@ input.date-selector {
     margin: auto;
 }
 .form-field-input-number button.decrement::after {
-    border-top: 5px solid #ccc;
+    border-top: 5px solid var(--border-color);
     border-left: 5px solid transparent;
     border-right: 5px solid transparent;
 }
 .form-field-input-number button.increment::after {
-    border-bottom: 5px solid #ccc;
+    border-bottom: 5px solid var(--border-color);
     border-left: 5px solid transparent;
     border-right: 5px solid transparent;
 }
@@ -2125,8 +2127,8 @@ input.date-selector {
 .form-field-input-localized input.localized-main.disabled,
 .form-field-input-localized input.localized-lang.disabled,
 .form-field-input-localized input.localized-value.disabled {
-    color: #777;
-    background-color: #eee;
+    color: var(--passive-text-color);
+    background-color: var(--bg-color-3);
     cursor: not-allowed;
 }
 
@@ -2271,16 +2273,16 @@ input.date-selector {
 ------------------------------------------------------- */
 .form-field-input-restrictions {
     display: block;
-    border: 1px solid #ccc;
+    border: 1px solid var(--passive-bg-color);
     border-top: 0;
     border-radius: 0 0 4px 4px;
 }
 
 .form-field-input-restrictions .restriction-controls-container {
-    background-color: #fff;
+    background-color: var(--bg-color);
     width: 100%;
     padding: 5px;
-    border-top: 1px solid #ccc;
+    border-top: 1px solid var(--border-color);
     border-radius: 0 0 4px 4px;
 }
 
@@ -2315,6 +2317,7 @@ input.date-selector {
 
 .form-field-input-restrictions .restriction-container {
     position: relative;
+    color: #333;
     height: 370px;
 }
 /* zero width space, so container takes up space */
@@ -2334,8 +2337,8 @@ input.date-selector {
     left: 0;
     right: 0;
     padding: 2px 6px;
-    background-color: rgba(255, 255, 255, .8);
-    color: #888;
+    background-color: var(--transparent-bg-color);
+    color: var(--passive-text-color);
     text-align: center;
     pointer-events: none;
     user-select: none;
@@ -2444,19 +2447,19 @@ div.combobox {
     position: absolute;
     left: 0; right: 0; bottom: 0; top: 0;
     margin: auto;
-    border-top: 5px solid #ccc;
+    border-top: 5px solid var(--border-color);
     border-left: 5px solid transparent;
     border-right: 5px solid transparent;
 }
 
 .combobox .combobox-option.raw-option {
     font-family: monospace;
-    color: #333;
+    color: var(--text-color);
 }
 
 .combobox .combobox-option.virtual-option {
     font-style: italic;
-    color: #333;
+    color: var(--text-color);
 }
 
 .form-field-input-wrap {
@@ -2645,23 +2648,23 @@ div.combobox {
 button.raw-tag-option {
     flex: 0 0 auto;
     padding: 3px;
-    background: #aaa;
-    color: #eee;
+    background: var(--muted-text-color);
+    color: var(--bg-color-3);
     margin: 0 3px;
 }
 button.raw-tag-option:focus,
 button.raw-tag-option.active {
-    color: #fff;
+    color: var(--bg-color);
     background: #597be7;
 }
 @media (hover: hover) {
     button.raw-tag-option:hover {
-        color: #fff;
+        color: var(--bg-color);
         background: #597be7;
     }
 }
 button.raw-tag-option.selected {
-    color: #fff;
+    color: var(--bg-color);
     background: #7092ff;
 }
 button.raw-tag-option svg.icon {
@@ -2708,8 +2711,8 @@ button.raw-tag-option svg.icon {
 .tag-row.readonly input.key,
 .tag-row.readonly input.value,
 .tag-row.readonly button.remove {
-    color: #777;
-    background-color: #eee;
+    color: var(--passive-text-color);
+    background-color: var(--bg-color-3);
     cursor: not-allowed;
 }
 
@@ -2804,7 +2807,7 @@ button.raw-tag-option svg.icon {
 
 /* Tag reference */
 .tag-reference-loading {
-    background-color: #f5f5f5;
+    background-color: var(--bg-color-2);
 }
 .tag-reference-loading .icon {
     background-image: url(img/mini-loader.gif);
@@ -2853,14 +2856,14 @@ img.tag-reference-wiki-image {
     width: 100%;
 }
 .raw-tag-editor .tag-row.readonly .tag-reference-body {
-    background: #f6f6f6;
-    color: #333;
+    background: var(--bg-color-2);
+    color: var(--text-color);
 }
 .raw-tag-editor .tag-row:not(:last-child) .tag-reference-body.expanded {
-    border-bottom: 1px solid #ccc;
+    border-bottom: 1px solid var(--border-color);
 }
 .raw-tag-editor .tag-row.readonly .tag-reference-body.expanded {
-    border-top: 1px solid #ccc;
+    border-top: 1px solid var(--border-color);
 }
 
 
@@ -3171,27 +3174,27 @@ img.tag-reference-wiki-image {
 /* Custom Data Editor
 ------------------------------------------------------- */
 .data-header {
-    background-color: #f6f6f6;
+    background-color: var(--bg-color-2);
     border-radius: 5px;
-    border: 1px solid #ccc;
+    border: 1px solid var(--border-color);
     display: flex;
     flex-flow: row nowrap;
     align-items: center;
 }
 
 .data-header-icon {
-    background-color: #fff;
+    background-color: var(--bg-color);
     padding: 10px;
     flex: 0 0 auto;
     position: relative;
     width: 60px;
     height: 60px;
-    border-right: 1px solid #ccc;
+    border-right: 1px solid var(--border-color);
     border-radius: 5px 0 0 5px;
 }
 .ideditor[dir='rtl'] .data-header-icon {
     border-right: unset;
-    border-left: 1px solid #ccc;
+    border-left: 1px solid var(--border-color);
     border-radius: 0 5px 5px 0;
 }
 
@@ -3201,7 +3204,7 @@ img.tag-reference-wiki-image {
 }
 
 .data-header-label {
-    background-color: #f6f6f6;
+    background-color: var(--bg-color-2);
     padding: 0 15px;
     flex: 1 1 100%;
     font-size: 14px;
@@ -3568,7 +3571,7 @@ div.full-screen > button:focus {
 }
 .ideditor[dir='rtl'] .issue-label .issue-info-button {
     border-left: 0;
-    border-right: 1px solid #ccc;
+    border-right: 1px solid var(--border-color);
 }
 .issue-container .issue-label .issue-info-button .icon {
     opacity: 0.5;
@@ -3626,49 +3629,49 @@ button.autofix.action.active {
 .suggestions-list *,
 .issue-container.active .issue.severity-suggestion,
 .issue-container.active .issue.severity-suggestion * {
-    border-color: #2f7eff;
+    border-color: var(--suggestion-border-color);
 }
 .suggestions-list .issue.severity-suggestion .issue-label,
 .issue.severity-suggestion .issue-fix-list,
 .suggestion-section {
-    background: #e1effe;
+    background: var(--suggestion-bg-color);
 }
 
 .issue-container.active .issue.severity-suggestion .issue-label {
-    background: #e1effe;
+    background: var(--suggestion-label-color);
 }
 
 .issue.severity-suggestion .issue-icon {
-    color: #49f;
+    color: var(--suggestion-icon-color);
 }
 
 .issue.severity-suggestion .issue-fix-item button.actionable,
 .issue-container.active .issue.severity-suggestion .issue-info-button {
-    color: #0066cc;
-    fill: #0066cc;
+    color: var(--suggestion-text-color);
+    fill: var(--suggestion-text-color);
 }
 .suggestions-list .issue.severity-suggestion .issue-label:active,
 .suggestions-list .issue.severity-suggestion .issue-label:focus,
 .issue.severity-suggestion .issue-fix-item button.actionable:active,
 .issue.severity-suggestion .issue-fix-item button.actionable:focus {
-    background: #abd5ff;
+    background: var(--suggestion-highlight-color);
 }
 .issue.severity-suggestion .issue-fix-item button.actionable:active,
 .issue.severity-suggestion .issue-fix-item button.actionable:focus,
 .issue-container.active .issue.severity-suggestion .issue-info-button:active,
 .issue-container.active .issue.severity-suggestion .issue-info-button:focus {
-    color: #0066cc;
-    fill: #1f4d82;
+    color: var(--suggestion-highlight-text-color);
+    fill: var(--suggestion-highlight-text-color);
 }
 @media (hover: hover) {
     .suggestions-list .issue.severity-suggestion .issue-label:hover,
     .issue.severity-warning .issue-fix-item button.actionable:hover {
-        background: #bdf;
+        background: var(--suggestion-highlight-color);
     }
     .issue.severity-suggestion .issue-fix-item button.actionable:hover,
     .issue-container.active .issue.severity-suggestion .issue-info-button:hover {
-        color: #1f4d82;
-        fill: #1f4d82;
+        color: var(--suggestion-highlight-text-color);
+        fill: var(--suggestion-highlight-text-color);
     }
 }
 
@@ -3730,49 +3733,49 @@ button.autofix.action.active {
 .errors-list *,
 .issue-container.active .issue.severity-error,
 .issue-container.active .issue.severity-error * {
-    border-color: #f77;
+    border-color: var(--error-border-color);
 }
 
 .errors-list .issue.severity-error .issue-label,
 .issue.severity-error .issue-fix-list,
 .error-section {
-    background: #ffd6d6;
+    background: var(--error-bg-color);
 }
 
 .issue-container.active .issue.severity-error .issue-label {
-    background: #ffc6c6;
+    background: var(--error-label-color);
 }
 
 .issue.severity-error .issue-fix-item button.actionable,
 .issue-container.active .issue.severity-error .issue-info-button {
-    color: #b91201;
-    fill: #b91201;
+    color: var(--error-text-color);
+    fill: var(--error-icon-color);
 }
 .issue.severity-error .issue-icon {
-    color: #dd1400;
+    color: var(--error-icon-color);
 }
 .errors-list .issue.severity-error .issue-label:active,
 .errors-list .issue.severity-error .issue-label:focus,
 .issue.severity-error .issue-fix-item button.actionable:active,
 .issue.severity-error .issue-fix-item button.actionable:focus {
-    background: #ffb6b6;
+    background: var(--error-highlight-color);
 }
 .issue.severity-error .issue-fix-item button.actionable:active,
 .issue.severity-error .issue-fix-item button.actionable:focus,
 .issue-container.active .issue.severity-error .issue-info-button:active,
 .issue-container.active .issue.severity-error .issue-info-button:focus {
-    color: #840c00;
-    fill: #840c00;
+    color: var(--error-highlight-text-color);
+    fill: var(--error-highlight-text-color);
 }
 @media (hover: hover) {
     .errors-list .issue.severity-error .issue-label:hover,
     .issue.severity-error .issue-fix-item button.actionable:hover {
-        background: #ffb6b6;
+        background: var(--error-highlight-color);
     }
     .issue.severity-error .issue-fix-item button.actionable:hover,
     .issue-container.active .issue.severity-error .issue-info-button:hover {
-        color: #840c00;
-        fill: #840c00;
+        color: var(--error-highlight-text-color);
+        fill: var(--error-highlight-text-color);
     }
 }
 
@@ -3822,13 +3825,13 @@ button.autofix.action.active {
 
 .section-issues-status .box {
     border-radius: 4px;
-    border: 1px solid #72d979;
-    background: #c6ffca;
+    border: 1px solid var(--valid-border-color);
+    background: var(--valid-bg-color);
     padding: 5px !important;
     display: flex;
 }
 .section-issues-status .icon {
-    color: #05ac10;
+    color: var(--valid-icon-color);
 }
 
 input.square-degrees-input {
@@ -3942,22 +3945,22 @@ li.issue-fix-item button:not(.actionable) .fix-icon {
 .issue-info .tagDiff-table {
     min-width: 60%;
     width: unset;
-    border: 1px solid #ccc;
+    border: 1px solid var(--border-color);
 }
 .issue-info .tagDiff-row {
-    border: 1px solid #ccc;
+    border: 1px solid var(--border-color);
 }
 .issue-info .tagDiff-cell {
     padding: 2px 10px;
     font-family: monospace;
     font-size: 10px;
-    border: 1px solid #ccc;
+    border: 1px solid var(--border-color);
 }
 .issue-info .tagDiff-cell-add {
-    background: #dfd;
+    background: var(--valid-bg-color);
 }
 .issue-info .tagDiff-cell-remove {
-    background: #fdd;
+    background: var(--error-bg-color);
 }
 
 
@@ -4322,8 +4325,8 @@ li.issue-fix-item button:not(.actionable) .fix-icon {
 }
 
 .inspector-hover .form-field-input-multicombo .chip {
-    background: #eee;
-    border: 1px solid #ccc;
+    background: var(--bg-color-3);
+    border: 1px solid var(--border-color);
 }
 
 /* no scrollbars */
@@ -4426,13 +4429,13 @@ li.issue-fix-item button:not(.actionable) .fix-icon {
 
 /* Show placeholder on hover for radio buttons */
 .inspector-hover .form-field-input-radio {
-    border: 1px solid #ccc;
+    border: 1px solid var(--border-color);
     border-top: 0;
     border-radius: 0 0 4px 4px;
 }
 .inspector-hover .form-field-input-radio .placeholder {
     opacity: 1;
-    color: #666;
+    color: var(--passive-text-color);
     padding: 5px 10px;
     width: 100%;
     height: auto;
@@ -4889,7 +4892,7 @@ img.tile-debug {
 .flash-icon.disabled use,
 .flash-icon.operation.disabled use {
     fill: rgba(32,32,32,0.7);
-    color: rgba(40,40,40,0.7);
+    color: #282828b3;
 }
 
 .flash-text {
@@ -5110,6 +5113,8 @@ img.tile-debug {
 
 .modal .loader {
     margin-bottom: 10px;
+    filter: var(--bg-filter);
+    mix-blend-mode: var(--mix-blend-mode);
 }
 .modal .description {
     text-align: center;
@@ -5233,7 +5238,7 @@ img.tile-debug {
 
 .save-supporting,
 .save-communityLinks {
-    border-top: 1px solid #ccc;
+    border-top: 1px solid var(--border-color);
 }
 
 .save-success table,
@@ -5362,12 +5367,12 @@ img.tile-debug {
 .modal-shortcuts a.tab:focus,
 .modal-shortcuts a.tab:active {
     color: #597be7;
-    background-color: #efefef;
+    background-color: var(--bg-color-3);
 }
 @media (hover: hover) {
     .modal-shortcuts a.tab:hover {
         color: #597be7;
-        background-color: #efefef;
+        background-color: var(--bg-color-3);
     }
 }
 
@@ -5405,11 +5410,11 @@ img.tile-debug {
 }
 
 .modal-shortcuts .shortcut-keys kbd {
-    color: #555;
+    color: var(--text-color);
 }
 
 .modal-shortcuts .shortcut-keys .gesture {
-    color: #333;
+    color: var(--text-color);
     padding: 3px;
 }
 
@@ -5460,8 +5465,8 @@ a.user-info {
 
 .note-save .field-warning,
 .field-warning {
-    background: #ffb;
-    border: 1px solid #ccc;
+    background: var(--warning-bg-color);
+    border: 1px solid var(--border-color);
     border-radius: 4px;
     padding: 10px;
 }
@@ -5514,8 +5519,8 @@ a.user-info {
 ------------------------------------------------------- */
 .conflicts-help {
     padding: 20px;
-    background-color: #ffffbb;
-    border-bottom: 1px solid #ccc;
+    background-color: var(--warning-bg-color);
+    border-bottom: 1px solid var(--border-color);
 }
 
 .conflicts-buttons {
@@ -5527,7 +5532,7 @@ button.conflicts-button {
 }
 
 .conflict-container {
-    border-bottom: 1px solid #ccc;
+    border-bottom: 1px solid var(--border-color);
 }
 
 .conflict-description {
@@ -5717,7 +5722,7 @@ button.conflicts-button {
 
 .tooltip-heading {
     font-weight: bold;
-    background: #f6f6f6;
+    background: var(--bg-color-2);
     padding: 10px;
     margin: -10px -10px 10px -10px;
     border-radius: 3px 3px 0 0;
@@ -5823,7 +5828,7 @@ li.hide + li.version .badge .tooltip .popover-arrow {
     position: absolute;
     display: flex;
     flex-direction: column;
-    background: #fff;
+    background: var(--bg-color);
     border-radius: 4px;
     /* padding is set in edit_menu.js */
 }
@@ -5873,7 +5878,7 @@ li.hide + li.version .badge .tooltip .popover-arrow {
     height: 10px;
     overflow: visible;
     width: 10px;
-    border-left: 1px solid #DDD;
+    border-left: 1px solid var(--border-color-2);
 }
 
 ::-webkit-scrollbar-track {
@@ -5961,7 +5966,7 @@ li.hide + li.version .badge .tooltip .popover-arrow {
 }
 @keyframes pulse {
     from  { background: #7092ff; }
-    to    { background: #c6d4ff; }
+    to    { background: var(--suggestion-label-color); }
 }
 
 .intro-nav-wrap button.chapter.finished {

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -5313,7 +5313,7 @@ img.tile-debug {
     padding: 5px 10px;
     margin: 0 5px;
     cursor: pointer;
-    color: #666;
+    color: var(--text-color);
     font-size: 16px;
     font-weight: bold;
 }
@@ -5358,7 +5358,6 @@ img.tile-debug {
 
 .modal-shortcuts .shortcut-keys {
     padding: 0 10px;
-    color: #767676;
     text-align: right;
     white-space: nowrap;
 }
@@ -5366,12 +5365,7 @@ img.tile-debug {
     text-align: left;
 }
 
-.modal-shortcuts .shortcut-keys kbd {
-    color: var(--text-color);
-}
-
 .modal-shortcuts .shortcut-keys .gesture {
-    color: var(--text-color);
     padding: 3px;
 }
 

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -138,14 +138,14 @@ strong {
 a,
 a:visited,
 a:active {
-    color: #7092ff;
+        color: var(--link-color);
 }
 a:focus {
-    color: #597be7;
+    color: var(--link-focus-color);
 }
 @media (hover: hover) {
     a:hover {
-        color: #597be7;
+        color: var(--link-focus-color);
     }
 }
 kbd {
@@ -360,7 +360,7 @@ button.hover {
     }
 }
 button.active {
-    background: #7092ff;
+    background: var(--link-color);
 }
 button.disabled {
     background-color: var(--transparent-button-color);
@@ -400,13 +400,13 @@ button.disabled .icon {
 
 /* Action buttons */
 button.action {
-    background: #7092ff;
+    background: var(--link-color);
     color: #fff;
     font-weight: bold;
 }
 button.action:focus,
 button.action:active {
-    background: #597be7;
+    background: var(--link-focus-color);
 }
 button.secondary-action {
     background: var(--bg-color-3);
@@ -431,7 +431,7 @@ button.secondary-action {
 
 @media (hover: hover) {
     button.action:hover {
-        background: #597be7;
+        background: var(--link-focus-color);
     }
     button.secondary-action:hover {
         background: var(--passive-bg-color);
@@ -1009,16 +1009,16 @@ a.hide-toggle {
     opacity: 0.5;
 }
 .feature-list-item .entity-type {
-    color: #7092ff;
+    color: var(--link-color);
     font-weight: bold;
 }
 .feature-list-item:active .entity-type,
 .feature-list-item:focus .entity-type {
-    color: #597be7;
+    color: var(--link-focus-color);
 }
 @media (hover: hover) {
     .feature-list-item:hover .entity-type {
-        color: #597be7;
+        color: var(--link-focus-color);
     }
 }
 .feature-list-item .entity-name {
@@ -1699,7 +1699,7 @@ input.date-selector {
 .form-field-input-combo input.known-value,
 .form-field-input-semicombo input.known-value,
 .form-field-input-multicombo input.known-value {
-    color: #7092ff;
+    color: var(--link-color);
 }
 
 .form-field-input-multicombo ul.chiplist {
@@ -1728,7 +1728,7 @@ input.date-selector {
     background-color: var(--nested-bg-color);
     border: 1px solid var(--nested-border-color);
     max-width: 100%;
-    color: #7092ff;
+    color: var(--link-color);
 }
 .form-field-input-multicombo li.chip.negated span {
     text-decoration: line-through;
@@ -1952,7 +1952,7 @@ input.date-selector {
     align-items: center;
     background: var(--bg-color);
     padding: 5px 10px;
-    color: #7092ff;
+    color: var(--link-color);
     border: 1px solid var(--border-color);
     border-top: 0;
     cursor: pointer;
@@ -2025,7 +2025,7 @@ input.date-selector {
     width: 100%;
     padding: 5px 10px;
     background-color: var(--bg-color);
-    color: #7092ff;
+    color: var(--link-color);
     cursor: pointer;
 }
 .form-field-input-radio > label.mixed {
@@ -2486,7 +2486,7 @@ div.combobox {
     left: 0;
     right: 0;
     height: 4px;
-    background-color: #7092ff;
+    background-color: var(--link-color);
     border-right-style: solid;
     border-right-color: lightgray;
 }
@@ -2540,17 +2540,17 @@ div.combobox {
     color: #666;
 }
 .field-help-nav-item.active {
-    color: #7092ff;
+    color: var(--link-color);
     border-bottom: 2px solid;
 }
 .field-help-nav-item:active,
 .field-help-nav-item:focus {
-    color: #597be7;
+    color: var(--link-focus-color);
     background-color: #efefef;
 }
 @media (hover: hover) {
     .field-help-nav-item:hover {
-        color: #597be7;
+        color: var(--link-focus-color);
         background-color: #efefef;
     }
 }
@@ -2655,17 +2655,17 @@ button.raw-tag-option {
 button.raw-tag-option:focus,
 button.raw-tag-option.active {
     color: var(--bg-color);
-    background: #597be7;
+    background: var(--link-focus-color);
 }
 @media (hover: hover) {
     button.raw-tag-option:hover {
         color: var(--bg-color);
-        background: #597be7;
+        background: var(--link-focus-color);
     }
 }
 button.raw-tag-option.selected {
     color: var(--bg-color);
-    background: #7092ff;
+    background: var(--link-color);
 }
 button.raw-tag-option svg.icon {
     width: 14px;
@@ -3308,14 +3308,14 @@ img.tag-reference-wiki-image {
 }
 .map-control > button.active,
 .map-control > button.active:active {
-    background: #7092ff;
+    background: var(--link-color);
 }
 @media (hover: hover) {
     .map-control > button:not(.disabled):hover {
         background: rgba(0, 0, 0, .8);
     }
     .map-control > button.active:hover {
-        background: #7092ff;
+        background: var(--link-color);
     }
 }
 
@@ -3414,7 +3414,7 @@ div.full-screen > button:focus {
 
 .layer-list > li {
     background-color: var(--bg-color);
-    color: #7092ff;
+    color: var(--link-color);
     position: relative;
     display: flex;
 }
@@ -3590,17 +3590,17 @@ button.autofix.action {
     flex: 0 0 20px;
     height: 20px;
     width: 20px;
-    background: #7092ff;
+    background: var(--link-color);
     color: #fff;
 }
 button.autofix.action:focus,
 button.autofix.action:active,
 button.autofix.action.active {
-    background: #597be7;
+    background: var(--link-focus-color);
 }
 @media (hover: hover) {
     button.autofix.action:hover {
-        background: #597be7;
+        background: var(--link-focus-color);
     }
 }
 
@@ -4735,7 +4735,7 @@ img.tile-debug {
 
 .panel-content .button {
     display: inline-block;
-    background: #7092ff;
+    background: var(--link-color);
     border-radius: 2px;
     padding: 0 4px;
     margin-top: 10px;
@@ -5180,7 +5180,7 @@ img.tile-debug {
     display: flex;
 }
 .modal-actions button {
-    color: #7092ff;
+    color: var(--link-color);
     border-bottom: 1px solid var(--border-color);
     border-radius: 0;
     min-height: 160px;
@@ -5212,7 +5212,7 @@ img.tile-debug {
 /* Restore Modal
 ------------------------------------------------------- */
 .modal-actions .logo-restore {
-    color: #7092ff;
+    color: var(--link-color);
 }
 .modal-actions .logo-reset {
     color: #e06c5e;
@@ -5322,7 +5322,7 @@ img.tile-debug {
 ------------------------------------------------------- */
 .modal-actions .logo-walkthrough,
 .modal-actions .logo-features {
-    color: #7092ff;
+    color: var(--link-color);
 }
 
 .modal-splash .section-preferences-third-party {
@@ -5361,17 +5361,17 @@ img.tile-debug {
     font-weight: bold;
 }
 .modal-shortcuts a.tab.active {
-    color: #7092ff;
+    color: var(--link-color);
     border-bottom: 2px solid;
 }
 .modal-shortcuts a.tab:focus,
 .modal-shortcuts a.tab:active {
-    color: #597be7;
+    color: var(--link-focus-color);
     background-color: var(--bg-color-3);
 }
 @media (hover: hover) {
     .modal-shortcuts a.tab:hover {
-        color: #597be7;
+        color: var(--link-focus-color);
         background-color: var(--bg-color-3);
     }
 }
@@ -5965,7 +5965,7 @@ li.hide + li.version .badge .tooltip .popover-arrow {
     animation-direction: alternate;
 }
 @keyframes pulse {
-    from  { background: #7092ff; }
+    from  { background: var(--link-color); }
     to    { background: var(--suggestion-label-color); }
 }
 
@@ -6079,5 +6079,5 @@ li.hide + li.version .badge .tooltip .popover-arrow {
 .huge-modal-button .illustration {
     height: 100px;
     width: 100px;
-    color: #7092ff;
+    color: var(--link-color);
 }

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -4020,9 +4020,9 @@ li.issue-fix-item button:not(.actionable) .fix-icon {
 }
 
 .nudge-container input.error {
-    border: 1px solid #ff7878;
+    border: 1px solid var(--warning-border-color);
     border-radius: 2px;
-    background: #ffb;
+    background: var(--warning-bg-color);
 }
 
 .nudge-container button {

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -3557,10 +3557,6 @@ div.full-screen > button:focus {
     flex: 1 1 auto;
     padding: 4px 5px;
 }
-.issue-label .issue-autofix {
-    flex: 0 0 auto;
-    padding: 5px 8px;
-}
 .issue-label .issue-info-button {
     height: unset;
     width: 32px;
@@ -3583,44 +3579,6 @@ div.full-screen > button:focus {
 }
 .ideditor[dir='rtl'] .issue-label .issue-info-button:last-child {
     border-radius: 4px 0 0 4px;
-}
-
-button.autofix.action {
-    flex: 0 0 20px;
-    height: 20px;
-    width: 20px;
-    background: var(--link-color);
-    color: #fff;
-}
-button.autofix.action:focus,
-button.autofix.action:active,
-button.autofix.action.active {
-    background: var(--link-focus-color);
-}
-@media (hover: hover) {
-    button.autofix.action:hover {
-        background: var(--link-focus-color);
-    }
-}
-
-/* fix all */
-.autofix-all {
-    display: flex;
-    flex-flow: row nowrap;
-    justify-content: flex-end;
-    margin-top: -25px;
-    padding-bottom: 5px;
-}
-.autofix-all-link-text {
-    padding: 0;
-}
-.autofix-all-link-icon svg {
-    margin: 0 9px;
-    background: currentColor;
-    border-radius: 4px;
-}
-.autofix-all-link-icon svg use {
-    color: #fff;
 }
 
 /* suggestion styles */

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -20,7 +20,7 @@
         "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell",
         "Fira Sans", "Droid Sans", "Helvetica Neue", "Arial",
         sans-serif;
-    color: #333;
+    color: var(--text-color);
 
     touch-action: none;
     -ms-user-select: none;
@@ -156,12 +156,12 @@ kbd {
     line-height: 1.3;
     min-width: 0.9em;
     vertical-align: baseline;
-    background-color: #fcfcfc;
-    border: solid 1px #ccc;
+    background-color: var(--outset-color);
+    border: solid 1px var(--border-color);
     margin: 0 2px;
-    border-bottom-color: #bbb;
+    border-bottom-color: var(--shadow-color);
     border-radius: 3px;
-    box-shadow: inset 0 -1px 0 #bbb;
+    box-shadow: inset 0 -1px 0 var(--shadow-color);
 }
 
 code {
@@ -180,9 +180,9 @@ input[type=url],
 input[type=tel],
 input[type=email],
 input[type=date] {
-    background-color: #fff;
-    color: #333;
-    border: 1px solid #ccc;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    border: 1px solid var(--border-color);
     padding: 0px 10px 0px 10px;
     border-radius: 4px;
     text-overflow: ellipsis;
@@ -214,7 +214,7 @@ textarea:active,
 input:active,
 textarea:focus,
 input:focus {
-    background-color: #f1f1f1;
+    background-color: var(--active-bg-color);
 }
 
 textarea.disabled,
@@ -286,16 +286,16 @@ table.tags, table.tags td, table.tags th {
 /* Utility Classes
 ------------------------------------------------------- */
 .fillL {
-    background: #fff;
-    color: #333;
+    background: var(--bg-color);
+    color: var(--text-color);
 }
 .fillL2 {
-    background: #f6f6f6;
-    color: #333;
+    background: var(--bg-color-2);
+    color: var(--text-color);
 }
 .fillL3 {
-    background: #ececec;
-    color: #333;
+    background: var(--bg-color-3);
+    color: var(--text-color);
 }
 .fillD {
     background: rgba(0,0,0,.5);
@@ -339,8 +339,8 @@ li.hide {
 button {
     text-align: center;
     border: 0;
-    background: #fff;
-    color: #333;
+    background: var(--bg-color);
+    color: var(--text-color);
     font-size: 12px;
     display: inline-block;
     border-radius: 4px;
@@ -350,11 +350,11 @@ button:focus,
 button:active,
 /* we want to fake hovering sometimes */
 button.hover {
-    background-color: #ececec;
+    background-color: var(--bg-color-3);
 }
 @media (hover: hover) {
     button:hover {
-        background-color: #ececec;
+        background-color: var(--bg-color-3);
     }
 }
 button.active {
@@ -407,18 +407,18 @@ button.action:active {
     background: #597be7;
 }
 button.secondary-action {
-    background: #ececec;
+    background: var(--bg-color-3);
     font-weight: bold;
 }
 button.secondary-action:focus,
 button.secondary-action:active {
-    background: #cccccc;
+    background: var(--passive-bg-color);
 }
 
 button.action.disabled,
 button[disabled].action {
-    background: #cccccc;
-    color: #888;
+    background: var(--passive-bg-color);
+    color: var(--passive-text-color);
     cursor: not-allowed;
 }
 
@@ -432,12 +432,12 @@ button.secondary-action {
         background: #597be7;
     }
     button.secondary-action:hover {
-        background: #cccccc;
+        background: var(--passive-bg-color);
     }
     button.action.disabled:hover,
     button[disabled].action:hover {
-        background: #cccccc;
-        color: #888;
+        background: var(--passive-bg-color);
+        color: var(--passive-text-color);
         cursor: not-allowed;
     }
 }
@@ -693,7 +693,7 @@ button.add-note svg.icon {
 /* Header for modals / panes
 ------------------------------------------------------- */
 .header {
-    border-bottom: 1px solid #ccc;
+    border-bottom: 1px solid var(--border-color);
     padding: 20px 40px;
     position: relative;
     display: flex;
@@ -811,9 +811,9 @@ a.hide-toggle {
     float: left;
     height: 100%;
     z-index: 10;
-    background: #f6f6f6;
+    background: var(--bg-color-2);
     -ms-user-select: element;
-    border: 0px solid #ccc;
+    border: 0px solid var(--border-color);
     border-right-width: 1px;
 }
 .ideditor[dir='rtl'] .sidebar {
@@ -966,7 +966,7 @@ a.hide-toggle {
 .feature-list-item {
     width: 100%;
     position: relative;
-    border-bottom: 1px solid #ccc;
+    border-bottom: 1px solid var(--border-color);
     border-radius: 0;
 }
 .no-results-item {
@@ -1068,7 +1068,7 @@ a.hide-toggle {
 .preset-list-button-wrap {
     min-height: 62px;
     display: flex;
-    border: 1px solid #ccc;
+    border: 1px solid var(--border-color);
     border-radius: 4px;
 }
 
@@ -1226,17 +1226,17 @@ a.hide-toggle {
     display: flex;
     flex-flow: row wrap;
     align-items: center;
-    background: #f6f6f6;
+    background: var(--bg-color-2);
     text-align: left;
     padding: 5px 10px;
-    border-left: 1px solid rgba(0, 0, 0, .1);
+    border-left: 1px solid var(--transparent-border-color);
     flex: 1 1 100%;
     align-self: stretch;
 }
 .ideditor[dir='rtl'] .preset-list-button .label {
     text-align: right;
     border-left: none;
-    border-right: 1px solid rgba(0, 0, 0, .1);
+    border-right: 1px solid var(--transparent-border-color);
 }
 .ideditor[dir='ltr'] .preset-list-item.mixed-types .preset-list-button .label {
     border-top-right-radius: 4px;
@@ -1280,11 +1280,11 @@ button.preset-reset .label.flash-bg {
 .preset-list-button:active .label,
 .preset-list-button.disabled,
 .preset-list-button.disabled .label {
-    background-color: #ececec;
+    background-color: var(--bg-color-3);
 }
 @media (hover: hover) {
     .preset-list-button:hover .label {
-        background-color: #ececec;
+        background-color: var(--bg-color-3);
     }
 }
 
@@ -1293,13 +1293,13 @@ button.preset-reset .label.flash-bg {
     flex: 0 0 auto;
 }
 .preset-list-button-wrap button.tag-reference-button:not(:hover):not(:active):not(:focus) {
-    background: #f6f6f6;
+    background: var(--bg-color-2);
 }
 .ideditor[dir='ltr'] .preset-list-button-wrap button.tag-reference-button {
-    border-left: 1px solid #ccc;
+    border-left: 1px solid var(--border-color);
 }
 .ideditor[dir='rtl'] .preset-list-button-wrap button.tag-reference-button {
-    border-right: 1px solid #ccc;
+    border-right: 1px solid var(--border-color);
 }
 .ideditor[dir='ltr'] .preset-list-button-wrap:not(.category) button:last-child {
     border-radius: 0 4px 4px 0;
@@ -1317,7 +1317,7 @@ button.preset-reset .label.flash-bg {
 
 .current .preset-list-button,
 .current .preset-list-button .label {
-    background-color: #e8ebff;
+    background-color: var(--selected-bg-color);
 }
 
 .category .preset-list-button:after,
@@ -1326,7 +1326,7 @@ button.preset-reset .label.flash-bg {
     position: absolute;
     top: -5px;
     left: -1px; right: -1px;
-    border: 1px solid #ccc;
+    border: 1px solid var(--border-color);
     border-bottom: none;
     border-radius: 6px 6px 0 0;
     height: 6px;
@@ -1350,7 +1350,7 @@ button.preset-reset .label.flash-bg {
 .subgrid .arrow {
     border: solid rgba(0, 0, 0, 0);
     border-width: 10px;
-    border-bottom-color: #ececec;
+    border-bottom-color: var(--bg-color-3);
     width: 0;
     height: 0;
     margin-left: 50%;
@@ -1377,7 +1377,7 @@ button.preset-reset .label.flash-bg {
     padding: 10px;
     margin: 0 -10px 10px -10px;
     border-radius: 8px;
-    background: #ececec;
+    background: var(--bg-color-3);
 }
 .section .grouped-items-area:empty {
     display: none;
@@ -1424,9 +1424,9 @@ button.preset-reset .label.flash-bg {
     flex: 1 1 100%;
     position: relative;
     font-weight: bold;
-    color: #333;
-    background: #f6f6f6;
-    border: 1px solid #ccc;
+    color: var(--text-color);
+    background: var(--bg-color-2);
+    border: 1px solid var(--border-color);
     border-radius: 4px 4px 0 0;
     overflow: hidden;
 }
@@ -1454,13 +1454,13 @@ button.preset-reset .label.flash-bg {
 
 .field-label button {
     flex: 0 0 auto;
-    border-left: 1px solid #ccc;
+    border-left: 1px solid var(--border-color);
     width: 32px;
     border-radius: 0;
 }
 .ideditor[dir='rtl'] .field-label button {
     border-left: none;
-    border-right: 1px solid #ccc;
+    border-right: 1px solid var(--border-color);
 }
 .field-label button:not(:hover):not(:active):not(:focus) {
     background: none;
@@ -1500,7 +1500,7 @@ button.preset-reset .label.flash-bg {
 .form-field-input-wrap > textarea,
 .form-field-input-wrap > ul.chiplist {
     flex: 1 1 auto;
-    border: 1px solid #ccc;
+    border: 1px solid var(--border-color);
     border-top: 0;
     border-radius: 0;
     position: relative;
@@ -1515,8 +1515,8 @@ button.preset-reset .label.flash-bg {
     flex: 0 0 auto;
     width: 32px;
     position: relative;
-    background-color: #fff;
-    border: 1px solid #ccc;
+    background-color: var(--bg-color);
+    border: 1px solid var(--border-color);
     border-radius: 0;
     border-top-width: 0;
     border-left-width: 0;
@@ -1528,11 +1528,11 @@ button.preset-reset .label.flash-bg {
 }
 .form-field-button:active,
 .form-field-button:focus {
-    background-color: #f1f1f1;
+    background-color: var(--active-bg-color);
 }
 @media (hover: hover) {
     .form-field-button:hover {
-        background-color: #f1f1f1;
+        background-color: var(--active-bg-color);
     }
 }
 .form-field-button .icon {
@@ -1595,14 +1595,14 @@ input.date-selector {
 ------------------------------------------------------- */
 .form-field ul.rows {
     flex: 1 1 auto;
-    border: 1px solid #ccc;
+    border: 1px solid var(--border-color);
     border-top: 0;
     border-radius: 0 0 4px 4px;
     overflow: hidden;
     width: 100%;
 }
 .form-field ul.rows li {
-    border-top: 1px solid #ccc;
+    border-top: 1px solid var(--border-color);
 }
 .form-field ul.rows li:first-child {
     border-top: 0;
@@ -1662,13 +1662,13 @@ input.date-selector {
 .structure-extras-wrap {
     width: 100%;
     padding: 10px 10px;
-    background: #fff;
-    border: 1px solid #ccc;
+    background: var(--bg-color);
+    border: 1px solid var(--border-color);
     border-top: 0px;
     border-radius: 0 0 4px 4px;
 }
 .structure-extras-wrap > ul.rows {
-    border: 1px solid #ccc;
+    border: 1px solid var(--border-color);
     border-radius: 4px;
 }
 
@@ -1702,7 +1702,7 @@ input.date-selector {
 
 .form-field-input-multicombo ul.chiplist {
     padding: 5px 8px 5px 8px;
-    background: #fff;
+    background: var(--bg-color);
     display: block;
     border-radius: 0 0 4px 4px;
     width: 100%;
@@ -1815,7 +1815,7 @@ input.date-selector {
 }
 
 .form-field-input-multicombo .input-wrap {
-    border: 1px solid #ddd;
+    border: 1px solid var(--border-color-2);
     width: 180px;
 }
 .form-field-input-multicombo input {
@@ -1948,10 +1948,10 @@ input.date-selector {
 .form-field-input-check {
     display: flex;
     align-items: center;
-    background: #fff;
+    background: var(--bg-color);
     padding: 5px 10px;
     color: #7092ff;
-    border: 1px solid #ccc;
+    border: 1px solid var(--border-color);
     border-top: 0;
     cursor: pointer;
 }
@@ -1967,8 +1967,8 @@ input.date-selector {
 }
 .form-field-input-check > .reverser {
     flex: 0 1 auto;
-    background-color: #eff2f7;
-    border: 1px solid #ccd5e3;
+    background-color: var(--nested-bg-color);
+    border: 1px solid var(--nested-border-color);
     border-radius: 2px;
     padding: 0px 8px;
     color: inherit;
@@ -1981,11 +1981,11 @@ input.date-selector {
 }
 .form-field-input-check > .reverser:active,
 .form-field-input-check > .reverser:focus {
-    background: #e3e8ef;
+    background: var(--nested-highlight-color);
 }
 @media (hover: hover) {
     .form-field-input-check > .reverser:hover {
-        background: #e3e8ef;
+        background: var(--nested-highlight-color);
     }
 }
 .form-field-input-check > .reverser.hide {
@@ -1993,11 +1993,11 @@ input.date-selector {
 }
 .form-field-input-check:active,
 .form-field-input-check:focus {
-    background: #f1f1f1;
+    background: var(--active-bg-color);
 }
 @media (hover: hover) {
     .form-field-input-check:hover {
-        background: #f1f1f1;
+        background: var(--active-bg-color);
     }
 }
 .form-field-input-check .set {
@@ -2022,7 +2022,7 @@ input.date-selector {
     align-items: center;
     width: 100%;
     padding: 5px 10px;
-    background-color: #fff;
+    background-color: var(--bg-color);
     color: #7092ff;
     cursor: pointer;
 }
@@ -2034,18 +2034,18 @@ input.date-selector {
 }
 .form-field-input-radio > label:active,
 .form-field-input-radio > label:focus {
-    background-color: #ececec;
+    background-color: var(--bg-color-3);
 }
 @media (hover: hover) {
     .form-field-input-radio > label:hover {
-        background-color: #ececec;
+        background-color: var(--bg-color-3);
     }
 }
 .form-field-input-radio > label.active {
-    background-color: #e8ebff;
+    background-color: var(--selected-bg-color);
 }
 .form-field-input-radio > label:not(:last-of-type) {
-    border-bottom: 1px solid #ccc;
+    border-bottom: 1px solid var(--border-color);
 }
 .form-field-input-radio > label > input[type="radio"] {
     flex: 0 1 auto;
@@ -2145,7 +2145,7 @@ input.date-selector {
     content: "";
     display: block;
     position: absolute;
-    background: #ccc;
+    background: var(--border-color);
     height: 11px;
     width: 1px;
     left: 0;
@@ -2172,7 +2172,7 @@ input.date-selector {
     flex: 1 1 auto;
     display: flex;
     flex-flow: row wrap;
-    border: 1px solid #ccc;
+    border: 1px solid var(--border-color);
     border-top: 0px;
 }
 
@@ -2189,7 +2189,7 @@ input.date-selector {
     border-bottom: 0;
 }
 .ideditor[dir='rtl'] .addr-row input {
-    border-right: 1px solid #ccc;
+    border-right: 1px solid var(--border-color);
     border-left: 0;
 }
 
@@ -2391,18 +2391,18 @@ div.combobox {
     display: none;
     box-shadow: 0 4px 10px 1px rgba(0,0,0,.2);
     margin-top: -1px;
-    background: #fff;
+    background: var(--bg-color);
     max-height: 245px;
     overflow-y: auto;
     overflow-x: hidden;
-    border: 1px solid #ccc;
+    border: 1px solid var(--border-color);
     border-radius: 0 0 4px 4px;
 }
 
 .combobox a {
     display: block;
     padding: 5px 10px;
-    border-top: 1px solid #ccc;
+    border-top: 1px solid var(--border-color);
     line-height: 0.95rem;
     break: all;
 }
@@ -2410,11 +2410,11 @@ div.combobox {
 .combobox a.selected,
 .combobox a:active,
 .combobox a:focus {
-    background: #ececec;
+    background: var(--bg-color-3);
 }
 @media (hover: hover) {
     .combobox a:hover {
-        background: #ececec;
+        background: var(--bg-color-3);
     }
 }
 
@@ -2629,7 +2629,7 @@ div.combobox {
 }
 
 .form-field-input-wrap .label {
-    background: #f6f6f6;
+    background: var(--bg-color-2);
     padding: 5px 10px;
 }
 
@@ -2716,30 +2716,30 @@ button.raw-tag-option svg.icon {
 .tag-row input {
     border: 0;
     border-radius: 0;
-    border-bottom: 1px solid #ccc;
-    border-left: 1px solid #ccc;
+    border-bottom: 1px solid var(--border-color);
+    border-left: 1px solid var(--border-color);
     width: 100%;
 }
 .ideditor[dir='rtl'] .tag-row input {
     border-left: none;
-    border-right: 1px solid #ccc;
+    border-right: 1px solid var(--border-color);
 }
 
 
 .tag-row input.key {
     font-weight: bold;
-    background-color: #f6f6f6;
+    background-color: var(--bg-color-2);
 }
 
 .tag-row input.value {
-    border-right: 1px solid #ccc;
+    border-right: 1px solid var(--border-color);
 }
 .ideditor[dir='rtl'] .tag-row input.value {
-    border-left: 1px solid #ccc;
+    border-left: 1px solid var(--border-color);
 }
 
 .tag-row:first-child input.key {
-    border-top: 1px solid #ccc;
+    border-top: 1px solid var(--border-color);
     border-top-left-radius: 4px;
 }
 .ideditor[dir='rtl'] .tag-row:first-child input.key {
@@ -2748,12 +2748,12 @@ button.raw-tag-option svg.icon {
 }
 
 .tag-row:first-child input.value {
-    border-top: 1px solid #ccc;
+    border-top: 1px solid var(--border-color);
 }
 .tag-row button {
     flex: 0 0 auto;
     width: 32px;
-    border: 1px solid #ccc;
+    border: 1px solid var(--border-color);
     border-top-width: 0;
     border-left-width: 0;
 }
@@ -2764,11 +2764,11 @@ button.raw-tag-option svg.icon {
 
 .tag-row button:active,
 .tag-row button:focus {
-    background: #f1f1f1;
+    background: var(--active-bg-color);
 }
 @media (hover: hover) {
     .tag-row button:hover {
-        background: #f1f1f1;
+        background: var(--active-bg-color);
     }
 }
 .tag-row button .icon {
@@ -3001,9 +3001,9 @@ img.tag-reference-wiki-image {
 ------------------------------------------------------- */
 .note-header,
 .qa-header {
-    background-color: #f6f6f6;
+    background-color: var(--bg-color-2);
     border-radius: 5px;
-    border: 1px solid #ccc;
+    border: 1px solid var(--border-color);
     display: flex;
     flex-flow: row nowrap;
     align-items: center;
@@ -3011,19 +3011,19 @@ img.tag-reference-wiki-image {
 
 .note-header-icon,
 .qa-header-icon {
-    background-color: #fff;
+    background-color: var(--bg-color);
     padding: 10px;
     flex: 0 0 auto;
     position: relative;
     width: 60px;
     height: 60px;
-    border-right: 1px solid #ccc;
+    border-right: 1px solid var(--border-color);
     border-radius: 5px 0 0 5px;
 }
 .ideditor[dir='rtl'] .note-header-icon,
 .ideditor[dir='rtl'] .qa-header-icon {
     border-right: unset;
-    border-left: 1px solid #ccc;
+    border-left: 1px solid var(--border-color);
     border-radius: 0 5px 5px 0;
 }
 
@@ -3045,7 +3045,7 @@ img.tag-reference-wiki-image {
 
 .note-header-label,
 .qa-header-label {
-    background-color: #f6f6f6;
+    background-color: var(--bg-color-2);
     padding: 0 15px;
     flex: 1 1 100%;
     font-size: 14px;
@@ -3062,16 +3062,16 @@ img.tag-reference-wiki-image {
 }
 
 .comments-container {
-    background: #ececec;
+    background: var(--bg-color-3);
     padding: 1px 10px;
     border-radius: 8px;
     margin-top: 20px;
 }
 
 .comment {
-    background-color: #fff;
+    background-color: var(--bg-color);
     border-radius: 5px;
-    border: 1px solid #ccc;
+    border: 1px solid var(--border-color);
     margin: 10px auto;
     display: flex;
     flex-flow: row nowrap;
@@ -3084,7 +3084,7 @@ img.tag-reference-wiki-image {
     width: 40px;
     height: 40px;
     object-fit: cover;
-    border: 1px solid #ccc;
+    border: 1px solid var(--border-color);
     border-radius: 20px;
 }
 .comment-main {
@@ -3104,14 +3104,14 @@ img.tag-reference-wiki-image {
 }
 .comment-author {
     font-weight: bold;
-    color: #333;
+    color: var(--text-color);
 }
 .comment-date {
-    color: #aaa;
+    color: var(--muted-text-color);
 }
 .inspector-hover .comment-text,
 .comment-text {
-    color: #333;
+    color: var(--text-color);
     margin-top: 10px;
     overflow-y: auto;
     max-height: 250px;
@@ -3126,11 +3126,11 @@ img.tag-reference-wiki-image {
 }
 
 .qa-details-container {
-    background: #ececec;
+    background: var(--bg-color-3);
     padding: 10px;
     margin-top: 20px;
     border-radius: 4px;
-    border: 1px solid #ccc;
+    border: 1px solid var(--border-color);
     display: flex;
     flex-direction: column;
 }
@@ -3405,12 +3405,12 @@ div.full-screen > button:focus {
 
 .layer-list, .controls-list {
     margin-bottom: 10px;
-    border: 1px solid #ccc;
+    border: 1px solid var(--border-color);
     border-radius: 4px;
 }
 
 .layer-list > li {
-    background-color: #fff;
+    background-color: var(--bg-color);
     color: #7092ff;
     position: relative;
     display: flex;
@@ -3430,14 +3430,14 @@ div.full-screen > button:focus {
     border-radius: 3px;
 }
 .layer-list li:not(:last-child) {
-    border-bottom: 1px solid #ccc;
+    border-bottom: 1px solid var(--border-color);
 }
 .layer-list li:active {
-    background-color: #ececec;
+    background-color: var(--bg-color-3);
 }
 @media (hover: hover) {
     .layer-list li:hover {
-        background-color: #ececec;
+        background-color: var(--bg-color-3);
     }
 }
 
@@ -3445,7 +3445,7 @@ div.full-screen > button:focus {
 .layer-list li.switch button,
 .layer-list li.active,
 .layer-list li.switch {
-    background: #e8ebff;
+    background: var(--selected-bg-color);
 }
 
 .layer-list li.best > div.best {
@@ -3499,7 +3499,7 @@ div.full-screen > button:focus {
 
 .map-data-pane .layer-list button,
 .background-pane .layer-list button {
-    border-left: 1px solid #ccc;
+    border-left: 1px solid var(--border-color);
     border-radius: 0;
     padding-left: 4px;
     padding-right: 4px;
@@ -3507,7 +3507,7 @@ div.full-screen > button:focus {
 .ideditor[dir='rtl'] .map-data-pane .layer-list button,
 .ideditor[dir='rtl'] .background-pane .layer-list button {
     border-left: none;
-    border-right: 1px solid #ccc;
+    border-right: 1px solid var(--border-color);
 }
 
 .map-data-pane .layer-list button .icon,
@@ -3563,7 +3563,7 @@ div.full-screen > button:focus {
     height: unset;
     width: 32px;
     flex: 0 0 auto;
-    border-left: 1px solid #ccc;
+    border-left: 1px solid var(--border-color);
     background-color: rgba(0,0,0,0);
 }
 .ideditor[dir='rtl'] .issue-label .issue-info-button {
@@ -3677,50 +3677,50 @@ button.autofix.action.active {
 .warnings-list *,
 .issue-container.active .issue.severity-warning,
 .issue-container.active .issue.severity-warning * {
-    border-color: #fb2;
+    border-color: var(--warning-border-color);
 }
 
 .warnings-list .issue.severity-warning .issue-label,
 .issue.severity-warning .issue-fix-list,
 .warning-section {
-    background: #ffc;
+    background: var(--warning-bg-color);
 }
 
 .issue-container.active .issue.severity-warning .issue-label {
-    background: #ffa;
+    background: var(--warning-label-color);
 }
 
 .issue.severity-warning .issue-icon {
-    color: #f90;
+    color: var(--warning-icon-color);
 }
 
 .issue.severity-warning .issue-fix-item button.actionable,
 .issue-container.active .issue.severity-warning .issue-info-button {
-    color: #b15500;
-    fill: #b15500;
+    color: var(--warning-text-color);
+    fill: var(--warning-text-color);
 }
 .warnings-list .issue.severity-warning .issue-label:active,
 .warnings-list .issue.severity-warning .issue-label:focus,
 .issue.severity-warning .issue-fix-item button.actionable:active,
 .issue.severity-warning .issue-fix-item button.actionable:focus {
-    background: #ff8;
+    background: var(--warning-highlight-color);
 }
 .issue.severity-warning .issue-fix-item button.actionable:active,
 .issue.severity-warning .issue-fix-item button.actionable:focus,
 .issue-container.active .issue.severity-warning .issue-info-button:active,
 .issue-container.active .issue.severity-warning .issue-info-button:focus {
-    color: #7f3d00;
-    fill: #7f3d00;
+    color: var(--warning-highlight-text-color);
+    fill: var(--warning-highlight-text-color);
 }
 @media (hover: hover) {
     .warnings-list .issue.severity-warning .issue-label:hover,
     .issue.severity-warning .issue-fix-item button.actionable:hover {
-        background: #ff8;
+        background: var(--warning-highlight-color);
     }
     .issue.severity-warning .issue-fix-item button.actionable:hover,
     .issue-container.active .issue.severity-warning .issue-info-button:hover {
-        color: #7f3d00;
-        fill: #7f3d00;
+        color: var(--warning-highlight-text-color);
+        fill: var(--warning-highlight-text-color);
     }
 }
 
@@ -3844,19 +3844,19 @@ input.square-degrees-input {
 /* Entity Issues List */
 .section-entity-issues .issue-container .issue {
     border-radius: 4px;
-    border: 1px solid #ccc;
-    background: #f6f6f6;
+    border: 1px solid var(--border-color);
+    background: var(--bg-color-2);
 }
 .section-entity-issues .issue-container:not(.active) .issue-text:active,
 .section-entity-issues .issue-container:not(.active) .issue-text:focus,
 .section-entity-issues .issue-container:not(.active) .issue-info-button:active,
 .section-entity-issues .issue-container:not(.active) .issue-info-button:focus {
-    background: #f1f1f1;
+    background: var(--active-bg-color);
 }
 @media (hover: hover) {
     .section-entity-issues .issue-container:not(.active) .issue-text:hover,
     .section-entity-issues .issue-container:not(.active) .issue-info-button:hover {
-        background: #f1f1f1;
+        background: var(--active-bg-color);
     }
 }
 .section-entity-issues .issue .issue-label .issue-text {
@@ -4005,7 +4005,7 @@ li.issue-fix-item button:not(.actionable) .fix-icon {
 /* Background - Adjust Alignment
 ------------------------------------------------------- */
 .background-pane .nudge-container {
-    border: 1px solid #ccc;
+    border: 1px solid var(--border-color);
     border-radius: 4px;
     padding: 10px;
     position: relative;
@@ -4018,8 +4018,8 @@ li.issue-fix-item button:not(.actionable) .fix-icon {
 }
 
 .nudge-container .nudge-outer-rect {
-    background-color: #eee;
-    border: 1px solid #ccc;
+    background-color: var(--widget-bg-color);
+    border: 1px solid var(--border-color);
     border-radius: 2px;
     padding: 20px 0;
     display: flex;
@@ -4035,8 +4035,8 @@ li.issue-fix-item button:not(.actionable) .fix-icon {
 }
 
 .nudge-container .nudge-inner-rect {
-    background-color: #fff;
-    border: 1px solid #ccc;
+    background-color: var(--bg-color);
+    border: 1px solid var(--border-color);
     border-radius: 2px;
     width: 65%;
     min-height: 20px;
@@ -4117,25 +4117,25 @@ li.issue-fix-item button:not(.actionable) .fix-icon {
 .background-pane .nudge.right::after {
     border-top: 5px solid transparent;
     border-bottom: 5px solid transparent;
-    border-left: 5px solid #222;
+    border-left: 5px solid var(--widget-color);
 }
 
 .background-pane .nudge.left::after {
     border-top: 5px solid transparent;
     border-bottom: 5px solid transparent;
-    border-right: 5px solid #222;
+    border-right: 5px solid var(--widget-color);
 }
 
 .background-pane .nudge.top::after {
     border-right: 5px solid transparent;
     border-left: 5px solid transparent;
-    border-bottom: 5px solid #222;
+    border-bottom: 5px solid var(--widget-color);
 }
 
 .background-pane .nudge.bottom::after {
     border-right: 5px solid transparent;
     border-left: 5px solid transparent;
-    border-top: 5px solid #222;
+    border-top: 5px solid var(--widget-color);
 }
 
 
@@ -4166,7 +4166,7 @@ li.issue-fix-item button:not(.actionable) .fix-icon {
     display: flex;
     flex-flow: row nowrap;
     justify-content: space-between;
-    border-bottom: 1px solid #ccc;
+    border-bottom: 1px solid var(--border-color);
     flex: 0 0 auto;
 }
 
@@ -4222,7 +4222,7 @@ li.issue-fix-item button:not(.actionable) .fix-icon {
 .help-pane .toc li a,
 .help-pane .nav a {
     display: block;
-    border: 1px solid #ccc;
+    border: 1px solid var(--border-color);
     padding: 5px 10px;
 }
 
@@ -4233,17 +4233,17 @@ li.issue-fix-item button:not(.actionable) .fix-icon {
 .help-pane .nav a:focus,
 .help-pane .toc li a:active,
 .help-pane .nav a:active {
-    background: #ececec;
+    background: var(--bg-color-3);
 }
 @media (hover: hover) {
     .help-pane .toc li a:hover,
     .help-pane .nav a:hover {
-        background: #ececec;
+        background: var(--bg-color-3);
     }
 }
 
 .help-pane .toc li a.selected {
-    background: #e8ebff;
+    background: var(--selected-bg-color);
 }
 
 .help-pane .toc li:first-child a {
@@ -4251,7 +4251,7 @@ li.issue-fix-item button:not(.actionable) .fix-icon {
 }
 
 .help-pane .toc li:nth-last-child(3) a {
-    border-bottom: 1px solid #ccc;
+    border-bottom: 1px solid var(--border-color);
     border-radius: 0 0 4px 4px
 }
 
@@ -4259,7 +4259,7 @@ li.issue-fix-item button:not(.actionable) .fix-icon {
 .help-pane .toc li.walkthrough a {
     overflow: hidden;
     margin-top: 10px;
-    border-bottom: 1px solid #ccc;
+    border-bottom: 1px solid var(--border-color);
     border-radius: 4px;
 }
 
@@ -4307,11 +4307,11 @@ li.issue-fix-item button:not(.actionable) .fix-icon {
 .inspector-hover input,
 .inspector-hover textarea,
 .inspector-hover label {
-    background: #ececec;
+    background: var(--bg-color-3);
 }
 .inspector-hover .preset-list-button,
 .inspector-hover .tag-row input {
-    background: #f6f6f6;
+    background: var(--bg-color-2);
 }
 
 .inspector-hover a,
@@ -4366,7 +4366,7 @@ li.issue-fix-item button:not(.actionable) .fix-icon {
     margin-bottom: 1px;
 }
 .inspector-hover .section-entity-issues .issue-container * {
-    border-color: #ccc !important;
+    border-color: var(--border-color) !important;
 }
 .inspector-hover .section-entity-issues .issue-container.active .issue-label {
     border-bottom: 0;
@@ -4517,6 +4517,7 @@ img.tile-debug {
     height: 100%;
     width: 100%;
     background: #000;
+    color: #333;
     user-select: none;
     touch-action: none;
     -webkit-touch-callout: none;
@@ -5132,7 +5133,7 @@ img.tile-debug {
 
 .modal-section {
     padding: 20px;
-    border-bottom: 1px solid #ccc;
+    border-bottom: 1px solid var(--border-color);
 }
 .modal-section p:not(:last-of-type) {
     padding-bottom: 20px;
@@ -5175,7 +5176,7 @@ img.tile-debug {
 }
 .modal-actions button {
     color: #7092ff;
-    border-bottom: 1px solid #ccc;
+    border-bottom: 1px solid var(--border-color);
     border-radius: 0;
     min-height: 160px;
     text-align: center;
@@ -5196,7 +5197,7 @@ img.tile-debug {
 }
 
 .modal-actions > :first-child {
-    border-right: 1px solid #ccc;
+    border-right: 1px solid var(--border-color);
 }
 
 .modal-section:last-child {
@@ -5485,9 +5486,9 @@ a.user-info {
 }
 
 .changeset-list {
-    border: 1px solid #ccc;
+    border: 1px solid var(--border-color);
     border-radius: 4px;
-    background: #fff;
+    background: var(--bg-color);
     margin-bottom: 10px;
     overflow: hidden;
 }
@@ -5499,7 +5500,7 @@ a.user-info {
     text-align: initial;
 }
 .changeset-list li {
-    border-top: 1px solid #ccc;
+    border-top: 1px solid var(--border-color);
 }
 .changeset-list li:first-child {
     border-top: 0;
@@ -5607,7 +5608,7 @@ button.conflicts-button {
     display: none;
 }
 .tooltip {
-    color: #333;
+    color: var(--text-color);
     font-size: 12px;
     white-space: initial;
 }
@@ -5672,7 +5673,7 @@ button.conflicts-button {
     min-width: 80px;
     padding: 10px;
     font-weight: normal;
-    background-color: #fff;
+    background-color: var(--bg-color);
 }
 
 .popover-arrow {
@@ -5686,28 +5687,28 @@ button.conflicts-button {
     bottom: -5px;
     left: 50%;
     margin-left: -5px;
-    border-top-color: #fff;
+    border-top-color: var(--bg-color);
     border-width: 5px 5px 0;
 }
 .popover.right .popover-arrow {
     top: 50%;
     left: -5px;
     margin-top: -5px;
-    border-right-color: #fff;
+    border-right-color: var(--bg-color);
     border-width: 5px 5px 5px 0;
 }
 .popover.left .popover-arrow {
     top: 50%;
     right: -5px;
     margin-top: -5px;
-    border-left-color: #fff;
+    border-left-color: var(--bg-color);
     border-width: 5px 0 5px 5px;
 }
 .popover.bottom .popover-arrow {
     top: -5px;
     left: 50%;
     margin-left: -5px;
-    border-bottom-color: #fff;
+    border-bottom-color: var(--bg-color);
     border-width: 0 5px 5px;
 }
 .popover:not(.arrowed) .popover-arrow {
@@ -5724,7 +5725,7 @@ button.conflicts-button {
 }
 
 .keyhint-wrap {
-    background: #f6f6f6;
+    background: var(--bg-color-2);
     padding: 10px;
     margin: 10px -10px -10px -10px;
     border-radius: 0 0 3px 3px;
@@ -5999,7 +6000,7 @@ li.hide + li.version .badge .tooltip .popover-arrow {
 .curtain-tooltip .popover-inner .instruction {
     font-weight: bold;
     display: block;
-    border-top: 1px solid #ccc;
+    border-top: 1px solid var(--border-color);
     margin-top: 10px;
     margin-left: -20px;
     margin-right: -20px;

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -5255,7 +5255,7 @@ img.tile-debug {
 
 .community-event,
 .community-more {
-    background-color: #efefef;
+    background-color: var(--bg-color-2);
     padding: 8px;
     border-radius: 4px;
     margin-bottom: 5px;

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -4278,7 +4278,7 @@ li.issue-fix-item button:not(.actionable) .fix-icon {
 .inspector-hover .form-field-input-multicombo .chip,
 .inspector-hover .form-field-input-check span,
 .inspector-hover .section-entity-issues .issue .icon {
-    color: #666;
+    color: var(--passive-text-color);
 }
 
 .inspector-hover .form-field-input-multicombo .chip {
@@ -4376,7 +4376,7 @@ li.issue-fix-item button:not(.actionable) .fix-icon {
 .inspector-hover .entity-editor-pane a.hide-toggle {
     opacity: 1;
     background-color: transparent;
-    color: #666;
+    color: var(--passive-text-color);
     padding-left: 0;
     border-width: 0;
 }

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     <meta name='viewport' content='width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no'/>
     <meta name='mobile-web-app-capable' content='yes'/>
     <meta name='apple-mobile-web-app-status-bar-style' content='black-translucent'/>
+    <meta name='color-scheme' content='light dark'>
     <style type='text/css'>
       /* apply document-level styling to standalone iD only */
       html, body {

--- a/index.html
+++ b/index.html
@@ -8,7 +8,6 @@
     <meta name='viewport' content='width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no'/>
     <meta name='mobile-web-app-capable' content='yes'/>
     <meta name='apple-mobile-web-app-status-bar-style' content='black-translucent'/>
-    <meta name='color-scheme' content='light dark'>
     <style type='text/css'>
       /* apply document-level styling to standalone iD only */
       html, body {

--- a/modules/core/validation/models.js
+++ b/modules/core/validation/models.js
@@ -16,7 +16,6 @@ export function validationIssue(attrs) {
 
     this.id = generateID.apply(this);      // generated - see below
     this.key = generateKey.apply(this);    // generated - see below (call after generating this.id)
-    this.autoFix = null;                   // generated - if autofix exists, will be set below
 
     // A unique, deterministic string hash.
     // Issues with identical id values are considered identical.
@@ -79,9 +78,6 @@ export function validationIssue(attrs) {
             fix.id = fix.title.stringId;
             // add a reference to the issue for use in actions
             fix.issue = issue;
-            if (fix.autoArgs) {
-                issue.autoFix = fix;
-            }
         });
         return fixes;
     };
@@ -101,7 +97,6 @@ export function validationIssueFix(attrs) {
     this.disabledReason = attrs.disabledReason; // Optional - a string explaining why the fix is unavailable, if any
     this.icon = attrs.icon;                     // Optional - shows 'iD-icon-wrench' if not set
     this.entityIds = attrs.entityIds || [];     // Optional - used for hover-higlighting.
-    this.autoArgs = attrs.autoArgs;             // Optional - pass [actions, annotation] arglist if this fix can automatically run
 
     this.issue = null;    // Generated link - added by validationIssue
 }

--- a/modules/ui/sections/validation_issues.js
+++ b/modules/ui/sections/validation_issues.js
@@ -114,32 +114,6 @@ export function uiSectionValidationIssues(id, severity, context) {
             .append('span')
             .attr('class', 'issue-message');
 
-        /*
-        labelsEnter
-            .append('span')
-            .attr('class', 'issue-autofix')
-            .each(function(d) {
-                if (!d.autoFix) return;
-
-                d3_select(this)
-                    .append('button')
-                    .attr('title', t('issues.fix_one.title'))
-                    .datum(d.autoFix)  // set button datum to the autofix
-                    .attr('class', 'autofix action')
-                    .on('click', function(d3_event, d) {
-                        d3_event.preventDefault();
-                        d3_event.stopPropagation();
-
-                        var issuesEntityIDs = d.issue.entityIds;
-                        utilHighlightEntities(issuesEntityIDs.concat(d.entityIds), false, context);
-
-                        context.perform.apply(context, d.autoArgs);
-                        context.validator().validate();
-                    })
-                    .call(svgIcon('#iD-icon-wrench'));
-            });
-        */
-
         // Update
         items = items
             .merge(itemsEnter)
@@ -150,62 +124,6 @@ export function uiSectionValidationIssues(id, severity, context) {
             .each(function(d) {
                 return d.message(context)(d3_select(this));
             });
-
-        /*
-        // autofix
-        var canAutoFix = issues.filter(function(issue) { return issue.autoFix; });
-
-        var autoFixAll = selection.selectAll('.autofix-all')
-            .data(canAutoFix.length ? [0] : []);
-
-        // exit
-        autoFixAll.exit()
-            .remove();
-
-        // enter
-        var autoFixAllEnter = autoFixAll.enter()
-            .insert('div', '.issues-list')
-            .attr('class', 'autofix-all');
-
-        var linkEnter = autoFixAllEnter
-            .append('a')
-            .attr('class', 'autofix-all-link')
-            .attr('href', '#');
-
-        linkEnter
-            .append('span')
-            .attr('class', 'autofix-all-link-text')
-            .call(t.append('issues.fix_all.title'));
-
-        linkEnter
-            .append('span')
-            .attr('class', 'autofix-all-link-icon')
-            .call(svgIcon('#iD-icon-wrench'));
-
-        if (severity === 'warning') {
-            renderIgnoredIssuesReset(selection);
-        }
-
-        // update
-        autoFixAll = autoFixAll
-            .merge(autoFixAllEnter);
-
-        autoFixAll.selectAll('.autofix-all-link')
-            .on('click', function() {
-                context.pauseChangeDispatch();
-                context.perform(actionNoop());
-                canAutoFix.forEach(function(issue) {
-                    var args = issue.autoFix.autoArgs.slice();  // copy
-                    if (typeof args[args.length - 1] !== 'function') {
-                        args.pop();
-                    }
-                    args.push(t('issues.fix_all.annotation'));
-                    context.replace.apply(context, args);
-                });
-                context.resumeChangeDispatch();
-                context.validator().validate();
-            });
-        */
     }
 
     context.validator().on('validated.uiSectionValidationIssues' + id, function() {

--- a/modules/validations/unsquare_way.js
+++ b/modules/validations/unsquare_way.js
@@ -61,15 +61,6 @@ export function validationUnsquareWay(context) {
         var points = nodes.map(function(node) { return context.projection(node.loc); });
         if (!geoOrthoCanOrthogonalize(points, isClosed, epsilon, degreeThreshold, true)) return [];
 
-        var autoArgs;
-        // don't allow autosquaring features linked to wikidata
-        if (!entity.tags.wikidata) {
-            // use same degree threshold as for detection
-            var autoAction = actionOrthogonalize(entity.id, context.projection, undefined, degreeThreshold);
-            autoAction.transitionable = false;  // when autofixing, do it instantly
-            autoArgs = [autoAction, t('operations.orthogonalize.annotation.feature', { n: 1 })];
-        }
-
         return [new validationIssue({
             type: type,
             subtype: 'building',
@@ -88,7 +79,6 @@ export function validationUnsquareWay(context) {
                     new validationIssueFix({
                         icon: 'iD-operation-orthogonalize',
                         title: t.append('issues.fix.square_feature.title'),
-                        autoArgs: autoArgs,
                         onClick: function(context, completionHandler) {
                             var entityId = this.issue.entityIds[0];
                             // use same degree threshold as for detection


### PR DESCRIPTION
Fixes #8214.
This builds on the original work from @AntonKhorev to make it able to sync with the OSM preference. See https://github.com/openstreetmap/openstreetmap-website/pull/6323 for that.

Making the theme respond anytime results in variables like `--bg-filter` and `--bg-blend-mode` to not need to watch for media query changes in JS.
Other styling changes away from JS have already been made in #11292.