### PR TITLE
replace `polygon-clipping` library with `polyclip-ts` to deduplicate deps

### DIFF
--- a/modules/services/vector_tile.js
+++ b/modules/services/vector_tile.js
@@ -3,7 +3,7 @@ import { dispatch as d3_dispatch } from 'd3-dispatch';
 import { deepEqual } from 'fast-equals';
 import turf_bboxClip from '@turf/bbox-clip';
 import stringify from 'fast-json-stable-stringify';
-import polygonClipping from 'polygon-clipping';
+import { union } from 'polyclip-ts';
 
 import Protobuf from 'pbf';
 import { VectorTile } from '@mapbox/vector-tile';
@@ -66,7 +66,7 @@ function vtToGeoJSON(data, tile, mergeCache) {
                     var merged = mergeCache[propertyhash];
                     if (merged && merged.length) {
                         var other = merged[0];
-                        var coords = polygonClipping.union(
+                        const coords = union(
                             feature.geometry.coordinates,
                             other.geometry.coordinates
                         );

--- a/modules/services/vector_tile.js
+++ b/modules/services/vector_tile.js
@@ -3,7 +3,7 @@ import { dispatch as d3_dispatch } from 'd3-dispatch';
 import deepEqual from 'fast-deep-equal';
 import turf_bboxClip from '@turf/bbox-clip';
 import stringify from 'fast-json-stable-stringify';
-import polygonClipping from 'polygon-clipping';
+import { union } from 'polyclip-ts';
 
 import Protobuf from 'pbf';
 import { VectorTile } from '@mapbox/vector-tile';
@@ -66,7 +66,7 @@ function vtToGeoJSON(data, tile, mergeCache) {
                     var merged = mergeCache[propertyhash];
                     if (merged && merged.length) {
                         var other = merged[0];
-                        var coords = polygonClipping.union(
+                        const coords = union(
                             feature.geometry.coordinates,
                             other.geometry.coordinates
                         );

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "osm-auth": "^3.1.1",
         "pannellum": "2.5.7",
         "pbf": "^4.0.1",
-        "polygon-clipping": "~0.15.7",
+        "polyclip-ts": "^0.16.8",
         "rbush": "4.0.1",
         "whatwg-fetch": "^3.6.20",
         "which-polygon": "2.2.1"
@@ -8094,25 +8094,6 @@
         "splaytree-ts": "^1.0.2"
       }
     },
-    "node_modules/polygon-clipping": {
-      "version": "0.15.7",
-      "resolved": "https://registry.npmjs.org/polygon-clipping/-/polygon-clipping-0.15.7.tgz",
-      "integrity": "sha512-nhfdr83ECBg6xtqOAJab1tbksbBAOMUltN60bU+llHVOL0e5Onm1WpAXXWXVB39L8AJFssoIhEVuy/S90MmotA==",
-      "license": "MIT",
-      "dependencies": {
-        "robust-predicates": "^3.0.2",
-        "splaytree": "^3.1.0"
-      }
-    },
-    "node_modules/polygon-clipping/node_modules/splaytree": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/splaytree/-/splaytree-3.2.3.tgz",
-      "integrity": "sha512-7OXrNWzy6CK+r7Ch9OLPBDTKfB6XlWHjX4P0RU5B3IgFuWPeYN0XtRtlexGRjgbQxpfaUve6jTAwBGWuGntz/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.20 || >=20"
-      }
-    },
     "node_modules/polylabel": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/polylabel/-/polylabel-1.1.0.tgz",
@@ -8492,6 +8473,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
       "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
+      "dev": true,
       "license": "Unlicense"
     },
     "node_modules/rolldown": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "osm-auth": "^3.1.1",
         "pannellum": "2.5.6",
         "pbf": "^4.0.1",
-        "polygon-clipping": "~0.15.7",
+        "polyclip-ts": "^0.16.8",
         "rbush": "4.0.1",
         "vitest": "^4.0.9",
         "whatwg-fetch": "^3.6.20",
@@ -347,7 +347,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -391,7 +390,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1227,7 +1225,6 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -2485,7 +2482,6 @@
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2605,7 +2601,6 @@
       "integrity": "sha512-jCzKdm/QK0Kg4V4IK/oMlRZlY+QOcdjv89U2NgKHZk1CYTj82/RVSx1mV/0gqCVMJ/DA+Zf/S4NBWNF8GQ+eqQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.0",
         "@typescript-eslint/types": "8.48.0",
@@ -2854,7 +2849,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3158,7 +3152,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -3319,7 +3312,6 @@
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.1.tgz",
       "integrity": "sha512-p4Z49OGG5W/WBCPSS/dH3jQ73kD6tiMmUM+bckNK6Jr5JHMG3k9bg/BvKR8lKmtVBKmOiuVaV2ws8s9oSbwysg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3350,8 +3342,7 @@
       "resolved": "https://registry.npmjs.org/cldr-core/-/cldr-core-48.0.0.tgz",
       "integrity": "sha512-iQnK68eOjEsHEOwCvi2CI7xbjcVlCdaSNTQrkwCgEMnyZUbHCgF0GPw2CXi0D2IGz+9Pj80cmcWzRFcF6zdrYQ==",
       "dev": true,
-      "license": "Unicode-3.0",
-      "peer": true
+      "license": "Unicode-3.0"
     },
     "node_modules/cldr-localenames-full": {
       "version": "48.0.0",
@@ -4026,7 +4017,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4658,7 +4648,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5528,8 +5517,7 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
       "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -5996,7 +5984,6 @@
       "integrity": "sha512-454TI39PeRDW1LgpyLPyURtB4Zx1tklSr6+OFOipsxGUH1WMTvk6C65JQdrj455+DP2uJ1+veBEHTGFKWVLFoA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.23",
         "@asamuzakjp/dom-selector": "^6.7.4",
@@ -9489,7 +9476,6 @@
       "integrity": "sha512-t54CUOsFMappY1Jbzb7fetWeO0n6K0k/4+/ZpkS+3Joz8I4VcvY9OiEBFRYISqaI2fq5sCiPtAjRDOzVYG8m+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.2",
@@ -9645,7 +9631,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.8.0.tgz",
       "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -10241,7 +10226,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/netlify-cli/node_modules/@rollup/rollup-android-arm64": {
       "version": "4.52.2",
@@ -10254,7 +10240,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/netlify-cli/node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.52.2",
@@ -10267,7 +10254,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/netlify-cli/node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.52.2",
@@ -10280,7 +10268,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/netlify-cli/node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.52.2",
@@ -10293,7 +10282,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/netlify-cli/node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.52.2",
@@ -10306,7 +10296,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.52.2",
@@ -10319,7 +10310,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.52.2",
@@ -10332,7 +10324,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.52.2",
@@ -10345,7 +10338,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.52.2",
@@ -10358,7 +10352,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.52.2",
@@ -10371,7 +10366,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.52.2",
@@ -10384,7 +10380,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.52.2",
@@ -10397,7 +10394,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.52.2",
@@ -10410,7 +10408,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.52.2",
@@ -10423,7 +10422,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.52.2",
@@ -10436,7 +10436,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.52.2",
@@ -10449,7 +10450,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/netlify-cli/node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.52.2",
@@ -10462,7 +10464,8 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/netlify-cli/node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.52.2",
@@ -10475,7 +10478,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/netlify-cli/node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.52.2",
@@ -10488,7 +10492,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/netlify-cli/node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.52.2",
@@ -10501,7 +10506,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/netlify-cli/node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.52.2",
@@ -10514,7 +10520,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/netlify-cli/node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
@@ -10609,6 +10616,7 @@
       "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -10620,6 +10628,7 @@
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -10630,12 +10639,28 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/express": {
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "^1"
+      }
+    },
     "node_modules/netlify-cli/node_modules/@types/express-serve-static-core": {
       "version": "4.19.6",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
       "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -10654,7 +10679,8 @@
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/netlify-cli/node_modules/@types/http-proxy": {
       "version": "1.17.16",
@@ -10670,7 +10696,8 @@
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/netlify-cli/node_modules/@types/node": {
       "version": "22.18.11",
@@ -10678,7 +10705,6 @@
       "integrity": "sha512-Gd33J2XIrXurb+eT2ktze3rJAfAp9ZNjlBdh4SVgyrKEOADwCbdUDaK7QgJno8Ue4kcajscsKqu6n8OBG3hhCQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -10694,14 +10720,16 @@
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
       "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/netlify-cli/node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/netlify-cli/node_modules/@types/retry": {
       "version": "0.12.2",
@@ -10715,6 +10743,7 @@
       "integrity": "sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/mime": "^1",
         "@types/node": "*"
@@ -10726,6 +10755,7 @@
       "integrity": "sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/http-errors": "*",
         "@types/node": "*",
@@ -11271,7 +11301,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -11314,7 +11343,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -14451,6 +14479,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -17730,7 +17759,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -17838,7 +17866,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -18505,6 +18532,49 @@
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true
+    },
+    "node_modules/netlify-cli/node_modules/rollup": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.2.tgz",
+      "integrity": "sha512-I25/2QgoROE1vYV+NQ1En9T9UFB9Cmfm2CJ83zZOlaDpvz29wGQSZXWKw7MiNXau7wYgB/T9fVIdIuEQ+KbiiA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.52.2",
+        "@rollup/rollup-android-arm64": "4.52.2",
+        "@rollup/rollup-darwin-arm64": "4.52.2",
+        "@rollup/rollup-darwin-x64": "4.52.2",
+        "@rollup/rollup-freebsd-arm64": "4.52.2",
+        "@rollup/rollup-freebsd-x64": "4.52.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.52.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.52.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.52.2",
+        "@rollup/rollup-linux-arm64-musl": "4.52.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.52.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.52.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.52.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.52.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.52.2",
+        "@rollup/rollup-linux-x64-gnu": "4.52.2",
+        "@rollup/rollup-linux-x64-musl": "4.52.2",
+        "@rollup/rollup-openharmony-arm64": "4.52.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.52.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.52.2",
+        "@rollup/rollup-win32-x64-gnu": "4.52.2",
+        "@rollup/rollup-win32-x64-msvc": "4.52.2",
+        "fsevents": "~2.3.2"
+      }
     },
     "node_modules/netlify-cli/node_modules/run-applescript": {
       "version": "7.1.0",
@@ -19696,7 +19766,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -21325,24 +21394,11 @@
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/polyclip-ts/-/polyclip-ts-0.16.8.tgz",
       "integrity": "sha512-JPtKbDRuPEuAjuTdhR62Gph7Is2BS1Szx69CFOO3g71lpJDFo78k4tFyi+qFOMVPePEzdSKkpGU3NBXPHHjvKQ==",
+      "license": "MIT",
       "dependencies": {
         "bignumber.js": "^9.1.0",
         "splaytree-ts": "^1.0.2"
       }
-    },
-    "node_modules/polygon-clipping": {
-      "version": "0.15.7",
-      "resolved": "https://registry.npmjs.org/polygon-clipping/-/polygon-clipping-0.15.7.tgz",
-      "integrity": "sha512-nhfdr83ECBg6xtqOAJab1tbksbBAOMUltN60bU+llHVOL0e5Onm1WpAXXWXVB39L8AJFssoIhEVuy/S90MmotA==",
-      "dependencies": {
-        "robust-predicates": "^3.0.2",
-        "splaytree": "^3.1.0"
-      }
-    },
-    "node_modules/polygon-clipping/node_modules/splaytree": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/splaytree/-/splaytree-3.1.2.tgz",
-      "integrity": "sha512-4OM2BJgC5UzrhVnnJA4BkHKGtjXNzzUfpQjCO8I05xYPsfS/VuQDwjCGGMi8rYQilHEV4j8NBqTFbls/PZEE7A=="
     },
     "node_modules/polylabel": {
       "version": "1.1.0",
@@ -21387,7 +21443,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -21724,7 +21779,8 @@
     "node_modules/robust-predicates": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
-      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="
+      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
+      "dev": true
     },
     "node_modules/rollup": {
       "version": "4.52.5",
@@ -22273,7 +22329,6 @@
       "integrity": "sha512-TOgRcwFPbfGtpqvZw+hyqJDvqfapr1qUlOizROIk4bBLjlsjlB00Pg6wMFXNtJRpu+eCZuVOaLatG7M8105kAw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.1",
         "@sinonjs/fake-timers": "^13.0.5",
@@ -22883,7 +22938,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -23053,7 +23107,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.4.tgz",
       "integrity": "sha512-NL8jTlbo0Tn4dUEXEsUg8KeyG/Lkmc4Fnzb8JXN/Ykm9G4HNImjtABMJgkQoVjOBN/j2WAwDTRytdqJbZsah7w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "osm-auth": "^3.1.1",
     "pannellum": "2.5.7",
     "pbf": "^4.0.1",
-    "polygon-clipping": "~0.15.7",
+    "polyclip-ts": "^0.16.8",
     "rbush": "4.0.1",
     "whatwg-fetch": "^3.6.20",
     "which-polygon": "2.2.1"

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "osm-auth": "^3.1.1",
     "pannellum": "2.5.6",
     "pbf": "^4.0.1",
-    "polygon-clipping": "~0.15.7",
+    "polyclip-ts": "^0.16.8",
     "rbush": "4.0.1",
     "vitest": "^4.0.9",
     "whatwg-fetch": "^3.6.20",


### PR DESCRIPTION
the [location-conflation](https://npm.im/@rapideditor/location-conflation) library has switched to a different library (see https://github.com/rapideditor/location-conflation/issues/67), which means we're bundling 2 depencies that do exactly the same thing. 

Vector tiles can be tested with `//demotiles.maplibre.org/tiles/{z}/{x}/{y}.pbf`