### PR TITLE
 Adding reflection axis preview on Flip Long/Short hover (#11769)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :sparkles: Usability & Accessibility
 * Don't suggest values from Taginfo for `addr:*` tags ([#11733], thanks [@k-yle])
 #### :scissors: Operations
+* Display reflection axis on the map while hovering the reflection operations in the edit menu ([#11774], thanks [@Kaushik4141])
 #### :camera: Street-Level
 #### :white_check_mark: Validation
 * Don't error on features with a sole `note` tag ([#11522])
@@ -62,9 +63,12 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#11699]: https://github.com/openstreetmap/iD/pull/11699
 [#11733]: https://github.com/openstreetmap/iD/pull/11733
 [#11760]: https://github.com/openstreetmap/iD/pull/11760
+[#11774]: https://github.com/openstreetmap/iD/pull/11774
 [@ilias52730]: https://github.com/ilias52730
 [@Razen04]: https://github.com/Razen04
 [@homersimpsons]: https://github.com/homersimpsons
+[@Kaushik4141]: https://github.com/Kaushik4141
+
 
 # v2.37.3
 ##### 2025-10-31

--- a/css/20_map.css
+++ b/css/20_map.css
@@ -320,6 +320,15 @@ g.vertex.highlighted .shadow {
     stroke: #7092ff;
 }
 
+/* Reflect Axis Indicator */
+line.reflect-axis-overlay {
+    stroke: #7092ff;
+    stroke-width: 3;
+    stroke-dasharray: 8, 4;
+    stroke-linecap: round;
+    pointer-events: none;
+}
+
 /* Turn Restrictions */
 .points-group.turns g.turn rect,
 .points-group.turns g.turn circle {

--- a/css/20_map.css
+++ b/css/20_map.css
@@ -320,15 +320,6 @@ g.vertex.highlighted .shadow {
     stroke: #7092ff;
 }
 
-/* Reflect Axis Indicator */
-line.reflect-axis-overlay {
-    stroke: #7092ff;
-    stroke-width: 3;
-    stroke-dasharray: 8, 4;
-    stroke-linecap: round;
-    pointer-events: none;
-}
-
 /* Turn Restrictions */
 .points-group.turns g.turn rect,
 .points-group.turns g.turn circle {
@@ -360,6 +351,15 @@ line.reflect-axis-overlay {
 .surface.tr path.shadow.related.only,
 .surface.tr g.vertex.related.only .shadow {
     stroke: #68f;
+}
+
+/* Auxiliary temporary geometries for operations, e.g. reflect axis indicator */
+g.auxiliary path.reflect-axis {
+    stroke: #7092ff;
+    stroke-width: 3;
+    stroke-dasharray: 8, 4;
+    stroke-linecap: round;
+    pointer-events: none;
 }
 
 /* Visual Diffs

--- a/modules/actions/reflect.js
+++ b/modules/actions/reflect.js
@@ -11,27 +11,7 @@ export function actionReflect(reflectIds, projection) {
         if (t === null || !isFinite(t)) t = 1;
         t = Math.min(Math.max(+t, 0), 1);
 
-        var nodes = utilGetAllNodes(reflectIds, graph);
-        var points = nodes.map(function(n) { return projection(n.loc); });
-        var ssr = geoGetSmallestSurroundingRectangle(points);
-
-        // Choose line pq = axis of symmetry.
-        // The shape's surrounding rectangle has 2 axes of symmetry.
-        // Reflect across the longer axis by default.
-        var p1 = [(ssr.poly[0][0] + ssr.poly[1][0]) / 2, (ssr.poly[0][1] + ssr.poly[1][1]) / 2 ];
-        var q1 = [(ssr.poly[2][0] + ssr.poly[3][0]) / 2, (ssr.poly[2][1] + ssr.poly[3][1]) / 2 ];
-        var p2 = [(ssr.poly[3][0] + ssr.poly[4][0]) / 2, (ssr.poly[3][1] + ssr.poly[4][1]) / 2 ];
-        var q2 = [(ssr.poly[1][0] + ssr.poly[2][0]) / 2, (ssr.poly[1][1] + ssr.poly[2][1]) / 2 ];
-        var p, q;
-
-        var isLong = (geoVecLength(p1, q1) > geoVecLength(p2, q2));
-        if ((_useLongAxis && isLong) || (!_useLongAxis && !isLong)) {
-            p = p1;
-            q = q1;
-        } else {
-            p = p2;
-            q = q2;
-        }
+        const [p, q] = action.getReflectAxis(graph);
 
         // reflect c across pq
         // http://math.stackexchange.com/questions/65503/point-reflection-over-a-line
@@ -39,16 +19,16 @@ export function actionReflect(reflectIds, projection) {
         var dy = q[1] - p[1];
         var a = (dx * dx - dy * dy) / (dx * dx + dy * dy);
         var b = 2 * dx * dy / (dx * dx + dy * dy);
-        for (var i = 0; i < nodes.length; i++) {
-            var node = nodes[i];
-            var c = projection(node.loc);
-            var c2 = [
+
+        const nodes = utilGetAllNodes(reflectIds, graph);
+        for (const node of nodes) {
+            const c = projection(node.loc);
+            const newLoc = projection.invert([
                 a * (c[0] - p[0]) + b * (c[1] - p[1]) + p[0],
                 b * (c[0] - p[0]) - a * (c[1] - p[1]) + p[1]
-            ];
-            var loc2 = projection.invert(c2);
-            node = node.move(geoVecInterp(node.loc, loc2, t));
-            graph = graph.replace(node);
+            ]);
+            graph = graph.replace(
+                node.move(geoVecInterp(node.loc, newLoc, t)));
         }
 
         return graph;
@@ -59,6 +39,28 @@ export function actionReflect(reflectIds, projection) {
         if (!arguments.length) return _useLongAxis;
         _useLongAxis = val;
         return action;
+    };
+
+
+    action.getReflectAxis = function(graph) {
+        const nodes = utilGetAllNodes(reflectIds, graph);
+        const points = nodes.map(function(n) { return projection(n.loc); });
+        const ssr = geoGetSmallestSurroundingRectangle(points);
+
+        // Choose line pq = axis of symmetry.
+        // The shape's surrounding rectangle has 2 axes of symmetry.
+        // Reflect across the longer axis by default.
+        const p1 = [(ssr.poly[0][0] + ssr.poly[1][0]) / 2, (ssr.poly[0][1] + ssr.poly[1][1]) / 2 ];
+        const q1 = [(ssr.poly[2][0] + ssr.poly[3][0]) / 2, (ssr.poly[2][1] + ssr.poly[3][1]) / 2 ];
+        const p2 = [(ssr.poly[3][0] + ssr.poly[4][0]) / 2, (ssr.poly[3][1] + ssr.poly[4][1]) / 2 ];
+        const q2 = [(ssr.poly[1][0] + ssr.poly[2][0]) / 2, (ssr.poly[1][1] + ssr.poly[2][1]) / 2 ];
+
+        const isLong = (geoVecLength(p1, q1) > geoVecLength(p2, q2));
+        if ((_useLongAxis && isLong) || (!_useLongAxis && !isLong)) {
+            return [p1, q1];
+        } else {
+            return [p2, q2];
+        }
     };
 
 

--- a/modules/operations/reflect.js
+++ b/modules/operations/reflect.js
@@ -74,6 +74,17 @@ export function operationReflect(context, selectedIDs, axis) {
     };
 
 
+    operation.getAuxiliaryGeometry = function() {
+        const graph = context.graph();
+        const [p, q] = _action.getReflectAxis(graph);
+        return [{
+            id: 'axis',
+            path: `M ${p[0]} ${p[1]} L ${q[0]} ${q[1]}`,
+            klass: 'reflect-axis'
+        }];
+    };
+
+
     operation.tooltip = function() {
         var disable = operation.disabled();
         return disable ?
@@ -84,11 +95,6 @@ export function operationReflect(context, selectedIDs, axis) {
 
     operation.annotation = function() {
         return t('operations.reflect.annotation.' + axis + '.feature', { n: selectedIDs.length });
-    };
-
-
-    operation.getReflectAxis = function() {
-        return _action.getReflectAxis(context.graph());
     };
 
 

--- a/modules/operations/reflect.js
+++ b/modules/operations/reflect.js
@@ -1,6 +1,7 @@
 import { t } from '../core/localizer';
 import { actionReflect } from '../actions/reflect';
 import { behaviorOperation } from '../behavior/operation';
+import { geoGetSmallestSurroundingRectangle, geoVecLength } from '../geo';
 import { utilGetAllNodes, utilTotalExtent } from '../util/util';
 
 
@@ -84,6 +85,29 @@ export function operationReflect(context, selectedIDs, axis) {
 
     operation.annotation = function() {
         return t('operations.reflect.annotation.' + axis + '.feature', { n: selectedIDs.length });
+    };
+
+
+    operation.getReflectAxis = function() {
+        if (nodes.length < 3) return null;
+
+        var points = nodes.map(function(n) { return context.projection(n.loc); });
+        var ssr = geoGetSmallestSurroundingRectangle(points);
+
+        // Calculate both potential axes (same logic as actionReflect)
+        var p1 = [(ssr.poly[0][0] + ssr.poly[1][0]) / 2, (ssr.poly[0][1] + ssr.poly[1][1]) / 2];
+        var q1 = [(ssr.poly[2][0] + ssr.poly[3][0]) / 2, (ssr.poly[2][1] + ssr.poly[3][1]) / 2];
+        var p2 = [(ssr.poly[3][0] + ssr.poly[4][0]) / 2, (ssr.poly[3][1] + ssr.poly[4][1]) / 2];
+        var q2 = [(ssr.poly[1][0] + ssr.poly[2][0]) / 2, (ssr.poly[1][1] + ssr.poly[2][1]) / 2];
+
+        var isLong = (geoVecLength(p1, q1) > geoVecLength(p2, q2));
+        var useLongAxis = (axis === 'long');
+
+        if ((useLongAxis && isLong) || (!useLongAxis && !isLong)) {
+            return [p1, q1];
+        } else {
+            return [p2, q2];
+        }
     };
 
 

--- a/modules/operations/reflect.js
+++ b/modules/operations/reflect.js
@@ -1,7 +1,6 @@
 import { t } from '../core/localizer';
 import { actionReflect } from '../actions/reflect';
 import { behaviorOperation } from '../behavior/operation';
-import { geoGetSmallestSurroundingRectangle, geoVecLength } from '../geo';
 import { utilGetAllNodes, utilTotalExtent } from '../util/util';
 
 
@@ -23,11 +22,11 @@ export function operationReflect(context, selectedIDs, axis) {
     var extent = utilTotalExtent(selectedIDs, context.graph());
 
 
-    var operation = function() {
-        var action = actionReflect(selectedIDs, context.projection)
-            .useLongAxis(Boolean(axis === 'long'));
+    var _action = actionReflect(selectedIDs, context.projection)
+        .useLongAxis(Boolean(axis === 'long'));
 
-        context.perform(action, operation.annotation());
+    var operation = function() {
+        context.perform(_action, operation.annotation());
 
         window.setTimeout(function() {
             context.validator().validate();
@@ -89,25 +88,7 @@ export function operationReflect(context, selectedIDs, axis) {
 
 
     operation.getReflectAxis = function() {
-        if (nodes.length < 3) return null;
-
-        var points = nodes.map(function(n) { return context.projection(n.loc); });
-        var ssr = geoGetSmallestSurroundingRectangle(points);
-
-        // Calculate both potential axes (same logic as actionReflect)
-        var p1 = [(ssr.poly[0][0] + ssr.poly[1][0]) / 2, (ssr.poly[0][1] + ssr.poly[1][1]) / 2];
-        var q1 = [(ssr.poly[2][0] + ssr.poly[3][0]) / 2, (ssr.poly[2][1] + ssr.poly[3][1]) / 2];
-        var p2 = [(ssr.poly[3][0] + ssr.poly[4][0]) / 2, (ssr.poly[3][1] + ssr.poly[4][1]) / 2];
-        var q2 = [(ssr.poly[1][0] + ssr.poly[2][0]) / 2, (ssr.poly[1][1] + ssr.poly[2][1]) / 2];
-
-        var isLong = (geoVecLength(p1, q1) > geoVecLength(p2, q2));
-        var useLongAxis = (axis === 'long');
-
-        if ((useLongAxis && isLong) || (!useLongAxis && !isLong)) {
-            return [p1, q1];
-        } else {
-            return [p2, q2];
-        }
+        return _action.getReflectAxis(context.graph());
     };
 
 

--- a/modules/renderer/background_source.js
+++ b/modules/renderer/background_source.js
@@ -1,6 +1,5 @@
 import { geoArea as d3_geoArea, geoMercatorRaw as d3_geoMercatorRaw } from 'd3-geo';
 import { json as d3_json } from 'd3-fetch';
-import { escape } from 'lodash-es';
 
 import { t, localizer } from '../core/localizer';
 import { geoExtent, geoSphericalDistance } from '../geo';
@@ -69,26 +68,26 @@ export function rendererBackgroundSource(data) {
 
     source.name = function() {
         var id_safe = source.id.replace(/\./g, '<TX_DOT>');
-        return t('imagery.' + id_safe + '.name', { default: escape(_name) });
+        return t('imagery.' + id_safe + '.name', { default: _name });
     };
 
 
     source.label = function() {
         var id_safe = source.id.replace(/\./g, '<TX_DOT>');
-        return t.append('imagery.' + id_safe + '.name', { default: escape(_name) });
+        return t.append('imagery.' + id_safe + '.name', { default: _name });
     };
 
 
     source.hasDescription = function() {
         var id_safe = source.id.replace(/\./g, '<TX_DOT>');
-        var descriptionText = localizer.tInfo('imagery.' + id_safe + '.description', { default: escape(_description) }).text;
+        var descriptionText = localizer.tInfo('imagery.' + id_safe + '.description', { default: _description }).text;
         return descriptionText !== '';
     };
 
 
     source.description = function() {
         var id_safe = source.id.replace(/\./g, '<TX_DOT>');
-        return t.append('imagery.' + id_safe + '.description', { default: escape(_description) });
+        return t.append('imagery.' + id_safe + '.description', { default: _description });
     };
 
 

--- a/modules/svg/osm.js
+++ b/modules/svg/osm.js
@@ -4,7 +4,7 @@ export function svgOsm(projection, context, dispatch) {
 
     function drawOsm(selection) {
         selection.selectAll('.layer-osm')
-            .data(['covered', 'areas', 'lines', 'points', 'labels'])
+            .data(['covered', 'areas', 'lines', 'points', 'auxiliary', 'labels'])
             .enter()
             .append('g')
             .attr('class', function(d) { return 'layer-osm ' + d; });

--- a/modules/ui/edit_menu.js
+++ b/modules/ui/edit_menu.js
@@ -10,6 +10,34 @@ import { utilGetDimensions } from '../util/dimensions';
 import { svgIcon } from '../svg/icon';
 
 
+// Helper function to draw/remove reflect axis overlay
+function drawReflectAxis(context, axisPoints, show) {
+    var surface = context.surface();
+    // Append to the OSM data layer to be in the same coordinate space as map features
+    var dataLayer = surface.selectAll('.data-layer.osm');
+    var axis = surface.selectAll('.reflect-axis-overlay');
+
+    if (!show || !axisPoints) {
+        axis.remove();
+        return;
+    }
+
+    // Create or update the axis line
+    if (axis.empty()) {
+        // Append to dataLayer if it exists, otherwise fall back to surface
+        var parent = dataLayer.empty() ? surface : dataLayer;
+        axis = parent.append('line')
+            .attr('class', 'reflect-axis-overlay');
+    }
+
+    axis
+        .attr('x1', axisPoints[0][0])
+        .attr('y1', axisPoints[0][1])
+        .attr('x2', axisPoints[1][0])
+        .attr('y2', axisPoints[1][1]);
+}
+
+
 export function uiEditMenu(context) {
     var dispatch = d3_dispatch('toggled');
 
@@ -93,14 +121,26 @@ export function uiEditMenu(context) {
                 d3_event.stopPropagation();
             })
             .on('mouseenter.highlight', function(d3_event, d) {
-                if (!d.relatedEntityIds || d3_select(this).classed('disabled')) return;
+                if (d3_select(this).classed('disabled')) return;
 
-                utilHighlightEntities(d.relatedEntityIds(), true, context);
+                if (d.relatedEntityIds) {
+                    utilHighlightEntities(d.relatedEntityIds(), true, context);
+                }
+
+                // Draw axis for reflect operations
+                if (d.getReflectAxis) {
+                    drawReflectAxis(context, d.getReflectAxis(), true);
+                }
             })
             .on('mouseleave.highlight', function(d3_event, d) {
-                if (!d.relatedEntityIds) return;
+                if (d.relatedEntityIds) {
+                    utilHighlightEntities(d.relatedEntityIds(), false, context);
+                }
 
-                utilHighlightEntities(d.relatedEntityIds(), false, context);
+                // Remove axis overlay for reflect operations
+                if (d.getReflectAxis) {
+                    drawReflectAxis(context, null, false);
+                }
             });
 
         buttonsEnter.each(function(d) {
@@ -155,6 +195,11 @@ export function uiEditMenu(context) {
 
             if (operation.relatedEntityIds) {
                 utilHighlightEntities(operation.relatedEntityIds(), false, context);
+            }
+
+            // Clean up axis overlay for reflect operations
+            if (operation.getReflectAxis) {
+                drawReflectAxis(context, null, false);
             }
 
             if (operation.disabled()) {
@@ -295,6 +340,9 @@ export function uiEditMenu(context) {
 
         _menu.remove();
         _tooltips = [];
+
+        // Clean up any reflect axis overlay
+        drawReflectAxis(context, null, false);
 
         dispatch.call('toggled', this, false);
     };

--- a/modules/ui/edit_menu.js
+++ b/modules/ui/edit_menu.js
@@ -10,34 +10,6 @@ import { utilGetDimensions } from '../util/dimensions';
 import { svgIcon } from '../svg/icon';
 
 
-// Helper function to draw/remove reflect axis overlay
-function drawReflectAxis(context, axisPoints, show) {
-    var surface = context.surface();
-    // Append to the OSM data layer to be in the same coordinate space as map features
-    var dataLayer = surface.selectAll('.data-layer.osm');
-    var axis = surface.selectAll('.reflect-axis-overlay');
-
-    if (!show || !axisPoints) {
-        axis.remove();
-        return;
-    }
-
-    // Create or update the axis line
-    if (axis.empty()) {
-        // Append to dataLayer if it exists, otherwise fall back to surface
-        var parent = dataLayer.empty() ? surface : dataLayer;
-        axis = parent.append('line')
-            .attr('class', 'reflect-axis-overlay');
-    }
-
-    axis
-        .attr('x1', axisPoints[0][0])
-        .attr('y1', axisPoints[0][1])
-        .attr('x2', axisPoints[1][0])
-        .attr('y2', axisPoints[1][1]);
-}
-
-
 export function uiEditMenu(context) {
     var dispatch = d3_dispatch('toggled');
 
@@ -127,9 +99,8 @@ export function uiEditMenu(context) {
                     utilHighlightEntities(d.relatedEntityIds(), true, context);
                 }
 
-                // Draw axis for reflect operations
-                if (d.getReflectAxis) {
-                    drawReflectAxis(context, d.getReflectAxis(), true);
+                if (d.getAuxiliaryGeometry) {
+                    drawAuxiliaryGeometry(context, d.getAuxiliaryGeometry());
                 }
             })
             .on('mouseleave.highlight', function(d3_event, d) {
@@ -137,9 +108,8 @@ export function uiEditMenu(context) {
                     utilHighlightEntities(d.relatedEntityIds(), false, context);
                 }
 
-                // Remove axis overlay for reflect operations
-                if (d.getReflectAxis) {
-                    drawReflectAxis(context, null, false);
+                if (d.getAuxiliaryGeometry) {
+                    drawAuxiliaryGeometry(context, []);
                 }
             });
 
@@ -195,11 +165,6 @@ export function uiEditMenu(context) {
 
             if (operation.relatedEntityIds) {
                 utilHighlightEntities(operation.relatedEntityIds(), false, context);
-            }
-
-            // Clean up axis overlay for reflect operations
-            if (operation.getReflectAxis) {
-                drawReflectAxis(context, null, false);
             }
 
             if (operation.disabled()) {
@@ -341,8 +306,8 @@ export function uiEditMenu(context) {
         _menu.remove();
         _tooltips = [];
 
-        // Clean up any reflect axis overlay
-        drawReflectAxis(context, null, false);
+        // Clean up any auxiliary overlays
+        drawAuxiliaryGeometry(context, []);
 
         dispatch.call('toggled', this, false);
     };
@@ -367,4 +332,22 @@ export function uiEditMenu(context) {
     };
 
     return utilRebind(editMenu, dispatch, 'on');
+}
+
+
+// Helper function to draw/remove reflect axis overlay
+function drawAuxiliaryGeometry(context, d) {
+    const surface = context.surface();
+    // Append to the OSM data layer to be in the same coordinate space as map features
+    const container = surface.selectAll('.data-layer.osm .auxiliary');
+    const paths = container.selectAll('path')
+        .data(d, d => d.id);
+
+    paths.exit().remove();
+    const enter = paths.enter()
+        .append('path');
+
+    enter.merge(paths)
+        .attr('class', d => d.klass)
+        .attr('d', d => d.path);
 }

--- a/modules/ui/init.js
+++ b/modules/ui/init.js
@@ -671,6 +671,8 @@ export function uiInit(context) {
     };
 
     ui.closeEditMenu = function() {
+        // try to regularly close the edit menu
+        _editMenu.close();
         // remove any existing menu no matter how it was added
         if (overMap !== undefined) {
             overMap.select('.edit-menu').remove();

--- a/test/spec/svg/osm.js
+++ b/test/spec/svg/osm.js
@@ -8,12 +8,13 @@ describe('iD.svgOsm', function () {
     it('creates default osm layers', function () {
         container.call(iD.svgOsm());
         var layers = container.selectAll('g.layer-osm').nodes();
-        expect(layers.length).to.eql(5);
+        expect(layers.length).to.eql(6);
         expect(d3.select(layers[0]).classed('covered')).to.be.true;
         expect(d3.select(layers[1]).classed('areas')).to.be.true;
         expect(d3.select(layers[2]).classed('lines')).to.be.true;
         expect(d3.select(layers[3]).classed('points')).to.be.true;
-        expect(d3.select(layers[4]).classed('labels')).to.be.true;
+        expect(d3.select(layers[4]).classed('auxiliary')).to.be.true;
+        expect(d3.select(layers[5]).classed('labels')).to.be.true;
     });
 
     it('creates default osm point layers', function () {


### PR DESCRIPTION
closes #11769
Display a dashed line indicating the flip axis when hovering over
Flip Long or Flip Short menu items Helps users visualize the
transformation before applying it

<img width="710" height="569" alt="image" src="https://github.com/user-attachments/assets/efde89da-892c-469c-83ad-02e6e205044d" />
<img width="737" height="535" alt="image" src="https://github.com/user-attachments/assets/491c3903-3371-4484-b0bb-16029ebb6691" />
