### PR TITLE
add JSDoc annotations to context.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,9 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Use full width for the dropdown box for the values of the `access` field ([#12065])
 #### :hammer: Development
 * Replace `sinon` with `vitest`'s built in spy/mock library ([#12058])
+* Add type annotations to `context.js` module ([#11589], thanks [@k-yle])
 
+[#11589]: https://github.com/openstreetmap/iD/pull/11589
 [#12010]: https://github.com/openstreetmap/iD/pull/12010
 [#12050]: https://github.com/openstreetmap/iD/issues/12050
 [#12051]: https://github.com/openstreetmap/iD/issues/12051

--- a/modules/core/context.js
+++ b/modules/core/context.js
@@ -40,16 +40,22 @@ export function coreContext() {
   let _defaultChangesetComment = context.initialHashParams.comment;
   let _defaultChangesetSource = context.initialHashParams.source;
   let _defaultChangesetHashtags = context.initialHashParams.hashtags;
+
+  /** @type {GetSet<iD.Context, string>} */
   context.defaultChangesetComment = function(val) {
     if (!arguments.length) return _defaultChangesetComment;
     _defaultChangesetComment = val;
     return context;
   };
+
+  /** @type {GetSet<iD.Context, string>} */
   context.defaultChangesetSource = function(val) {
     if (!arguments.length) return _defaultChangesetSource;
     _defaultChangesetSource = val;
     return context;
   };
+
+  /** @type {GetSet<iD.Context, string>} */
   context.defaultChangesetHashtags = function(val) {
     if (!arguments.length) return _defaultChangesetHashtags;
     _defaultChangesetHashtags = val;
@@ -61,6 +67,7 @@ export function coreContext() {
 
   // If true, iD will update the title based on what the user is doing
   let _setsDocumentTitle = true;
+  /** @type {GetSet<iD.Context, boolean>} */
   context.setsDocumentTitle = function(val) {
     if (!arguments.length) return _setsDocumentTitle;
     _setsDocumentTitle = val;
@@ -68,6 +75,7 @@ export function coreContext() {
   };
   // The part of the title that is always the same
   let _documentTitleBase = document.title;
+  /** @type {GetSet<iD.Context, string>} */
   context.documentTitleBase = function(val) {
     if (!arguments.length) return _documentTitleBase;
     _documentTitleBase = val;
@@ -75,7 +83,7 @@ export function coreContext() {
   };
 
 
-  /* User interface and keybinding */
+  /** User interface and keybinding @type {ReturnType<uiInit>} */
   let _ui;
   context.ui = () => _ui;
   context.lastPointerType = () => _ui.lastPointerType();
@@ -89,8 +97,11 @@ export function coreContext() {
   // Instantiate the connection here because it doesn't require passing in
   // `context` and it's needed for pre-init calls like `preauth`
   let _connection = services.osm;
+  /** @type {ReturnType<coreHistory>} */
   let _history;
+  /** @type {ReturnType<coreValidator>} */
   let _validator;
+  /** @type {ReturnType<coreUploader>} */
   let _uploader;
   context.connection = () => _connection;
   context.history = () => _history;
@@ -106,6 +117,7 @@ export function coreContext() {
   };
 
 
+  /** @param {string | string[]} locale */
   // A string or array or locale codes to prefer over the browser's settings
   context.locale = function(locale) {
     if (!arguments.length) return localizer.localeCode();
@@ -292,6 +304,7 @@ export function coreContext() {
   // and history changes can happen frequently (e.g. when dragging).
   context.debouncedSave = debounce(context.save, 100);
 
+  /** @template {Function} T @param {T} fn @returns {T} */
   function withDebouncedSave(fn) {
     return function() {
       const result = fn.apply(_history, arguments);
@@ -345,10 +358,13 @@ export function coreContext() {
 
 
   /* Copy/Paste */
+  /** @type {iD.Graph} */
   let _copyGraph;
   context.copyGraph = () => _copyGraph;
 
+  /** @type {string[]} */
   let _copyIDs = [];
+  /** @type {GetSet<iD.Context, string[]>} */
   context.copyIDs = function(val) {
     if (!arguments.length) return _copyIDs;
     _copyIDs = val;
@@ -365,11 +381,13 @@ export function coreContext() {
 
 
   /* Background */
+  /** @type {ReturnType<rendererBackground>} */
   let _background;
   context.background = () => _background;
 
 
   /* Features */
+  /** @type {ReturnType<rendererFeatures>} */
   let _features;
   context.features = () => _features;
   context.hasHiddenConnections = (id) => {
@@ -380,11 +398,13 @@ export function coreContext() {
 
 
   /* Photos */
+  /** @type {ReturnType<rendererPhotos>} */
   let _photos;
   context.photos = () => _photos;
 
 
   /* Map */
+  /** @type {ReturnType<rendererMap>} */
   let _map;
   context.map = () => _map;
   context.layers = () => _map.layers();
@@ -408,7 +428,9 @@ export function coreContext() {
     downloaded: false   // downloaded data from osm
   };
   context.debugFlags = () => _debugFlags;
+  /** @param {keyof _debugFlags} flag */
   context.getDebug = (flag) => flag && _debugFlags[flag];
+  /** @param {keyof _debugFlags} flag @param {boolean} val */
   context.setDebug = function(flag, val) {
     if (arguments.length === 1) val = true;
     _debugFlags[flag] = val;
@@ -419,7 +441,10 @@ export function coreContext() {
 
   /* Container */
   let _container = d3_select(null);
+  /** @type {'light' | 'dark'} */
   let _theme;
+
+  /** @type {GetSet<iD.Context, typeof _container>} */
   context.container = function(val) {
     if (!arguments.length) return _container;
     _container = val;
@@ -458,7 +483,9 @@ export function coreContext() {
     return context;
   };
 
+  /** @type {Tags} */
   let _assetMap = {};
+  /** @type {GetSet<iD.Context, Tags>} */
   context.assetMap = function(val) {
     if (!arguments.length) return _assetMap;
     _assetMap = val;
@@ -466,12 +493,14 @@ export function coreContext() {
     return context;
   };
 
+  /** @param {string} val */
   context.asset = (val) => {
     if (/^http(s)?:\/\//i.test(val)) return val;
     const filename = _assetPath + val;
     return _assetMap[filename] || filename;
   };
 
+  /** @param {string} val */
   context.imagePath = (val) => context.asset(`img/${val}`);
 
 
@@ -509,8 +538,20 @@ export function coreContext() {
   context.projection = geoRawMercator();
   context.curtainProjection = geoRawMercator();
 
+  // these lines are required to define the type-definitions.
+  // the actual value is assigned below, in the `init` function.
+  context.graph = /** @type {() => iD.Graph} */ (undefined);
+  context.pauseChangeDispatch = /** @type {Function} */ (undefined);
+  context.resumeChangeDispatch = /** @type {Function} */ (undefined);
+  context.perform = /** @type {typeof _history.perform} */ (undefined);
+  context.replace = /** @type {typeof _history.replace} */ (undefined);
+  context.pop = /** @type {typeof _history.pop} */ (undefined);
+  context.overwrite = /** @type {typeof _history.overwrite} */ (undefined);
+  context.undo = /** @type {typeof _history.undo} */ (undefined);
+  context.redo = /** @type {typeof _history.redo} */ (undefined);
+  context.on = /** @type {any} */ (undefined);
 
-  /** @returns {iD.Context} */
+  /** @returns {typeof context} */
   context.init = () => {
 
     instantiateInternal();


### PR DESCRIPTION
Same purpose/rationale as #10618: autocomplete makes it much easier to work in this repository, all it takes is a few lines of comments.

The last few lines are a bit of a hack, but there's no other concise solution[^1]

[^1]: except for migrating this huge file to typescript, but that's pretty infeasible