### PR TITLE
Capitalized the initial letter of genus, species, and taxon tag values 

### DIFF
--- a/modules/ui/commit.js
+++ b/modules/ui/commit.js
@@ -30,10 +30,22 @@ var readOnlyTags = [
     /^closed:keepright$/,
     /^closed:osmose:/
 ];
+var taxonKeys = [
+    'genus',
+    'family',
+    'subfamily',
+    'tribe'
+];
+
 
 // treat most punctuation (except -, _, +, &) as hashtag delimiters - #4398
 // from https://stackoverflow.com/a/25575009
 var hashtagRegex = /([#＃][^\u2000-\u206F\u2E00-\u2E7F\s\\'!"#$%()*,.\/:;<=>?@\[\]^`{|}~]+)/g;
+function capitalizeFirstLetter(value) {
+    if (!value || typeof value !== 'string') return value;
+    return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
 
 
 export function uiCommit(context) {
@@ -560,8 +572,15 @@ export function uiCommit(context) {
             } else if (onInput) {
                 tags[k] = v;
             } else {
-                tags[k] = context.cleanTagValue(v);
+                var cleaned = context.cleanTagValue(v);
+
+                if (taxonKeys.indexOf(k) !== -1) {
+                    cleaned = capitalizeFirstLetter(cleaned);
+                }
+
+                tags[k] = cleaned;
             }
+
         });
 
         if (!onInput) {

--- a/modules/ui/fields/localized.js
+++ b/modules/ui/fields/localized.js
@@ -11,6 +11,12 @@ import { uiCombobox } from '../combobox';
 import { utilArrayUniq, utilGetSetValue, utilNoAuto, utilRebind, utilTotalExtent, utilUniqueDomId } from '../../util';
 import { uiLengthIndicator } from '../length_indicator';
 
+const languageDisplayNames =
+    (typeof Intl !== 'undefined' && Intl.DisplayNames)
+        ? new Intl.DisplayNames([navigator.language], { type: 'language' })
+        : null;
+
+
 var _languagesArray = [];
 
 export const LANGUAGE_SUFFIX_REGEX = /^(.*):([a-z]{2,3}(?:-[A-Z][a-z]{3})?(?:-[A-Z]{2})?)$/;
@@ -340,7 +346,20 @@ export function uiFieldLocalized(field, context) {
                 (d.nativeName && d.nativeName.toLowerCase().indexOf(v) >= 0) ||
                 d.code.toLowerCase().indexOf(v) >= 0;
         }).map(function(d) {
-            return { value: d.label };
+            cb(langItems
+                .map(function(d) {
+                    const displayName = languageDisplayNames?.of(d.code) || d.label || d.code;
+                    return {
+                        value: displayName,
+                        title: d.code
+                    };
+                })
+                .filter(function(d) {
+                    return d.value.toLowerCase().indexOf(v) >= 0 ||
+                        d.title.toLowerCase().indexOf(v) >= 0;
+                })
+            );
+
         }));
     }
 
@@ -451,6 +470,7 @@ export function uiFieldLocalized(field, context) {
         entries.classed('present', true);
 
         utilGetSetValue(entries.select('.localized-lang'), function(d) {
+            lang = lang.toLowerCase();
             var langItem = _languagesArray.find(function(item) {
                 return item.code === d.lang;
             });


### PR DESCRIPTION
Fixes #[1697](https://github.com/openstreetmap/iD/issues/11679)

Automatically capitalize the first letter of scientific taxon tag values (genus, family, subfamily, tribe) when saving, ensuring correct nomenclature.