### PR TITLE
fix typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 # v2.37.2
 ##### 2025-10-30
 
-* Correctly resolve subtitles of NSI presets when base preset has a crossreferenced string ([#11527])
+* Correctly resolve subtitles of NSI presets when base preset has a cross-referenced string ([#11527])
 
 [#11527]: https://github.com/openstreetmap/iD/issues/11527
 


### PR DESCRIPTION
github launched a new UI which is overly dramatic about typos in untouched files:

<img width="1261" height="424" alt="image" src="https://github.com/user-attachments/assets/f4a2ffb6-41df-484b-a2ad-20e84b0f3e15" />


so let's fix this one to make the warning disappear