### PR TITLE
[Fix] Modal-like sidebar layout on mobile screens

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -732,10 +732,22 @@ button.add-note svg.icon {
     right: 0;
     top: 0;
 }
+
+
+.sidebar .header button.sidebar-toggle {
+    position: absolute;
+    right: 40px;
+    top: 0;
+}
+
 .ideditor[dir='rtl'] .field-help-title button.close,
 .ideditor[dir='rtl'] .sidebar .header button.close,
 .ideditor[dir='rtl'] .preset-list-pane .header button.preset-choose {
     left: 0;
+    right: auto;
+}
+.ideditor[dir='rtl'] .sidebar .header button.sidebar-toggle {
+    left: 40px;
     right: auto;
 }
 
@@ -818,6 +830,7 @@ a.hide-toggle {
     border: 0px solid var(--border-color);
     border-right-width: 1px;
 }
+
 .ideditor[dir='rtl'] .sidebar {
     float: right;
     border-right-width: 0px;

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -860,7 +860,7 @@ a.hide-toggle {
     }
 
     .sidebar.collapsed {
-        transform: translateX(-200%);
+        transform: translateX(200%);
     }
 
     .sidebar .sidebar-resizer { display: none; }

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -860,7 +860,7 @@ a.hide-toggle {
     }
 
     .sidebar.collapsed {
-        transform: translateX(100%);
+        transform: translateX(200%);
     }
 
     .sidebar .sidebar-resizer { display: none; }

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -860,7 +860,7 @@ a.hide-toggle {
     }
 
     .sidebar.collapsed {
-        transform: translateX(200%);
+        transform: translateX(100%);
     }
 
     .sidebar .sidebar-resizer { display: none; }

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -860,7 +860,7 @@ a.hide-toggle {
     }
 
     .sidebar.collapsed {
-        transform: translateX(200%);
+        transform: translateX(-200%);
     }
 
     .sidebar .sidebar-resizer { display: none; }

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -839,6 +839,39 @@ a.hide-toggle {
     left: -6px;
 }
 
+/* Mobile: make the sidebar act like a full-screen modal */
+@media (max-width: 640px) {
+    .sidebar {
+        position: fixed;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        width: 100% !important;
+        max-width: none !important;
+        z-index: 10000;
+        transform: translateX(100%);
+        transition: transform 200ms ease;
+        -webkit-overflow-scrolling: touch;
+    }
+
+    .sidebar:not(.collapsed) {
+        transform: translateX(0);
+    }
+
+    .sidebar.collapsed {
+        transform: translateX(100%);
+    }
+
+    .sidebar .sidebar-resizer { display: none; }
+
+    /* dim the main content when sidebar modal is open */
+    .main-content.inactive {
+        pointer-events: none;
+        filter: grayscale(80%) brightness(80%);
+    }
+}
+
 .sidebar.collapsed > *:not(.sidebar-resizer) {
     display: none;
 }

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -839,39 +839,6 @@ a.hide-toggle {
     left: -6px;
 }
 
-/* Mobile: make the sidebar act like a full-screen modal */
-@media (max-width: 640px) {
-    .sidebar {
-        position: fixed;
-        top: 0;
-        right: 0;
-        bottom: 0;
-        left: 0;
-        width: 100% !important;
-        max-width: none !important;
-        z-index: 10000;
-        transform: translateX(100%);
-        transition: transform 200ms ease;
-        -webkit-overflow-scrolling: touch;
-    }
-
-    .sidebar:not(.collapsed) {
-        transform: translateX(0);
-    }
-
-    .sidebar.collapsed {
-        transform: translateX(100%);
-    }
-
-    .sidebar .sidebar-resizer { display: none; }
-
-    /* dim the main content when sidebar modal is open */
-    .main-content.inactive {
-        pointer-events: none;
-        filter: grayscale(80%) brightness(80%);
-    }
-}
-
 .sidebar.collapsed > *:not(.sidebar-resizer) {
     display: none;
 }

--- a/modules/ui/entity_editor.js
+++ b/modules/ui/entity_editor.js
@@ -29,6 +29,10 @@ export function uiEntityEditor(context) {
     var _newFeature;
 
     var _sections;
+    var isMobile = (
+        window.matchMedia &&
+        window.matchMedia('(max-width: 640px)').matches
+    );
 
     function entityEditor(selection) {
 
@@ -50,6 +54,14 @@ export function uiEntityEditor(context) {
             .attr('class', 'preset-reset preset-choose')
             .attr('title', t('inspector.back_tooltip'))
             .call(svgIcon(`#iD-icon-${direction}`));
+
+        // Sidebar toggle (appears to the left of the close button)
+        isMobile && headerEnter
+            .append('button')
+            .attr('class', 'sidebar-toggle')
+            .attr('title', t('sidebar.tooltip'))
+            .on('click', function() { context.ui().sidebar.toggle(); })
+            .call(svgIcon('#iD-icon-sidebar-' + (localizer.textDirection() === 'rtl' ? 'right' : 'left')));
 
         headerEnter
             .append('button')

--- a/modules/ui/feature_list.js
+++ b/modules/ui/feature_list.js
@@ -37,12 +37,25 @@ export const idMatch = q => {
 
 export function uiFeatureList(context) {
     var _geocodeResults;
+    var isMobile = (
+        window.matchMedia &&
+        window.matchMedia('(max-width: 640px)').matches
+    );
 
 
     function featureList(selection) {
         var header = selection
             .append('div')
             .attr('class', 'header fillL');
+
+        isMobile && header
+            .append('button')
+            .attr('class', 'close')
+            .attr('title', 'toggle')
+            .on('click', function() {
+                context.ui().sidebar.toggle();
+            })
+            .call(svgIcon('#iD-icon-sidebar-left'));
 
         header
             .append('h2')

--- a/modules/ui/init.js
+++ b/modules/ui/init.js
@@ -143,6 +143,15 @@ export function uiInit(context) {
             .attr('class', 'sidebar')
             .call(ui.sidebar);
 
+        // If we're on a mobile-sized screen and the sidebar is opened by default,
+        // collapse it by invoking the existing toggle logic so behavior is consistent.
+        if (window.matchMedia && window.matchMedia('(max-width:640px)').matches) {
+            var sidebarSel = container.select('.sidebar');
+            if (!sidebarSel.classed('collapsed')) {
+                context.ui().sidebar.toggle();
+            }
+        }
+
         var content = container
             .append('div')
             .attr('class', 'main-content active');

--- a/modules/ui/sidebar.js
+++ b/modules/ui/sidebar.js
@@ -28,6 +28,10 @@ export function uiSidebar(context) {
     var _wasData = false;
     var _wasNote = false;
     var _wasQaItem = false;
+    var isMobile = (
+        window.matchMedia &&
+        window.matchMedia('(max-width: 640px)').matches
+    );
 
     // use pointer events on supported platforms; fallback to mouse events
     var _pointerPrefix = 'PointerEvent' in window ? 'pointer' : 'mouse';
@@ -41,10 +45,19 @@ export function uiSidebar(context) {
         var dragOffset;
 
         // Set the initial width constraints
-        selection
-            .style('min-width', minWidth + 'px')
-            .style('max-width', '400px')
-            .style('width', '33.3333%');
+        if (isMobile) {
+            selection
+                .style('width', '100vw')
+                .style('min-width', null)
+                .style('max-width', null)
+                .style('position', 'fixed')
+                .style('z-index', '110');
+        } else {
+            selection
+                .style('min-width', minWidth + 'px')
+                .style('max-width', '400px')
+                .style('width', '33.3333%');
+        }
 
         var resizer = selection
             .append('div')

--- a/modules/ui/sidebar.js
+++ b/modules/ui/sidebar.js
@@ -53,6 +53,10 @@ export function uiSidebar(context) {
 
         var downPointerId, lastClientX, containerLocGetter;
 
+        function isMobileScreen() {
+            return window.matchMedia && window.matchMedia('(max-width: 640px)').matches;
+        }
+
         function pointerdown(d3_event) {
             if (downPointerId) return;
 
@@ -362,6 +366,23 @@ export function uiSidebar(context) {
             var xMarginProperty = isRTL ? 'margin-right' : 'margin-left';
 
             sidebarWidth = selection.node().getBoundingClientRect().width;
+
+            // On mobile, set dimming and click-to-close immediately for modal behavior
+            if (isMobileScreen()) {
+                if (!isCollapsing) {
+                    // expanding -> dim the main content and attach close handler
+                    container.select('.main-content').classed('inactive', true).on('click.sidebar-close', function() {
+                        if (!selection.classed('collapsed')) {
+                            sidebar.toggle();
+                        }
+                    });
+                    resizer.style('display', 'none');
+                } else {
+                    // collapsing -> un-dim and remove handler
+                    container.select('.main-content').classed('inactive', false).on('click.sidebar-close', null);
+                    resizer.style('display', null);
+                }
+            }
 
             // switch from % to px
             selection.style('width', sidebarWidth + 'px');

--- a/modules/ui/sidebar.js
+++ b/modules/ui/sidebar.js
@@ -53,10 +53,6 @@ export function uiSidebar(context) {
 
         var downPointerId, lastClientX, containerLocGetter;
 
-        function isMobileScreen() {
-            return window.matchMedia && window.matchMedia('(max-width: 640px)').matches;
-        }
-
         function pointerdown(d3_event) {
             if (downPointerId) return;
 
@@ -366,23 +362,6 @@ export function uiSidebar(context) {
             var xMarginProperty = isRTL ? 'margin-right' : 'margin-left';
 
             sidebarWidth = selection.node().getBoundingClientRect().width;
-
-            // On mobile, set dimming and click-to-close immediately for modal behavior
-            if (isMobileScreen()) {
-                if (!isCollapsing) {
-                    // expanding -> dim the main content and attach close handler
-                    container.select('.main-content').classed('inactive', true).on('click.sidebar-close', function() {
-                        if (!selection.classed('collapsed')) {
-                            sidebar.toggle();
-                        }
-                    });
-                    resizer.style('display', 'none');
-                } else {
-                    // collapsing -> un-dim and remove handler
-                    container.select('.main-content').classed('inactive', false).on('click.sidebar-close', null);
-                    resizer.style('display', null);
-                }
-            }
 
             // switch from % to px
             selection.style('width', sidebarWidth + 'px');


### PR DESCRIPTION
## What changed
The sidebar now behaves like a modal on small screens to improve usability on mobile devices.

## Details
- The sidebar is toggled off by default on mobile screen sizes.
- It can be opened using the **Inspect** button, which toggles the sidebar.
- Additional toggle buttons are added to the headers of the feature list and entity editor, allowing mobile users to easily navigate back to the map view.

Closes #11739  
Relates to #9815

## Screenshots
<img width="388" height="242" alt="Sidebar closed on mobile" src="https://github.com/user-attachments/assets/63df901c-eeb4-4b5d-b6d2-8877a25bce0f" />

<img width="388" height="576" alt="Sidebar open as modal on mobile" src="https://github.com/user-attachments/assets/398d988d-6911-42e2-818a-cdd2a59e1f0d" />

## Testing
- Tested locally with `npm start`
- Verified behavior using browser mobile emulation
- Confirmed desktop layout remains unchanged

## Checklist
- [x] Tested locally
- [x] No unrelated changes
