### PR TITLE
Added a mutually exclusive key and value and updated the functions to work with string and object

### DIFF
--- a/modules/osm/tags.js
+++ b/modules/osm/tags.js
@@ -364,7 +364,11 @@ export const osmMutuallyExclusiveTagPairs = [
     ['noaddress', 'addr:housenumber'],
     ['noaddress', 'addr:housename'],
     ['noaddress', 'addr:unit'],
-    ['addr:nostreet', 'addr:street']
+    ['addr:nostreet', 'addr:street'],
+    [
+      {key: 'crossing', value:'unmarked'},
+      {key: 'crossing_ref', value: 'zebra'}
+    ]
 ];
 
 

--- a/modules/osm/tags.js
+++ b/modules/osm/tags.js
@@ -368,7 +368,8 @@ export const osmMutuallyExclusiveTagPairs = [
     [
       {key: 'crossing', value:'unmarked'},
       {key: 'crossing_ref', value: 'zebra'}
-    ]
+    ],
+    [ 'crossing_ref', { key: 'crossing:markings', value: 'no' } ]
 ];
 
 

--- a/modules/validations/mutually_exclusive_tags.js
+++ b/modules/validations/mutually_exclusive_tags.js
@@ -38,7 +38,7 @@ export function validationMutuallyExclusiveTags(/* context */) {
         }).filter((pair) => {
             // noname=no is double-negation, thus positive and not conflicting. We'll ignore those
             return !(isIgnoredNoTag(pair[0], entity.tags) ||
-                     isIgnoredNoTag(pair[0], entity.tags));
+                     isIgnoredNoTag(pair[1], entity.tags));
         });
 
         // Additional:

--- a/modules/validations/mutually_exclusive_tags.js
+++ b/modules/validations/mutually_exclusive_tags.js
@@ -12,12 +12,33 @@ export function validationMutuallyExclusiveTags(/* context */) {
 
     const validation = function checkMutuallyExclusiveTags(entity /*, graph */) {
 
+        function matchesRule(rule, tags){
+          if (typeof rule === 'string') {
+            return rule in tags;
+          }
+          return tags[rule.key] === rule.value;
+        }
+
+        function isIgnoredNoTag(rule, tags){
+          return typeof rule === 'string' && rule.match(/^(addr:)?no[a-z]/) && tags[rule] === 'no';
+        }
+
+        // To get the key
+        function ruleKey(rule){
+          return typeof rule === 'string' ? rule : rule.key;
+        }
+
+        // To get the key or both key and value for the UI
+        function ruleLabel(rule) {
+          return typeof rule === 'string' ? rule : `${rule.key}=${rule.value}`;
+        }
+
         let pairsFounds = tagKeyPairs.filter((pair) => {
-            return (pair[0] in entity.tags && pair[1] in entity.tags);
+            return matchesRule(pair[0], entity.tags) && matchesRule(pair[1], entity.tags);
         }).filter((pair) => {
             // noname=no is double-negation, thus positive and not conflicting. We'll ignore those
-            return !((pair[0].match(/^(addr:)?no[a-z]/) && entity.tags[pair[0]] === 'no') ||
-                     (pair[1].match(/^(addr:)?no[a-z]/) && entity.tags[pair[1]] === 'no'));
+            return !(isIgnoredNoTag(pair[0], entity.tags) ||
+                     isIgnoredNoTag(pair[0], entity.tags));
         });
 
         // Additional:
@@ -48,13 +69,13 @@ export function validationMutuallyExclusiveTags(/* context */) {
                     let entity = context.hasEntity(this.entityIds[0]);
                     return entity ? t.append(`issues.${type}.${subtype}.message`, {
                         feature: utilDisplayLabel(entity, context.graph()),
-                        tag1: pair[0],
-                        tag2: pair[1]
+                        tag1: ruleLabel(pair[0]),
+                        tag2: ruleLabel(pair[1])
                     }) : '';
                 },
                 reference: (selection) => showReference(selection, pair, subtype),
                 entityIds: [entity.id],
-                dynamicFixes: () => pair.slice(0,2).map((tagToRemove) => createIssueFix(tagToRemove))
+                dynamicFixes: () => pair.slice(0,2).map((tagToRemove) => createIssueFix(ruleKey(tagToRemove)))
             });
         });
 
@@ -81,7 +102,7 @@ export function validationMutuallyExclusiveTags(/* context */) {
                 .enter()
                 .append('div')
                 .attr('class', 'issue-reference')
-                .call(t.append(`issues.${type}.${subtype}.reference`, { tag1: pair[0], tag2: pair[1] }));
+                .call(t.append(`issues.${type}.${subtype}.reference`, { tag1: ruleLabel(pair[0]), tag2: ruleLabel(pair[1]) }));
         }
 
         return issues;

--- a/test/spec/validations/mutually_exclusive_tags.js
+++ b/test/spec/validations/mutually_exclusive_tags.js
@@ -81,4 +81,21 @@ describe('iD.validations.mutually_exclusive_tags', function () {
         expect(issue.entityIds).to.have.lengthOf(1);
         expect(issue.entityIds[0]).to.eql('n-1');
     });
+
+    it('ignores double-negative tags like noname=no', async () => {
+        createNode({ name: 'Liluah St.', 'noname': 'no' });
+        let validator = iD.validationMutuallyExclusiveTags(context);
+        await setTimeout(20);
+        let issues = validate(validator);
+        expect(issues).to.have.lengthOf(0);
+    });
+
+    it('flags actual conflicts like name=* and noname=yes', async () => {
+        createNode({ crossing_ref: 'zebra', 'crossing': 'unmarked' });
+        let validator = iD.validationMutuallyExclusiveTags(context);
+        await setTimeout(20);
+        let issues = validate(validator);
+        expect(issues).to.have.lengthOf(1);
+        expect(issues[0].type).to.eql('mutually_exclusive_tags');
+    });
 });


### PR DESCRIPTION
Fixes #9449 

## Changes made:


1. Added a key and value pair in the `osmMutuallyExclusiveTagPairs` for `crossing=unmarked` and `crossing_ref=zebra`.
2. Updated the way to get pairsFound to handle both string and object.

## Before:
<img width="1440" height="787" alt="Screenshot 2025-12-15 at 7 11 04 PM" src="https://github.com/user-attachments/assets/33bad495-744a-4556-8011-68ca6da48085" />

> There is no warning for `crossing_ref=zebra` and `crossing=unmarked`

## After:
<img width="1440" height="787" alt="Screenshot 2025-12-15 at 7 11 37 PM" src="https://github.com/user-attachments/assets/3b7c4bc1-b616-4c3d-af77-eb35cd14993b" />

> Now there will be a warning for those specific key=value pairs.
