### PR TITLE
Fixed #9406: By treating aerialway=station as valid start/end point which suppresses the false warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Use Röntgen icon set directly from upstream npm package ([#11784], thanks [@tordans])
 * Replace deprecated `document.createEvent`/`initEvent` with modern [Event] constructor ([#11870], thanks [@JaiswalShivang])
 * Fix crash in country combo field when entering unrecognized ISO country codes ([#11904], thanks [@JaiswalShivang])
-* Fixed showing "Disconnected Way" warnings for paths ending at aerialway stations and stopping locations. ([#9406], thanks [@Razen04])
+* Fixed showing "Disconnected Way" warnings for ways ending at aerialway stations and stopping locations. ([#9406], thanks [@Razen04])
 
 
 [#8464]: https://github.com/openstreetmap/iD/issues/8464

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Use Röntgen icon set directly from upstream npm package ([#11784], thanks [@tordans])
 * Replace deprecated `document.createEvent`/`initEvent` with modern [Event] constructor ([#11870], thanks [@JaiswalShivang])
 * Fix crash in country combo field when entering unrecognized ISO country codes ([#11904], thanks [@JaiswalShivang])
+* Fixed showing "Disconnected Way" warnings for paths ending at aerialway stations and stopping locations. ([#9406], thanks [@Razen04])
 
 
 [#8464]: https://github.com/openstreetmap/iD/issues/8464
@@ -93,6 +94,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#11862]: https://github.com/openstreetmap/iD/pull/11862
 [#11870]: https://github.com/openstreetmap/iD/issues/11870
 [#11904]: https://github.com/openstreetmap/iD/issues/11904
+[#9406]: https://github.com/openstreetmap/iD/issues/9406
 [#id-tagging-schema/pull/1507]: https://github.com/openstreetmap/id-tagging-schema/pull/1507
 [@ilias52730]: https://github.com/ilias52730
 [@Razen04]: https://github.com/Razen04

--- a/modules/validations/disconnected_way.js
+++ b/modules/validations/disconnected_way.js
@@ -151,6 +151,9 @@ export function validationDisconnectedWay() {
                 vertex.tags.entrance !== 'no') return true;
             if (vertex.tags.amenity === 'parking_entrance') return true;
 
+            // treat nodes inside gandola stations and ski lifts as connected
+            if (vertex.tags.aerialway === 'station') return true;
+
             return false;
         }
 

--- a/modules/validations/disconnected_way.js
+++ b/modules/validations/disconnected_way.js
@@ -151,8 +151,10 @@ export function validationDisconnectedWay() {
                 vertex.tags.entrance !== 'no') return true;
             if (vertex.tags.amenity === 'parking_entrance') return true;
 
-            // treat nodes inside gandola stations and ski lifts as connected
-            if (vertex.tags.aerialway === 'station') return true;
+            // treat nodes inside gondola stations and ski lifts as connected
+            if (vertex.tags.aerialway) {
+                if (vertex.tags.aerialway === 'station' || vertex.tags.public_transport === 'stop_position') return true;
+            }
 
             return false;
         }


### PR DESCRIPTION
## Description
Currently, iD warns for paths which are not connected to any other route any is contained within a building like gondola stations which is a false positive. This has been explained in detail in Issue #9406.

## Fix
The fix to this is simple, we just add an extra check in the `isConnectedVertex` function to check if a vertex in the path has `aerialway=station` and return `true` for that, which means the path is valid to have start/end in the gandola station even if they are not connected to any other roads or highway(which they aren't supposed to).

Fixes #9406 

## Before:

<img width="1440" height="769" alt="Screenshot 2025-12-13 at 3 53 10 PM" src="https://github.com/user-attachments/assets/d352cbd6-514e-4960-9d92-1ac31efa4b78" />

## After the if statement:

<img width="1440" height="769" alt="Screenshot 2025-12-13 at 3 53 47 PM" src="https://github.com/user-attachments/assets/95774735-fdeb-42cc-ae43-07f5a643406d" />


## References
This is similar to issue #3906 - which showed problems with foothpaths connecting two buildings.