### PR TITLE
Fix language initialization for Firefox when quality is present on the requested locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :hammer: Development
 * Change package name to `@openstreetmap/id` to be able to publish releases on npm
 
+
 [#11522]: https://github.com/openstreetmap/iD/issues/11522
 [#11636]: https://github.com/openstreetmap/iD/pull/11636
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :mortar_board: Walkthrough / Help
 #### :hammer: Development
 * Change package name to `@openstreetmap/id` to be able to publish releases on npm
-
+* Fix language initialization for Firefox when quality is present on the requested locales
 
 [#11522]: https://github.com/openstreetmap/iD/issues/11522
 [#11636]: https://github.com/openstreetmap/iD/pull/11636

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,12 +44,12 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Don't error on features with a sole `note` tag ([#11522])
 #### :bug: Bugfixes
 * Fix some gpx/geojson properties not visible, such as numbers or complex data structures ([#11636], thanks [@k-yle])
+* Fix language initialization for Firefox when quality is present on the requested locales
 #### :earth_asia: Localization
 #### :hourglass: Performance
 #### :mortar_board: Walkthrough / Help
 #### :hammer: Development
 * Change package name to `@openstreetmap/id` to be able to publish releases on npm
-* Fix language initialization for Firefox when quality is present on the requested locales
 
 [#11522]: https://github.com/openstreetmap/iD/issues/11522
 [#11636]: https://github.com/openstreetmap/iD/pull/11636

--- a/modules/core/localizer.js
+++ b/modules/core/localizer.js
@@ -148,19 +148,21 @@ export function coreLocalizer() {
         /** @type {string[]} */
         let toUse = [];
         for (const locale of requestedLocales) {
-            if (supportedLocales[locale]) toUse.push(locale);
+            const safeLocale = locale.split(';')[0].trim(); // strip any quality values like ";q=0.5"
 
-            if ('Intl' in window && 'Locale' in window.Intl) {
+            try {
+              if ('Intl' in window && 'Locale' in window.Intl) {
                 // Full locale ('es-ES'), add fallback to the base ('es')
-                const localeObj = new Intl.Locale(locale);
+                const localeObj = new Intl.Locale(safeLocale);
                 const withoutScript = `${localeObj.language}-${localeObj.region}`;
                 const base = localeObj.language;
 
                 if (supportedLocales[withoutScript]) toUse.push(withoutScript);
                 if (supportedLocales[base]) toUse.push(base);
-            } else if (locale.includes('-')) {
-                // legacy logic: if Intl.Locale is not available
-                let langPart = locale.split('-')[0];
+              }
+            } catch {
+                // legacy logic: if Intl.Locale is not available or fails
+                let langPart = safeLocale.split('-')[0];
                 if (supportedLocales[langPart]) toUse.push(langPart);
             }
         }

--- a/test/spec/core/localizer.js
+++ b/test/spec/core/localizer.js
@@ -110,6 +110,12 @@ describe('iD.coreLocalizer', function() {
             [['zh-Hans-CN'], ['zh-CN', 'zh', 'en']],
             [['zh-Hans'], ['zh', 'en']],
             [['fr-Latn'], ['fr', 'en']],
+            // Firefox-style locales with quality values (see #11700)
+            [['en;q=0.5'], ['en']],
+            [['en-AU;q=0.9'], ['en-AU', 'en']],
+            [['zh-CN;q=0.8'], ['zh-CN', 'zh', 'en']],
+            [['fr;q=0.7', 'en;q=0.3'], ['fr', 'en']],
+            [['zh-Hans-CN;q=1.0'], ['zh-CN', 'zh', 'en']],
         ])('resolves %s to %s', (requested, matching) => {
             const localiser = iD.coreLocalizer();
             localiser.preferredLocaleCodes(requested);


### PR DESCRIPTION
Firefox returns locales like "en-US;q=0.5" in Accept-Language header which are not valid [BCP 47](https://en.wikipedia.org/wiki/IETF_language_tag), the only valid values for `Intl.Locale` constructor.

This causes it to throw an exception [at this point](https://github.com/openstreetmap/iD/blob/490c86fa3985deee78cc541c7c1e3c3afd56b108/modules/core/localizer.js#L155) skipping the execution of [updateForCurrentLocale](https://github.com/openstreetmap/iD/blob/490c86fa3985deee78cc541c7c1e3c3afd56b108/modules/core/localizer.js#L134)

<img width="383" height="266" alt="Screenshot 2025-12-17 at 19 18 13" src="https://github.com/user-attachments/assets/ecfadadd-7a60-456d-9841-1c0439fb051a" />

This solution, strips quality values before passing locales to `Intl.Locale` constructor and fallbacks to the legacy logic in case of an exception.


Before
<img width="848" height="236" alt="Screenshot 2025-12-17 at 18 54 31" src="https://github.com/user-attachments/assets/30d49e41-91fc-4612-adb0-dd2e891ebc5a" />

After
<img width="848" height="236" alt="Screenshot 2025-12-17 at 18 54 41" src="https://github.com/user-attachments/assets/53ce0213-0945-4c7a-9b0d-988afd5d8e3d" />

The test have been extended to cover cases of locales with quality [localizer.js](https://github.com/openstreetmap/iD/pull/11700/changes#diff-193e1de822f0df63bd5288d4c9debc093499286899eadf214bfee818c6f81740)

Related issue: https://community.openstreetmap.org/t/edit-map-with-id-dont-work/101362