### PR TITLE
keep recently edited relations in membership dropdown for entire session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 # Unreleased (2.38.0-dev)
 
 #### :sparkles: Usability & Accessibility
+* Keep recently edited relations in relation membership dropdown for entire session ([#11588], thanks [@k-yle])
 #### :scissors: Operations
 #### :camera: Street-Level
 #### :white_check_mark: Validation
@@ -49,6 +50,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :hammer: Development
 
 [#11522]: https://github.com/openstreetmap/iD/issues/11522
+[#11588]: https://github.com/openstreetmap/iD/pull/11588
 
 # v2.37.3
 ##### 2025-10-31

--- a/modules/ui/sections/raw_membership_editor.js
+++ b/modules/ui/sections/raw_membership_editor.js
@@ -51,6 +51,8 @@ export function uiSectionRawMembershipEditor(context) {
     var _maxMemberships = 1000;
     /** @type {Set<string>} relations that were added after this panel was opened */
     const recentlyAdded = new Set();
+    /** @type {Set<string>} all relations that had members added during this edit session */
+    const previouslySelected = new Set();
 
     function getSharedParentRelations() {
         var parents = [];
@@ -216,6 +218,7 @@ export function uiSectionRawMembershipEditor(context) {
 
         if (d.relation) {
             recentlyAdded.add(d.relation.id);
+            previouslySelected.add(d.relation.id);
             context.perform(
                 actionAddMembers(d.relation.id, _entityIDs, role),
                 t('operations.add_member.annotation', {
@@ -314,8 +317,22 @@ export function uiSectionRawMembershipEditor(context) {
             });
         } else {
 
+            // any relation that has previously been added will remain
+            // in the dropdown for the rest of the edit session.
+            for (const id of previouslySelected) {
+                const relation = context.hasEntity(id);
+                if (relation && relation.id !== entityID) {
+                    result.push({
+                        relation,
+                        value: baseDisplayValue(relation),
+                        display: baseDisplayLabel(relation)
+                    });
+                }
+            }
+
             context.history().intersects(context.map().extent()).forEach(function(entity) {
                 if (entity.type !== 'relation' || entity.id === entityID) return;
+                if (previouslySelected.has(entity.id)) return; // already added above
 
                 var value = baseDisplayValue(entity);
                 if (q && (value + ' ' + entity.id).toLowerCase().indexOf(q.toLowerCase()) === -1) return;


### PR DESCRIPTION
Closes #3622

The relation dropdown list now remembers relations that you've already added during this edit session. Even if those relations are no longer visible on screen.

Showing every downloaded relation as originally proposed in #3622 becomes pretty chaotic, I think this is a reasonable compromise which is still quite helpful 
