### PR TITLE
Fixed streetside viewfield

### DIFF
--- a/modules/services/streetside.js
+++ b/modules/services/streetside.js
@@ -667,7 +667,6 @@ export default {
       this._pendingSelected = null;
     }
 
-
     return this;
   },
 

--- a/modules/services/streetside.js
+++ b/modules/services/streetside.js
@@ -700,6 +700,8 @@ export default {
 
     let d = this.cachedImage(key);
 
+    let viewer = context.container().select('.photoviewer');
+    if (!viewer.empty()) viewer.datum(d);
     // Save the selected bubble until viewer is initialized
     this._pendingSelected = d;
 

--- a/modules/services/streetside.js
+++ b/modules/services/streetside.js
@@ -662,6 +662,12 @@ export default {
         .classed('hide', false);
     }
 
+    if (this._pendingSelected) {
+      context.container().select('.photoviewer').datum(this._pendingSelected);
+      this._pendingSelected = null;
+    }
+
+
     return this;
   },
 
@@ -695,8 +701,8 @@ export default {
 
     let d = this.cachedImage(key);
 
-    let viewer = context.container().select('.photoviewer');
-    if (!viewer.empty()) viewer.datum(d);
+    // Save the selected bubble until viewer is initialized
+    this._pendingSelected = d;
 
     this.setStyles(context, null, true);
 


### PR DESCRIPTION
Currently when you have the Bing Streetside photo overlay turned on, the viewfield (yellow cone that shows you where on the map you are looking) doesn't show up unless the image viewer is already open. So the first time you click on one of the circles viewfield doesn't appear.

To fix this issue I moved .datum() to the end of the showViewer() function.