### PR TITLE
tag values with wiki page may be documented as bad

### DIFF
--- a/modules/services/taginfo.js
+++ b/modules/services/taginfo.js
@@ -97,7 +97,7 @@ function filterValues(allowUpperCase, key) {
         if (!allowUpperCase &&
             !(key === 'type' && d.value === 'associatedStreet') &&
             d.value.match(/[A-Z*]/) !== null) return false;  // exclude uppercase letters
-        return d.count > 100 || d.in_wiki; // exclude rare undocumented tags
+        return d.count > 100; // exclude rare tags
     };
 }
 


### PR DESCRIPTION
fixes #5460 again (admittedly, iD is not suggesting `highway=unsurfaced` again so it is less bad than it used to be)

redo of #5461

amends a2cacaaf2456de4c8443a7b5dab0ac3393be5deb