### PR TITLE
Fixes unexpected NSI matches

### DIFF
--- a/modules/services/nsi.js
+++ b/modules/services/nsi.js
@@ -540,7 +540,23 @@ function _upgradeTags(tags, loc) {
     if (hits[0].match !== 'primary' && hits[0].match !== 'alternate') break;  // a generic match, stop looking
 
     const searchName = tuple.n.toLowerCase().replace(/[^a-z0-9]/g, '');
-    if (searchName.length < 3) continue;  // skip too-short names
+    for (let i = hits.length - 1; i >= 0; i--) {
+      const matchItem = _nsi.ids.get(hits[i].itemID);
+      if (matchItem) {
+        const matchName = (matchItem.tags.name || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+        if (searchName && matchName) {
+          if (searchName.length < 5) {
+            //directly compare short names:
+            if (searchName !== matchName) {
+              hits.splice(i, 1);
+            }
+          }
+        }
+      }
+    }
+    
+    if (!hits.length) continue;  // if all matches were filtered out, try next tuple
+    
 
     // A match may contain multiple results, the first one is likely the best one for this location
     // e.g. `['pfk-a54c14', 'kfc-1ff19c', 'kfc-658eea']`

--- a/modules/services/nsi.js
+++ b/modules/services/nsi.js
@@ -540,7 +540,7 @@ function _upgradeTags(tags, loc) {
     if (hits[0].match !== 'primary' && hits[0].match !== 'alternate') break;  // a generic match, stop looking
 
     const searchName = tuple.n.toLowerCase().replace(/[^a-z0-9]/g, '');
-    if(searchName.length < 3) continue;  // skip too-short names
+    if (searchName.length < 3) continue;  // skip too-short names
 
     // A match may contain multiple results, the first one is likely the best one for this location
     // e.g. `['pfk-a54c14', 'kfc-1ff19c', 'kfc-658eea']`

--- a/modules/services/nsi.js
+++ b/modules/services/nsi.js
@@ -539,6 +539,9 @@ function _upgradeTags(tags, loc) {
     if (!hits || !hits.length) continue;  // no match, try next tuple
     if (hits[0].match !== 'primary' && hits[0].match !== 'alternate') break;  // a generic match, stop looking
 
+    const searchName = tuple.n.toLowerCase().replace(/[^a-z0-9]/g, '');
+    if(searchName.length < 3) continue;  // skip too-short names
+
     // A match may contain multiple results, the first one is likely the best one for this location
     // e.g. `['pfk-a54c14', 'kfc-1ff19c', 'kfc-658eea']`
     let itemID, item;


### PR DESCRIPTION
### Issue Fixed:
#11215 

### Issue:
**Before:**
NSI was suggesting tag upgradation for "OK Plus" with "Circle K"
<img width="412" height="508" alt="image" src="https://github.com/user-attachments/assets/9814591a-126c-4311-81a8-9632d2964bb0" />

**After:**
No such error is suggested.

### PR Explanation:
When gathering all the names, for example in "OK Plus"
A tuple was generated for "OK Plus" as well as "OK".
When comparing "ok" with "circlek", we obtain a match (I believe it happens because "ok" is a very short string)
I fixed it by directly comparing the complete search string so that it doesn't accidentally match with strings it isn't completely similar to.

### Feedback:
I could not understand why we're using `gatherNames()` and `gatherTuples()`.