### PR TITLE
Added info that there are more presets than visible on the screen

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -1086,6 +1086,12 @@ a.hide-toggle {
     background: var(--bg-color-3);
 }
 
+.preset-search-info {
+    padding: 10px;
+    font-size: 12px;
+    color: #666;
+}
+
 .preset-icon-container {
     position: relative;
     width: 60px;

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -745,6 +745,7 @@ en:
     remove: Remove
     search: Search
     search_feature_type: Search feature type
+    search_more: These are not all the possibilities. To see more, enter the name of the store or place you are looking for in the search box.
     unknown: Unknown
     incomplete: <not downloaded>
     feature_list: Search features

--- a/modules/ui/preset_list.js
+++ b/modules/ui/preset_list.js
@@ -128,6 +128,13 @@ export function uiPresetList(context) {
             .on('keypress', keypress)
             .on('input', _debounce(inputevent));
 
+        var searchInfo = selection
+            .append('div')
+            .attr('class', 'preset-search-info');
+
+        searchInfo.append('span')
+            .html(t.html('inspector.search_more'));
+
         if (_autofocus) {
             search.node().focus();
 


### PR DESCRIPTION
Previously, when adding a node in the editor, users only saw a limited set of presets (top suggestions and initial ~10 presets). This caused confusion for new mappers, who might think these are the only options available.

This PR adds an informational note at the start of the preset list
<img width="1167" height="657" alt="Screenshot 2025-10-16 at 2 36 05 AM" src="https://github.com/user-attachments/assets/acd9617f-65ac-4df6-8709-c9093b689c84" />

Closes: #11465
