### PR TITLE
fix `*_1` keys still being suggested by the raw tag editor

### DIFF
--- a/modules/ui/sections/raw_tag_editor.js
+++ b/modules/ui/sections/raw_tag_editor.js
@@ -427,7 +427,7 @@ export function uiSectionRawTagEditor(id, context) {
                         const filtered = data
                             .filter(d => _tags[d.value] === undefined) // already used tag
                             .filter(d => !(d.value in _discardTags)) // do not suggest discardable tags (see #9817)
-                            .filter(d => !/_\d$/.test(d)) // tag like name_1 (see #9422)
+                            .filter(d => !/_\d$/.test(d.value)) // tag like name_1 (see #9422)
                             .filter(d => d.value.toLowerCase().includes(value.toLowerCase())); // tag does not match user input
                         callback(sort(value, filtered));
                     }


### PR DESCRIPTION
Closes #11632, Closes #9422

It seems like ac172a2b0ef3cb6f230711a0f971f319cd6d26ea doesn't work, because `d` is an object, not a string. 

we could convert taginfo.js to typescript to prevent bugs like this, but I'll leave that for a future PR