### PR TITLE
Fix search bar autofocus after drawing

### DIFF
--- a/modules/ui/inspector.js
+++ b/modules/ui/inspector.js
@@ -87,7 +87,7 @@ export function uiInspector(context) {
             wrap.style('right', '-100%');
             editorPane.classed('hide', true);
             presetPane.classed('hide', false)
-                .call(presetList.autofocus(false));
+                .call(presetList.autofocus(_newFeature));
         } else {
             wrap.style('right', '0%');
             presetPane.classed('hide', true);

--- a/modules/ui/inspector.js
+++ b/modules/ui/inspector.js
@@ -87,7 +87,7 @@ export function uiInspector(context) {
             wrap.style('right', '-100%');
             editorPane.classed('hide', true);
             presetPane.classed('hide', false)
-                .call(presetList.autofocus(_newFeature));
+                .call(presetList);
         } else {
             wrap.style('right', '0%');
             presetPane.classed('hide', true);


### PR DESCRIPTION
Restore keyboard focus to the search bar after completing the drawing
of a point, line, or area so users can immediately filter presets.

Use the _newFeature flag to distinguish:
- New features from drawing: autofocus enabled
- Existing untagged vertices: autofocus disabled

Fixes #11793
