### PR TITLE
Remove icon color override

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -1447,7 +1447,6 @@ button.preset-reset .label.flash-bg {
 
 .label-text .label-textannotation svg.icon {
     margin: 0 8px;
-    color: #333;
     opacity: 0.5;
     width: 14px;
     height: 14px;


### PR DESCRIPTION
Without the override, the icon automatically inherits the correct fill color.
And the text color also works in dark mode, see this before/after:
<img alt="image" src="https://github.com/user-attachments/assets/fe067441-497d-49ee-8d3f-2fbbc5f0eb40" />
