### PR TITLE
11655: show warning if invalid ref:REI input tag is found

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1880,6 +1880,9 @@ en:
         message: '{feature} has an invalid URL'
         message_multi: '{feature} has multiple invalid URLs'
         reference: 'URLs must start with "http://" or "https://".'
+      ref_rei:
+        message: '{feature} has an invalid ref:REI value'
+        reference: 'ref:REI values must be 8 characters long.'
     line_as_area:
       message: '{feature} should be a line, not an area'
     line_as_point:

--- a/modules/validations/invalid_format.js
+++ b/modules/validations/invalid_format.js
@@ -27,6 +27,15 @@ export function validationFormatting() {
                 .call(t.append('issues.invalid_format.email.reference'));
         }
 
+        function showReferenceRefRei(selection) {
+            selection.selectAll('.issue-reference')
+                .data([0])
+                .enter()
+                .append('div')
+                .attr('class', 'issue-reference')
+                .call(t.append('issues.invalid_format.ref_rei.reference'));
+        }
+
         function isValidURL(url, strict = false) {
             try {
                 // First try strict WHATWG parsing
@@ -170,6 +179,25 @@ export function validationFormatting() {
                     entityIds: [entity.id],
                     hash: emails.join(),
                     data: (emails.length > 1) ? '_multi' : ''
+                }));
+            }
+        }
+
+        if (entity.tags['ref:REI']) {
+            var value = entity.tags['ref:REI'].trim();
+            // Value must be 8 characters long OR match 00-00-0000 format
+            if (value.length !== 8 && !/^\d{2}-\d{2}-\d{4}$/.test(value)) {
+                issues.push(new validationIssue({
+                    type: type,
+                    subtype: 'ref_rei',
+                    severity: 'warning',
+                    message: function(context) {
+                        var entity = context.hasEntity(this.entityIds[0]);
+                        return entity ? t.append('issues.invalid_format.ref_rei.message',
+                            { feature: utilDisplayLabel(entity, context.graph()) }) : '';
+                    },
+                    reference: showReferenceRefRei,
+                    entityIds: [entity.id]
                 }));
             }
         }


### PR DESCRIPTION
Implements openstreetmap/id-tagging-schema#2055 

Added REI tag validation logic to modules/validations/invalid_format.js
Added en localization for the same to data/core.yaml

When an invalid value is entered to a ref:REI tag, a warning is displayed to the user

Valid formats: A string of length 8 characters `00000000` or in the format `00-00-0000`

<img width="319" height="457" alt="image" src="https://github.com/user-attachments/assets/7cad00ac-a0d7-4892-a1e9-739e4e562f0f" />
