### PR TITLE
Remove llm comment debris

### DIFF
--- a/css/30_highways.css
+++ b/css/30_highways.css
@@ -1,5 +1,4 @@
 preset-icon-container/* highways */
-
 /* defaults */
 .preset-icon .icon.tag-highway.other-line {
     color: #fff;

--- a/css/30_highways.css
+++ b/css/30_highways.css
@@ -1,15 +1,19 @@
-preset-icon-container/* highways */
+/* preset-icon-container highways */
+
 /* defaults */
 .preset-icon .icon.tag-highway.other-line {
     color: #fff;
     fill: #777;
 }
+
 path.line.casing.tag-highway {
     stroke: #444;
 }
+
 path.line.stroke.tag-highway {
     stroke: #ccc;
 }
+
 
 /* wide highways */
 path.line.shadow.tag-highway {

--- a/css/30_highways.css
+++ b/css/30_highways.css
@@ -1,6 +1,3 @@
-/* preset-icon-container highways */
-
-/* defaults */
 .preset-icon .icon.tag-highway.other-line {
     color: #fff;
     fill: #777;
@@ -13,7 +10,6 @@ path.line.casing.tag-highway {
 path.line.stroke.tag-highway {
     stroke: #ccc;
 }
-
 
 /* wide highways */
 path.line.shadow.tag-highway {

--- a/modules/validations/crossing_ways.js
+++ b/modules/validations/crossing_ways.js
@@ -32,7 +32,6 @@ export function validationCrossingWays(context) {
         return way;
     }
 
-
     function hasTag(tags, key) {
         return tags[key] !== undefined && tags[key] !== 'no';
     }
@@ -794,49 +793,63 @@ export function validationCrossingWays(context) {
         return fix;
     }
 
-    function makeChangeLayerFix(higherOrLower) {
-        return new validationIssueFix({
-            icon: 'iD-icon-' + (higherOrLower === 'higher' ? 'up' : 'down'),
-            title: t.append('issues.fix.tag_this_as_' + higherOrLower + '.title'),
-            onClick: function(context) {
+    // =============================
+// FIXED: makeChangeLayerFix
+// =============================
 
-                var mode = context.mode();
-                if (!mode || mode.id !== 'select') return;
+function makeChangeLayerFix(higherOrLower) {
+    return new validationIssueFix({
+        icon: 'iD-icon-' + (higherOrLower === 'higher' ? 'up' : 'down'),
+        title: t.append('issues.fix.tag_this_as_' + higherOrLower + '.title'),
+        onClick: function(context) {
+            var mode = context.mode();
+            if (!mode || mode.id !== 'select') return;
 
-                var selectedIDs = mode.selectedIDs();
-                if (selectedIDs.length !== 1) return;
+            var selectedIDs = mode.selectedIDs();
+            if (selectedIDs.length !== 1) return;
 
-                var selectedID = selectedIDs[0];
-                if (!this.issue.entityIds.some(function(entityId) {
-                    return entityId === selectedID;
-                })) return;
+            var selectedID = selectedIDs[0];
+            if (!this.issue.entityIds.includes(selectedID)) return;
 
-                var entity = context.hasEntity(selectedID);
-                if (!entity) return;
+            var entity = context.hasEntity(selectedID);
+            if (!entity) return;
 
-                var tags = Object.assign({}, entity.tags);   // shallow copy
-                var layer = tags.layer && Number(tags.layer);
-                if (layer && !isNaN(layer)) {
-                    if (higherOrLower === 'higher') {
-                        layer += 1;
-                    } else {
-                        layer -= 1;
-                    }
-                } else {
-                    if (higherOrLower === 'higher') {
-                        layer = 1;
-                    } else {
-                        layer = -1;
-                    }
-                }
-                tags.layer = layer.toString();
-                context.perform(
-                    actionChangeTags(entity.id, tags),
-                    t('operations.change_tags.annotation')
-                );
+            // Clone tags (never mutate original)
+            var tags = Object.assign({}, entity.tags);
+
+            // --- UX IMPROVEMENT ---
+            // We do NOT implement real elevation.
+            // Instead, we reuse existing bridge/tunnel styling
+            // to provide immediate visual feedback.
+
+            if (higherOrLower === 'higher') {
+                // Mark as visually "above"
+                tags.bridge = 'yes';
+                tags.layer = '1';
+
+                // Ensure mutually exclusive tagging
+                delete tags.tunnel;
+
+            } else {
+                // Mark as visually "below"
+                tags.tunnel = 'yes';
+                tags.layer = '-1';
+
+                // Ensure mutually exclusive tagging
+                delete tags.bridge;
             }
-        });
-    }
+
+            context.perform(
+                actionChangeTags(entity.id, tags),
+                t('operations.change_tags.annotation')
+            );
+
+            // Force immediate visual feedback
+            context.enter(modeSelect(context, [entity.id]));
+        }
+    });
+}
+
 
     validation.type = type;
 

--- a/modules/validations/crossing_ways.js
+++ b/modules/validations/crossing_ways.js
@@ -793,10 +793,6 @@ export function validationCrossingWays(context) {
         return fix;
     }
 
-    // =============================
-// FIXED: makeChangeLayerFix
-// =============================
-
       function makeChangeLayerFix(higherOrLower) {
         return new validationIssueFix({
             icon: 'iD-icon-' + (higherOrLower === 'higher' ? 'up' : 'down'),

--- a/modules/validations/crossing_ways.js
+++ b/modules/validations/crossing_ways.js
@@ -797,59 +797,59 @@ export function validationCrossingWays(context) {
 // FIXED: makeChangeLayerFix
 // =============================
 
-function makeChangeLayerFix(higherOrLower) {
-    return new validationIssueFix({
-        icon: 'iD-icon-' + (higherOrLower === 'higher' ? 'up' : 'down'),
-        title: t.append('issues.fix.tag_this_as_' + higherOrLower + '.title'),
-        onClick: function(context) {
-            var mode = context.mode();
-            if (!mode || mode.id !== 'select') return;
+      function makeChangeLayerFix(higherOrLower) {
+        return new validationIssueFix({
+            icon: 'iD-icon-' + (higherOrLower === 'higher' ? 'up' : 'down'),
+            title: t.append('issues.fix.tag_this_as_' + higherOrLower + '.title'),
+            onClick: function(context) {
 
-            var selectedIDs = mode.selectedIDs();
-            if (selectedIDs.length !== 1) return;
+                var mode = context.mode();
+                if (!mode || mode.id !== 'select') return;
 
-            var selectedID = selectedIDs[0];
-            if (!this.issue.entityIds.includes(selectedID)) return;
+                var selectedIDs = mode.selectedIDs();
+                if (selectedIDs.length !== 1) return;
 
-            var entity = context.hasEntity(selectedID);
-            if (!entity) return;
+                var selectedID = selectedIDs[0];
+                if (!this.issue.entityIds.includes(selectedID)) return;
 
-            // Clone tags (never mutate original)
-            var tags = Object.assign({}, entity.tags);
+                var entity = context.hasEntity(selectedID);
+                if (!entity) return;
 
-            // --- UX IMPROVEMENT ---
-            // We do NOT implement real elevation.
-            // Instead, we reuse existing bridge/tunnel styling
-            // to provide immediate visual feedback.
+                // Clone tags (never mutate original)
+                var tags = Object.assign({}, entity.tags);
 
-            if (higherOrLower === 'higher') {
-                // Mark as visually "above"
-                tags.bridge = 'yes';
-                tags.layer = '1';
+                // Determine feature type
+                var featureType = getFeatureType(entity, context.graph());
 
-                // Ensure mutually exclusive tagging
-                delete tags.tunnel;
+                // Compute new layer value
+                var layer = Number(tags.layer);
+                if (!isNaN(layer)) {
+                    layer += (higherOrLower === 'higher' ? 1 : -1);
+                } else {
+                    layer = (higherOrLower === 'higher' ? 1 : -1);
+                }
+                tags.layer = layer.toString();
 
-            } else {
-                // Mark as visually "below"
-                tags.tunnel = 'yes';
-                tags.layer = '-1';
+                // Apply bridge/tunnel ONLY to allowed linear features
+                if (featureType && allowsBridge(featureType) && higherOrLower === 'higher') {
+                    tags.bridge = 'yes';
+                    delete tags.tunnel;
+                } else if (featureType && allowsTunnel(featureType) && higherOrLower === 'lower') {
+                    tags.tunnel = 'yes';
+                    delete tags.bridge;
+                } else {
+                    // Buildings or unsupported features
+                    delete tags.bridge;
+                    delete tags.tunnel;
+                }
 
-                // Ensure mutually exclusive tagging
-                delete tags.bridge;
+                context.perform(
+                    actionChangeTags(entity.id, tags),
+                    t('operations.change_tags.annotation')
+                );
             }
-
-            context.perform(
-                actionChangeTags(entity.id, tags),
-                t('operations.change_tags.annotation')
-            );
-
-            // Force immediate visual feedback
-            context.enter(modeSelect(context, [entity.id]));
-        }
-    });
-}
-
+        });
+    }
 
     validation.type = type;
 


### PR DESCRIPTION
This commit removes comment-only and whitespace-only changes that were #11624
introduced during drafting.

No functional or behavioral changes are intended.
