### PR TITLE
fix: Warnings for source:esri/Google_Open_Buildings #11410

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Display relative time section of "last edited {time ago} by…" text in the correct language when the user's locale is different from the browser language ([#11361])
 * Fix the help info not working for some namespaced fields like `payment:*` and `socket:*` ([#11402], thanks [@k-yle])
 * Fix crash when a way has more than 2000 nodes ([#11360])
+* Fix data `source`s incorrectly flagged as _proprietary data_: `esri/Google_Open_Buildings` ([#11412], thanks [@Ankitgkp])
 #### :earth_asia: Localization
 #### :hourglass: Performance
 * Compress changesets before uploading, to slightly reduce bandwidth ([#11353], thank [@k-yle])
@@ -68,6 +69,8 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#11361]: https://github.com/openstreetmap/iD/issues/11361
 [#11365]: https://github.com/openstreetmap/iD/issues/11365
 [#11402]: https://github.com/openstreetmap/iD/pull/11402
+[#11412]: https://github.com/openstreetmap/iD/pull/11412
+[@Ankitgkp]: https://github.com/Ankitgkp
 
 
 # v2.36.0

--- a/modules/validations/incompatible_source.js
+++ b/modules/validations/incompatible_source.js
@@ -14,7 +14,7 @@ const incompatibleRules = [
   {
     id: 'google',
     regex: /(google)/i,
-    exceptRegex: /((books|drive)\.google|google\s?(books|drive|plus))|(esri\/Google_Africa_Buildings)/i
+    exceptRegex: /((books|drive)\.google|google\s?(books|drive|plus))|(esri\/Google_(Africa|Open)_Buildings)/i
   }
 ];
 

--- a/test/spec/validations/incompatible_source.js
+++ b/test/spec/validations/incompatible_source.js
@@ -68,4 +68,10 @@ describe('iD.validations.incompatible_source', function () {
         var issues = validate();
         expect(issues).to.have.lengthOf(0);
     });
+
+    it('does not flag buildings in the google-open-buildings dataset', function() {
+        createWay({ building: 'yes', source: 'esri/Google_Open_Buildings' });
+        var issues = validate();
+        expect(issues).to.have.lengthOf(0);
+    });
 });


### PR DESCRIPTION
#11410

Add exception for Google_Open_Buildings dataset in incompatible source validation

Update regex pattern to include both Google_Africa_Buildings and Google_Open_Buildings
Add test case for Google_Open_Buildings dataset
Google_Open_Buildings is ODbL compatible and should not be flagged as incompatible

Fixes issue where Google_Open_Buildings dataset was incorrectly flagged as
having an incompatible source, despite being released under an ODbL compatible
license and available by default in Rapid editor.