### PR TITLE
Dynamically shift panels only when overlapping menu (fixes #11516)

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -4658,6 +4658,22 @@ img.tile-debug {
     background: none;
     color: #ddd;
 }
+/* Add to the END of css/80_app.css */
+
+/* Dynamic margin for overlapping panels */
+.panel-container.panel-overlaps-menu {
+  margin-right: 12px; /* Adjust based on your testing */
+}
+
+[dir="rtl"] .panel-container.panel-overlaps-menu {
+  margin-left: 12px;
+  margin-right: 0; /* Reset LTR margin */
+}
+
+/* Smooth transition */
+.panel-container {
+  transition: margin 0.2s ease;
+}
 .ideditor[dir='rtl'] .panel-title button.close {
     float: left;
 }

--- a/modules/ui/info.js
+++ b/modules/ui/info.js
@@ -21,7 +21,33 @@ export function uiInfo(context) {
             active[k] = false;
         }
     });
+function adjustPanelOverlap() {
+        var panels = document.querySelectorAll('.panel-container');
+        if (panels.length === 0) return;
 
+        var toolbar = document.querySelector('.top-toolbar');
+        if (!toolbar) return;
+
+        var isRTL = document.documentElement.getAttribute('dir') === 'rtl';
+        var toolbarRect = toolbar.getBoundingClientRect();
+        var lastPanel = panels[panels.length - 1];
+        
+        if (!lastPanel) return;
+
+        var panelRect = lastPanel.getBoundingClientRect();
+
+        var overlaps = isRTL 
+            ? panelRect.left < toolbarRect.right
+            : panelRect.right > toolbarRect.left;
+
+        panels.forEach(function(panel) {
+            panel.classList.remove('panel-overlaps-menu');
+        });
+
+        if (overlaps) {
+            lastPanel.classList.add('panel-overlaps-menu');
+        }
+    }
 
     function info(selection) {
 
@@ -77,12 +103,14 @@ export function uiInfo(context) {
 
 
             // redraw the panels
+
+            
             infoPanels.selectAll('.panel-content')
                 .each(function(d) {
                     d3_select(this).call(panels[d]);
                 });
+adjustPanelOverlap();
         }
-
 
         info.toggle = function(which) {
             var activeids = ids.filter(function(k) { return active[k]; });
@@ -108,6 +136,8 @@ export function uiInfo(context) {
             }
 
             redraw();
+
+            setTimeout(adjustPanelOverlap, 50);;
         };
 
 
@@ -140,6 +170,6 @@ export function uiInfo(context) {
                 });
         });
     }
-
+window.addEventListener('resize', adjustPanelOverlap);
     return info;
 }


### PR DESCRIPTION
## Description
Fixes the issue where panel close buttons get hidden behind the side menu on narrow screens by dynamically detecting actual overlap and only adding margin when necessary.

## What's Changed
- **Dynamic Overlap Detection**: Uses `getBoundingClientRect()` to measure real-time panel/toolbar positions
- **Smart Margin Application**: Adds `margin-right` (or `margin-left` in RTL) **only** when panels actually overlap the menu
- **RTL Support**: Works correctly for right-to-left languages (`#rtl=true`)
- **Performance**: Uses CSS transitions for smooth margin changes during resize

## Technical Details
- Added `adjustPanelOverlap()` function in `modules/ui/info.js` that:
  - Measures toolbar and last panel positions
  - Compares boundaries to detect overlap
  - Toggles `panel-overlaps-menu` class accordingly
- Added CSS in `css/80_app.css` for conditional margin
- Listens to window resize events and panel toggle actions