### PR TITLE
Restore URL validation for website and url fields

### DIFF
--- a/modules/validations/invalid_format.js
+++ b/modules/validations/invalid_format.js
@@ -50,7 +50,10 @@ export function validationFormatting() {
         Object.keys(entity.tags).forEach(function(tag) {
             if (tag === 'image') return; // skip image
             if (!/(website|url)/i.test(tag)) return; // only process website/url tags
-            var value = entity.tags[tag].trim();
+            var raw = entity.tags[tag];
+            if (!raw) return; // skip empty or undefined
+            var value = raw.trim();
+            if (!value) return; // skip empty string after trim
             if (value.includes(';')) {
                 // If semicolon present, validate each part
                 var parts = value.split(';').map(function(s) { return s.trim(); });

--- a/modules/validations/invalid_format.js
+++ b/modules/validations/invalid_format.js
@@ -46,67 +46,65 @@ export function validationFormatting() {
                 .call(t.append('issues.invalid_format.website.reference'));
         }
 
-        // URL field validation - check multiple possible URL tags (excluding image which allows File: format)
-        const urlTags = ['website', 'url', 'website:mobile', 'contact:website', 'contact:url', 'source:website', 'source:url'];
-
-        urlTags.forEach(function(tag) {
-            if (entity.tags[tag]) {
-                var value = entity.tags[tag].trim();
-                if (value.includes(';')) {
-                    // If semicolon present, validate each part
-                    var parts = value.split(';').map(function(s) { return s.trim(); });
-                    var invalidParts = parts.filter(function(x) { return !isValidURL(x); });
-                    if (invalidParts.length) {
-                        // Always warn if any split parts are invalid
-                        issues.push(new validationIssue({
-                            type: type,
-                            subtype: 'website',
-                            severity: 'warning',
-                            message: function(context) {
-                                var entity = context.hasEntity(this.entityIds[0]);
-                                return entity ? t.append('issues.invalid_format.website.message' + this.data,
-                                    { feature: utilDisplayLabel(entity, context.graph()), site: invalidParts.join(', ') }) : '';
-                            },
-                            reference: showReferenceWebsite,
-                            entityIds: [entity.id],
-                            hash: tag + '=' + invalidParts.join(),
-                            data: (invalidParts.length > 1) ? '_multi' : ''
-                        }));
-                    } else if (!isValidURL(value)) {
-                        // All split parts valid, but whole value still invalid
-                        issues.push(new validationIssue({
-                            type: type,
-                            subtype: 'website',
-                            severity: 'warning',
-                            message: function(context) {
-                                var entity = context.hasEntity(this.entityIds[0]);
-                                return entity ? t.append('issues.invalid_format.website.message',
-                                    { feature: utilDisplayLabel(entity, context.graph()), site: value }) : '';
-                            },
-                            reference: showReferenceWebsite,
-                            entityIds: [entity.id],
-                            hash: tag + '=' + value,
-                            data: ''
-                        }));
-                    }
-                } else {
-                    // No semicolon, validate whole value
-                    if (!isValidURL(value)) {
-                        issues.push(new validationIssue({
-                            type: type,
-                            subtype: 'website',
-                            severity: 'warning',
-                            message: function(context) {
-                                var entity = context.hasEntity(this.entityIds[0]);
-                                return entity ? t.append('issues.invalid_format.website.message',
-                                    { feature: utilDisplayLabel(entity, context.graph()), site: value }) : '';
-                            },
-                            reference: showReferenceWebsite,
-                            entityIds: [entity.id],
-                            hash: tag + '=' + value,
-                            data: ''
-                        }));
-                    }
+        // Refactored: Iterate all tags, skip 'image', process tags matching /(website|url)/
+        Object.keys(entity.tags).forEach(function(tag) {
+            if (tag === 'image') return; // skip image
+            if (!/(website|url)/i.test(tag)) return; // only process website/url tags
+            var value = entity.tags[tag].trim();
+            if (value.includes(';')) {
+                // If semicolon present, validate each part
+                var parts = value.split(';').map(function(s) { return s.trim(); });
+                var invalidParts = parts.filter(function(x) { return !isValidURL(x); });
+                if (invalidParts.length) {
+                    // Always warn if any split parts are invalid
+                    issues.push(new validationIssue({
+                        type: type,
+                        subtype: 'website',
+                        severity: 'warning',
+                        message: function(context) {
+                            var entity = context.hasEntity(this.entityIds[0]);
+                            return entity ? t.append('issues.invalid_format.website.message' + this.data,
+                                { feature: utilDisplayLabel(entity, context.graph()), site: invalidParts.join(', ') }) : '';
+                        },
+                        reference: showReferenceWebsite,
+                        entityIds: [entity.id],
+                        hash: tag + '=' + invalidParts.join(),
+                        data: (invalidParts.length > 1) ? '_multi' : ''
+                    }));
+                } else if (!isValidURL(value)) {
+                    // All split parts valid, but whole value still invalid
+                    issues.push(new validationIssue({
+                        type: type,
+                        subtype: 'website',
+                        severity: 'warning',
+                        message: function(context) {
+                            var entity = context.hasEntity(this.entityIds[0]);
+                            return entity ? t.append('issues.invalid_format.website.message',
+                                { feature: utilDisplayLabel(entity, context.graph()), site: value }) : '';
+                        },
+                        reference: showReferenceWebsite,
+                        entityIds: [entity.id],
+                        hash: tag + '=' + value,
+                        data: ''
+                    }));
+                }
+            } else {
+                // No semicolon, validate whole value
+                if (!isValidURL(value)) {
+                    issues.push(new validationIssue({
+                        type: type,
+                        subtype: 'website',
+                        severity: 'warning',
+                        message: function(context) {
+                            var entity = context.hasEntity(this.entityIds[0]);
+                            return entity ? t.append('issues.invalid_format.website.message',
+                                { feature: utilDisplayLabel(entity, context.graph()), site: value }) : '';
+                        },
+                        reference: showReferenceWebsite,
+                        entityIds: [entity.id],
+                        hash: tag + '=' + value,
+                        data: ''
+                    }));
                 }
             }
         });

--- a/modules/validations/invalid_format.js
+++ b/modules/validations/invalid_format.js
@@ -26,11 +26,14 @@ export function validationFormatting() {
                 .call(t.append('issues.invalid_format.email.reference'));
         }
 
-        /* see https://github.com/openstreetmap/iD/issues/6831#issuecomment-537121379
-        function isSchemePresent(url) {
-            var valid_scheme = /^https?:\/\//i;
-            return (!url || valid_scheme.test(url));
+        function isValidURL(url) {
+            try {
+                return Boolean(new URL(url));
+            } catch {
+                return false;
+            }
         }
+
         function showReferenceWebsite(selection) {
             selection.selectAll('.issue-reference')
                 .data([0])
@@ -40,31 +43,35 @@ export function validationFormatting() {
                 .call(t.append('issues.invalid_format.website.reference'));
         }
 
-        if (entity.tags.website) {
-            // Multiple websites are possible
-            // If ever we support ES6, arrow functions make this nicer
-            var websites = entity.tags.website
-                .split(';')
-                .map(function(s) { return s.trim(); })
-                .filter(function(x) { return !isSchemePresent(x); });
+        // URL field validation - check multiple possible URL tags
+        const urlTags = ['website', 'url', 'website:mobile', 'contact:website', 'contact:url', 'image', 'source:website', 'source:url'];
 
-            if (websites.length) {
-                issues.push(new validationIssue({
-                    type: type,
-                    subtype: 'website',
-                    severity: 'warning',
-                    message: function(context) {
-                        var entity = context.hasEntity(this.entityIds[0]);
-                        return entity ? t.append('issues.invalid_format.website.message' + this.data,
-                            { feature: utilDisplayLabel(entity, context.graph()), site: websites.join(', ') }) : '';
-                    },
-                    reference: showReferenceWebsite,
-                    entityIds: [entity.id],
-                    hash: websites.join(),
-                    data: (websites.length > 1) ? '_multi' : ''
-                }));
+        urlTags.forEach(function(tag) {
+            if (entity.tags[tag]) {
+                // Multiple URLs are possible, separated by semicolons
+                var urls = entity.tags[tag]
+                    .split(';')
+                    .map(function(s) { return s.trim(); })
+                    .filter(function(x) { return !isValidURL(x); });
+
+                if (urls.length) {
+                    issues.push(new validationIssue({
+                        type: type,
+                        subtype: 'website',
+                        severity: 'warning',
+                        message: function(context) {
+                            var entity = context.hasEntity(this.entityIds[0]);
+                            return entity ? t.append('issues.invalid_format.website.message' + this.data,
+                                { feature: utilDisplayLabel(entity, context.graph()), site: urls.join(', ') }) : '';
+                        },
+                        reference: showReferenceWebsite,
+                        entityIds: [entity.id],
+                        hash: tag + '=' + urls.join(),
+                        data: (urls.length > 1) ? '_multi' : ''
+                    }));
+                }
             }
-        }*/
+        });
 
         if (entity.tags.email) {
             // Multiple emails are possible

--- a/modules/validations/invalid_format.js
+++ b/modules/validations/invalid_format.js
@@ -29,7 +29,7 @@ export function validationFormatting() {
         function isValidURL(url) {
             try {
                 // First try strict WHATWG parsing
-                new URL(url);
+                new URL(url); // eslint-disable-line no-new
                 return true;
             } catch {
                 // Fallback: accept if it looks like a valid scheme://something, even if semicolons are present
@@ -52,31 +52,61 @@ export function validationFormatting() {
         urlTags.forEach(function(tag) {
             if (entity.tags[tag]) {
                 var value = entity.tags[tag].trim();
-                // First, try validating the entire value as a single URL
-                if (isValidURL(value)) {
-                    return; // Valid, skip further checks
-                }
-                // If not valid, split on semicolons and check each part
-                var urls = value
-                    .split(';')
-                    .map(function(s) { return s.trim(); })
-                    .filter(function(x) { return !isValidURL(x); });
-
-                if (urls.length) {
-                    issues.push(new validationIssue({
-                        type: type,
-                        subtype: 'website',
-                        severity: 'warning',
-                        message: function(context) {
-                            var entity = context.hasEntity(this.entityIds[0]);
-                            return entity ? t.append('issues.invalid_format.website.message' + this.data,
-                                { feature: utilDisplayLabel(entity, context.graph()), site: urls.join(', ') }) : '';
-                        },
-                        reference: showReferenceWebsite,
-                        entityIds: [entity.id],
-                        hash: tag + '=' + urls.join(),
-                        data: (urls.length > 1) ? '_multi' : ''
-                    }));
+                if (value.includes(';')) {
+                    // If semicolon present, validate each part
+                    var parts = value.split(';').map(function(s) { return s.trim(); });
+                    var invalidParts = parts.filter(function(x) { return !isValidURL(x); });
+                    if (invalidParts.length) {
+                        // Always warn if any split parts are invalid
+                        issues.push(new validationIssue({
+                            type: type,
+                            subtype: 'website',
+                            severity: 'warning',
+                            message: function(context) {
+                                var entity = context.hasEntity(this.entityIds[0]);
+                                return entity ? t.append('issues.invalid_format.website.message' + this.data,
+                                    { feature: utilDisplayLabel(entity, context.graph()), site: invalidParts.join(', ') }) : '';
+                            },
+                            reference: showReferenceWebsite,
+                            entityIds: [entity.id],
+                            hash: tag + '=' + invalidParts.join(),
+                            data: (invalidParts.length > 1) ? '_multi' : ''
+                        }));
+                    } else if (!isValidURL(value)) {
+                        // All split parts valid, but whole value still invalid
+                        issues.push(new validationIssue({
+                            type: type,
+                            subtype: 'website',
+                            severity: 'warning',
+                            message: function(context) {
+                                var entity = context.hasEntity(this.entityIds[0]);
+                                return entity ? t.append('issues.invalid_format.website.message',
+                                    { feature: utilDisplayLabel(entity, context.graph()), site: value }) : '';
+                            },
+                            reference: showReferenceWebsite,
+                            entityIds: [entity.id],
+                            hash: tag + '=' + value,
+                            data: ''
+                        }));
+                    }
+                } else {
+                    // No semicolon, validate whole value
+                    if (!isValidURL(value)) {
+                        issues.push(new validationIssue({
+                            type: type,
+                            subtype: 'website',
+                            severity: 'warning',
+                            message: function(context) {
+                                var entity = context.hasEntity(this.entityIds[0]);
+                                return entity ? t.append('issues.invalid_format.website.message',
+                                    { feature: utilDisplayLabel(entity, context.graph()), site: value }) : '';
+                            },
+                            reference: showReferenceWebsite,
+                            entityIds: [entity.id],
+                            hash: tag + '=' + value,
+                            data: ''
+                        }));
+                    }
                 }
             }
         });

--- a/modules/validations/invalid_format.js
+++ b/modules/validations/invalid_format.js
@@ -28,9 +28,12 @@ export function validationFormatting() {
 
         function isValidURL(url) {
             try {
-                return Boolean(new URL(url));
+                // First try strict WHATWG parsing
+                new URL(url);
+                return true;
             } catch {
-                return false;
+                // Fallback: accept if it looks like a valid scheme://something, even if semicolons are present
+                return /^https?:\/\/\S+$/i.test(url);
             }
         }
 
@@ -48,8 +51,13 @@ export function validationFormatting() {
 
         urlTags.forEach(function(tag) {
             if (entity.tags[tag]) {
-                // Multiple URLs are possible, separated by semicolons
-                var urls = entity.tags[tag]
+                var value = entity.tags[tag].trim();
+                // First, try validating the entire value as a single URL
+                if (isValidURL(value)) {
+                    return; // Valid, skip further checks
+                }
+                // If not valid, split on semicolons and check each part
+                var urls = value
                     .split(';')
                     .map(function(s) { return s.trim(); })
                     .filter(function(x) { return !isValidURL(x); });

--- a/modules/validations/invalid_format.js
+++ b/modules/validations/invalid_format.js
@@ -46,11 +46,23 @@ export function validationFormatting() {
                 .call(t.append('issues.invalid_format.website.reference'));
         }
 
-        Object.keys(entity.tags).forEach(function(tag) {
-            if (!/\b(website|url)\b/i.test(tag)) return;
-            var raw = entity.tags[tag];
-            if (!raw) return;
-            var value = raw.trim();
+        const websiteValidationIssueBase = {
+            type: type,
+            subtype: 'website',
+            severity: 'warning',
+            message: function(context) {
+                var entity = context.hasEntity(this.entityIds[0]);
+                return entity ? t.append('issues.invalid_format.website.message' + this.data,
+                    { feature: utilDisplayLabel(entity, context.graph()), site: this.value }) : '';
+            },
+            reference: showReferenceWebsite,
+            entityIds: [entity.id]
+        };
+
+        Object.entries(entity.tags).forEach(function([key, tag]) {
+            if (!/\b(website|url)\b/i.test(key)) return;
+            if (!tag) return;
+            var value = tag.trim();
             if (!value) return;
             if (value.includes(';')) {
 
@@ -58,33 +70,21 @@ export function validationFormatting() {
                 var invalidParts = parts.filter(function(x) { return !isValidURL(x); });
                 if (invalidParts.length) {
                     issues.push(new validationIssue({
-                        type: type,
-                        subtype: 'website',
-                        severity: 'warning',
-                        message: function(context) {
-                            var entity = context.hasEntity(this.entityIds[0]);
-                            return entity ? t.append('issues.invalid_format.website.message' + this.data,
-                                { feature: utilDisplayLabel(entity, context.graph()), site: invalidParts.join(', ') }) : '';
-                        },
-                        reference: showReferenceWebsite,
-                        entityIds: [entity.id],
-                        hash: tag + '=' + invalidParts.join(),
+                        ...websiteValidationIssueBase,
+
+                        value: invalidParts.join(', '),
+
+                        hash: key + '=' + invalidParts.join(),
                         data: (invalidParts.length > 1) ? '_multi' : ''
                     }));
                 } else if (!isValidURL(value)) {
                     // All split parts valid, but whole value still invalid
                     issues.push(new validationIssue({
-                        type: type,
-                        subtype: 'website',
-                        severity: 'warning',
-                        message: function(context) {
-                            var entity = context.hasEntity(this.entityIds[0]);
-                            return entity ? t.append('issues.invalid_format.website.message',
-                                { feature: utilDisplayLabel(entity, context.graph()), site: value }) : '';
-                        },
-                        reference: showReferenceWebsite,
-                        entityIds: [entity.id],
-                        hash: tag + '=' + value,
+                        ...websiteValidationIssueBase,
+
+                        value: value,
+
+                        hash: key + '=' + value,
                         data: ''
                     }));
                 }
@@ -92,17 +92,11 @@ export function validationFormatting() {
                 // No semicolon, validate whole value
                 if (!isValidURL(value)) {
                     issues.push(new validationIssue({
-                        type: type,
-                        subtype: 'website',
-                        severity: 'warning',
-                        message: function(context) {
-                            var entity = context.hasEntity(this.entityIds[0]);
-                            return entity ? t.append('issues.invalid_format.website.message',
-                                { feature: utilDisplayLabel(entity, context.graph()), site: value }) : '';
-                        },
-                        reference: showReferenceWebsite,
-                        entityIds: [entity.id],
-                        hash: tag + '=' + value,
+                        ...websiteValidationIssueBase,
+
+                        value: value,
+
+                        hash: key + '=' + value,
                         data: ''
                     }));
                 }

--- a/modules/validations/invalid_format.js
+++ b/modules/validations/invalid_format.js
@@ -43,8 +43,8 @@ export function validationFormatting() {
                 .call(t.append('issues.invalid_format.website.reference'));
         }
 
-        // URL field validation - check multiple possible URL tags
-        const urlTags = ['website', 'url', 'website:mobile', 'contact:website', 'contact:url', 'image', 'source:website', 'source:url'];
+        // URL field validation - check multiple possible URL tags (excluding image which allows File: format)
+        const urlTags = ['website', 'url', 'website:mobile', 'contact:website', 'contact:url', 'source:website', 'source:url'];
 
         urlTags.forEach(function(tag) {
             if (entity.tags[tag]) {

--- a/modules/validations/invalid_format.js
+++ b/modules/validations/invalid_format.js
@@ -46,20 +46,17 @@ export function validationFormatting() {
                 .call(t.append('issues.invalid_format.website.reference'));
         }
 
-        // Refactored: Iterate all tags, skip 'image', process tags matching /(website|url)/
         Object.keys(entity.tags).forEach(function(tag) {
-            if (tag === 'image') return; // skip image
-            if (!/(website|url)/i.test(tag)) return; // only process website/url tags
+            if (!/\b(website|url)\b/i.test(tag)) return;
             var raw = entity.tags[tag];
-            if (!raw) return; // skip empty or undefined
+            if (!raw) return;
             var value = raw.trim();
-            if (!value) return; // skip empty string after trim
+            if (!value) return;
             if (value.includes(';')) {
-                // If semicolon present, validate each part
+
                 var parts = value.split(';').map(function(s) { return s.trim(); });
                 var invalidParts = parts.filter(function(x) { return !isValidURL(x); });
                 if (invalidParts.length) {
-                    // Always warn if any split parts are invalid
                     issues.push(new validationIssue({
                         type: type,
                         subtype: 'website',

--- a/test/spec/renderer/map.js
+++ b/test/spec/renderer/map.js
@@ -10,6 +10,8 @@ describe('iD.Map', function() {
         context = iD.coreContext().assetPath('../dist/').init().container(content);
         map = context.map();
         content.call(map);
+        // Set default dimensions for map before zoom/center tests
+        map.dimensions([1000, 1000]);
     });
 
     afterEach(function() {

--- a/test/spec/renderer/map.js
+++ b/test/spec/renderer/map.js
@@ -154,6 +154,10 @@ describe('iD.Map', function() {
             line     = behavior.append('div').attr('class', 'way line');
             area     = behavior.append('div').attr('class', 'way area');
             midpoint = behavior.append('div').attr('class', 'midpoint');
+            // Ensure map dimensions set for any map instance created in nested tests
+            if (typeof map !== 'undefined' && typeof map.dimensions === 'function') {
+                map.dimensions([1000, 1000]);
+            }
         });
 
         afterEach(function() {

--- a/test/spec/validations/invalid_format.js
+++ b/test/spec/validations/invalid_format.js
@@ -1,0 +1,119 @@
+describe('iD.validations.invalid_format', function () {
+    var context;
+
+    beforeEach(function() {
+        context = iD.coreContext().assetPath('../dist/').init();
+    });
+
+    function createPointWithTags(tags) {
+        var n = iD.osmNode({id: 'n-1', loc: [4,4], tags: tags});
+        context.perform(iD.actionAddEntity(n));
+        return n;
+    }
+
+    function validate(entity) {
+        var validator = iD.validationFormatting(context);
+        return validator(entity, context.graph());
+    }
+
+    describe('URL validation', function() {
+        it('should not flag valid URLs', function() {
+            var entity = createPointWithTags({
+                website: 'https://example.com',
+                'contact:website': 'http://test.org',
+                url: 'https://www.valid-site.net/path?query=1'
+            });
+            var issues = validate(entity);
+            expect(issues).to.have.lengthOf(0);
+        });
+
+        it('should flag URLs missing scheme', function() {
+            var entity = createPointWithTags({
+                website: 'example.com'
+            });
+            var issues = validate(entity);
+            expect(issues).to.have.lengthOf(1);
+            expect(issues[0].type).to.eql('invalid_format');
+            expect(issues[0].subtype).to.eql('website');
+        });
+
+        it('should flag malformed URLs', function() {
+            var entity = createPointWithTags({
+                website: 'not-a-url',
+                url: 'invalid://bad url with spaces'
+            });
+            var issues = validate(entity);
+            expect(issues).to.have.lengthOf(2);
+            issues.forEach(function(issue) {
+                expect(issue.type).to.eql('invalid_format');
+                expect(issue.subtype).to.eql('website');
+            });
+        });
+
+        it('should handle multiple URLs separated by semicolons', function() {
+            var entity = createPointWithTags({
+                website: 'https://example.com;invalid-url;http://valid.org'
+            });
+            var issues = validate(entity);
+            expect(issues).to.have.lengthOf(1);
+            expect(issues[0].type).to.eql('invalid_format');
+            expect(issues[0].subtype).to.eql('website');
+            expect(issues[0].data).to.eql('');
+        });
+
+        it('should handle multiple invalid URLs', function() {
+            var entity = createPointWithTags({
+                website: 'bad-url1;bad-url2'
+            });
+            var issues = validate(entity);
+            expect(issues).to.have.lengthOf(1);
+            expect(issues[0].type).to.eql('invalid_format');
+            expect(issues[0].subtype).to.eql('website');
+            expect(issues[0].data).to.eql('_multi');
+        });
+
+        it('should validate all URL tags', function() {
+            var entity = createPointWithTags({
+                website: 'bad-url',
+                url: 'another-bad-url',
+                'contact:website': 'yet-another-bad',
+                'source:url': 'still-bad'
+            });
+            var issues = validate(entity);
+            expect(issues).to.have.lengthOf(4);
+            issues.forEach(function(issue) {
+                expect(issue.type).to.eql('invalid_format');
+                expect(issue.subtype).to.eql('website');
+            });
+        });
+
+        it('should not flag empty URL fields', function() {
+            var entity = createPointWithTags({
+                website: '',
+                url: undefined
+            });
+            var issues = validate(entity);
+            expect(issues).to.have.lengthOf(0);
+        });
+    });
+
+    describe('Email validation', function() {
+        it('should not flag valid emails', function() {
+            var entity = createPointWithTags({
+                email: 'test@example.com'
+            });
+            var issues = validate(entity);
+            expect(issues).to.have.lengthOf(0);
+        });
+
+        it('should flag invalid emails', function() {
+            var entity = createPointWithTags({
+                email: 'not-an-email'
+            });
+            var issues = validate(entity);
+            expect(issues).to.have.lengthOf(1);
+            expect(issues[0].type).to.eql('invalid_format');
+            expect(issues[0].subtype).to.eql('email');
+        });
+    });
+});


### PR DESCRIPTION
#11436 
Improves URL validation in invalid_format.js by replacing regex-based validation with URL constructor validation as recommended in #8827. Validates multiple URL fields (website, url, contact:website, etc.) and handles semicolon-separated values. Prevents malformed URLs like "example.com" that cause incorrect relative linking behavior.