### PR TITLE
Support point feature creation via query paramters

### DIFF
--- a/modules/core/context.js
+++ b/modules/core/context.js
@@ -21,6 +21,7 @@ import { rendererBackground, rendererFeatures, rendererMap, rendererPhotos } fro
 import { services } from '../services';
 import { uiInit } from '../ui/init';
 import { utilKeybinding, utilRebind, utilStringQs, utilCleanOsmString } from '../util';
+import {osmNode} from '../osm';
 
 
 export function coreContext() {
@@ -250,6 +251,27 @@ export function coreContext() {
   context.cleanTagValue = (val) => utilCleanOsmString(val, context.maxCharsForTagValue());
   context.cleanRelationRole = (val) => utilCleanOsmString(val, context.maxCharsForRelationRole());
 
+  // Inspect URL to see if there is a request to add a point feature using query parameters.
+  const urlParams = new URLSearchParams(window.location.search);
+  if (urlParams.get('add_point')) {
+    const newPoint = osmNode({
+      loc: [parseFloat(urlParams.get('lon')), parseFloat(urlParams.get('lat'))],
+      tags: {}
+    });
+    // Extract all query parameters as tag values (excluding special ones)
+    for (const [key, value] of urlParams.entries()) {
+      if (!['add_point', 'lat', 'lon'].includes(key)) {
+        newPoint.tags[key] = decodeURIComponent(value);
+      }
+    }
+    if (newPoint.isDegenerate()) {
+      /* eslint-disable no-console */
+      console.error('invalid lat/lon supplied in query parameters');
+      /* eslint-enable no-console */
+    } else {
+      context.pendingAddPoint = newPoint;
+    }
+  }
 
   /* History */
   let _inIntro = false;

--- a/modules/modes/browse.js
+++ b/modules/modes/browse.js
@@ -9,6 +9,8 @@ import { modeDragNode } from './drag_node';
 import { modeDragNote } from './drag_note';
 
 import { operationPaste } from '../operations/paste';
+import {actionAddEntity} from '../actions';
+import {modeSelect} from './select';
 
 export function modeBrowse(context) {
     var mode = {
@@ -53,6 +55,20 @@ export function modeBrowse(context) {
             context.ui().sidebar.show(sidebar);
         } else {
             context.ui().sidebar.select(null);
+        }
+
+        // Check for pending point creation
+        if (context.pendingAddPoint) {
+            context.map().centerZoom(context.pendingAddPoint.loc, 18);
+            setTimeout(() => {
+                context.perform(
+                  actionAddEntity(context.pendingAddPoint),
+                  t('operations.add.annotation.point')
+                );
+                context.enter(modeSelect(context, [context.pendingAddPoint.id]));
+                context.ui().sidebar.select([context.pendingAddPoint.id]);
+                context.pendingAddPoint = null;
+            }, 500);
         }
     };
 


### PR DESCRIPTION

I like the web editor. Not everyone is a JOSM warrior. I might have some data that I have collected and wish to curate in OSM using the web editor. I don't like typing. Perhaps I can create a series of URLs such as:

``
http://localhost:8080/?add_point=true&lat=57.1436&lon=-2.0970&name=Tasty&shop=bakery
``

It's a contrived example. More likely it would be a sequence of URLs with richer parameters, but you get the idea. I bootstrap myself into the web editor and can take it from there.

Tested on Chrome and Firefox.

My first iD PR. I gave read guidelines and hopefully done my best :-)