### PR TITLE
add wikimedia commons as an photo service

### DIFF
--- a/css/60_photos.css
+++ b/css/60_photos.css
@@ -350,6 +350,20 @@ li.list-item-photos.list-item-mapilio.active:after {
     overflow: hidden;
 }
 
+/* commons Image Layer */
+li.list-item-photos.list-item-commons.active:after {
+    background-color: #069;
+}
+.layer-commons {
+    pointer-events: none;
+}
+.layer-commons .viewfield-group * {
+    fill: #069;
+    stroke: #ffffff;
+    stroke-opacity: .6;
+    fill-opacity: .6;
+}
+
 /* panoramax Image Layer */
 li.list-item-photos.list-item-panoramax.active:after {
     background-color: #ff6f00;

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1381,6 +1381,9 @@ en:
     tooltip: "Street-level photos from the Norwegian Public Roads Administration"
     publisher: "Norwegian Public Roads Administration"
     view_on: "View it on Vegbilder"
+  commons:
+    title: Wikimedia Commons
+    tooltip: Georeferenced photos with a compatible license from Wikimedia Commons
   mapillary_images:
     tooltip: "Street-level photos from Mapillary"
   mapillary_map_features:

--- a/modules/core/context.js
+++ b/modules/core/context.js
@@ -382,6 +382,7 @@ export function coreContext() {
 
 
   /* Photos */
+  /** @type {ReturnType<typeof rendererPhotos>} */
   let _photos;
   context.photos = () => _photos;
 
@@ -422,6 +423,7 @@ export function coreContext() {
   /* Container */
   let _container = d3_select(null);
   let _theme;
+  /** @type {GetSet<typeof context, typeof _container>} */
   context.container = function(val) {
     if (!arguments.length) return _container;
     _container = val;

--- a/modules/geo/vector.ts
+++ b/modules/geo/vector.ts
@@ -1,4 +1,5 @@
 export type Vec2 = [x: number, y: number];
+export type Vec3 = [x: number, y: number, z: number];
 
 // vector equals
 export function geoVecEqual(a: Vec2, b: Vec2, epsilon?: number) {

--- a/modules/renderer/background_source.js
+++ b/modules/renderer/background_source.js
@@ -21,7 +21,8 @@ window.matchMedia?.(`
 });
 
 
-function localeDateString(s) {
+// TODO: deduplicate
+export function localeDateString(s) {
     if (!s) return null;
     var options = { day: 'numeric', month: 'short', year: 'numeric' };
     var d = new Date(s);

--- a/modules/renderer/photos.js
+++ b/modules/renderer/photos.js
@@ -7,12 +7,15 @@ import { utilQsString, utilStringQs } from '../util';
 
 export function rendererPhotos(context) {
     var dispatch = d3_dispatch('change');
-    var _layerIDs = ['streetside', 'mapillary', 'mapillary-map-features', 'mapillary-signs', 'kartaview', 'mapilio', 'vegbilder', 'panoramax'];
+    var _layerIDs = ['streetside', 'mapillary', 'mapillary-map-features', 'mapillary-signs', 'kartaview', 'mapilio', 'vegbilder', 'panoramax', 'commons'];
     var _allPhotoTypes = ['flat', 'panoramic'];
     var _shownPhotoTypes = _allPhotoTypes.slice();   // shallow copy
     var _dateFilters = ['fromDate', 'toDate'];
+    /** @type {string | undefined} */
     var _fromDate;
+    /** @type {string | undefined} */
     var _toDate;
+    /** @type {string[] | undefined} */
     var _usernames;
 
     function photos() {}
@@ -169,7 +172,8 @@ export function rendererPhotos(context) {
      */
     photos.shouldFilterDateBySlider = function(){
         return showsLayer('mapillary') || showsLayer('kartaview') || showsLayer('mapilio')
-        || showsLayer('streetside') || showsLayer('vegbilder') || showsLayer('panoramax');
+        || showsLayer('streetside') || showsLayer('vegbilder') || showsLayer('panoramax')
+        || showsLayer('commons');
     };
 
     /**
@@ -184,7 +188,11 @@ export function rendererPhotos(context) {
      * @returns If the Username filter should be drawn
      */
     photos.shouldFilterByUsername = function() {
-        return !showsLayer('mapillary') && showsLayer('kartaview') && !showsLayer('streetside') || showsLayer('panoramax');
+        return (
+            (!showsLayer('mapillary') && showsLayer('kartaview') && !showsLayer('streetside'))
+            || showsLayer('panoramax')
+            || showsLayer('commons')
+        );
     };
 
     photos.showsPhotoType = function(val) {
@@ -274,8 +282,8 @@ export function rendererPhotos(context) {
                         service.ensureViewerLoaded(context)
                             .then(function() {
                                 service
-                                    .selectImage(context, photoKey)
-                                    .showViewer(context);
+                                    .showViewer(context)
+                                    .selectImage(context, photoKey);
                             });
                     });
                 }

--- a/modules/services/commons.ts
+++ b/modules/services/commons.ts
@@ -1,0 +1,357 @@
+import { dispatch as d3_dispatch } from 'd3-dispatch';
+import RBush, { type BBox } from 'rbush';
+import type { Tile } from '../util/tiler';
+import { utilTiler, utilQsString, utilStringQs } from '../util';
+import { planePhotoFrame } from './plane_photo';
+import { services } from '.';
+import type { Projection } from '../geo/raw_mercator';
+import { searchLimited, type WithBbox } from '../util/partition';
+import type { Vec2 } from '../geo/vector';
+import { getRelativeDate } from '../util/date';
+import { uiTooltip } from '../ui';
+import { localeDateString } from '../renderer/background_source';
+
+export interface CommonsPhoto {
+    pageid: number;
+    ns: number;
+    title: string;
+    index: number;
+    coordinates: {
+        lat: number;
+        lon: number;
+        primary: '';
+        globe: 'earth';
+    }[];
+    imagerepository: 'local';
+    imageinfo: {
+        /** ISO Date */
+        timestamp: string;
+        user: string;
+        size: number;
+        width: number;
+        height: number;
+        thumburl: string;
+        thumbwidth: number;
+        thumbheight: number;
+        responsiveUrls: { [size: number]: string; };
+        url: string;
+        descriptionurl: string;
+        descriptionshorturl: string;
+        metadata: { name: string; value: unknown }[];
+        extmetadata: {
+            LicenseShortName: {
+                value: 'Public domain';
+                source: 'commons-desc-page';
+                hidden: '';
+            };
+        };
+    }[];
+}
+
+interface ApiResponse {
+    error?: {
+        code: string;
+        info: string;
+        docref: string;
+    };
+    batchcomplete?: boolean;
+    continue?: {
+        iicontinue: string;
+        cocontinue: string;
+        continue: string;
+    };
+    query?: {
+        pages: {
+            [pageId: string]: CommonsPhoto;
+        };
+    };
+}
+
+export function getCommonsPhotoLoc(photo: CommonsPhoto): Vec2 {
+    return [photo.coordinates[0].lon, photo.coordinates[0].lat];
+}
+export function getCommonsPhotoDate(photo: CommonsPhoto) {
+    return new Date(photo.imageinfo[0].timestamp);
+}
+
+
+const minZoom = 10; // TODO: reconsider
+const maxZoom = 20;
+
+interface Cache {
+    images: {
+        rtree: RBush<WithBbox<CommonsPhoto>>;
+        byPageId: { [pageId: string]: CommonsPhoto };
+    };
+    requests: {
+        loaded: { [tileId: string]: true };
+        inflight: { [tileId: string]: AbortController };
+    };
+};
+
+function createCache(): Cache {
+    return {
+        images: { rtree: new RBush(), byPageId: {} },
+        requests: { loaded: {}, inflight: {} }
+    };
+}
+let _cache = createCache();
+
+
+
+export default new class CommonsService {
+    dispatch = d3_dispatch('loadedImages', 'viewerChanged');
+    // @ts-expect-error -- hack
+    on = (...args) => this.dispatch.on(...args);
+
+    #photoViewer: ReturnType<typeof planePhotoFrame> | undefined;
+
+    activeImage: CommonsPhoto | undefined;
+
+    #createRequetUrl(bbox: BBox) {
+        // docs: https://www.mediawiki.org/wiki/Extension:GeoData#API
+        const qs = new URLSearchParams({
+            format: 'json',
+            formatversion: '2',
+            origin: '*', // for CORS
+            action: 'query',
+            generator: 'geosearch',
+            ggsnamespace: '6', // the `File:` namespace
+            ggslimit: '500',
+            ggsbbox: `${bbox.maxY}|${bbox.minX}|${bbox.minY}|${bbox.maxX}`,
+            prop: 'coordinates|imageinfo',
+            iiprop: 'extmetadata|metadata|size|timestamp|url|user',
+            iiextmetadatafilter: 'LicenseShortName',
+            iiurlwidth: '300',
+        });
+        return `https://commons.wikimedia.org/w/api.php?${qs}`;
+    }
+
+    loadTiles(projection: Projection) {
+        const tiler = utilTiler()
+            .zoomExtent([minZoom, maxZoom])
+            .skipNullIsland(true);
+
+        const tiles = tiler.getTiles(projection);
+        if (!tiles) return;
+        for (const tile of tiles) {
+            this.#loadTile(tile);
+        }
+    }
+
+    cachedImage(pageId: string) {
+        return _cache.images.byPageId[pageId];
+    }
+
+    async #loadTile(tile: Tile) {
+        const cache = _cache.requests;
+        const tileId = tile.id;
+
+        if (cache.loaded[tileId] || cache.inflight[tileId]) return;
+        const controller = new AbortController();
+        cache.inflight[tileId] = controller;
+
+        // @ts-expect-error -- blocked by other PR
+        const url = this.#createRequetUrl(tile.extent.bbox());
+
+        try {
+            const response = await fetch(url, { signal: controller.signal });
+            if (!response.ok) {
+                throw new Error(response.status + ' ' + response.statusText);
+            }
+            const data: ApiResponse = await response.json();
+
+            if (data.error) {
+                throw new Error(`${data.error.code}: ${data.error.info}`);
+            }
+
+            const newPhotos = Object
+                .values(data.query?.pages || {})
+                .filter(photo => photo.coordinates && photo.imageinfo); // TODO: temp hack, why are some missing coords?
+
+            // load the API response into the cache
+            for (const photo of newPhotos) {
+                _cache.images.byPageId[photo.pageid] = photo;
+            }
+            _cache.images.rtree.load(Object.values(newPhotos).map(photo => {
+                const [x, y] = getCommonsPhotoLoc(photo);
+                return { minX: x, maxX: x, minY: y, maxY: y, data: photo };
+            }));
+
+            this.dispatch.call('loadedImages');
+        } catch (ex) {
+            console.error(ex); // eslint-disable-line no-console
+        }
+        cache.loaded[tileId] = true;
+        delete cache.inflight[tileId];
+    }
+
+    reset() {
+        Object.values(_cache.requests.inflight).forEach(request => request.abort());
+        _cache = createCache();
+    };
+
+    /** get visible images from the cache */
+    getImages(projection: Projection): CommonsPhoto[] {
+        return searchLimited(5, projection, _cache.images.rtree).map(item => item.data);
+    }
+
+    getCachedImage(pageId: string) {
+        return _cache.images.byPageId[pageId];
+    }
+
+    /** update the currently highlighted bubble */
+    setStyles(context: iD.Context, hovered: CommonsPhoto | undefined) {
+        context.container()
+            .selectAll<HTMLElement, CommonsPhoto>('.layer-commons .viewfield-group')
+            .classed('highlighted', (d) => d.pageid === hovered?.pageid)
+            .classed('hovered', (d) => d.pageid === hovered?.pageid)
+            .classed('currentView', (d) => d.pageid === this.activeImage?.pageid);
+
+        context.container().selectAll('.layer-commons .viewfield-group .viewfield')
+            .attr('d', 'M 8,13 m -10,0 a 10,10 0 1,0 20,0 a 10,10 0 1,0 -20,0');
+    }
+
+    /** Updates the URL to save the current shown image */
+    #updateUrlImage(pageid: number | undefined) {
+        const hash = utilStringQs(window.location.hash);
+        if (pageid) {
+            hash.photo = `commons/${pageid}`;
+        } else {
+            delete hash.photo;
+        }
+        window.history.replaceState(null, '', `#${utilQsString(hash, true)}`);
+    }
+
+    /** Loads the selected image in the frame */
+    selectImage(context: iD.Context, id: number | string) {
+        const d = _cache.images.byPageId[id];
+
+        this.activeImage = d;
+        this.#updateUrlImage(d.pageid);
+
+        const viewerLink = d.imageinfo[0].url;
+
+        let viewer = context.container().select('.photoviewer');
+        if (!viewer.empty()) viewer.datum(d);
+
+        this.setStyles(context, undefined); // TODO: why?
+
+        let wrap = context.container()
+            .select('.photoviewer .commons-wrapper');
+
+
+        this.#photoViewer!
+            .showPhotoFrame(wrap)
+            .selectPhoto({ image_path: viewerLink });
+
+        let attribution = wrap.selectAll('.photo-attribution').text('');
+
+        attribution
+            .append('div')
+            .attr('class', 'attribution-row');
+
+        attribution
+            .append('a')
+            .attr('class', 'report-photo')
+            .attr('href', d.imageinfo[0].descriptionurl)
+            .attr('target', '_blank')
+            .attr('rel', 'noopener')
+            .text(d.imageinfo[0].extmetadata.LicenseShortName.value);
+
+        attribution
+            .append('span')
+            .text('|');
+
+        attribution
+            .append('span')
+            .text(getRelativeDate(new Date(d.imageinfo[0].timestamp)))
+            .call(uiTooltip()
+                .title(() => localeDateString(d.imageinfo[0].timestamp))
+                .placement('top'));
+
+        attribution
+            .append('span')
+            .text('|');
+
+        attribution
+            .append('a')
+            .attr('class', 'image-link')
+            .attr('target', '_blank')
+            .attr('rel', 'noopener')
+            .attr('href', `https://commons.wikimedia.org/wiki/User:${d.imageinfo[0].user}`)
+            .text(`User:${d.imageinfo[0].user}`);
+
+        return this;
+    }
+
+    showViewer(context: iD.Context) {
+        const wrap = context.container().select('.photoviewer');
+        const isHidden = wrap.selectAll('.photo-wrapper.commons-wrapper.hide').size();
+
+        if (isHidden) {
+            // hide the photo viewers from any other service
+            for (const service of Object.values(services)) {
+                if (service === this) continue;
+                if ('hideViewer' in service) {
+                    service.hideViewer(context);
+                }
+            }
+            wrap
+                .classed('hide', false)
+                .selectAll('.photo-wrapper.commons-wrapper')
+                .classed('hide', false);
+        }
+
+        return this;
+    }
+
+
+    #isLoaded = false;
+    // eslint-disable-next-line require-await
+    async ensureViewerLoaded(context: iD.Context) {
+
+        let imgWrap = context.container()
+            .select('#ideditor-viewer-commons-simple > img');
+
+        if (!imgWrap.empty()) imgWrap.remove();
+
+        if (this.#isLoaded) return;
+        this.#isLoaded = true;
+
+        let wrap = context.container()
+            .select('.photoviewer')
+            .selectAll('.commons-wrapper')
+            .data([0]);
+
+        let wrapEnter = wrap.enter()
+            .append('div')
+            .attr('class', 'photo-wrapper commons-wrapper')
+            .classed('hide', true)
+            .on('dblclick.zoom', null);
+
+        wrapEnter
+            .append('div')
+            .attr('class', 'photo-attribution fillD');
+
+        this.#photoViewer = planePhotoFrame(context, wrapEnter);
+        this.#photoViewer.event.on('viewerChanged', () => this.dispatch.call('viewerChanged'));
+    }
+
+    /** Hides the current viewer if shown, resets the active image and sequence */
+    hideViewer(context: iD.Context) {
+        let viewer = context.container().select('.photoviewer');
+        if (!viewer.empty()) viewer.datum(null);
+        this.#updateUrlImage(undefined);
+        viewer
+            .classed('hide', true)
+            .selectAll('.photo-wrapper')
+            .classed('hide', true);
+        context.container().selectAll('.viewfield-group, .sequence, .icon-sign')
+            .classed('currentView', false);
+
+        this.activeImage = undefined;
+
+        this.setStyles(context, undefined);
+    }
+};

--- a/modules/services/index.js
+++ b/modules/services/index.js
@@ -1,4 +1,5 @@
 import serviceKeepRight from './keepRight';
+import serviceCommons from './commons';
 import serviceOsmose from './osmose';
 import serviceMapillary from './mapillary';
 import serviceMapRules from './maprules';
@@ -18,6 +19,7 @@ import servicePanoramax from './panoramax';
 
 
 export let services = {
+  commons: serviceCommons,
   geocoder: serviceNominatim,
   keepRight: serviceKeepRight,
   osmose: serviceOsmose,

--- a/modules/services/panoramax.js
+++ b/modules/services/panoramax.js
@@ -50,6 +50,7 @@ let _activeImage;
 let _isViewerOpen = false;
 
 
+// TODO: deduplicate
 // Partition viewport into higher zoom tiles
 function partitionViewport(projection) {
     const z = geoScaleToZoom(projection.scale());

--- a/modules/services/plane_photo.js
+++ b/modules/services/plane_photo.js
@@ -3,7 +3,7 @@ import { zoom as d3_zoom, zoomIdentity as d3_zoomIdentity } from 'd3-zoom';
 import { utilSetTransform, utilRebind } from '../util';
 
 
-export async function planePhotoFrame(context, selection) {
+export function planePhotoFrame(context, selection) {
     const dispatch = d3_dispatch('viewerChanged');
 
     const module = {};
@@ -68,8 +68,6 @@ export async function planePhotoFrame(context, selection) {
       _viewerDimensions = dimensions;
       updateTransform();
     });
-
-    await Promise.resolve();
 
     /**
      * Shows the photo frame if hidden

--- a/modules/svg/commons_images.ts
+++ b/modules/svg/commons_images.ts
@@ -1,0 +1,224 @@
+import _throttle from 'lodash-es/throttle';
+
+import { select as d3_select } from 'd3-selection';
+import { services } from '../services';
+import type { Projection } from '../geo/raw_mercator';
+import type { Dispatch } from 'd3';
+import { getCommonsPhotoDate, getCommonsPhotoLoc, type CommonsPhoto } from '../services/commons';
+import { svgPointTransform } from './helpers';
+
+interface Layer {
+    (selection: d3.Selection): void;
+    enabled: GetSet<Layer, boolean>;
+    supported(): boolean;
+    rendered(zoom: number): boolean;
+}
+
+let _enabled = false;
+
+export function svgCommonsImages(
+    projection: Projection,
+    context: iD.Context,
+    dispatch: Dispatch<object, {
+        change: [];
+        photoDatesChanged: [provider: string, dates: unknown[]];
+    }>,
+) {
+    const transform = svgPointTransform(projection);
+    const throttledRedraw = _throttle(() => dispatch.call('change'), 1000);
+    const minZoom = 16;
+    const viewFieldZoomLevel = 18;
+    let layer = d3_select<any, 0>(null);
+
+    services.commons?.on('loadedImages', throttledRedraw);
+
+
+    function filterImages(photos: CommonsPhoto[], skipDateFilter = false) {
+        const fromDate = context.photos().fromDate();
+        const toDate = context.photos().toDate();
+        const usernames = context.photos().usernames();
+
+        if (fromDate && !skipDateFilter) {
+            photos = photos.filter((photo) => +getCommonsPhotoDate(photo) >= +new Date(fromDate));
+        }
+        if (toDate && !skipDateFilter) {
+            photos = photos.filter((photo) => +getCommonsPhotoDate(photo) <= +new Date(toDate));
+        }
+        if (usernames) {
+            photos = photos.filter((photo) => usernames.includes(photo.imageinfo[0].user));
+        }
+
+        return photos;
+    }
+
+    function showLayer() {
+        editOn();
+
+        layer
+            .style('opacity', 0)
+            .transition()
+            .duration(250)
+            .style('opacity', 1)
+            .on('end', function () { dispatch.call('change'); });
+    }
+
+    function hideLayer() {
+        throttledRedraw.cancel();
+
+        layer
+            .transition()
+            .duration(250)
+            .style('opacity', 0)
+            .on('end', editOff);
+    }
+
+    function editOn() {
+        layer.style('display', 'block');
+    }
+
+
+    function editOff() {
+        layer.selectAll('.viewfield-group').remove();
+        layer.style('display', 'none');
+    }
+
+    function click(d3_event: MouseEvent, image: CommonsPhoto) {
+        services.commons.ensureViewerLoaded(context);
+        services.commons
+            .showViewer(context)
+            .selectImage(context, image.pageid);
+
+        context.map().centerEase(getCommonsPhotoLoc(image));
+    }
+
+    function mouseover(d3_event: MouseEvent, image: CommonsPhoto) {
+        services.commons.setStyles(context, image);
+    }
+
+
+    function mouseout() {
+        services.commons.setStyles(context, undefined);
+    }
+
+    function update(this: any) {
+        const zoom = ~~context.map().zoom();
+        const showViewfields = (zoom >= viewFieldZoomLevel);
+
+        let images = services.commons && zoom >= minZoom
+            ? services.commons.getImages(projection)
+            : [];
+
+        dispatch.call('photoDatesChanged', this, 'commons', images.map(getCommonsPhotoDate));
+
+        images = filterImages(images);
+
+        const activeImage = services.commons.activeImage;
+        const activeImageId = activeImage ? activeImage.pageid : null;
+
+        const groups = layer
+            .selectAll<SVGGElement, CommonsPhoto>('.viewfield-group')
+            .data(images, d => d.pageid);
+
+        // exit
+        groups.exit().remove();
+
+        // enter
+        const groupsEnter = groups.enter()
+            .append('g')
+            .attr('class', 'viewfield-group')
+            .on('mouseenter', mouseover)
+            .on('mouseleave', mouseout)
+            .on('click', click);
+
+        groupsEnter
+            .append('g')
+            .attr('class', 'viewfield-scale');
+
+        // update
+        const markers = groups
+            .merge(groupsEnter)
+            .sort((a, b) => {
+                // the selected photo is always the topmost
+                if (a.pageid === activeImageId) return 1;
+                if (b.pageid === activeImageId) return -1;
+                // put the newest on top, in case there are many close together
+                return +getCommonsPhotoDate(a) - +getCommonsPhotoDate(b);
+            })
+            .attr('transform', (d) => transform({ loc: getCommonsPhotoLoc(d) }))
+            .select('.viewfield-scale');
+
+        markers.selectAll('circle')
+            .data([0])
+            .enter()
+            .append('circle')
+            .attr('dx', '0')
+            .attr('dy', '0')
+            .attr('r', '6');
+
+        const viewfields = markers.selectAll('.viewfield')
+            .data(showViewfields ? [0] : []);
+
+        viewfields.exit().remove();
+
+        viewfields.enter()
+            .insert('path', 'circle')
+            .attr('class', 'viewfield')
+            .attr('transform', 'scale(1.5,1.5),translate(-8, -13)')
+            .attr('d', 'M 6,9 C 8,8.4 8,8.4 10,9 L 16,-2 C 12,-5 4,-5 0,-2 z');
+
+        services.commons.setStyles(context, undefined);
+    }
+
+    const drawImages: Layer = function (this: Layer, selection) {
+        layer = selection.selectAll('.layer-commons')
+            .data([0]);
+
+        layer.exit().remove();
+
+        const layerEnter = layer.enter()
+            .append('g')
+            .attr('class', 'layer-commons')
+            .style('display', _enabled ? 'block' : 'none');
+
+        layer = layerEnter.merge(layer);
+
+        if (_enabled) {
+            let zoom = ~~context.map().zoom();
+            if (zoom >= minZoom) {
+                editOn();
+                update();
+                services.commons.loadTiles(projection);
+            } else {
+                editOff();
+                dispatch.call('photoDatesChanged', this, 'commons', []);
+                services.commons.hideViewer(context);
+            }
+        } else {
+            dispatch.call('photoDatesChanged', this, 'commons', []);
+        }
+    };
+
+    drawImages.enabled = function(this: Layer, _: boolean) {
+        if (!arguments.length) return _enabled;
+        _enabled = _;
+        if (_enabled) {
+            showLayer();
+            context.photos().on('change.commons_images', update);
+        } else {
+            hideLayer();
+            context.photos().on('change.commons_images', null);
+        }
+        dispatch.call('change');
+        return this;
+    } as never;
+
+
+    drawImages.supported = () => true;
+
+    drawImages.rendered = function(zoom) {
+      return zoom >= minZoom;
+    };
+
+
+    return drawImages;
+}

--- a/modules/svg/helpers.js
+++ b/modules/svg/helpers.js
@@ -181,7 +181,9 @@ export function svgPath(projection, graph, isArea) {
 }
 
 
+/** @param {iD.Projection} projection */
 export function svgPointTransform(projection) {
+    /** @param {{ loc: import('../geo/vector').Vec2 }} entity */
     var svgpoint = function(entity) {
         // http://jsperf.com/short-array-join
         var pt = projection(entity.loc);

--- a/modules/svg/index.js
+++ b/modules/svg/index.js
@@ -1,4 +1,5 @@
 export { svgAreas } from './areas.js';
+export { svgCommonsImages } from './commons_images.js';
 export { svgData } from './data.js';
 export { svgDebug } from './debug.js';
 export { svgDefs } from './defs.js';

--- a/modules/svg/layers.js
+++ b/modules/svg/layers.js
@@ -1,6 +1,6 @@
 import { dispatch as d3_dispatch } from 'd3-dispatch';
 import { select as d3_select } from 'd3-selection';
-
+import { svgCommonsImages } from './commons_images';
 import { svgData } from './data';
 import { svgLocalPhotos} from './local_photos';
 import { svgDebug } from './debug';
@@ -33,6 +33,7 @@ export function svgLayers(projection, context) {
         { id: 'keepRight', layer: svgKeepRight(projection, context, dispatch) },
         { id: 'osmose', layer: svgOsmose(projection, context, dispatch) },
         { id: 'streetside', layer: svgStreetside(projection, context, dispatch)},
+        { id: 'commons', layer: svgCommonsImages(projection, context, dispatch)},
         { id: 'mapillary', layer: svgMapillaryImages(projection, context, dispatch) },
         { id: 'mapillary-position', layer: svgMapillaryPosition(projection, context, dispatch) },
         { id: 'mapillary-map-features',  layer: svgMapillaryMapFeatures(projection, context, dispatch) },

--- a/modules/svg/local_photos.js
+++ b/modules/svg/local_photos.js
@@ -87,7 +87,7 @@ export function svgLocalPhotos(projection, context, dispatch) {
             .on('click.forward', () => stepPhotos(1))
             .text('▶');
 
-        return planePhotoFrame(context, viewerEnter)
+        return Promise.resolve(planePhotoFrame(context, viewerEnter))
             .then(planePhotoFrame => _photoFrame = planePhotoFrame);
     }
 

--- a/modules/ui/tooltip.js
+++ b/modules/ui/tooltip.js
@@ -2,6 +2,7 @@ import { utilFunctor } from '../util/util';
 import { t } from '../core/localizer';
 import { uiPopover } from './popover';
 
+/** @returns {any} */
 export function uiTooltip(klass) {
 
     var tooltip = uiPopover((klass || '') + ' tooltip')

--- a/modules/util/partition.ts
+++ b/modules/util/partition.ts
@@ -1,0 +1,27 @@
+import { geoScaleToZoom } from '../geo';
+import { utilTiler } from './tiler';
+import type { Projection } from '../geo/raw_mercator';
+import type RBush from 'rbush';
+import type { BBox } from 'rbush';
+
+export interface WithBbox<T> extends BBox {
+  data: T;
+}
+
+export function partitionViewport(projection: Projection) {
+  let z = geoScaleToZoom(projection.scale());
+  let z2 = (Math.ceil(z * 2) / 2) + 2.5;   // round to next 0.5 and add 2.5
+  let tiler = utilTiler().zoomExtent([z2, z2]);
+
+  return (tiler.getTiles(projection) || []).map(tile => tile.extent);
+}
+
+
+/** no more than `limit` results per partition */
+export function searchLimited<T>(limit: number | undefined, projection: Projection, rtree: RBush<T>): T[] {
+  limit ||= 5;
+
+  return partitionViewport(projection)
+    // @ts-expect-error -- fixed in a different PR
+    .flatMap((extent) => rtree.search(extent.bbox()).slice(0, limit));
+}

--- a/modules/util/tiler.js
+++ b/modules/util/tiler.js
@@ -3,6 +3,7 @@ import { clamp } from 'lodash-es';
 
 import { geoExtent, geoScaleToZoom } from '../geo';
 
+/** @typedef {{ id: string; xyz: import('../geo/vector').Vec3; extent: geoExtent }} Tile */
 
 export function utilTiler() {
     var _size = [256, 256];
@@ -74,6 +75,7 @@ export function utilTiler() {
 
     /**
      * getTiles() returns an array of tiles that cover the map view
+     * @returns {false | Tile[]}
      */
     tiler.getTiles = function(projection) {
         var origin = [
@@ -140,6 +142,7 @@ export function utilTiler() {
     };
 
 
+    /** @type {GetSet<typeof tiler, Vec2>} */
     tiler.zoomExtent = function(val) {
         if (!arguments.length) return _zoomExtent;
         _zoomExtent = val;
@@ -176,6 +179,7 @@ export function utilTiler() {
     };
 
 
+    /** @type {GetSet<typeof tiler, boolean>} */
     tiler.skipNullIsland = function(val) {
         if (!arguments.length) return _skipNullIsland;
         _skipNullIsland = val;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2259,10 +2259,11 @@
       "dev": true
     },
     "node_modules/@types/d3-dispatch": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.6.tgz",
-      "integrity": "sha512-4fvZhzMeeuBJYZXRXrRIQnvUYfyXwYmLsdiN7XXmVNQKKw1cM8a5WdID0g1hVFZDqT9ZqZEY5pD44p24VS7iZQ==",
-      "dev": true
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/d3-drag": {
       "version": "3.0.7",

--- a/test/spec/svg/layers.js
+++ b/test/spec/svg/layers.js
@@ -26,25 +26,28 @@ describe('iD.svgLayers', function () {
     it('creates default data layers', function () {
         container.call(iD.svgLayers(projection, context));
         var nodes = container.selectAll('svg .data-layer').nodes();
-        expect(nodes.length).to.eql(18);
-        expect(d3.select(nodes[0]).classed('osm')).to.be.true;
-        expect(d3.select(nodes[1]).classed('notes')).to.be.true;
-        expect(d3.select(nodes[2]).classed('data')).to.be.true;
-        expect(d3.select(nodes[3]).classed('keepRight')).to.be.true;
-        expect(d3.select(nodes[4]).classed('osmose')).to.be.true;
-        expect(d3.select(nodes[5]).classed('streetside')).to.be.true;
-        expect(d3.select(nodes[6]).classed('mapillary')).to.be.true;
-        expect(d3.select(nodes[7]).classed('mapillary-position')).to.be.true;
-        expect(d3.select(nodes[8]).classed('mapillary-map-features')).to.be.true;
-        expect(d3.select(nodes[9]).classed('mapillary-signs')).to.be.true;
-        expect(d3.select(nodes[10]).classed('kartaview')).to.be.true;
-        expect(d3.select(nodes[11]).classed('mapilio')).to.be.true;
-        expect(d3.select(nodes[12]).classed('vegbilder')).to.be.true;
-        expect(d3.select(nodes[13]).classed('panoramax')).to.be.true;
-        expect(d3.select(nodes[14]).classed('local-photos')).to.be.true;
-        expect(d3.select(nodes[15]).classed('debug')).to.be.true;
-        expect(d3.select(nodes[16]).classed('geolocate')).to.be.true;
-        expect(d3.select(nodes[17]).classed('touch')).to.be.true;
+        expect(nodes.length).to.eql(19);
+        expect(nodes.map(node => node.className.baseVal)).toStrictEqual([
+            'data-layer osm',
+            'data-layer notes',
+            'data-layer data',
+            'data-layer keepRight',
+            'data-layer osmose',
+            'data-layer streetside',
+            'data-layer commons',
+            'data-layer mapillary',
+            'data-layer mapillary-position',
+            'data-layer mapillary-map-features',
+            'data-layer mapillary-signs',
+            'data-layer kartaview',
+            'data-layer mapilio',
+            'data-layer vegbilder',
+            'data-layer panoramax',
+            'data-layer local-photos',
+            'data-layer debug',
+            'data-layer geolocate',
+            'data-layer touch',
+        ]);
     });
 
 });


### PR DESCRIPTION
Closes #10640

images from [Wikimedia Commons](https://commons.wikimedia.org) are now available alongside streetlevel imagery like Mapillary:

<img width="442" height="308" alt="image" src="https://github.com/user-attachments/assets/1177f750-ff4e-4725-92ef-0d9aa9453021" />

This uses Mediawiki's [Geosearch](https://www.mediawiki.org/wiki/API:Geosearch)+[Imageinfo](https://www.mediawiki.org/wiki/API:Imageinfo) API ([example](https://commons.wikimedia.org/w/api.php?format=json&formatversion=2&origin=*&action=query&generator=geosearch&ggsnamespace=6&ggslimit=500&ggsbbox=-36.835668247244385%7C174.76638793945315%7C-36.83676736421915%7C174.76776123046878&prop=coordinates%7Cimageinfo&iiprop=timestamp%7Cuser%7Curl%7Cextmetadata%7Cmetadata%7Csize&iiextmetadatafilter=LicenseShortName&iiurlwidth=300)), which was discussed in https://github.com/openstreetmap/iD/issues/10640#issuecomment-3137220974


The PR is a draft because it's blocked by several other PRs, and there are a lot of issues to consider:
- [ ] the API only provides basic metadata and EXIF data, but not [structured data](https://commons.wikimedia.org/wiki/Commons:Structured_data). 
  - [ ] therefore, the _date_ is the uploaded date, not the capture date. which could be years apart.
  - [ ] therefore, the _username_ is the uploader, not the author. which is often different (e.g. [flickr2commons](https://commons.wikimedia.org/wiki/Commons:Flickr2Commons)) 
  - [ ] no support for heading/bearing yet, although this could be obtained from the EXIF (`GPSImgDirection` & co.) if we decide not to use [structured data](https://commons.wikimedia.org/wiki/Commons:Structured_data).
- [ ] there's no filter to exclude incompatible licenses yet. I'm guessing CC-0 is the only compatible license?
  - [ ] The license information comes from [`LicenseShortName`](https://commons.wikimedia.org/wiki/Commons:Machine-readable_data). There is a also a boolean called [`AttributionRequired`](https://commons.wikimedia.org/wiki/Commons:Machine-readable_data), maybe we could filter based on `AttributionRequired=false` instead of hardcoding compatible license names ?
- [ ] are we adhering to [wikimedia's API terms](https://foundation.wikimedia.org/wiki/Policy:Wikimedia_Foundation_API_Usage_Guidelines)? I think so, but maybe we should tweak the tiling logic to further reduce the number of API requests
  - [ ] _share a kind ping to the [Wikimedia Foundation "SRE" Team](https://www.mediawiki.org/wiki/Wikimedia_Site_Reliability_Engineering), to bring this feature to their attention - as it could have an impact on API traffic_ - see [#11666 (comment 3661238897)](https://github.com/openstreetmap/iD/pull/11666#issuecomment-3661238897)