### PR TITLE
Fix Mapillary parent/child photo overlay toggling

### DIFF
--- a/modules/ui/sections/photo_overlays.js
+++ b/modules/ui/sections/photo_overlays.js
@@ -13,7 +13,10 @@ export function uiSectionPhotoOverlays(context) {
     let _savedLayers = [];
     let _layersHidden = false;
     const _streetLayerIDs = ['streetside', 'mapillary', 'mapillary-map-features', 'mapillary-signs', 'kartaview', 'mapilio', 'vegbilder', 'panoramax'];
-
+    const _mapillaryChildLayerIDs = [
+    'mapillary-map-features',
+    'mapillary-signs'
+];
     var settingsLocalPhotos = uiSettingsLocalPhotos(context)
         .on('change',  localPhotosChanged);
 
@@ -434,7 +437,20 @@ export function uiSectionPhotoOverlays(context) {
      * @param {*} which Id of the selected layer
      */
     function toggleLayer(which) {
+        if (which === 'mapillary') {
+        const enabled = !showsLayer('mapillary');
+        setLayer('mapillary', enabled);
+
+        _mapillaryChildLayerIDs.forEach(id => {
+            setLayer(id, enabled);
+        });
+        return;
+        }
         setLayer(which, !showsLayer(which));
+        if (_mapillaryChildLayerIDs.includes(which)) {
+        const allEnabled = _mapillaryChildLayerIDs.every(id => showsLayer(id));
+        setLayer('mapillary', allEnabled);
+    }
     }
 
     /**


### PR DESCRIPTION
### Problem
The Mapillary Data panel violates expected parent/child toggle behavior (#11671).
Disabling the Mapillary master checkbox does not disable its subordinate overlays, leading to an inconsistent and confusing UI state.

### Screenshots

**Before**
Parent Mapillary toggle disabled, but child overlays remain enabled:
![Before](https://github.com/user-attachments/assets/6783ace0-dadd-42a6-958a-f20f65998b7d)

**After**
Disabling the Mapillary parent toggle correctly disables all child overlays:
![After](https://github.com/user-attachments/assets/d66365de-df47-4a42-abfb-515c512d5b4c)

### Solution
This change enforces correct parent/child toggle logic for Mapillary overlays:
- Disabling the Mapillary parent checkbox now disables all Mapillary child overlays.
- Enabling or disabling child overlays updates the parent checkbox state accordingly.
- Child overlays remain independently configurable when the parent is enabled.

### Scope
- UI logic only (Photo Overlays / Mapillary section)
- No changes to rendering, data loading, or Mapillary integration

### Testing
- Toggled Mapillary parent checkbox on/off
- Verified all Mapillary child overlays follow parent state
- Verified parent state updates when child overlays are toggled individually

Fixes #11671
