### PR TITLE
Change indent_size to tab in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,4 +16,4 @@ indent_size = 4
 [*.{js,mjs}]
 end_of_line = lf
 insert_final_newline = true
-indent_size = tab_width
+indent_size = tab


### PR DESCRIPTION
Neovim shows this warning:
'editorconfig: invalid value for option indent_size: tab_width. indent_size must be a number'

Per specification it should either be a number or a 'tab'.

https://spec.editorconfig.org/#supported-pairs
```Set to a whole number defining the number of columns used for each indentation level and the width of soft tabs (when supported). If this equals tab, the indent_size shall be set to the tab size, which should be tab_width (if specified); else, the tab size set by the editor. The values are case-insensitive.```