### PR TITLE
render special oneway arrows for the `priority` direction

### DIFF
--- a/modules/osm/tags.js
+++ b/modules/osm/tags.js
@@ -214,7 +214,10 @@ export const osmOneWayForwardTags = {
         'spillway': true,
         'stream': true,
         'tidal_channel': true
-    }
+    },
+    'railway:preferred_direction': {
+        'forward': 'forward',
+    },
 };
 export const osmOneWayBackwardTags = {
     'conveying': {
@@ -222,6 +225,9 @@ export const osmOneWayBackwardTags = {
     },
     'oneway': {
         '-1': true,
+    },
+    'railway:preferred_direction': {
+        'backward': 'backward',
     },
 };
 export const osmOneWayBiDirectionalTags = {
@@ -231,6 +237,9 @@ export const osmOneWayBiDirectionalTags = {
     'oneway': {
         'alternating': true,
         'reversible': true,
+    },
+    'railway:preferred_direction': {
+        'both': true,
     },
 };
 export const osmOneWayTags = merge(

--- a/modules/osm/way.js
+++ b/modules/osm/way.js
@@ -162,6 +162,24 @@ const prototype = {
         return !!utilCheckTagDictionary(this.tags, osmOneWayBiDirectionalTags);
     },
 
+    /**
+     * @returns {'forward' | 'backward'} for bidirectional ways that have
+     *          a defined priority in one direction.
+     */
+    priorityDirection() {
+        if (!this.isBiDirectional()) return undefined;
+
+        if (['forward', 'backward'].includes(this.tags.priority)) {
+            return this.tags.priority;
+        }
+        if (
+            ['forward', 'backward'].includes(this.tags['railway:preferred_direction']) &&
+            ['regular', 'possible', 'signals'].includes(this.tags['railway:bidirectional'])
+        ) {
+            return this.tags['railway:preferred_direction'];
+        }
+    },
+
     /** @returns {boolean} */
     isOneWay() {
         if (this.tags.oneway === 'no') return false;

--- a/modules/svg/defs.js
+++ b/modules/svg/defs.js
@@ -29,22 +29,38 @@ export function svgDefs(context) {
 
         /** @param {string} name @param {string} colour */
         function addOnewayMarker(name, colour) {
-            _defsSelection
+            const VARIANTS = [
+                {
+                    id: 'normal',
+                    viewBox: '0 0 10 5',
+                    d: 'M 6,3 L 0,3 L 0,2 L 6,2 L 5,0 L 10,2.5 L 5,5 z', // -->
+                    markerWidth: 2,
+                },
+                {
+                    id: 'priority',
+                    viewBox: '0 0 16 5',
+                    d: 'M 12 3 L 7 5 L 8 3 H 0 V 2 H 8 L 7 0 L 12 2 L 11 0 L 16 2.5 L 11 5 z', // -->>
+                    markerWidth: 3.3,
+                },
+            ];
+            for (const variant of VARIANTS) {
+              _defsSelection
                 .append('marker')
-                .attr('id', `ideditor-oneway-marker-${name}`)
-                .attr('viewBox', '0 0 10 5')
+                .attr('id', `ideditor-oneway-marker-${name}-${variant.id}`)
+                .attr('viewBox', variant.viewBox)
                 .attr('refX', 4)
                 .attr('refY', 2.5)
-                .attr('markerWidth', 2)
+                .attr('markerWidth', variant.markerWidth)
                 .attr('markerHeight', 2)
                 .attr('markerUnits', 'strokeWidth')
                 .attr('orient', 'auto')
                 .append('path')
                 .attr('class', 'oneway-marker-path')
-                .attr('d', 'M 6,3 L 0,3 L 0,2 L 6,2 L 5,0 L 10,2.5 L 5,5 z')
+                .attr('d', variant.d)
                 .attr('stroke', 'none')
                 .attr('fill', colour)
                 .attr('opacity', '1');
+            }
         }
         addOnewayMarker('black', '#333'); // default
         addOnewayMarker('white', '#fff'); // for dark lines (bridges under construction, railways, etc.)

--- a/modules/svg/helpers.js
+++ b/modules/svg/helpers.js
@@ -121,7 +121,7 @@ export function svgMarkerSegments(projection, graph, dt, shouldReverse = () => f
                             for (let j = 0; j < coord.length; j++) {
                                 segment += (j === 0 ? 'M' : 'L') + coord[j][0] + ',' + coord[j][1];
                             }
-                            segments.push({ id: entity.id, index: i++, d: segment });
+                            segments.push({ id: entity.id, index: i++, d: segment, direction: 'forward' });
                         }
 
                         if (_shouldReverse || _bothDirections) {
@@ -129,7 +129,7 @@ export function svgMarkerSegments(projection, graph, dt, shouldReverse = () => f
                             for (let j = coord.length - 1; j >= 0; j--) {
                                 segment += (j === coord.length - 1 ? 'M' : 'L') + coord[j][0] + ',' + coord[j][1];
                             }
-                            segments.push({ id: entity.id, index: i++, d: segment });
+                            segments.push({ id: entity.id, index: i++, d: segment, direction: 'backward' });
                         }
                     }
 

--- a/modules/svg/lines.js
+++ b/modules/svg/lines.js
@@ -316,8 +316,11 @@ export function svgLines(projection, context) {
                 .call(drawLineGroup, 'stroke', true);
 
             addMarkers(layergroup, 'oneway', 'onewaygroup', onewaydata, (d) => {
-                const category = onewayArrowColour(graph.entity(d.id).tags);
-                return `url(#ideditor-oneway-marker-${category})`;
+                const way = graph.entity(d.id);
+                const category = onewayArrowColour(way.tags);
+                const variant = way.priorityDirection() === d.direction ? 'priority' : 'normal';
+
+                return `url(#ideditor-oneway-marker-${category}-${variant})`;
             });
             addMarkers(layergroup, 'sided', 'sidedgroup', sideddata,
                 function marker(d) {

--- a/test/spec/svg/lines.js
+++ b/test/spec/svg/lines.js
@@ -145,9 +145,9 @@ describe('iD.svgLines', function () {
             var selection = surface.selectAll('g.onewaygroup > path');
 
             expect(selection.size()).to.eql(3);
-            expect(selection.nodes()[0].attributes['marker-mid'].nodeValue).to.eql('url(#ideditor-oneway-marker-black)');
-            expect(selection.nodes()[1].attributes['marker-mid'].nodeValue).to.eql('url(#ideditor-oneway-marker-black)');
-            expect(selection.nodes()[2].attributes['marker-mid'].nodeValue).to.eql('url(#ideditor-oneway-marker-black)');
+            expect(selection.nodes()[0].attributes['marker-mid'].nodeValue).to.eql('url(#ideditor-oneway-marker-black-normal)');
+            expect(selection.nodes()[1].attributes['marker-mid'].nodeValue).to.eql('url(#ideditor-oneway-marker-black-normal)');
+            expect(selection.nodes()[2].attributes['marker-mid'].nodeValue).to.eql('url(#ideditor-oneway-marker-black-normal)');
         });
 
         it('has two marker layers for alternating oneway ways', function() {
@@ -162,8 +162,8 @@ describe('iD.svgLines', function () {
 
             var selection = surface.selectAll('g.onewaygroup > path');
             expect(selection.size()).to.eql(2);
-            expect(selection.nodes()[0].attributes['marker-mid'].nodeValue).to.eql('url(#ideditor-oneway-marker-black)');
-            expect(selection.nodes()[1].attributes['marker-mid'].nodeValue).to.eql('url(#ideditor-oneway-marker-black)');
+            expect(selection.nodes()[0].attributes['marker-mid'].nodeValue).to.eql('url(#ideditor-oneway-marker-black-normal)');
+            expect(selection.nodes()[1].attributes['marker-mid'].nodeValue).to.eql('url(#ideditor-oneway-marker-black-normal)');
         });
 
         it('has no marker layer for oneway=no ways', function() {


### PR DESCRIPTION
this is just an experiment. [bidirectional ways](http://osm.wiki/Tag:oneway=alternating) can sometimes have one direction which has priority. Typically signposted as [<img src="https://upload.wikimedia.org/wikipedia/commons/c/c3/Vienna_Convention_road_sign_B5-V1.svg" height="20px" />](https://commons.wikimedia.org/wiki/File:Vienna_Convention_road_sign_B5-V1.svg) and [<img src="https://upload.wikimedia.org/wikipedia/commons/9/95/Vienna_Convention_road_sign_B6.svg" height="20px" />](https://commons.wikimedia.org/wiki/File:Vienna_Convention_road_sign_B6.svg),  and tagged as [`priority=forward`/`backward`](https://osm.wiki/Key:priority).

The same concept exists for railways: the interlocking can support [wrong-road running](http://osm.wiki/Key:railway:bidirectional), but there might still be a [preferred direction](http://osm.wiki/Key:railway:preferred_direction).

we could render this to map it easier to map:

<img width="867" height="264" alt="image" src="https://github.com/user-attachments/assets/b234f83d-bdc3-4d28-b151-7cc4dccfd8da" />

alternatives:

<img width="901" height="55" alt="image" src="https://github.com/user-attachments/assets/8406c1d2-ad49-48c1-8675-e169673598cd" />
<img width="867" height="57" alt="image" src="https://github.com/user-attachments/assets/c907fe9e-71dc-40b5-a3d0-9c1236d82e94" />





real example:

<img width="635" height="309" alt="image" src="https://github.com/user-attachments/assets/1f0ad506-175a-401d-a3a9-131c81368b7d" />

currently it looks quite chaotic, i'm not really sure how to do this well...


