### PR TITLE
Improve feature_info & issue_info: auto-expand and scroll to it

### DIFF
--- a/modules/ui/feature_info.js
+++ b/modules/ui/feature_info.js
@@ -1,4 +1,5 @@
 import { t } from '../core/localizer';
+import { utilTriggerEvent } from '../util';
 import { uiTooltip } from './tooltip';
 
 export function uiFeatureInfo(context) {
@@ -39,7 +40,14 @@ export function uiFeatureInfo(context) {
                     tooltipBehavior.hide();
                     d3_event.preventDefault();
                     // open the Map Data pane
-                    context.ui().togglePanes(context.container().select('.map-panes .map-data-pane'));
+                    var pane = context.container().select('.map-panes .map-data-pane');
+                    context.ui().togglePanes(pane);
+                    var section = pane.select('.section-map-features');
+                    var toggle = section.select('.hide-toggle-map_features');
+                    if (!toggle.classed('expanded')) {
+                        utilTriggerEvent(toggle, 'click', { button: 0 });
+                    }
+                    section.node().scrollIntoView({ block: 'nearest' });
                 });
         }
 

--- a/modules/ui/issues_info.js
+++ b/modules/ui/issues_info.js
@@ -3,6 +3,7 @@ import { select as d3_select } from 'd3-selection';
 import { prefs } from '../core/preferences';
 import { svgIcon } from '../svg/icon';
 import { t } from '../core/localizer';
+import { utilTriggerEvent } from '../util';
 import { uiTooltip } from './tooltip';
 
 
@@ -72,7 +73,14 @@ export function uiIssuesInfo(context) {
 
                         tooltipBehavior.hide(d3_select(this));
                         // open the Issues pane
-                        context.ui().togglePanes(context.container().select('.map-panes .issues-pane'));
+                        var pane = context.container().select('.map-panes .issues-pane');
+                        context.ui().togglePanes(pane);
+                        var section = pane.select('.section-issues-errors');
+                        var toggle = section.select('.hide-toggle-issues_errors');
+                        if (!toggle.classed('expanded')) {
+                            utilTriggerEvent(toggle, 'click', { button: 0 });
+                        }
+                        section.node().scrollIntoView({ block: 'nearest' });
                     });
 
                 chipSelection.call(svgIcon('#' + d.iconID));


### PR DESCRIPTION
Fixes: #9402 

**Previously:**
1. Clicking “X hidden features” only opened the Map Data pane.
2. Clicking "Warnings and Errors" only opened the Issues pane

**After this PR:**
1. Clicking "X hidden features"
    - Opens the Map Data pane
    - The Map Features section is expanded (if not already expanded by the user)
    - The pane scrolls to the Map Features section

2. Clicking "Warnings and Errors:"
    - Opens the Issue pane
    - The Errors section is expanded (if not already expanded by the user)
    - The pane scrolls to the Errors section

**Video Demonstration**

FeatureInfo behavior:

https://github.com/user-attachments/assets/915e1987-b81b-4a3c-8fd3-b40e9ee80bcf

IssuesInfo behavior:

https://github.com/user-attachments/assets/342f00af-ad43-4248-8e9d-4c11c9434f38

