### PR TITLE
A couple of strings fixes/typos

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -2270,7 +2270,7 @@ en:
       add_name: "Let's pretend that you have local knowledge of this cafe, and you know its name. **Add a name for the cafe.**"
       add_reminder: "All entered information should be objective and verifiable."
       add_close: "The feature editor will remember all of your changes automatically. **When you are finished adding the name, press the {button} button or `{esc}` to close the feature editor.**"
-      reselect: "Often points will already exist, but have mistakes or be incomplete. We can edit existing points. **Select the cafe you just created.**"
+      reselect: "Often points will already exist, but have mistakes or are incomplete. We can edit existing points. **Select the cafe you just created.**"
       update: "Let's fill in some more details for this cafe. You can change its name, add a cuisine, or add an address. **Change the cafe details.**"
       update_close: "**When you are finished updating the cafe, press the {button} button or `{esc}` to close the feature editor.**"
       rightclick: "You can {rightclick} right-click on any feature to see the *edit menu*, which shows a list of editing operations that can be performed.{br}A right-click might be the same as a control-click or two-finger click. **Right-click to select the point you created and show the edit menu.**"

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -477,8 +477,8 @@ en:
             single_node: Divide this line into two at this point.
             multiple_node: Divide this line at these points.
           multiple:
-            single_node: "Divide all lines at this point. Tip: To limit this operation to a specific line, select both the line and point before performing the split."
-            multiple_node: "Divide all lines at these points. Tip: To limit this operation to a specific line, select the line as well as the points before performing the split."
+            single_node: "Divide all lines at this point. Tip: To limit this operation to a specific line, select both the line and point before performing the split."
+            multiple_node: "Divide all lines at these points. Tip: To limit this operation to a specific line, select the line as well as the points before performing the split."
         area:
           single:
             single_node: Divide the edge of this area into two at this point.
@@ -1585,7 +1585,7 @@ en:
       connect_line_h: "Connecting Lines"
       connect_line: "Having roads connected properly is important for the map and essential for providing driving directions."
       connect_line_display: "The connections between roads are drawn with gray circles. The endpoints of a line are drawn with larger white circles if they don't connect to anything."
-      connect_line_drag: "To connect a line to another feature, drag one of the line's nodes onto the other feature until both features snap together. Tip: You can hold down the `{alt}` key to prevent nodes from connecting to other features."
+      connect_line_drag: "To connect a line to another feature, drag one of the line's nodes onto the other feature until both features snap together. Tip: You can hold down the `{alt}` key to prevent nodes from connecting to other features."
       connect_line_tag: "If you know that the connection has traffic lights or crosswalks, you can add them by selecting the connecting node and using the feature editor to select the correct feature's type."
       disconnect_line_h: "Disconnecting Lines"
       disconnect_line_command: "To disconnect a road from another feature, {rightclick} right-click or {longpress_icon} long-press the connecting node and choose the {disconnect_icon} **{disconnect}** operation from the edit menu."
@@ -1706,7 +1706,7 @@ en:
           about: "This field allows you to inspect and modify turn restrictions. It displays a model of the selected intersection including other nearby connected roads."
           from_via_to: "A turn restriction always contains: one **FROM way**, one **TO way**, and either one **VIA node** or one or more **VIA ways**."
           maxdist: "The \"{distField}\" slider controls how far to search for additional connected roads."
-          maxvia: "The \"{viaField}\" slider adjusts how many via ways may be included in the search. (Tip: simple is better)"
+          maxvia: "The \"{viaField}\" slider adjusts how many via ways may be included in the search. (Tip: simple is better)"
         inspecting:
           title: Inspecting
           about: "Hover over any **FROM** segment to see whether it has any turn restrictions. Each possible **TO** destination will be drawn with a colored shadow showing whether a restriction exists."
@@ -2284,7 +2284,7 @@ en:
       start_playground: "Let's add this playground to the map by drawing an area. Areas are drawn by placing *nodes* along the outer edge of the feature."
       starting_node_click: "**Click or press `{space}` to place a starting node on one of the corners of the playground.**"
       starting_node_tap: "**{tap_icon} Tap to place a starting node on one of the corners of the playground.**"
-      continue_playground: "Continue drawing the area by placing more nodes along the playground's edge. It is OK to connect the area to the existing walking paths.{br}Tip: You can hold down the `{alt}` key to prevent nodes from connecting to other features. **Continue drawing an area for the playground.**"
+      continue_playground: "Continue drawing the area by placing more nodes along the playground's edge. It is OK to connect the area to the existing walking paths.{br}Tip: You can hold down the `{alt}` key to prevent nodes from connecting to other features. **Continue drawing an area for the playground.**"
       finish_area_click: "Finish the area by pressing `{return}`, or clicking again on either the first or last node."
       finish_area_tap: "Finish the area by {tap_icon} tapping again on either the first or last node, or by pressing `{return}` on a keyboard."
       finish_playground: "**Finish drawing an area for the playground.**"

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -583,7 +583,7 @@ en:
   zoom_in_edit: Zoom in to edit
   login: Log In
   logout: Log Out
-  loading_auth: "Connecting to OpenStreetMap..."
+  loading_auth: "Connecting to OpenStreetMap…"
   report_a_bug: Report a bug
   help_translate: Help translate
   sidebar:
@@ -696,11 +696,11 @@ en:
     relation: relation
     note: note
   geocoder:
-    search: Search worldwide...
+    search: Search worldwide…
     no_results_worldwide: No results found
   geolocate:
     title: Show My Location
-    locating: "Locating, please wait..."
+    locating: "Locating, please wait…"
     location_unavailable: Your location is unavailable.
   inspector:
     zoom_to:
@@ -721,7 +721,7 @@ en:
     title_count: "{title} ({count})"
     add_to_relation: Add to a relation
     add_tag: Add new tag
-    new_relation: New relation...
+    new_relation: New relation…
     choose_relation: Choose a parent relation
     role: Role
     multiple_roles: Multiple Roles
@@ -1038,7 +1038,7 @@ en:
     error: Errors occurred while trying to save
     status_code: "Server returned status code {code}"
     unknown_error_details: "Please ensure you are connected to the internet."
-    uploading: Uploading changes to OpenStreetMap...
+    uploading: Uploading changes to OpenStreetMap…
     conflict_progress: "Checking for conflicts: {num} of {total}"
     unsaved_changes: You have unsaved changes
     conflict:


### PR DESCRIPTION
These are a couple of strings fixes or typos, but several notes must be made:
- For the pure English spelling, English isn't my native language and while the sentence seemed completely wrong to me when I read it, it might be me who's completely mistaken and missing some English skills here, which results in me trying to correct what I think is a mistake while it isn't.
- Regarding the unbreakable spaces, having lines ending with "Tip:" and then a new line isn't correct, which is the reason for the replacement. I didn't look in the file (or if there are other files?) for other occurrences for colons as the fact it's a YamL file make it quite difficult to only look for colons as it'd basically be every line. Maybe it'd be needed to look for every second or more colon or something along?
- About the replacement of three dots by ellipses is probably the one I'm the most unsure about. It's a mistake often made due to how difficult it is to produce the ellipsis on some OS, but here in the context of something loading it might be completely preferred to have three dots to simulate a loading with one dot appearing after another.

Finally, I'm not sure what kind of markup is used here, and couldn't find the answer in the code (I don't practice JS, maybe it's a common one for this ecosystem?) but saw several markups with pairs or curly braces, so maybe ellipses or unbreakable spaces should be done that way too?

Let me know if I'm wrong about some (or even all!) of these changes and if I should adapt (drop commits) the PR accordingly!