### PR TITLE
Adds optional chaining to hasEntity call (Fix Issue #11437)

### DIFF
--- a/modules/svg/labels.js
+++ b/modules/svg/labels.js
@@ -719,7 +719,7 @@ export function svgLabels(projection, context) {
                     // in select mode: hide labels of currently selected line(s)
                     // to still allow accessing midpoints
                     // https://github.com/openstreetmap/iD/issues/11220
-                    context.mode().selectedIDs().includes(id) && graph.hasEntity(id).geometry(graph) === 'line');
+                    context.mode().selectedIDs().includes(id) && graph.hasEntity(id)?.geometry(graph) === 'line');
             hideIds.push.apply(hideIds, nearMouse);
             hideIds = utilArrayUniq(hideIds);
         }


### PR DESCRIPTION
I also experienced Issue #11437 when onboarding to openstreetmap recently and therefore thought it would be a fitting first issue to fix!

Upon investigation of the problem, I believe the reason it's not progressing to the next "undo" step in the walkthrough is because there is an error when trying to hide the labels near the mouse; by the time it is trying to hide the labels, the point has already been deleted, thus the call `graph.hasEntity(id)` returns `undefined`.

This then causes the error as seen below in the screenshot of the console. 

There are 3 different ways I thought of approaching this problem: 

1. **Change the logical ordering of events,** such that this labeling event happens before a deleted point event so that the error isn't thrown in the first place (i.e. this label hide can successfully happen). This seemed like both the most involved and most intrusive change. As a new contributor, I definitely don't have the knowledge of this project to make a change this big and therefore decided against it. 
2. **Change the `filterLabels` function** such that it conditionally filters based on if the entity is still available. This seemed like a good solution and I am potentially interested in moving forward with this one, but why I eventually decided against implementing it is similar to the reason cited above- as a new contributor I'm afraid of the other affects this could have throughout the project that I am not yet aware of at this point :) 
3. **Add some (slight) error handling.** This is the approach that I ended up opting for, through adding optional chaining to the `hasEntity` call within the `filterLabels` function. This effectively eliminates the TypeError as it safeguards against an undefined value being returned by `hasEntity`. _That being said,_ I am slightly concerned about the possibility of this not fully protecting against a TypeError, as I was having a hard time finding the definition of the `hasEntity` function, and am not sure if it could return something like a boolean, in which case this TypeError will persist. 

Anyways this is lots of words for a one character change LOL. Excited for a review and (hopefully) my first contribution <3 

<img width="1221" height="794" alt="Screenshot 2025-09-24 at 10 09 50 PM" src="https://github.com/user-attachments/assets/e2f43970-3c87-407c-a031-80557b8cf362" />
