### PR TITLE
Added Morocco to address_formats.json

### DIFF
--- a/data/address_formats.json
+++ b/data/address_formats.json
@@ -71,6 +71,14 @@
       ["postcode", "city"]
     ]
   },
+{
+    "countryCodes": ["ma"],
+    "format": [
+      ["housename"],
+      ["housenumber", "street+place"],
+      ["postcode", "city"]
+    ]
+  }
   {
     "countryCodes": ["mo"],
     "format": [

--- a/data/address_formats.json
+++ b/data/address_formats.json
@@ -71,14 +71,14 @@
       ["postcode", "city"]
     ]
   },
-{
+  {
     "countryCodes": ["ma"],
     "format": [
       ["housename"],
       ["housenumber", "street+place"],
       ["postcode", "city"]
     ]
-  }
+  },
   {
     "countryCodes": ["mo"],
     "format": [


### PR DESCRIPTION
In Morocco, most buildings have house names. A developer will call their building "Résidence Soraya" for exemple (see image). Similar issue was fixed for Bolivia (#10727).

<img width="415" height="320" alt="image" src="https://github.com/user-attachments/assets/fdd75906-c311-48d3-a1cf-bf285cc3267a" />

Common practice currently is to add these names to the `name=*` tag. This happens because there are no clear guidelines, but also because the `addr:housename` field is missing from the default preset. Mappers see a prominent "Name" field and logically fill it in, even though `addr:housename` is the correct tag for the address data.

I made some extensive research about address formats in Morocco. I looked through documents from the country's postal service and the Universal Postal Union. I was surprised there's actually a very precise addressing scheme, detailed on [this document](https://codepostal.ma/annuaire.pdf) and [this one](https://www.upu.int/UPU/media/upu/PostalEntitiesFiles/addressingUnit/marEn.pdf):

```
Unit
House name
House number and street
Extra info (Lieu-dit/Place) if necessary and/or if no street
Postcode and City
```

An example of an apartment's address in an apartment building would be:

```
Appartement 4
Résidence Soraya
15 Rue Al Fourate
20000 Casablanca
```
So I came up with this preset for Morocco:
```
    "format": [
      ["housename"],
      ["housenumber", "street+place"],
      ["postcode", "city"]
    ]
```
- For mapping in Morocco (and in most countries), a `unit` field would be clutter for the majority of use cases (building polygons or ground-floor POIs). If a specific office in a building needs to be mapped, the user can manually add `addr:unit` and `addr:floor`.

- `street+place` is consistent with other presets. In many parts of Morocco, houses have numbers but no street names. This allows users to input the neighborhood/hamlet/village name (Lieu-dit) in the street/place field, which the editor can then change to `addr:place`.

I plan on documenting this on Morocco's wiki, change all past buildings I mapped from `name` to `addr:housename`, and encourage others to do so in the country.