### PR TITLE
fixes rare tag value auto suggestions (fix #11782)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 
 #### :sparkles: Usability & Accessibility
 * Don't suggest values from Taginfo for `addr:*` tags ([#11733], thanks [@k-yle])
+* Don't suggest values from Taginfo for tags with less than 100 uses, even if they're documented on the wiki ([#11794], thanks [@Kaushik4141])
 #### :scissors: Operations
 * Display reflection axis on the map while hovering the reflection operations in the edit menu ([#11774], thanks [@Kaushik4141])
 #### :camera: Street-Level
@@ -66,6 +67,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#11760]: https://github.com/openstreetmap/iD/pull/11760
 [#11774]: https://github.com/openstreetmap/iD/pull/11774
 [#11784]: https://github.com/openstreetmap/iD/pull/11784
+[#11794]: https://github.com/openstreetmap/iD/pull/11794
 [@ilias52730]: https://github.com/ilias52730
 [@Razen04]: https://github.com/Razen04
 [@homersimpsons]: https://github.com/homersimpsons

--- a/modules/services/taginfo.js
+++ b/modules/services/taginfo.js
@@ -97,7 +97,7 @@ function filterValues(allowUpperCase, key) {
         if (!allowUpperCase &&
             !(key === 'type' && d.value === 'associatedStreet') &&
             d.value.match(/[A-Z*]/) !== null) return false;  // exclude uppercase letters
-        return d.count > 100 || d.in_wiki; // exclude rare undocumented tags
+        return d.count > 100; // exclude rare undocumented tags
     };
 }
 

--- a/test/spec/services/taginfo.js
+++ b/test/spec/services/taginfo.js
@@ -256,7 +256,7 @@ describe('iD.serviceTaginfo', function() {
             }));
         });
 
-        it('includes unpopular values with a wiki page', async () => {
+        it('excludes unpopular values even if they have a wiki page', async () => {
             fetchMock.mock(/\/key\/values/, {
                 body: '{"data":[{"value":"party","description":"A place for partying", "count":1, "in_wiki": true}]}',
                 status: 200,
@@ -268,7 +268,7 @@ describe('iD.serviceTaginfo', function() {
 
             await setTimeout(50);
             expect(callback).to.have.been.calledWith(
-                null, [{'value':'party','title':'A place for partying'}]
+                null, []
             );
         });
 


### PR DESCRIPTION

Removed d.in_wiki from the filter condition for tag values in modules/services/taginfo.js
Updated test/spec/services/taginfo.js to ensure unpopular values with a wiki page are now excluded from suggestions
<img width="451" height="195" alt="image" src="https://github.com/user-attachments/assets/38ed84e0-73e5-44ac-b5f2-a927763c45c3" />


Fixes #11782 and replaces #11781