### PR TITLE
Fix turn restriction vertex fill color

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -2317,6 +2317,7 @@ input.date-selector {
 
 .form-field-input-restrictions .restriction-container {
     position: relative;
+    color: #333;
     height: 370px;
 }
 /* zero width space, so container takes up space */


### PR DESCRIPTION
Fixing a regression from #11308 by reverting part of 34b85c4f98d79e604f7f9f43a4e63ae2b33297df to make icons in the restriction editor show like in the main editor window:
|before|after|
|-|-|
|<img src="https://github.com/user-attachments/assets/40d662e4-102d-418c-bd34-676d2a7d8498" />|<img src="https://github.com/user-attachments/assets/f4fbf1c6-9366-4515-b440-e7d4c7fbf2eb" />|