### PR TITLE
Make panel close button visually distinct (#11672)

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -4144,8 +4144,13 @@ li.issue-fix-item button:not(.actionable) .fix-icon {
 }
 
 .pane-heading button {
-    width: 40px;
+    width: 50px;
     border-radius: 0;
+    background-color:  black;
+}
+
+.pane-heading button:hover {
+    background-color: #121212; /* slightly lighter */
 }
 
 .pane-content {


### PR DESCRIPTION
This PR increases the panel close button width from 40px to 50px, adjusts its background color to better distinguish it from adjacent tool buttons, and adds an explicit hover style to preserve clear interaction feedback.