### PR TITLE
fix: guard against undefined options in source filtering

### DIFF
--- a/modules/ui/changeset_editor.js
+++ b/modules/ui/changeset_editor.js
@@ -89,7 +89,7 @@ export function uiChangesetEditor(context) {
                     // based on the values used in recent changesets.
                     const recentSources = changesets
                         .flatMap((changeset) => changeset.tags.source?.split(';'))
-                        .filter(value => !sourceField.options.includes(value))
+                        .filter(value => !sourceField.options?.includes(value))
                         .filter(Boolean)
                         .map(title => ({ title, value: title, klass: 'raw-option' }));
 


### PR DESCRIPTION
Adds another guard to prevent #11532.