### PR TITLE
Fix tab-autocomplete matching for case-sensitive fields

### DIFF
--- a/modules/ui/combobox.js
+++ b/modules/ui/combobox.js
@@ -346,7 +346,7 @@ export function uiCombobox(context, klass) {
             var bestIndex = -1;
             for (var i = 0; i < suggestionValues.length; i++) {
                 var suggestion = suggestionValues[i];
-                var compare = _caseSensitive ? suggestion : suggestion.toLowerCase();
+                var compare = suggestion.toLowerCase();
 
                 // if search string matches suggestion exactly, pick it..
                 if (compare === val) {


### PR DESCRIPTION
This PR fixes tab-autocomplete behavior for case-sensitive fields by matching suggestions in a case-insensitive way while preserving the original suggestion casing when inserted #11679.