### PR TITLE
fix non-string properties not visible in the raw tag editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :white_check_mark: Validation
 * Don't error on features with a sole `note` tag ([#11522])
 #### :bug: Bugfixes
+* Fix some gpx/geojson properties not visible, such as numbers or complex data structures ([#11636], thanks [@k-yle])
 #### :earth_asia: Localization
 #### :hourglass: Performance
 #### :mortar_board: Walkthrough / Help
@@ -51,6 +52,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 
 
 [#11522]: https://github.com/openstreetmap/iD/issues/11522
+[#11636]: https://github.com/openstreetmap/iD/pull/11636
 
 # v2.37.3
 ##### 2025-10-31

--- a/modules/ui/data_editor.js
+++ b/modules/ui/data_editor.js
@@ -1,7 +1,7 @@
 import { t } from '../core/localizer';
 import { modeBrowse } from '../modes/browse';
 import { svgIcon } from '../svg/icon';
-
+import { stringifyProperties } from '../util/object';
 import { uiDataHeader } from './data_header';
 import { uiSectionRawTagEditor } from './sections/raw_tag_editor';
 
@@ -64,7 +64,7 @@ export function uiDataEditor(context) {
             .attr('class', 'raw-tag-editor data-editor')
             .merge(rte)
             .call(rawTagEditor
-                .tags((_datum && _datum.properties) || {})
+                .tags(stringifyProperties(_datum?.properties || {}))
                 .state('hover')
                 .render
             )

--- a/modules/util/index.js
+++ b/modules/util/index.js
@@ -33,7 +33,7 @@ export { utilHashcode } from './util';
 export { utilHighlightEntities } from './util';
 export { utilKeybinding } from './keybinding';
 export { utilNoAuto } from './util';
-export { utilObjectOmit, utilCheckTagDictionary } from './object';
+export { utilObjectOmit, utilCheckTagDictionary, stringifyProperties } from './object';
 export { utilCompareIDs } from './util';
 export { utilOldestID } from './util';
 export { utilPrefixCSSProperty } from './util';

--- a/modules/util/object.js
+++ b/modules/util/object.js
@@ -29,3 +29,28 @@ export function utilCheckTagDictionary(tags, tagDictionary) {
     }
     return undefined;
 }
+
+/**
+ * converts every value in an object to a string, if
+ * it's not already a string.
+ * @param {Record<string, unknown>} object
+ */
+export function stringifyProperties(object) {
+    /** @type {Tags} */
+    const tags = {};
+    for (const key in object) {
+        switch (typeof object[key]) {
+            case 'undefined':
+                break; // skip property
+            case 'string':
+                tags[key] = object[key];
+                break;
+            default:
+                tags[key] = JSON.stringify(
+                    object[key],
+                    (_, value) => typeof value === 'bigint' ? value.toString() : value
+                );
+        }
+    }
+    return tags;
+}

--- a/test/spec/util/object.ts
+++ b/test/spec/util/object.ts
@@ -20,3 +20,26 @@ describe('iD.utilCheckTagDictionary', () => {
         expect(iD.utilCheckTagDictionary({ surface: 'paved' }, dictionary)).toBe(0);
     });
 });
+
+describe('stringifyProperties', () => {
+    it('converts object properties to a string', () => {
+        const input = {
+            a: 'a',
+            b: 1,
+            c: null,
+            d: undefined,
+            e: { f: 1 },
+            g: [1, 2n],
+            h: 1n,
+        };
+        expect(iD.stringifyProperties(input)).toStrictEqual({
+            a: 'a',
+            b: '1',
+            c: 'null',
+            // d (undefined) is skipped
+            e: '{"f":1}',
+            g: '[1,"2"]',
+            h: '"1"',
+        });
+    });
+});


### PR DESCRIPTION
If you load a gpx/geojson/mvt file via the Custom Map Data pane, only string properties work. Numbers/booleans/arrays/objects don't work.

<img width="330" height="217" alt="image" src="https://github.com/user-attachments/assets/fc3ddc1f-9897-4e5a-b1a8-817e05e33529" />
