### PR TITLE
fix: Rename merge operation title to "Merge (combine)" in keyboard shortcuts

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -313,7 +313,7 @@ en:
       connected_to_hidden: This can't be disconnected because it is connected to a hidden feature.
       relation: This can't be disconnected because it connects members of a relation.
     merge:
-      title: Merge
+      title: Merge (combine)
       description: Merge these features.
       key: C
       annotation:


### PR DESCRIPTION
fixes #11557

### Description
Updates the keyboard shortcuts list entry for the merge operation from "Merge" to "Merge (combine)". This improves discoverability while keeping "Merge" as the primary, more intuitive name.

### Changes
- Updated merge operation title in `data/core.yaml` from "Merge" to "Merge (combine)"
- Users can now search for either "merge" or "combine" when looking for this operation
- Maintains consistency with existing help text that refers to "combining" features

### Testing
- [x] Keyboard shortcuts list displays "C Merge (combine)"
- [x] Help text for merge operation correctly references the updated title
- [x] npm test passes
- [x] npm start shows correct UI rendering

### Checklist
- [x] Code change is complete
- [x] Tests pass
- [ ] CHANGELOG.md updated (if applicable)