### PR TITLE
fix help info for multiCombo fields not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Include the number of changeset tags with incompatible sources in `warnings:incompatible_source` changeset tag ([#8400])
 #### :bug: Bugfixes
 * Display relative time section of "last edited {time ago} by…" text in the correct language when the user's locale is different from the browser language ([#11361])
+* Fix the help info not working for some namespaced fields like `payment:*` and `socket:*` ([#11402], thanks [@k-yle])
 * Fix crash when a way has more than 2000 nodes ([#11360])
 #### :earth_asia: Localization
 #### :hourglass: Performance
@@ -66,6 +67,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#11360]: https://github.com/openstreetmap/iD/issues/11360
 [#11361]: https://github.com/openstreetmap/iD/issues/11361
 [#11365]: https://github.com/openstreetmap/iD/issues/11365
+[#11402]: https://github.com/openstreetmap/iD/pull/11402
 
 
 # v2.36.0

--- a/modules/ui/field.js
+++ b/modules/ui/field.js
@@ -213,7 +213,7 @@ export function uiField(context, presetField, entityIDs, options) {
                 if (options.wrap && options.info) {
                     var referenceKey = d.key || '';
                     if (d.type === 'multiCombo') {   // lookup key without the trailing ':'
-                        referenceKey = referenceKey.replace(/:$/, '');
+                        referenceKey = referenceKey.replace(/:$/, ':*');
                     }
 
                     var referenceOptions = d.reference || {


### PR DESCRIPTION
Closes #11164, Closes https://github.com/openstreetmap/id-tagging-schema/issues/1586

replaces #11385, https://github.com/openstreetmap/id-tagging-schema/pull/1701, https://github.com/openstreetmap/id-tagging-schema/pull/1703, https://github.com/ideditor/schema-builder/pull/237

It's a one-line-fix as [mentioned here](https://github.com/openstreetmap/id/pull/11385#discussion_r2321432151), then we don't need to set a custom [`reference`](https://github.com/ideditor/schema-builder#reference) for these [`multiCombo` fields](https://github.com/ideditor/schema-builder#:~:text=multiCombo).

There are 3 `multiCombo` keys (marked with an ❌) where the wikibase properties need updating to be consistent with the other 14:

<table>
<thead>
    <tr>
        <th>key</th>
        <th>👎docs for <code>key</code></th>
        <th>👍docs for <code>key:*</code></th>
    </tr>
</thead>
<tbody>
    <tr>
        <td><code>blood:*</code></td>
        <td></td>
        <td></td>
    </tr>
    <tr>
        <td><code>communication:*</code></td>
        <td></td>
        <td>Prefix to provide more info on the type of communication of a transmitter or receiving installation.</td>
    </tr>
    <tr>
        <td>❌<code>currency:*</code></td>
        <td>Currency accepted or dispensed.</td>
        <td></td>
    </tr>
    <tr>
        <td><code>diet:*</code></td>
        <td></td>
        <td>The prefix for several diet:* keys to describe dietary options. Should not itself be used as a key.</td>
    </tr>
    <tr>
        <td><code>drink:*</code></td>
        <td>Used to specify specific drinks served or sold.</td>
        <td>Describes if (and optionally how) a certain drink is available at an amenity or shop.</td>
    </tr>
    <tr>
        <td>❌<code>kneipp_water_cure:*</code></td>
        <td>The single basin inside a Kneipp facility.</td>
        <td></td>
    </tr>
    <tr>
        <td><code>language:*</code></td>
        <td></td>
        <td>A namespace for keys that indicate the languages offered or taught at a point of interest (for example, language:en for English).</td>
    </tr>
    <tr>
        <td><code>monitoring:*</code></td>
        <td></td>
        <td></td>
    </tr>
    <tr>
        <td><code>payment:*</code></td>
        <td>Using this key is discouraged, use payment: prefix instead.</td>
        <td>Defines if a certain payment method is accepted or not.</td>
    </tr>
    <tr>
        <td><code>recycling:*</code></td>
        <td></td>
        <td>Description of the materials collected at this site for recycling purposes</td>
    </tr>
    <tr>
        <td><code>scuba_diving:*</code></td>
        <td></td>
        <td></td>
    </tr>
    <tr>
        <td>❌<code>diplomatic:services:*</code></td>
        <td>Specifies the services provided by an embassy, consulate or other diplomatic office.</td>
        <td></td>
    </tr>
    <tr>
        <td><code>fuel:*</code></td>
        <td>Specifies the type of fuel used with the installed infrastructure, e.g. fire pit, barbecue, kiln or with tag:substance=fuel or tag:content=fuel.</td>
        <td>Describes fuel types.</td>
    </tr>
    <tr>
        <td><code>plant:output:*</code></td>
        <td>Forms of power generated in a power plant and the rating if known.</td>
        <td>Forms of power generated in a power plant and the rating if known</td>
    </tr>
    <tr>
        <td><code>service:bicycle:*</code></td>
        <td></td>
        <td>Specifying bicycle services are available at the tagged entity. Include subkey(s) to specify the type(s) of service available.</td>
    </tr>
    <tr>
        <td><code>service:vehicle:*</code></td>
        <td></td>
        <td>Services for vehicles</td>
    </tr>
</tbody>
</table>

<details>
<summary>click here to view the script to generate the table</summary>

```js
// from https://github.com/search?q=repo%3Aopenstreetmap%2Fid-tagging-schema+%22type%22%3A+%22multiCombo%22&type=code
const list = ['blood', 'communication', 'currency', 'diet', 'drink', 'kneipp_water_cure', 'language', 'monitoring', 'payment', 'recycling', 'scuba_diving', 'diplomatic:services', 'fuel', 'plant:output', 'service:bicycle', 'service:vehicle'];

const out = [];
for (const item of list) {
    const no = await fetch(`https://wiki.openstreetmap.org/w/api.php?action=wbgetentities&sites=wiki&titles=Locale:en|Key:${item}&languages=en&languagefallback=1&origin=*&format=json`).then(r=>r.json());
    const yes = await fetch(`https://wiki.openstreetmap.org/w/api.php?action=wbgetentities&sites=wiki&titles=Locale:en|Key:${item}:*&languages=en&languagefallback=1&origin=*&format=json`).then(r=>r.json());

    delete no.entities[-1];
    const noText = Object.values(no.entities)[0].descriptions?.en?.value || '';
    delete yes.entities[-1];
    const yesText = Object.values(yes.entities)[0].descriptions?.en?.value || '';

    out.push([item, noText, yesText]);
}
console.table(out);
```

</details>
