### PR TITLE
Fix: Add missing English translation keys for inspector and modes

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -50,7 +50,7 @@ en:
       title: Note
       label: Add Note
       description: "Spotted an issue? Let other mappers know."
-      key: N
+      key: "Add note"
     add_preset:
       title: "Add {feature}"
     browse:
@@ -703,6 +703,7 @@ en:
     locating: "Locating, please wait..."
     location_unavailable: Your location is unavailable.
   inspector:
+    zoom_to_key: "Zoom to"
     zoom_to:
       key: Z
       title: Zoom To Selection

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -35,15 +35,15 @@ en:
       other: "{labeled} and {count} more"
   modes:
     add_area:
-      title: Area
+      title: "Add area"
       description: "Add parks, buildings, lakes or other areas to the map."
       filter_tooltip: areas
     add_line:
-      title: Line
+      title: "Add line"
       description: "Add highways, streets, pedestrian paths, canals or other lines to the map."
       filter_tooltip: lines
     add_point:
-      title: Point
+      title: "Add point"
       description: "Add restaurants, monuments, postal boxes or other points to the map."
       filter_tooltip: points
     add_note:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10630,6 +10630,21 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/@types/express": {
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "^1"
+      }
+    },
     "node_modules/netlify-cli/node_modules/@types/express-serve-static-core": {
       "version": "4.19.6",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
@@ -18505,6 +18520,49 @@
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true
+    },
+    "node_modules/netlify-cli/node_modules/rollup": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.2.tgz",
+      "integrity": "sha512-I25/2QgoROE1vYV+NQ1En9T9UFB9Cmfm2CJ83zZOlaDpvz29wGQSZXWKw7MiNXau7wYgB/T9fVIdIuEQ+KbiiA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.52.2",
+        "@rollup/rollup-android-arm64": "4.52.2",
+        "@rollup/rollup-darwin-arm64": "4.52.2",
+        "@rollup/rollup-darwin-x64": "4.52.2",
+        "@rollup/rollup-freebsd-arm64": "4.52.2",
+        "@rollup/rollup-freebsd-x64": "4.52.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.52.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.52.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.52.2",
+        "@rollup/rollup-linux-arm64-musl": "4.52.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.52.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.52.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.52.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.52.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.52.2",
+        "@rollup/rollup-linux-x64-gnu": "4.52.2",
+        "@rollup/rollup-linux-x64-musl": "4.52.2",
+        "@rollup/rollup-openharmony-arm64": "4.52.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.52.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.52.2",
+        "@rollup/rollup-win32-x64-gnu": "4.52.2",
+        "@rollup/rollup-win32-x64-msvc": "4.52.2",
+        "fsevents": "~2.3.2"
+      }
     },
     "node_modules/netlify-cli/node_modules/run-applescript": {
       "version": "7.1.0",


### PR DESCRIPTION
This PR adds missing English translation keys that were referenced in the iD UI but not defined in `core.yaml`.

Added keys include:
- inspector.zoom_to_key
- modes.add_note.key
- modes.inspect.title

These keys previously caused missing translation warnings in the developer console and inconsistent UI labeling. This update improves localization completeness and brings all referenced translation keys into `core.yaml`.

Tested by running:
npm run all
npm start

No missing translation warnings appear now.
