### PR TITLE
Style: adjust panel close button background and hover state

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -4144,9 +4144,16 @@ li.issue-fix-item button:not(.actionable) .fix-icon {
 }
 
 .pane-heading button {
-    width: 40px;
-    border-radius: 0;
+  width: 50px;
+  border-radius: 0;
+  background-color: var(--bg-color-3);
+  color: var(--text-color);
 }
+
+.pane-heading button:hover {
+  background-color: var(--active-bg-color);
+}
+
 
 .pane-content {
     height: 100%;


### PR DESCRIPTION
Updates the panel close button styling using theme-based background
and hover colors.

CSS-only change; no behavior changes.