### PR TITLE
process `terms` and `aliases` as arrays

### DIFF
--- a/modules/core/localizer.js
+++ b/modules/core/localizer.js
@@ -331,6 +331,14 @@ export function coreLocalizer() {
                 locale: locale
             };
           }
+          if (Array.isArray(result)) {
+            // found an array of localized strings!
+            // for example: `terms` or `aliases` from id-tagging-schema
+            return {
+                text: result,
+                locale: locale
+            };
+          }
         }
         // no localized string found...
 

--- a/modules/presets/field.js
+++ b/modules/presets/field.js
@@ -46,10 +46,9 @@ export function presetField(fieldID, field, allFields) {
 
   _this.placeholder = () => _this.resolveReference('placeholder').t('placeholder', { 'default': '' });
 
-  _this.originalTerms = (_this.terms || []).join();
+  _this.originalTerms = _this.terms;
 
-  _this.terms = () => _this.resolveReference('label').t('terms', { 'default': _this.originalTerms })
-    .toLowerCase().trim().split(/\s*,+\s*/);
+  _this.terms = () => _this.resolveReference('label').t('terms', { 'default': _this.originalTerms });
 
   _this.increment = _this.type === 'number' ? (_this.increment || 1) : undefined;
 

--- a/modules/presets/preset.js
+++ b/modules/presets/preset.js
@@ -27,11 +27,11 @@ export function presetPreset(presetID, preset, addable, allFields, allPresets) {
 
   _this.safeid = utilSafeClassName(presetID);  // for use in css classes, selectors, element ids
 
-  _this.originalTerms = (_this.terms || []).join();
+  _this.originalTerms = _this.terms;
 
   _this.originalName = _this.name || '';
 
-  _this.originalAliases = (_this.aliases || []).join('\n');
+  _this.originalAliases = _this.aliases || [];
 
   _this.originalScore = _this.matchScore || 1;
 
@@ -142,16 +142,12 @@ export function presetPreset(presetID, preset, addable, allFields, allPresets) {
 
   _this.aliases = () => {
     return resolveReference('originalName')
-      .t('aliases', { 'default': _this.originalAliases })
-      .trim()
-      .split(/\s*[\r\n]+\s*/)
-      .filter(Boolean);
+      .t('aliases', { 'default': _this.originalAliases });
   };
 
   _this.terms = () => {
     return resolveReference('originalName')
-      .t('terms', { 'default': _this.originalTerms })
-      .toLowerCase().trim().split(/\s*,+\s*/);
+      .t('terms', { 'default': _this.originalTerms });
   };
 
   _this.searchName = () => {


### PR DESCRIPTION
Blocked by https://github.com/ideditor/schema-builder/pull/227, this would need to be merged at the same time that we upgrade to id-tagging-schema v7 