### PR TITLE
fix layer tag overriden when adding a bridge or tunnel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Fix data `source`s incorrectly flagged as _proprietary data_: `esri/Google_Open_Buildings` ([#11412], thanks [@Ankitgkp])
 * Keep `natural=coastline` tag on the way when a coastline way that is also an area (e.g. `place=islet`) is split and converted into a multipolygon ([#9563])
 * Fix address preset from being hidden in presets list when "point" features are hidden, but "address points" visible ([#11456])
+* Preserve existing `layer` tags when adding a bridge or tunnel ([#11511], thanks [@k-yle])
 #### :earth_asia: Localization
 #### :hourglass: Performance
 * Compress changesets before uploading, to slightly reduce bandwidth ([#11353], thank [@k-yle])
@@ -87,6 +88,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#11442]: https://github.com/openstreetmap/iD/pull/11442
 [#11456]: https://github.com/openstreetmap/iD/issues/11456
 [#11466]: https://github.com/openstreetmap/iD/issues/11466
+[#11511]: https://github.com/openstreetmap/iD/pull/11511
 [@Ankitgkp]: https://github.com/Ankitgkp
 [@AntonKhorev]: https://github.com/AntonKhorev
 [@bgo-bell]: https://github.com/bgo-bell

--- a/modules/ui/fields/radio.js
+++ b/modules/ui/fields/radio.js
@@ -20,6 +20,7 @@ export function uiFieldRadio(field, context) {
     var radioData = (field.options || strings.options || field.keys).slice();  // shallow copy
     var typeField;
     var layerField;
+    let _tags = {};
     var _oldType = {};
     var _entityIDs = [];
 
@@ -250,9 +251,15 @@ export function uiFieldRadio(field, context) {
 
         if (field.type === 'structureRadio') {
             if (activeKey === 'bridge') {
-                t.layer = '1';
+                // if there already is an a layer tag, respect it if it's >0
+                const hasExistingLayer = !Number.isNaN(+_tags.layer) && +_tags.layer > 0;
+
+                t.layer = hasExistingLayer ? _tags.layer : '1';
             } else if (activeKey === 'tunnel' && t.tunnel !== 'building_passage') {
-                t.layer = '-1';
+                // if there already is an a layer tag, respect it if it's <0
+                const hasExistingLayer = !Number.isNaN(+_tags.layer) && +_tags.layer < 0;
+
+                t.layer = hasExistingLayer ? _tags.layer : '-1';
             } else {
                 t.layer = undefined;
             }
@@ -263,6 +270,7 @@ export function uiFieldRadio(field, context) {
 
 
     radio.tags = function(tags) {
+        _tags = tags;
         function isOptionChecked(d) {
             if (field.key) {
                 return tags[field.key] === d;

--- a/test/spec/ui/fields/radio.ts
+++ b/test/spec/ui/fields/radio.ts
@@ -22,7 +22,7 @@ describe('iD.uiFieldRadio', () => {
                 { bridge: 'yes', layer: '2' }
             ],
             [
-                // negative layers are overriden with layer=1
+                // negative layers are overridden with layer=1
                 { layer: '-3' },
                 'bridge',
                 { bridge: 'yes', layer: '1' }

--- a/test/spec/ui/fields/radio.ts
+++ b/test/spec/ui/fields/radio.ts
@@ -1,0 +1,71 @@
+describe('iD.uiFieldRadio', () => {
+    describe('structureRadio', () => {
+        let context: iD.Context;
+        let selection: d3.Selection;
+
+        beforeEach(() => {
+            context = iD.coreContext().assetPath('../dist/').init();
+            selection = d3.select(document.createElement('div'));
+        });
+
+        it.each<[fromTags: Tags, optionToClick: string, toTags: Tags]>([
+            [
+                // if no tags, it should add layer=1
+                {},
+                'bridge',
+                { bridge: 'yes', layer: '1' }
+            ],
+            [
+                // existing positive layer should be respected
+                { layer: '2' },
+                'bridge',
+                { bridge: 'yes', layer: '2' }
+            ],
+            [
+                // negative layers are overriden with layer=1
+                { layer: '-3' },
+                'bridge',
+                { bridge: 'yes', layer: '1' }
+            ],
+            [
+                // changing a tunnel to a bridge should change layer
+                { layer: '-1', tunnel: 'yes' },
+                'bridge',
+                { bridge: 'yes', layer: '1' }
+            ],
+            [
+                // opposite direction: changing to a tunnel:
+                { layer: '-3' },
+                'tunnel',
+                { tunnel: 'yes', layer: '-3' }
+            ],
+        ])('given %s, after clicking on ‘%s’, changes tags to %s', (fromTags, optionToClick, toTags) => {
+            const field = iD.presetField('a', {
+                type: 'structureRadio',
+                keys: ['bridge', 'tunnel'],
+                options: ['bridge', 'tunnel'],
+            });
+            const instance = iD.uiFieldRadio(field, context);
+            const onChange = vi.fn();
+
+            selection.call(instance);
+            instance.on('change', onChange);
+            instance.tags(fromTags);
+
+            // confirm that bridge+tunnel buttons are displayed
+            const options = selection.selectAll<HTMLLabelElement, unknown>('label').nodes();
+            expect(options).toHaveLength(2);
+            expect(options[0].querySelector('.localized-text')?.innerHTML).toBe('bridge');
+            expect(options[1].querySelector('.localized-text')?.innerHTML).toBe('tunnel');
+
+            // click one of the radio button
+            const index = field.keys.indexOf(optionToClick);
+            const radioToClick = options[index].querySelector('input')!;
+            radioToClick.checked = true;
+            d3.select(radioToClick).dispatch('change');
+
+            expect(onChange).toHaveBeenCalledTimes(1);
+            expect(onChange).toHaveBeenNthCalledWith(1, toTags);
+        });
+    });
+});


### PR DESCRIPTION
if a line already has `highway=*` + `layer=-3`, and you click on the `tunnel` option in the UI, then it will replace `layer=-3` with `layer=-1` which is unexpected. 

However, if the `layer` is >0, then it does make sense to change it to -1.

The opposite applies for bridges. 

So, instead of blindly overriding the `layer` tag with `1` or `-1`, we now have a more nuanced solution which respects existing tag values (if they make sense).

see unit tests for more examples.