### PR TITLE
Update CONTRIBUTING.md with further details about Transifex signup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -212,10 +212,11 @@ switch to the development database.
 ## Translating
 
 Translations are managed using the
-[Transifex](https://app.transifex.com/openstreetmap/id-editor/) platform. After
-signing up, you can go to [iD's project
-page](https://app.transifex.com/openstreetmap/id-editor/) and
-click **Translate** to start translating. Translations are divided into
+[Transifex](https://app.transifex.com/openstreetmap/id-editor/) platform. Sign up to Transifex via the
+["Join This Project"](https://app.transifex.com/join/?o=openstreetmap&p=id-editor&t=opensource) link on
+the [iD's project page](https://app.transifex.com/openstreetmap/id-editor/) and
+click **Translate** to start translating. If you try to join via the home page "Sign up" link you won't
+be able to create an account without a "business email". Translations are divided into
 separate resources:
 
 * *core* - contains text for the main interface of iD


### PR DESCRIPTION
After a contributor was unable to create an account to help with translations due to Transifex only allowing "business email's", we discovered there is a specific signup flow that must be followed to allow contributors to create accounts without a "business email".