### PR TITLE
Now multiCombo Languages will show human readable languages instead of ISO codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :bug: Bugfixes
 * Fix some gpx/geojson properties not visible, such as numbers or complex data structures ([#11636], thanks [@k-yle])
 #### :earth_asia: Localization
+* The Languages field shows language names in your preferred language. ([#11699], thanks [@Razen04])
 #### :hourglass: Performance
 #### :mortar_board: Walkthrough / Help
 #### :hammer: Development
@@ -53,6 +54,8 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 
 [#11522]: https://github.com/openstreetmap/iD/issues/11522
 [#11636]: https://github.com/openstreetmap/iD/pull/11636
+[#11699]: https://github.com/openstreetmap/iD/pull/11699
+[@Razen04]: https://github.com/Razen04
 
 # v2.37.3
 ##### 2025-10-31

--- a/modules/core/localizer.js
+++ b/modules/core/localizer.js
@@ -61,6 +61,7 @@ export function coreLocalizer() {
     localizer.usesMetric = () => _usesMetric;
     localizer.languageNames = () => _languageNames;
     localizer.scriptNames = () => _scriptNames;
+    localizer.languages = () => _dataLanguages; // Expose all the languages supported
 
 
     // The client app may want to manually set the locale, regardless of the

--- a/modules/ui/fields/combo.js
+++ b/modules/ui/fields/combo.js
@@ -115,11 +115,12 @@ export function uiFieldCombo(field, context) {
     function displayValue(tval) {
         tval = tval || '';
         // Issue #11652
-        if (field.key === 'language:'){
+        // Ignore language: key and when tval is not others
+        if (field.key === 'language:' && tval !== 'others'){
           let langName = localizer.languageName(tval);
           if (langName) {
             return langName;
-          };
+          }
         }
 
         var stringsField = field.resolveReference('stringsCrossReference');
@@ -142,7 +143,8 @@ export function uiFieldCombo(field, context) {
         tval = tval || '';
 
         // Issue #11652
-        if (field.key === 'language:'){
+        // Ignore language: key and when tval is not others
+        if (field.key === 'language:' && tval !== 'others'){
           let langName = localizer.languageName(tval);
           if (langName) return selection => selection.text(langName);
         }
@@ -190,6 +192,37 @@ export function uiFieldCombo(field, context) {
     }
 
     function getOptions(allOptions) {
+        // Get dropdown list for language: key via localizer instead of taginfo
+        if (field.key === 'language:') {
+          let codes = Object.keys(localizer.languages());
+
+          let options = codes.map((c) => {
+            let name = localizer.languageName(c);
+            return {
+              key: c,
+              value: name,
+              title: name,
+              display: selection => selection.text(name)
+            };
+          }).filter(Boolean);
+
+          options.sort((a, b) => {
+            return a.value.localeCompare(b.value);
+          });
+
+          // inserting others because it does not come via _dataLanguages
+          options.push({
+            key: 'others',
+            value: 'others',
+            title: 'others',
+            display: selection => selection.text('others'),
+            klass: 'raw-option'
+          });
+
+
+          return options;
+        }
+
         var stringsField = field.resolveReference('stringsCrossReference');
         if (!(field.options || stringsField.options)) return [];
 
@@ -241,6 +274,9 @@ export function uiFieldCombo(field, context) {
         var queryFilter = d => d.value.toLowerCase().includes(q.toLowerCase()) || d.key.toLowerCase().includes(q.toLowerCase());
         if (hasStaticValues()) {
             setStaticValues(callback, queryFilter);
+
+            // If it is language field, we don't need to request for values, we get it from getOptions
+            if (field.key === 'language:') return;
         }
 
         var stringsField = field.resolveReference('stringsCrossReference');
@@ -302,17 +338,9 @@ export function uiFieldCombo(field, context) {
                 const labelId = getLabelId(stringsField, v);
                 var isLocalizable = stringsField.hasTextForStringId(labelId);
                 var label = stringsField.t(labelId, { default: v });
-                // If this is a language field, force the label to be the human readable name
-                if (['language:'].includes(field.key)) {
-                    let langName = localizer.languageName(v);
-                    if (langName) {
-                        label = langName;
-                        isLocalizable = true;
-                    }
-                }
                 return {
                     key: v,
-                    value: v,
+                    value: label,
                     title: stringsField.t(`options.${v}.description`, { default:
                         isLocalizable ? label : (d.title !== label ? d.title : '') }),
                     display: addComboboxIcons(stringsField.t.append(labelId, { default: label }), v),
@@ -737,6 +765,8 @@ export function uiFieldCombo(field, context) {
                 .classed('raw-value', function(d) {
                     var k = d.key;
                     if (_isMulti) k = k.replace(field.key, '');
+                    // Ignore the raw-value class for key language:
+                    if (field.key === 'language:' && localizer.languageName(k) && k !== 'others') return false;
                     return !stringsField.hasTextForStringId('options.' + k);
                 })
                 .classed('draggable', allowDragAndDrop)

--- a/modules/ui/fields/combo.js
+++ b/modules/ui/fields/combo.js
@@ -4,7 +4,7 @@ import { drag as d3_drag } from 'd3-drag';
 import * as countryCoder from '@rapideditor/country-coder';
 
 import { fileFetcher } from '../../core/file_fetcher';
-import { t } from '../../core/localizer';
+import { localizer, t } from '../../core/localizer';
 import { services } from '../../services';
 import { uiCombobox } from '../combobox';
 import { svgIcon } from '../../svg/icon';
@@ -114,6 +114,13 @@ export function uiFieldCombo(field, context) {
     // (for multiCombo, tval should be the key suffix, not the entire key)
     function displayValue(tval) {
         tval = tval || '';
+        // Issue #11652
+        if (field.key === 'language:'){
+          let langName = localizer.languageName(tval);
+          if (langName) {
+            return langName;
+          };
+        }
 
         var stringsField = field.resolveReference('stringsCrossReference');
         const labelId = getLabelId(stringsField, tval);
@@ -133,6 +140,12 @@ export function uiFieldCombo(field, context) {
     // (for multiCombo, tval should be the key suffix, not the entire key)
     function renderValue(tval) {
         tval = tval || '';
+
+        // Issue #11652
+        if (field.key === 'language:'){
+          let langName = localizer.languageName(tval);
+          if (langName) return selection => selection.text(langName);
+        }
 
         var stringsField = field.resolveReference('stringsCrossReference');
         const labelId = getLabelId(stringsField, tval);
@@ -289,12 +302,20 @@ export function uiFieldCombo(field, context) {
                 const labelId = getLabelId(stringsField, v);
                 var isLocalizable = stringsField.hasTextForStringId(labelId);
                 var label = stringsField.t(labelId, { default: v });
+                // If this is a language field, force the label to be the human readable name
+                if (['language:'].includes(field.key)) {
+                    let langName = localizer.languageName(v);
+                    if (langName) {
+                        label = langName;
+                        isLocalizable = true;
+                    }
+                }
                 return {
                     key: v,
-                    value: label,
+                    value: v,
                     title: stringsField.t(`options.${v}.description`, { default:
-                        isLocalizable ? v : (d.title !== label ? d.title : '') }),
-                    display: addComboboxIcons(stringsField.t.append(labelId, { default: v }), v),
+                        isLocalizable ? label : (d.title !== label ? d.title : '') }),
+                    display: addComboboxIcons(stringsField.t.append(labelId, { default: label }), v),
                     klass: isLocalizable ? '' : 'raw-option'
                 };
             });

--- a/modules/ui/fields/combo.js
+++ b/modules/ui/fields/combo.js
@@ -774,7 +774,7 @@ export function uiFieldCombo(field, context) {
                     var k = d.key;
                     if (_isMulti) k = k.replace(field.key, '');
                     // Ignore the raw-value class for key language:
-                    if (field.key === 'language:' && localizer.languageName(k) && k !== 'others') return false;
+                    if (field.key === 'language:' && localizer.languageName(k) !== k) return false;
                     return !stringsField.hasTextForStringId('options.' + k);
                 })
                 .classed('draggable', allowDragAndDrop)

--- a/modules/ui/fields/combo.js
+++ b/modules/ui/fields/combo.js
@@ -192,12 +192,16 @@ export function uiFieldCombo(field, context) {
     }
 
     function getOptions(allOptions) {
+        var stringsField = field.resolveReference('stringsCrossReference');
         // Get dropdown list for language: key via localizer instead of taginfo
         if (field.key === 'language:') {
           let codes = Object.keys(localizer.languages());
 
           let options = codes.map((c) => {
             let name = localizer.languageName(c);
+
+            // Omit names which are null or equal to the code itself
+            if (!name || name === c) return null;
             return {
               key: c,
               value: name,
@@ -206,24 +210,28 @@ export function uiFieldCombo(field, context) {
             };
           }).filter(Boolean);
 
+          const localeCode = localizer.localeCode();
+
           options.sort((a, b) => {
-            return a.value.localeCompare(b.value);
+            return a.value.localeCompare(b.value, localeCode);
           });
+
+          const v = 'others';
+          const labelId = getLabelId(stringsField, v);
 
           // inserting others because it does not come via _dataLanguages
           options.push({
-            key: 'others',
-            value: 'others',
-            title: 'others',
-            display: selection => selection.text('others'),
-            klass: 'raw-option'
+            key: v,
+            value: stringsField.t(labelId, { default: v }),
+            title: stringsField.t(`options.${v}.description`, { default: v }),
+            display: addComboboxIcons(stringsField.t.append(labelId, { default: v }), v),
+            klass: stringsField.hasTextForStringId(labelId) ? '' : 'raw-option'
           });
 
 
           return options;
         }
 
-        var stringsField = field.resolveReference('stringsCrossReference');
         if (!(field.options || stringsField.options)) return [];
 
         let options;


### PR DESCRIPTION
Fixes #11652 

## Changes made:
- `displayValue` function now looks at the field.key and if it is `language:`, it will use `localizer.languageName` on `tval`.
- `renderValue` function will also look at the field.key and it does the same like `displayName`
- The `comboData` array will now have `value=v` so that choosing 'Hindi' will not make tag as `language:Hindi=yes` and instead it will be `language:hi=yes`.

Before can be seen on the issue, here is the after image:

<img width="1440" height="787" alt="Screenshot 2025-12-17 at 8 52 55 PM" src="https://github.com/user-attachments/assets/df30f7f5-4e7f-4749-a01c-90bd365fa07d" />


Btw I have a doubt, when we click on the dropdown we see some language only like Hindi is not present but when I type hi, I can see Hindi as an option and can set it, is it intentional?