### PR TITLE
Introduce LLM rules for Cursor and Copilot

### DIFF
--- a/.cursor/rules/javascript.mdc
+++ b/.cursor/rules/javascript.mdc
@@ -1,0 +1,7 @@
+---
+description: General rules
+globs:
+alwaysApply: true
+---
+
+Read [`.github/instructions/javascript.md`](../../.github/instructions/javascript.md)

--- a/.github/instructions/javascript.md
+++ b/.github/instructions/javascript.md
@@ -1,0 +1,19 @@
+---
+applyTo: '*'
+---
+
+# Formatting
+
+Rules for new code
+- Use `indent_style = space`, `indent_size = 4`.
+- Add TypeScript comments where possible and feasable for functions and variables; always prefer to infer return types when possible.
+- All new code has to use `const`, `let`.
+- Do not reformat untouched cod.
+
+# Always run…
+
+On relevant code changes, always run:
+
+ - `npm run lint:fix && npm run lint`
+ - `npm run build`
+ - `npm run test:spec -- --run`


### PR DESCRIPTION
The two most commonly used AI powered code editors are Cursor and VS Code with Copilot.
This PR adds two files that are rules for prompts for those LLM Chats.
Unfortunately, there is no standardization yet between tools, so you have to have separate files per software.
We can, however, put all the information in one file and tell the agent to look at the other file. That might be slightly less performant (don't know) but it certainly reduces maintanace cost.

Its only a few rules ATM which have instructions on stuff that the LLM had issues figuring out by itself due to the special way some parts of iD are configured.

Ref
- https://docs.github.com/en/copilot/how-tos/configure-custom-instructions/add-repository-instructions
- https://docs.cursor.com/en/context/rules
