### PR TITLE
Styling improvements for the custom map data panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 # Unreleased (2.38.0-dev)
 
 #### :sparkles: Usability & Accessibility
+* Minor usability improvements for custom map data ([#11635], [#11637], thanks [@k-yle])
 #### :scissors: Operations
 #### :camera: Street-Level
 #### :white_check_mark: Validation
@@ -51,6 +52,8 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 
 
 [#11522]: https://github.com/openstreetmap/iD/issues/11522
+[#11635]: https://github.com/openstreetmap/iD/pull/11635
+[#11637]: https://github.com/openstreetmap/iD/pull/11637
 
 # v2.37.3
 ##### 2025-10-31

--- a/modules/ui/data_editor.js
+++ b/modules/ui/data_editor.js
@@ -37,12 +37,12 @@ export function uiDataEditor(context) {
             .call(t.append('map_data.title'));
 
 
-        var body = selection.selectAll('.body')
+        var body = selection.selectAll('.inspector-body')
             .data([0]);
 
         body = body.enter()
             .append('div')
-            .attr('class', 'body')
+            .attr('class', 'inspector-body entity-editor')
             .merge(body);
 
         var editor = body.selectAll('.data-editor')
@@ -51,7 +51,7 @@ export function uiDataEditor(context) {
         // enter/update
         editor.enter()
             .append('div')
-            .attr('class', 'modal-section data-editor')
+            .attr('class', 'data-editor section')
             .merge(editor)
             .call(dataHeader.datum(_datum));
 

--- a/modules/ui/entity_editor.js
+++ b/modules/ui/entity_editor.js
@@ -81,7 +81,7 @@ export function uiEntityEditor(context) {
         // Enter
         var bodyEnter = body.enter()
             .append('div')
-            .attr('class', 'entity-editor inspector-body sep-top');
+            .attr('class', 'entity-editor inspector-body');
 
         // Update
         body = body


### PR DESCRIPTION
Closes #9628

just some padding and removal of the weird `<hr />`

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td><img width="316" alt="image" src="https://github.com/user-attachments/assets/65e55821-3ab7-45b3-a5fc-010b34f72f7a" />
 <td><img width="316" alt="image" src="https://github.com/user-attachments/assets/ea239634-ef46-4a0e-9991-d89a4f274150" />
</table>




