### PR TITLE
Add missing Mapillary mouseover tooltips (#11670)

### DIFF
--- a/modules/ui/sections/photo_overlays.js
+++ b/modules/ui/sections/photo_overlays.js
@@ -100,10 +100,21 @@ export function uiSectionPhotoOverlays(context) {
             .append('label')
             .each(function(d) {
                 var titleID;
-                if (d.id === 'mapillary-signs') titleID = 'mapillary.signs.tooltip';
-                else if (d.id === 'mapillary') titleID = 'mapillary_images.tooltip';
-                else if (d.id === 'kartaview') titleID = 'kartaview_images.tooltip';
-                else titleID = d.id.replace(/-/g, '_') + '.tooltip';
+                if (d.id === 'mapillary-signs') {
+    titleID = 'Show Mapillary traffic signs';
+}
+else if (d.id === 'mapillary') {
+    titleID = 'Show Mapillary street-level photos';
+}
+else if (d.id === 'mapillary-map-features') {
+    titleID = 'Show Mapillary detected map features';
+}
+else if (d.id === 'kartaview') {
+    titleID = 'Show Kartaview images';
+}
+else {
+    titleID = d.id.replace(/-/g, '_') + ' layer';
+}
                 d3_select(this)
                     .call(uiTooltip()
                         .title(() => {
@@ -116,7 +127,6 @@ export function uiSectionPhotoOverlays(context) {
                         .placement('top')
                     );
             });
-
         labelEnter
             .append('input')
             .attr('type', 'checkbox')


### PR DESCRIPTION

This PR adds missing mouseover tooltips for Mapillary-related layers, as requested in issue #11670.

Changes made:

  - Added readable tooltip strings for:
  - Mapillary traffic signs (`mapillary-signs`)
  - Mapillary street-level photos (`mapillary`)
  - Mapillary map features (`mapillary-map-features`)
  - Kartaview images (`kartaview`)
  - Replaced raw internal tooltip IDs with user-friendly descriptions.

Fixes #11670
