### PR TITLE
Fix inconsistent squaring between ways and nodes

### DIFF
--- a/modules/operations/orthogonalize.js
+++ b/modules/operations/orthogonalize.js
@@ -28,9 +28,24 @@ export function operationOrthogonalize(context, selectedIDs) {
         if (entity.type === 'way' && new Set(entity.nodes).size > 2 ) {
             if (_type && _type !== 'feature') return null;
             _type = 'feature';
-            return actionOrthogonalize(entityID, context.projection);
 
-        // square a single vertex
+            var graph = context.graph();
+            var nodes = graph.childNodes(entity);
+
+            // Apply vertex-based orthogonalization to all nodes
+            return function(graph, t) {
+                nodes.forEach(function(node) {
+                    var action = actionOrthogonalize(
+                        entityID,
+                        context.projection,
+                        node.id
+                    );
+                    if (!action.disabled(graph)) {
+                        graph = action(graph, t);
+                    }
+                });
+                return graph;
+            };
         } else if (geometry === 'vertex') {
             if (_type && _type !== 'corner') return null;
             _type = 'corner';


### PR DESCRIPTION
Fixes #11580

### Problem
When squaring a building by selecting the whole way, the result can be distorted.
However, squaring the same building by selecting all of its nodes produces a clean,
correct rectangle.

This means two different squaring actions on the same geometry lead to different results,
which is confusing for users.

### Cause
Squaring a way and squaring selected nodes were using different orthogonalization paths.
The node-based approach produces better and more stable results.

### Solution
This PR makes squaring a way reuse the same vertex-based orthogonalization logic that is
used when squaring selected nodes. This ensures consistent behavior regardless of whether
the user squares a way or its nodes.

### Result
- Squaring a way now produces the same result as squaring all its nodes
- No change to existing node-based squaring behavior

### Testing
Tested locally using the dev OSM API with way `4307298815`.
Verified before/after behavior to confirm the results are now identical.

### Before

https://github.com/user-attachments/assets/8b443561-2e89-41f8-9ee4-665078fa1083

### After

now It is not distorting the selected area and giving same output on square and nodes 
<img width="1366" height="607" alt="image" src="https://github.com/user-attachments/assets/edca8453-171c-4c0b-9eb9-6aa3d9531819" />



