### PR TITLE
Feat: Click to switch features that are crossing ways

### DIFF
--- a/modules/validations/crossing_ways.js
+++ b/modules/validations/crossing_ways.js
@@ -408,7 +408,6 @@ export function validationCrossingWays(context) {
             crossingTypeID += '_connectable';
         }
 
-        // Differentiate based on the loc rounded to 4 digits, since two ways can cross multiple times.
         var uniqueID = crossing.crossPoint[0].toFixed(4) + ',' + crossing.crossPoint[1].toFixed(4);
 
         return new validationIssue({
@@ -419,10 +418,52 @@ export function validationCrossingWays(context) {
                 var graph = context.graph();
                 var entity1 = graph.hasEntity(this.entityIds[0]),
                     entity2 = graph.hasEntity(this.entityIds[1]);
-                return (entity1 && entity2) ? t.append('issues.crossing_ways.message', {
-                    feature: utilDisplayLabel(entity1, graph, featureType1 === 'building'),
-                    feature2: utilDisplayLabel(entity2, graph, featureType2 === 'building')
-                }) : '';
+               return entity1 && entity2
+                   ? function (selection) {
+                         selection.html(
+                             t('issues.crossing_ways.message', {
+                                 feature:
+                                     '<span class="feature-link feature1"></span>',
+                                 feature2:
+                                     '<span class="feature-link feature2"></span>',
+                             })
+                         );
+
+                         selection
+                             .select('.feature1')
+                             .text(
+                                 utilDisplayLabel(
+                                     entity1,
+                                     graph,
+                                     featureType1 === 'building'
+                                 )
+                             )
+                             .style('cursor', 'pointer')
+                             .style('text-decoration', 'underline')
+                             .on('click', () =>
+                                 context.enter(
+                                     modeSelect(context, [entity1.id])
+                                 )
+                             );
+
+                         selection
+                             .select('.feature2')
+                             .text(
+                                 utilDisplayLabel(
+                                     entity2,
+                                     graph,
+                                     featureType2 === 'building'
+                                 )
+                             )
+                             .style('cursor', 'pointer')
+                             .style('text-decoration', 'underline')
+                             .on('click', () =>
+                                 context.enter(
+                                     modeSelect(context, [entity2.id])
+                                 )
+                             );
+                     }
+                   : '';
             },
             reference: showReference,
             entityIds: entities.map(function(entity) {
@@ -511,6 +552,7 @@ export function validationCrossingWays(context) {
                 .append('div')
                 .attr('class', 'issue-reference')
                 .call(t.append('issues.crossing_ways.' + crossingTypeID + '.reference'));
+
         }
     }
 

--- a/modules/validations/crossing_ways.js
+++ b/modules/validations/crossing_ways.js
@@ -409,7 +409,6 @@ export function validationCrossingWays(context) {
         }
 
         // Differentiate based on the loc rounded to 4 digits, since two ways can cross multiple times.
-
         var uniqueID = crossing.crossPoint[0].toFixed(4) + ',' + crossing.crossPoint[1].toFixed(4);
 
         return new validationIssue({

--- a/modules/validations/crossing_ways.js
+++ b/modules/validations/crossing_ways.js
@@ -408,6 +408,8 @@ export function validationCrossingWays(context) {
             crossingTypeID += '_connectable';
         }
 
+        // Differentiate based on the loc rounded to 4 digits, since two ways can cross multiple times.
+
         var uniqueID = crossing.crossPoint[0].toFixed(4) + ',' + crossing.crossPoint[1].toFixed(4);
 
         return new validationIssue({

--- a/modules/validations/crossing_ways.js
+++ b/modules/validations/crossing_ways.js
@@ -419,66 +419,67 @@ export function validationCrossingWays(context) {
             message: function(context) {
                 var graph = context.graph();
                 var entity1 = graph.hasEntity(this.entityIds[0]),
-                    entity2 = graph.hasEntity(this.entityIds[1]);
-     return entity1 && entity2
-         ? t.append('issues.crossing_ways.message', {
-               feature: (selection) => {
-                   if (context.selectedIDs().includes(entity1.id)) {
-                       selection
-                           .append('span')
-                           .text(
-                               utilDisplayLabel(
-                                   entity1,
-                                   graph,
-                                   featureType1 === 'building'
-                               )
-                           );
-                   } else {
-                       selection
-                           .append('a')
-                           .classed('feature-link', true)
-                           .text(
-                               utilDisplayLabel(
-                                   entity1,
-                                   graph,
-                                   featureType1 === 'building'
-                               )
-                           )
-                           .on('click', () => {
-                               context.enter(modeSelect(context, [entity1.id]));
-                           });
-                   }
-               },
-               feature2: (selection) => {
-                   if (context.selectedIDs().includes(entity2.id)) {
-                       selection
-                           .append('span')
-                           .text(
-                               utilDisplayLabel(
-                                   entity2,
-                                   graph,
-                                   featureType2 === 'building'
-                               )
-                           );
-                   } else {
-                       selection
-                           .append('a')
-                           .classed('feature-link', true)
-                           .text(
-                               utilDisplayLabel(
-                                   entity2,
-                                   graph,
-                                   featureType2 === 'building'
-                               )
-                           )
-                           .on('click', () => {
-                               context.enter(modeSelect(context, [entity2.id]));
-                           });
-                   }
-               },
-           })
-         : '';
-
+                entity2 = graph.hasEntity(this.entityIds[1]);
+                
+                return entity1 && entity2
+                ? t.append('issues.crossing_ways.message', {
+                    feature: (selection) => {
+                        if (context.selectedIDs().includes(entity1.id)) {
+                            selection
+                            .append('span')
+                            .text(
+                                utilDisplayLabel(
+                                    entity1,
+                                    graph,
+                                    featureType1 === 'building'
+                                )
+                            );
+                        } else {
+                            selection
+                            .append('a')
+                            .classed('feature-link', true)
+                            .text(
+                                utilDisplayLabel(
+                                    entity1,
+                                    graph,
+                                    featureType1 === 'building'
+                                )
+                            )
+                            .on('click', () => {
+                                context.enter(modeSelect(context, [entity1.id]));
+                            });
+                        }
+                    },
+             
+                    feature2: (selection) => {
+                        if (context.selectedIDs().includes(entity2.id)) {
+                            selection
+                            .append('span')
+                            .text(
+                                utilDisplayLabel(
+                                    entity2,
+                                    graph,
+                                    featureType2 === 'building'
+                                )
+                            );
+                        } else {
+                            selection
+                            .append('a')
+                            .classed('feature-link', true)
+                            .text(
+                                utilDisplayLabel(
+                                    entity2,
+                                    graph,
+                                    featureType2 === 'building'
+                                )
+                            )
+                            .on('click', () => {
+                                context.enter(modeSelect(context, [entity2.id]));
+                            });
+                        }
+                    },
+                })
+                : '';
             },
             reference: showReference,
             entityIds: entities.map(function(entity) {
@@ -567,7 +568,6 @@ export function validationCrossingWays(context) {
                 .append('div')
                 .attr('class', 'issue-reference')
                 .call(t.append('issues.crossing_ways.' + crossingTypeID + '.reference'));
-
         }
     }
 

--- a/modules/validations/crossing_ways.js
+++ b/modules/validations/crossing_ways.js
@@ -420,52 +420,43 @@ export function validationCrossingWays(context) {
                 var graph = context.graph();
                 var entity1 = graph.hasEntity(this.entityIds[0]),
                     entity2 = graph.hasEntity(this.entityIds[1]);
-               return entity1 && entity2
-                   ? function (selection) {
-                         selection.html(
-                             t('issues.crossing_ways.message', {
-                                 feature:
-                                     '<span class="feature-link feature1"></span>',
-                                 feature2:
-                                     '<span class="feature-link feature2"></span>',
-                             })
-                         );
-
-                         selection
-                             .select('.feature1')
-                             .text(
-                                 utilDisplayLabel(
-                                     entity1,
-                                     graph,
-                                     featureType1 === 'building'
-                                 )
-                             )
-                             .style('cursor', 'pointer')
-                             .style('text-decoration', 'underline')
-                             .on('click', () =>
-                                 context.enter(
-                                     modeSelect(context, [entity1.id])
-                                 )
-                             );
-
-                         selection
-                             .select('.feature2')
-                             .text(
-                                 utilDisplayLabel(
-                                     entity2,
-                                     graph,
-                                     featureType2 === 'building'
-                                 )
-                             )
-                             .style('cursor', 'pointer')
-                             .style('text-decoration', 'underline')
-                             .on('click', () =>
-                                 context.enter(
-                                     modeSelect(context, [entity2.id])
-                                 )
-                             );
-                     }
-                   : '';
+                return entity1 && entity2
+                    ? t.append('issues.crossing_ways.message', {
+                          feature: (selection) => {
+                              selection
+                                  .append('a')
+                                  .classed('feature-link', true)
+                                  .text(
+                                      utilDisplayLabel(
+                                          entity1,
+                                          graph,
+                                          featureType1 === 'building'
+                                      )
+                                  )
+                                  .on('click', () =>
+                                      context.enter(
+                                          modeSelect(context, [entity1.id])
+                                      )
+                                  );
+                          },
+                          feature2: (selection) =>
+                              selection
+                                  .append('a')
+                                  .classed('feature-link', true)
+                                  .text(
+                                      utilDisplayLabel(
+                                          entity2,
+                                          graph,
+                                          featureType2 === 'building'
+                                      )
+                                  )
+                                  .on('click', () =>
+                                      context.enter(
+                                          modeSelect(context, [entity2.id])
+                                      )
+                                  ),
+                      })
+                    : '';
             },
             reference: showReference,
             entityIds: entities.map(function(entity) {

--- a/modules/validations/crossing_ways.js
+++ b/modules/validations/crossing_ways.js
@@ -420,43 +420,65 @@ export function validationCrossingWays(context) {
                 var graph = context.graph();
                 var entity1 = graph.hasEntity(this.entityIds[0]),
                     entity2 = graph.hasEntity(this.entityIds[1]);
-                return entity1 && entity2
-                    ? t.append('issues.crossing_ways.message', {
-                          feature: (selection) => {
-                              selection
-                                  .append('a')
-                                  .classed('feature-link', true)
-                                  .text(
-                                      utilDisplayLabel(
-                                          entity1,
-                                          graph,
-                                          featureType1 === 'building'
-                                      )
-                                  )
-                                  .on('click', () =>
-                                      context.enter(
-                                          modeSelect(context, [entity1.id])
-                                      )
-                                  );
-                          },
-                          feature2: (selection) =>
-                              selection
-                                  .append('a')
-                                  .classed('feature-link', true)
-                                  .text(
-                                      utilDisplayLabel(
-                                          entity2,
-                                          graph,
-                                          featureType2 === 'building'
-                                      )
-                                  )
-                                  .on('click', () =>
-                                      context.enter(
-                                          modeSelect(context, [entity2.id])
-                                      )
-                                  ),
-                      })
-                    : '';
+     return entity1 && entity2
+         ? t.append('issues.crossing_ways.message', {
+               feature: (selection) => {
+                   if (context.selectedIDs().includes(entity1.id)) {
+                       selection
+                           .append('span')
+                           .text(
+                               utilDisplayLabel(
+                                   entity1,
+                                   graph,
+                                   featureType1 === 'building'
+                               )
+                           );
+                   } else {
+                       selection
+                           .append('a')
+                           .classed('feature-link', true)
+                           .text(
+                               utilDisplayLabel(
+                                   entity1,
+                                   graph,
+                                   featureType1 === 'building'
+                               )
+                           )
+                           .on('click', () => {
+                               context.enter(modeSelect(context, [entity1.id]));
+                           });
+                   }
+               },
+               feature2: (selection) => {
+                   if (context.selectedIDs().includes(entity2.id)) {
+                       selection
+                           .append('span')
+                           .text(
+                               utilDisplayLabel(
+                                   entity2,
+                                   graph,
+                                   featureType2 === 'building'
+                               )
+                           );
+                   } else {
+                       selection
+                           .append('a')
+                           .classed('feature-link', true)
+                           .text(
+                               utilDisplayLabel(
+                                   entity2,
+                                   graph,
+                                   featureType2 === 'building'
+                               )
+                           )
+                           .on('click', () => {
+                               context.enter(modeSelect(context, [entity2.id]));
+                           });
+                   }
+               },
+           })
+         : '';
+
             },
             reference: showReference,
             entityIds: entities.map(function(entity) {


### PR DESCRIPTION
Fixes #11328

This PR , turns the labels of the crossing  features  into a link which when clicked on would select that  feature.
This makes it easier for users to navigate between crossing features.

Screenshot:
<img width="583" height="255" alt="Screenshot 2025-08-24 232411" src="https://github.com/user-attachments/assets/d79b913a-c1ba-4a44-8ead-e0343f9d7b22" />
