### PR TITLE
make the raw-tag-editor disabled for custom map data

### DIFF
--- a/modules/ui/data_editor.js
+++ b/modules/ui/data_editor.js
@@ -10,7 +10,7 @@ export function uiDataEditor(context) {
     var dataHeader = uiDataHeader();
     var rawTagEditor = uiSectionRawTagEditor('custom-data-tag-editor', context)
         .expandedByDefault(true)
-        .readOnlyTags([/./]);
+        .readOnlyTags([/.*/]);
     var _datum;
 
 


### PR DESCRIPTION
As a consequence of #10889 , it now looks like you can add tags to readonly layers like vector tiles or .gpx files.

changed so that the entire last row is disabled.

<img width="333" height="574" alt="image" src="https://github.com/user-attachments/assets/a7b74bbc-d5a9-428a-959f-c1900351dd00" />