### PR TITLE
remove pointless dependency

### DIFF
--- a/modules/services/nsi.js
+++ b/modules/services/nsi.js
@@ -1,6 +1,4 @@
 import { Matcher } from 'name-suggestion-index';
-import parseVersion from 'vparse';
-
 import { fileFetcher, locationManager } from '../core';
 import { presetManager } from '../presets';
 
@@ -48,9 +46,7 @@ const notBranches = /(coop|express|wireless|factory|outlet)/i;
 //
 function setNsiSources() {
   const nsiVersion = packageJSON.dependencies['name-suggestion-index'] || packageJSON.devDependencies['name-suggestion-index'];
-  const v = parseVersion(nsiVersion);
-  const vMinor = `${v.major}.${v.minor}`;
-  const cdn = nsiCdnUrl.replace('{version}', vMinor);
+  const cdn = nsiCdnUrl.replace('{version}', nsiVersion);
   const sources = {
     'nsi_data': cdn + 'dist/json/nsi.min.json',
     'nsi_dissolved': cdn + 'dist/wikidata/dissolved.min.json',

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,8 +95,7 @@
         "sinon-chai": "^4.0.1",
         "svg-sprite": "2.0.4",
         "typescript": "^5.9.3",
-        "typescript-eslint": "^8.56.0",
-        "vparse": "~1.1.0"
+        "typescript-eslint": "^8.56.0"
       },
       "engines": {
         "node": ">=22"
@@ -24975,17 +24974,6 @@
         "jsdom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vparse": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/vparse/-/vparse-1.1.0.tgz",
-      "integrity": "sha512-XjzUAUOvhsGxGZD2ih9Bky+xKyNI3NPfIMf8nPWjC21pTFLwqj0/TMicmeFlYtxB/gJgyCMgJQ28xr+ARYx6sg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10",
-        "npm": ">=1.4"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -135,8 +135,7 @@
     "sinon-chai": "^4.0.1",
     "svg-sprite": "2.0.4",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.56.0",
-    "vparse": "~1.1.0"
+    "typescript-eslint": "^8.56.0"
   },
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
When constructing a CDN URL for NSI assets, NSI's version number is parsed with "[vparse](https://npm.im/vparse)", and then the semver-patch part is removed.

As far as I can tell, this extra parsing is not required, because [the jsdeliver CDN](https://cdn.jsdelivr.net/npm/name-suggestion-index@~7.0/dist/json/nsi.min.json) supports any semver syntax. None of the other assets do this extra parsing.


cc @bhousel, since this you added this because of https://github.com/openstreetmap/iD/pull/8305#discussion_r663055241 