### PR TITLE
Don't suggest values from Taginfo for `addr:*` tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 # Unreleased (2.38.0-dev)
 
 #### :sparkles: Usability & Accessibility
+* Don't suggest values from Taginfo for `addr:*` tags ([#11733], thanks [@k-yle])
 #### :scissors: Operations
 #### :camera: Street-Level
 #### :white_check_mark: Validation
@@ -45,6 +46,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :bug: Bugfixes
 * Fix some gpx/geojson properties not visible, such as numbers or complex data structures ([#11636], thanks [@k-yle])
 #### :earth_asia: Localization
+* Add Moroccan phone number formats ([#11651], thanks [@ilias52730])
 * The Languages field shows language names in your preferred language. ([#11699], thanks [@Razen04])
 #### :hourglass: Performance
 #### :mortar_board: Walkthrough / Help
@@ -54,7 +56,10 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 
 [#11522]: https://github.com/openstreetmap/iD/issues/11522
 [#11636]: https://github.com/openstreetmap/iD/pull/11636
+[#11651]: https://github.com/openstreetmap/iD/pull/11651
 [#11699]: https://github.com/openstreetmap/iD/pull/11699
+[#11733]: https://github.com/openstreetmap/iD/pull/11733
+[@ilias52730]: https://github.com/ilias52730
 [@Razen04]: https://github.com/Razen04
 
 # v2.37.3

--- a/modules/services/taginfo.js
+++ b/modules/services/taginfo.js
@@ -13,7 +13,7 @@ var _inflight = {};
 var _popularKeys = {};
 // manually exclude some additional keys – #5377, #7485, #10287
 // these will be returned by keys(), but taginfo will not be queried for values() requests
-var _extraExcludedKeys = /^(postal_code|via|((int_|loc_|nat_|official_|old_|ref_|reg_|short_|full_|sorting_|alt_|artist_|long_|bridge:|tunnel:)?name(:left|:right)?(:[a-z]+)?))$/;
+var _extraExcludedKeys = /^(addr:.+|postal_code|via|((int_|loc_|nat_|official_|old_|ref_|reg_|short_|full_|sorting_|alt_|artist_|long_|bridge:|tunnel:)?name(:left|:right)?(:[a-z]+)?))$/;
 
 var _taginfoCache = {};
 

--- a/modules/services/taginfo.js
+++ b/modules/services/taginfo.js
@@ -11,7 +11,7 @@ import { taginfoApiUrl } from '../../config/id.js';
 var apibase = taginfoApiUrl;
 var _inflight = {};
 var _popularKeys = {};
-// manually exclude some additional keys – #5377, #7485, #10287
+// manually exclude some additional keys – #5377, #7485, #10287, #11733
 // these will be returned by keys(), but taginfo will not be queried for values() requests
 var _extraExcludedKeys = /^(addr:.+|postal_code|via|((int_|loc_|nat_|official_|old_|ref_|reg_|short_|full_|sorting_|alt_|artist_|long_|bridge:|tunnel:)?name(:left|:right)?(:[a-z]+)?))$/;
 


### PR DESCRIPTION
This was [reported](https://discord.com/channels/413070382636072960/926020366927790130/1455322775492493526) on the osm discord. 

Same as #10287, but for [`addr:*`](https://osm.wiki/Key:addr) instead of [`name:*`](https://osm.wiki/Key:name). Taginfo suggestions aren't useful for either tag.

We already [filter out values with an uppercase letter](https://github.com/openstreetmap/iD/blob/b36341dfa347578fe0add2f6c61b6c35124f2ab5/modules/services/taginfo.js#L99), which is why the dropdown only includes some popular CJK characters 😆

<img width="439" height="164" alt="image" src="https://github.com/user-attachments/assets/769ee54e-c5a9-411a-8c2c-1fc39991650b" />


In a future PR we could use the same suggestions as the address picker, but that would quite a fair bit of refactoring