### PR TITLE
directly handle "emergency" access values as area-key exceptions

### DIFF
--- a/modules/osm/tags.js
+++ b/modules/osm/tags.js
@@ -69,6 +69,8 @@ export function osmSetAreaKeys(value) {
 // `highway` and `railway` are typically linear features, but there
 // are a few exceptions that should be treated as areas, even in the
 // absence of a proper `area=yes` or `areaKeys` tag.. see #4194
+// similarly, some tags are both used as a primary key for area features,
+// but also as an attribute tag for linear features (e.g. `emergency=yes`)
 export var osmAreaKeysExceptions = {
     highway: {
         elevator: true,
@@ -92,6 +94,14 @@ export var osmAreaKeysExceptions = {
     },
     amenity: {
         bicycle_parking: true
+    },
+    emergency: {
+        yes: false,
+        no: false,
+        private: false,
+        designated: false,
+        destination: false,
+        official: false
     }
 };
 
@@ -103,6 +113,9 @@ export function osmTagSuggestingArea(tags) {
     var returnTags = {};
     for (var realKey in tags) {
         const key = osmRemoveLifecyclePrefix(realKey);
+        if (key in osmAreaKeysExceptions && osmAreaKeysExceptions[key][tags[realKey]] === false) {
+            continue;
+        }
         if (key in osmAreaKeys && !(tags[realKey] in osmAreaKeys[key])) {
             returnTags[realKey] = tags[realKey];
             return returnTags;


### PR DESCRIPTION
…instead of relying on the presence of dummy presets in the tagging schema.

This would unblock https://github.com/openstreetmap/id-tagging-schema/pull/1680, see also that issue for background.