### PR TITLE
feat: implemented full-width mobile sidebar with close button

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -866,31 +866,36 @@ a.hide-toggle {
         height: 20px;
         fill: currentColor;
     }
+
     .sidebar-close-button {
         position: absolute;
-        top: 10px;
-        right: 10px;
-        z-index: 9999; /* Increased to stay above all inspector elements */
-        padding: 10px;
-        background: white; /* Changed from transparent for better visibility on mobile */
-        border-radius: 50%; /* Makes it look like a clean circular button */
+        top: 0;
+        right: 0;
+        width: 40px;
+        height: 40px;
+        background: transparent;
         border: none;
+        border-radius: 0;        
+        outline: none;           
+        -webkit-appearance: none; 
+        appearance: none;  
         cursor: pointer;
         display: flex;
         align-items: center;
         justify-content: center;
-        box-shadow: 0 2px 5px rgba(0,0,0,0.2); /* Helps it pop against map data */
+        font-size: 20px;
+        color: #fff;
+        font-weight: 300;
+    }
+
+    .sidebar-close-button:hover {
+        background: rgba(255,255,255,0.1);
     }
 
     .sidebar-close-button.hide {
         display: none !important;
     }
 
-    .sidebar-close-button .icon {
-        width: 24px;
-        height: 24px;
-        fill: #333;
-    }
 }
 
 .sidebar-resizer {

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -806,7 +806,7 @@ a.hide-toggle {
 }
 
 
-/* Sidebar / Inspector
+/* Sidebar / Inspector 
 ------------------------------------------------------- */
 .sidebar {
     position: relative;
@@ -822,6 +822,75 @@ a.hide-toggle {
     float: right;
     border-right-width: 0px;
     border-left-width: 1px;
+}
+
+/* MOBILE MODAL OVERRIDE */
+@media screen and (max-width: 850px) {
+    /* When the sidebar is open, hide the map */
+    .ideditor.sidebar-modal-open .main-content,
+    .ideditor.sidebar-modal-open .sidebar-resizer {
+        display: none !important;
+    }
+
+    /* sidebar fill the entire screen */
+    .ideditor.sidebar-modal-open .sidebar {
+        position: fixed; 
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        width: 100% !important;
+        max-width: 100% !important;
+        z-index: 9999; 
+        margin: 0 !important;
+        border: none;
+    }
+
+    /* header button visible and easy to tap */
+    .ideditor.sidebar-modal-open .sidebar .header button.close {
+        display: flex !important;
+        align-items: center;
+        justify-content: center;
+        width: 44px; /* Thumb-friendly tap target */
+        height: 44px;
+        position: absolute;
+        top: 5px;
+        right: 5px;
+        z-index: 100;
+        cursor: pointer;
+    }
+
+    /* icon inside is centered */
+    .ideditor.sidebar-modal-open .sidebar .header button.close svg {
+        width: 20px;
+        height: 20px;
+        fill: currentColor;
+    }
+    .sidebar-close-button {
+        position: absolute;
+        top: 10px;
+        right: 10px;
+        z-index: 9999; /* Increased to stay above all inspector elements */
+        padding: 10px;
+        background: white; /* Changed from transparent for better visibility on mobile */
+        border-radius: 50%; /* Makes it look like a clean circular button */
+        border: none;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        box-shadow: 0 2px 5px rgba(0,0,0,0.2); /* Helps it pop against map data */
+    }
+
+    .sidebar-close-button.hide {
+        display: none !important;
+    }
+
+    .sidebar-close-button .icon {
+        width: 24px;
+        height: 24px;
+        fill: #333;
+    }
 }
 
 .sidebar-resizer {

--- a/modules/ui/sidebar.js
+++ b/modules/ui/sidebar.js
@@ -161,11 +161,7 @@ export function uiSidebar(context) {
                 sidebar.collapse();
             });
 
-        closeButton
-            .append('svg')
-            .attr('class', 'icon')
-            .append('use')
-            .attr('href', '#iD-icon-close');
+        closeButton.text('✕');
 
         var hoverModeSelect = function(targets) {
             context.container().selectAll('.feature-list-item button').classed('hover', false);

--- a/modules/ui/sidebar.js
+++ b/modules/ui/sidebar.js
@@ -152,6 +152,21 @@ export function uiSidebar(context) {
             .append('div')
             .attr('class', 'inspector-hidden inspector-wrap');
 
+        // Add a close button that only shows up on mobile
+        var closeButton = selection
+            .append('button')
+            .attr('class', 'sidebar-close-button hide') // 'hide' by default
+            .on('click', function(d3_event) {
+                d3_event.preventDefault();
+                sidebar.collapse();
+            });
+
+        closeButton
+            .append('svg')
+            .attr('class', 'icon')
+            .append('use')
+            .attr('href', '#iD-icon-close');
+
         var hoverModeSelect = function(targets) {
             context.container().selectAll('.feature-list-item button').classed('hover', false);
 
@@ -367,14 +382,26 @@ export function uiSidebar(context) {
             selection.style('width', sidebarWidth + 'px');
 
             var startMargin, endMargin, lastMargin;
-            if (isCollapsing) {
-                startMargin = lastMargin = 0;
-                endMargin = -sidebarWidth;
-            } else {
-                startMargin = lastMargin = -sidebarWidth;
-                endMargin = 0;
-            }
+            // mobile sidebar fullwidth 
+            var isMobile = (window.innerWidth <= 850);
+            closeButton.classed('hide', !isMobile || isCollapsing);
+            var idContainer = d3_select('.ideditor');
 
+            if (isCollapsing) {
+           
+            if (isMobile) {
+                idContainer.classed('sidebar-modal-open', false);
+            }
+            startMargin = lastMargin = 0;
+            endMargin = -sidebarWidth;
+            } else {
+           
+            if (isMobile) {
+                idContainer.classed('sidebar-modal-open', true);
+            }   
+            startMargin = lastMargin = -sidebarWidth;
+            endMargin = 0;
+        }
             if (!isCollapsing) {
                 // unhide the sidebar's content before it transitions onscreen
                 selection.classed('collapsed', isCollapsing);
@@ -421,6 +448,16 @@ export function uiSidebar(context) {
         context.map().on('crossEditableZoom.sidebar', function(within) {
             if (!within && !selection.select('.inspector-hover').empty()) {
                 hover([]);
+            }
+        });
+        // close button 
+        selection.on('click.sidebar-close', function(d3_event) {
+            if (window.innerWidth > 850) return;
+            
+           
+            if (d3_event.target.closest('button.close')) {
+                d3_event.preventDefault();
+                sidebar.collapse(); 
             }
         });
     }


### PR DESCRIPTION
This PR fixes the issue #11739 improves the mobile experience by turning the sidebar into a full-width modal on screens smaller than 850px.

# Changes
  Fixes #11739
- **UI:** Sidebar now takes 100% width on mobile devices.
- **Logic:** Added a custom floating 'X' close button in `modules/ui/sidebar.js`.
- **CSS:** Added media queries in `css/80_app.css` to hide the map when the modal (sidebar) is active and takes full width.
- 
### Testing
- Verified using Chrome DevTools.