### PR TITLE
Pr 11567 fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
         "esbuild": "^0.25.12",
         "esbuild-visualizer": "^0.7.0",
         "eslint": "^9.39.1",
-        "fake-indexeddb": "^6.2.4",
+        "fake-indexeddb": "^6.2.5",
         "fetch-mock": "^11.1.1",
         "gaze": "^1.1.3",
         "happen": "^0.3.2",
@@ -4699,9 +4699,9 @@
       }
     },
     "node_modules/fake-indexeddb": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.4.tgz",
-      "integrity": "sha512-INKeIKEtSViN4yVtEWEUqbsqmaIy7Ls+MfU0yxQVXg67pOJ/sH1ZxcVrP8XrKULUFohcPD9gnmym+qBfEybACw==",
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "esbuild": "^0.25.12",
     "esbuild-visualizer": "^0.7.0",
     "eslint": "^9.39.1",
-    "fake-indexeddb": "^6.2.4",
+    "fake-indexeddb": "^6.2.5",
     "fetch-mock": "^11.1.1",
     "gaze": "^1.1.3",
     "happen": "^0.3.2",


### PR DESCRIPTION
fix(build): confirm fake-indexeddb@6.2.5 passes on Node 24

Locally verified Dependabot PR #11567.
- Ran full build + tests under Node 22 and 24 (both ✅)
- No code changes required, just confirming compatibility.
- Adds empty commit to retrigger CI for Node 24 environment.

Closes #11567.
