### PR TITLE
The preset list items now correctly scroll into the view when clicked

### DIFF
--- a/modules/ui/preset_list.js
+++ b/modules/ui/preset_list.js
@@ -361,6 +361,33 @@ export function uiPresetList(context) {
                 shown = true;
                 var members = preset.members.matchAllGeometry(entityGeometries());
                 sublist.call(drawList, members);
+
+                requestAnimationFrame(() => {
+                    const container = box.node().closest('.inspector-body');
+                    if (!container) return;
+
+                    const childItems = box.node().querySelectorAll('.preset-list-item');
+                    if (!childItems.length) return;
+
+                    const target = childItems[Math.min(1, childItems.length - 1)];
+
+                    const targetRect = target.getBoundingClientRect();
+                    const containerRect = container.getBoundingClientRect();
+
+                    const notVisible =
+                        targetRect.top < containerRect.top ||
+                        targetRect.bottom > containerRect.bottom;
+
+                    if (notVisible) {
+                        target.scrollIntoView({
+                            block: 'nearest',
+                            behavior: 'smooth'
+                        });
+                    }
+                });
+
+
+
                 box.transition()
                     .duration(200)
                     .style('opacity', '1')


### PR DESCRIPTION
## Fix preset list scrolling behaviour on category expand

**Fixes:** openstreetmap/iD#11762

### Description

This PR resolves an issue where expanding a category in the preset list did not scroll newly revealed child items into view. This could be confusing, as it was not immediately clear that additional presets had appeared.

With this change:

- When a category expands, the first visible child presets are automatically scrolled into view within `.inspector-body`.
- This provides immediate visual feedback that the expansion action succeeded.
- Improves usability when interacting with long or deeply nested preset lists.

### Implementation

- Detects the expanded `.subgrid` element after layout has completed.
- Checks whether child preset items fall outside the visible viewport of `.inspector-body`.
- Scrolls the first relevant child item(s) into view when necessary.
- Uses `requestAnimationFrame` to ensure DOM measurements occur after expansion.
- Uses `scrollIntoView({ block: 'nearest' })` to avoid excessive or jarring scroll jumps.

### How to test

1. Open the preset inspector for an area with nested presets (e.g. **Natural Features**).
2. Scroll near the bottom of the preset list.
3. Expand a category.
4. Verify that the first newly revealed child preset(s) are automatically scrolled into view.

### Demo

![v-sub](https://github.com/user-attachments/assets/33ffe87f-47c9-4472-a550-0ab173908313)

### Checklist

- [x] Tested manually in supported browsers
- [x] No regressions introduced in inspector navigation
- [x] Code follows project style guidelines
