### PR TITLE
Update lasso selection description in core.yaml

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -2420,7 +2420,7 @@ en:
         title: "Selecting features"
         select_one: "Select a single feature"
         select_multi: "Select multiple features"
-        lasso: "Draw a selection lasso around features"
+        lasso: "Lasso select (points only)"
         search: "Find features matching search text"
       with_selected:
         title: "With features selected"

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -2420,7 +2420,7 @@ en:
         title: "Selecting features"
         select_one: "Select a single feature"
         select_multi: "Select multiple features"
-        lasso: "Draw a selection lasso to select points with area"
+        lasso: "Draw a selection lasso to select points in an area"
         search: "Find features matching search text"
       with_selected:
         title: "With features selected"

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -2420,7 +2420,7 @@ en:
         title: "Selecting features"
         select_one: "Select a single feature"
         select_multi: "Select multiple features"
-        lasso: "Lasso select (points only)"
+        lasso: "Draw a selection lasso to select points with area"
         search: "Find features matching search text"
       with_selected:
         title: "With features selected"


### PR DESCRIPTION
Sure, if the user could find
> multiselect_lasso: "Another way to select multiple features is to hold down the `{shift}` key, then press and hold down the {leftclick} left mouse button and drag the mouse to draw a selection lasso. All of the points inside the lasso area will be selected.

via a mouseover while looking at the keyboards shortcut list, this change wouldn't be needed.

Else users will bang their head: why can't I select those houses?

(No, a subsequent CTRL+up arrow won't select the way that the nodes are from either. Only works when one node is selected.)