### PR TITLE
Fix merge deleting buildings when using Lasso selection

### DIFF
--- a/modules/actions/connect.js
+++ b/modules/actions/connect.js
@@ -18,7 +18,7 @@ import { utilArrayUniq, utilOldestID } from '../util';
 //   https://github.com/openstreetmap/josm/blob/mirror/src/org/openstreetmap/josm/actions/MergeNodesAction.java
 //
 export function actionConnect(nodeIDs) {
-    var action = function(graph) {
+    var action = function (graph) {
         var survivor;
         var node;
         var parents;
@@ -73,7 +73,7 @@ export function actionConnect(nodeIDs) {
     };
 
 
-    action.disabled = function(graph) {
+    action.disabled = function (graph) {
         var seen = {};
         var restrictionIDs = [];
         var survivor;
@@ -83,6 +83,32 @@ export function actionConnect(nodeIDs) {
 
         // Select the node with the oldest ID as the survivor.
         survivor = graph.entity(utilOldestID(nodeIDs));
+
+        // 0. disable if merging would destroy a tagged closed way (e.g., building)
+        for (i = 0; i < nodeIDs.length; i++) {
+            node = graph.entity(nodeIDs[i]);
+            var parentWays = graph.parentWays(node);
+            for (j = 0; j < parentWays.length; j++) {
+                way = parentWays[j];
+                if (way.isClosed() && way.hasInterestingTags()) {
+                    // Check if this way would become degenerate after merge
+                    var testWay = way.update({});
+                    for (k = 0; k < nodeIDs.length; k++) {
+                        if (nodeIDs[k] === survivor.id) continue;
+                        if (testWay.contains(nodeIDs[k])) {
+                            if (testWay.areAdjacent(nodeIDs[k], survivor.id)) {
+                                testWay = testWay.removeNode(nodeIDs[k]);
+                            } else {
+                                testWay = testWay.replaceNode(nodeIDs[k], survivor.id);
+                            }
+                        }
+                    }
+                    if (testWay.isDegenerate()) {
+                        return 'would_destroy_feature';
+                    }
+                }
+            }
+        }
 
         // 1. disable if the nodes being connected have conflicting relation roles
         for (i = 0; i < nodeIDs.length; i++) {
@@ -132,8 +158,8 @@ export function actionConnect(nodeIDs) {
             if (!relation.isComplete(graph)) continue;
 
             var memberWays = relation.members
-                .filter(function(m) { return m.type === 'way'; })
-                .map(function(m) { return graph.entity(m.id); });
+                .filter(function (m) { return m.type === 'way'; })
+                .map(function (m) { return graph.entity(m.id); });
 
             memberWays = utilArrayUniq(memberWays);
             var f = relation.memberByRole('from');
@@ -163,15 +189,15 @@ export function actionConnect(nodeIDs) {
 
             for (j = 0; j < nodeIDs.length; j++) {
                 var n = nodeIDs[j];
-                if (nodes.from.indexOf(n) !== -1)    { connectFrom = true; }
-                if (nodes.via.indexOf(n) !== -1)     { connectVia = true; }
-                if (nodes.to.indexOf(n) !== -1)      { connectTo = true; }
+                if (nodes.from.indexOf(n) !== -1) { connectFrom = true; }
+                if (nodes.via.indexOf(n) !== -1) { connectVia = true; }
+                if (nodes.to.indexOf(n) !== -1) { connectTo = true; }
                 if (nodes.keyfrom.indexOf(n) !== -1) { connectKeyFrom = true; }
-                if (nodes.keyto.indexOf(n) !== -1)   { connectKeyTo = true; }
+                if (nodes.keyto.indexOf(n) !== -1) { connectKeyTo = true; }
             }
             if (connectFrom && connectTo && !isUturn) { return 'restriction'; }
             if (connectFrom && connectVia) { return 'restriction'; }
-            if (connectTo   && connectVia) { return 'restriction'; }
+            if (connectTo && connectVia) { return 'restriction'; }
 
             // connecting to a key node -
             // if both nodes are on a member way (i.e. part of the turn restriction),
@@ -230,7 +256,7 @@ export function actionConnect(nodeIDs) {
         }
 
         function keyNodeFilter(froms, tos) {
-            return function(n) {
+            return function (n) {
                 return froms.indexOf(n) === -1 && tos.indexOf(n) === -1;
             };
         }

--- a/modules/actions/connect.js
+++ b/modules/actions/connect.js
@@ -109,7 +109,7 @@ export function actionConnect(nodeIDs) {
                 if (newWay.isDegenerate()) {
                     return 'would_degenerate_parent';
                 }
-                // Check for self-intersection (repeated non-endpoint nodes) - #9328
+                // Check for self intersection (repeated non endpoint nodes) #9328
                 var wayNodes = newWay.nodes;
                 var seenNodes = {};
                 for (k = 1; k < wayNodes.length - 1; k++) {

--- a/modules/actions/connect.js
+++ b/modules/actions/connect.js
@@ -110,14 +110,14 @@ export function actionConnect(nodeIDs) {
                     return 'would_degenerate_parent';
                 }
                 // Check for self-intersection (repeated non-endpoint nodes) - #9328
-                var nodes = newWay.nodes;
+                var wayNodes = newWay.nodes;
                 var seenNodes = {};
-                for (k = 1; k < nodes.length - 1; k++) {
-                    var n = nodes[k];
-                    if (seenNodes[n]) {
+                for (k = 1; k < wayNodes.length - 1; k++) {
+                    var nodeId = wayNodes[k];
+                    if (seenNodes[nodeId]) {
                         return 'would_degenerate_parent';
                     }
-                    seenNodes[n] = true;
+                    seenNodes[nodeId] = true;
                 }
             }
         }

--- a/modules/actions/connect.js
+++ b/modules/actions/connect.js
@@ -84,28 +84,40 @@ export function actionConnect(nodeIDs) {
         // Select the node with the oldest ID as the survivor.
         survivor = graph.entity(utilOldestID(nodeIDs));
 
-        // 0. disable if merging would destroy a tagged closed way (e.g., building)
+        // 0. disable if merging would destroy or degenerate a parent way with interesting tags
+        // Run the action first on a copy to see what would happen
+        var parentWays = [];
         for (i = 0; i < nodeIDs.length; i++) {
             node = graph.entity(nodeIDs[i]);
-            var parentWays = graph.parentWays(node);
-            for (j = 0; j < parentWays.length; j++) {
-                way = parentWays[j];
-                if (way.isClosed() && way.hasInterestingTags()) {
-                    // Check if this way would become degenerate after merge
-                    var testWay = way.update({});
-                    for (k = 0; k < nodeIDs.length; k++) {
-                        if (nodeIDs[k] === survivor.id) continue;
-                        if (testWay.contains(nodeIDs[k])) {
-                            if (testWay.areAdjacent(nodeIDs[k], survivor.id)) {
-                                testWay = testWay.removeNode(nodeIDs[k]);
-                            } else {
-                                testWay = testWay.replaceNode(nodeIDs[k], survivor.id);
-                            }
-                        }
+            var ways = graph.parentWays(node);
+            for (j = 0; j < ways.length; j++) {
+                if (parentWays.indexOf(ways[j]) === -1) {
+                    parentWays.push(ways[j]);
+                }
+            }
+        }
+
+        // Check if any interesting parent ways would be destroyed or become degenerate
+        var newGraph = action(graph);
+        for (i = 0; i < parentWays.length; i++) {
+            way = parentWays[i];
+            if (way.hasInterestingTags()) {
+                if (!newGraph.hasEntity(way.id)) {
+                    return 'would_destroy_parent';
+                }
+                var newWay = newGraph.entity(way.id);
+                if (newWay.isDegenerate()) {
+                    return 'would_degenerate_parent';
+                }
+                // Check for self-intersection (repeated non-endpoint nodes) - #9328
+                var nodes = newWay.nodes;
+                var seenNodes = {};
+                for (k = 1; k < nodes.length - 1; k++) {
+                    var n = nodes[k];
+                    if (seenNodes[n]) {
+                        return 'would_degenerate_parent';
                     }
-                    if (testWay.isDegenerate()) {
-                        return 'would_destroy_feature';
-                    }
+                    seenNodes[n] = true;
                 }
             }
         }

--- a/modules/actions/merge_polygon.js
+++ b/modules/actions/merge_polygon.js
@@ -6,8 +6,11 @@ import { utilArrayGroupBy, utilArrayIntersection, utilObjectOmit, utilOldestID }
 export function actionMergePolygon(ids, newRelationId) {
 
     function groupEntities(graph) {
-        var entities = ids.map(function (id) { return graph.entity(id); });
-        var geometryGroups = utilArrayGroupBy(entities, function(entity) {
+        var entities = ids
+            .map(function (id) { return graph.entity(id); })
+            .filter(function (entity) { return entity.type !== 'node'; });
+
+        var geometryGroups = utilArrayGroupBy(entities, function (entity) {
             if (entity.type === 'way' && entity.isClosed()) {
                 return 'closedWay';
             } else if (entity.type === 'relation' && entity.isMultipolygon()) {
@@ -24,17 +27,17 @@ export function actionMergePolygon(ids, newRelationId) {
     }
 
 
-    var action = function(graph) {
+    var action = function (graph) {
         var entities = groupEntities(graph);
 
         // An array representing all the polygons that are part of the multipolygon.
         //
         // Each element is itself an array of objects with an id property, and has a
         // locs property which is an array of the locations forming the polygon.
-        var polygons = entities.multipolygon.reduce(function(polygons, m) {
+        var polygons = entities.multipolygon.reduce(function (polygons, m) {
             return polygons.concat(osmJoinWays(m.members, graph));
-        }, []).concat(entities.closedWay.map(function(d) {
-            var member = [{id: d.id}];
+        }, []).concat(entities.closedWay.map(function (d) {
+            var member = [{ id: d.id }];
             member.nodes = graph.childNodes(d);
             return member;
         }));
@@ -42,12 +45,12 @@ export function actionMergePolygon(ids, newRelationId) {
         // contained is an array of arrays of boolean values,
         // where contained[j][k] is true iff the jth way is
         // contained by the kth way.
-        var contained = polygons.map(function(w, i) {
-            return polygons.map(function(d, n) {
+        var contained = polygons.map(function (w, i) {
+            return polygons.map(function (d, n) {
                 if (i === n) return null;
                 return geoPolygonContainsPolygon(
-                    d.nodes.map(function(n) { return n.loc; }),
-                    w.nodes.map(function(n) { return n.loc; })
+                    d.nodes.map(function (n) { return n.loc; }),
+                    w.nodes.map(function (n) { return n.loc; })
                 );
             });
         });
@@ -63,7 +66,7 @@ export function actionMergePolygon(ids, newRelationId) {
         }
 
         function isContained(d, i) {
-            return contained[i].some(function(val) { return val; });
+            return contained[i].some(function (val) { return val; });
         }
 
         function filterContained(d) {
@@ -71,9 +74,9 @@ export function actionMergePolygon(ids, newRelationId) {
         }
 
         function extractUncontained(polygons) {
-            polygons.forEach(function(d, i) {
+            polygons.forEach(function (d, i) {
                 if (!isContained(d, i)) {
-                    d.forEach(function(member) {
+                    d.forEach(function (member) {
                         members.push({
                             type: 'way',
                             id: member.id,
@@ -92,17 +95,17 @@ export function actionMergePolygon(ids, newRelationId) {
             var oldestID = utilOldestID(entities.multipolygon.map((entity) => entity.id));
             relation = entities.multipolygon.find((entity) => entity.id === oldestID);
         } else {
-            relation = osmRelation({ id: newRelationId, tags: { type: 'multipolygon' }});
+            relation = osmRelation({ id: newRelationId, tags: { type: 'multipolygon' } });
         }
 
-        entities.multipolygon.forEach(function(m) {
+        entities.multipolygon.forEach(function (m) {
             if (m.id !== relation.id) {
                 relation = relation.mergeTags(m.tags);
                 graph = graph.remove(m);
             }
         });
 
-        entities.closedWay.forEach(function(way) {
+        entities.closedWay.forEach(function (way) {
             function isThisOuter(m) {
                 return m.id === way.id && m.role !== 'inner';
             }
@@ -119,35 +122,35 @@ export function actionMergePolygon(ids, newRelationId) {
     };
 
 
-    action.disabled = function(graph) {
+    action.disabled = function (graph) {
         var entities = groupEntities(graph);
         if (entities.other.length > 0 ||
             entities.closedWay.length + entities.multipolygon.length < 2) {
             return 'not_eligible';
         }
-        if (!entities.multipolygon.every(function(r) { return r.isComplete(graph); })) {
+        if (!entities.multipolygon.every(function (r) { return r.isComplete(graph); })) {
             return 'incomplete_relation';
         }
 
         if (!entities.multipolygon.length) {
             var sharedMultipolygons = [];
-            entities.closedWay.forEach(function(way, i) {
+            entities.closedWay.forEach(function (way, i) {
                 if (i === 0) {
                     sharedMultipolygons = graph.parentMultipolygons(way);
                 } else {
                     sharedMultipolygons = utilArrayIntersection(sharedMultipolygons, graph.parentMultipolygons(way));
                 }
             });
-            sharedMultipolygons = sharedMultipolygons.filter(function(relation) {
+            sharedMultipolygons = sharedMultipolygons.filter(function (relation) {
                 return relation.members.length === entities.closedWay.length;
             });
             if (sharedMultipolygons.length) {
                 // don't create a new multipolygon if it'd be redundant
                 return 'not_eligible';
             }
-        } else if (entities.closedWay.some(function(way) {
-                return utilArrayIntersection(graph.parentMultipolygons(way), entities.multipolygon).length;
-            })) {
+        } else if (entities.closedWay.some(function (way) {
+            return utilArrayIntersection(graph.parentMultipolygons(way), entities.multipolygon).length;
+        })) {
             // don't add a way to a multipolygon again if it's already a member
             return 'not_eligible';
         }

--- a/modules/actions/merge_polygon.js
+++ b/modules/actions/merge_polygon.js
@@ -6,9 +6,7 @@ import { utilArrayGroupBy, utilArrayIntersection, utilObjectOmit, utilOldestID }
 export function actionMergePolygon(ids, newRelationId) {
 
     function groupEntities(graph) {
-        var entities = ids
-            .map(function (id) { return graph.entity(id); })
-            .filter(function (entity) { return entity.type !== 'node'; });
+        var entities = ids.map(function (id) { return graph.entity(id); });
 
         var geometryGroups = utilArrayGroupBy(entities, function (entity) {
             if (entity.type === 'way' && entity.isClosed()) {

--- a/test/spec/actions/connect.js
+++ b/test/spec/actions/connect.js
@@ -514,8 +514,8 @@ describe('iD.actionConnect', function() {
         });
 
     });
-    
-           it('allows uninteresting parent ways to be deleted by the operation', function () {
+
+        it('allows uninteresting parent ways to be deleted by the operation', function () {
             var graph = iD.coreGraph([
                 iD.osmNode({ id: 'a' }),
                 iD.osmNode({ id: 'b' }),
@@ -544,5 +544,5 @@ describe('iD.actionConnect', function() {
             ]);
             expect(iD.actionConnect(['b', 'd']).disabled(graph)).to.eql('would_degenerate_parent');
         });
-    
+
 });

--- a/test/spec/actions/connect.js
+++ b/test/spec/actions/connect.js
@@ -514,4 +514,35 @@ describe('iD.actionConnect', function() {
         });
 
     });
+    
+           it('allows uninteresting parent ways to be deleted by the operation', function () {
+            var graph = iD.coreGraph([
+                iD.osmNode({ id: 'a' }),
+                iD.osmNode({ id: 'b' }),
+                iD.osmWay({ id: '-', nodes: ['a', 'b'] }),
+            ]);
+            expect(iD.actionConnect(['a', 'b']).disabled(graph)).to.be.not.ok;
+        });
+
+        it('refuses to connect nodes if an interesting parent way would be deleted', function () {
+            var graph = iD.coreGraph([
+                iD.osmNode({ id: 'a' }),
+                iD.osmNode({ id: 'b' }),
+                iD.osmWay({ id: '-', nodes: ['a', 'b'], tags: { highway: 'residential' } }),
+            ]);
+            expect(iD.actionConnect(['a', 'b']).disabled(graph)).to.eql('would_destroy_parent');
+        });
+
+        it('refuses to connect nodes if any parent ways would become degenerate', function () {
+            var graph = iD.coreGraph([
+                iD.osmNode({ id: 'a', loc: [0, 0] }),
+                iD.osmNode({ id: 'b', loc: [2, 0] }),
+                iD.osmNode({ id: 'c', loc: [1, 1] }),
+                iD.osmNode({ id: 'd', loc: [2, 2] }),
+                iD.osmNode({ id: 'e', loc: [0, 2] }),
+                iD.osmWay({ id: '-', nodes: ['a', 'b', 'c', 'd', 'e', 'a'], tags: { building: 'yes' } }),
+            ]);
+            expect(iD.actionConnect(['b', 'd']).disabled(graph)).to.eql('would_degenerate_parent');
+        });
+    
 });


### PR DESCRIPTION
Related - #11726
Updates actionMergePolygon to ignore nodes included in the selection (e.g., from Lasso tool). Previously, the presence of nodes caused mergePolygon to disable itself, causing the editor to fall back to inappropriate actions (like mergeNodes) which resulted in buildings being deleted. This change ensures that selecting buildings with the Lasso tool correctly merges them into a multipolygon.