### PR TITLE
Added info message at an intersection or at the end of path while cycling using [ or ] keybindings

### DIFF
--- a/modules/modes/select.js
+++ b/modules/modes/select.js
@@ -552,12 +552,27 @@ export function modeSelect(context, selectedIDs) {
                 index = length - 2;
             }
 
-            if (index !== -1) {
-                context.enter(
-                    mode.selectedIDs([way.nodes[index]])
-                        .follow(true)
-                );
+            if (index === -1) {
+              context.ui().flash
+                .duration(4000)
+                .iconName('#iD-icon-info')
+                .label('This is the last node of the path.')();
+              return;
             }
+
+            const node = context.entity(way.nodes[index]);
+            const parentWays = context.graph().parentWays(node);
+            if (parentWays.length > 1) {
+              context.ui().flash
+                  .duration(4000)
+                  .iconName('#iD-icon-info')
+                  .label('This node is part of multiple ways. Select manually to switch paths or continue in the same path.')();
+            }
+
+            context.enter(
+              mode.selectedIDs([way.nodes[index]])
+                .follow(true)
+            );
         }
 
 
@@ -578,12 +593,27 @@ export function modeSelect(context, selectedIDs) {
                 index = 0;
             }
 
-            if (index !== -1) {
-                context.enter(
-                    mode.selectedIDs([way.nodes[index]])
-                        .follow(true)
-                );
+            if (index === -1) {
+              context.ui().flash
+                .duration(4000)
+                .iconName('#iD-icon-info')
+                .label('This is the last node of the path.')();
+              return;
             }
+
+            const node = context.entity(way.nodes[index]);
+            const parentWays = context.graph().parentWays(node);
+            if (parentWays.length > 1) {
+              context.ui().flash
+                .duration(4000)
+                .iconName('#iD-icon-info')
+                .label('This node is part of multiple ways. Select manually to switch paths or continue in the same path.')();
+            }
+
+            context.enter(
+              mode.selectedIDs([way.nodes[index]])
+                .follow(true)
+            );
         }
 
 


### PR DESCRIPTION
### Fixes:
1. Detects end nodes on the moving path and shows the appropriate message.
2. When encountering a path node that has multiple parents, the user is prompted to switch paths which is optional.
3. Ensures cycling remains within the same path unless user explicitly switches.

Fixes #9818 

### Demo video:

https://github.com/user-attachments/assets/d9871468-5230-473c-a083-4080bc27c9ca

