### PR TITLE
Add standard keyboard scrolling to member list

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -2877,6 +2877,13 @@ img.tag-reference-wiki-image {
 .section-raw-membership-editor .member-list {
     position: relative; /* required for drag-and-drop */
     padding-top: 5px;
+    overflow-y: auto;
+    max-height: 400px;
+}
+.section-raw-member-editor .member-list:focus,
+.section-raw-membership-editor .member-list:focus {
+    outline: 2px solid #0066ff;
+    outline-offset: -2px;
 }
 .section-raw-member-editor .member-list li,
 .section-raw-membership-editor .member-list li {

--- a/modules/ui/sections/raw_member_editor.js
+++ b/modules/ui/sections/raw_member_editor.js
@@ -144,6 +144,12 @@ export function uiSectionRawMemberEditor(context) {
         list = list.enter()
             .append('ul')
             .attr('class', 'member-list')
+            .attr('tabindex', '0')
+            .on('mousedown.memberlist', function() {
+                this.focus();
+                d3_event.stopPropagation();
+            })
+            .on('keydown.memberlist', handleListKeydown)
             .merge(list);
 
 
@@ -389,6 +395,45 @@ export function uiSectionRawMemberEditor(context) {
                     role.property('value', origValue);
                 })
             );
+        }
+
+
+        function handleListKeydown(d3_event) {
+            d3_event.preventDefault();
+            d3_event.stopImmediatePropagation();
+
+            // Only handle navigation keys when list is focused
+            if (!['PageDown', 'PageUp', 'End', 'Home', 'ArrowDown', 'ArrowUp'].includes(d3_event.key)) {
+                return;
+            }
+
+            var listNode = d3_select(this).node();
+            if (!listNode) return;
+
+            var listHeight = listNode.clientHeight;
+            var scrollTop = listNode.scrollTop;
+            var scrollHeight = listNode.scrollHeight;
+
+            switch(d3_event.key) {
+                case 'PageDown':
+                    listNode.scrollTop = Math.min(scrollTop + listHeight, scrollHeight - listHeight);
+                    break;
+                case 'PageUp':
+                    listNode.scrollTop = Math.max(scrollTop - listHeight, 0);
+                    break;
+                case 'End':
+                    listNode.scrollTop = scrollHeight;
+                    break;
+                case 'Home':
+                    listNode.scrollTop = 0;
+                    break;
+                case 'ArrowDown':
+                    listNode.scrollTop = Math.min(scrollTop + 40, scrollHeight - listHeight);
+                    break;
+                case 'ArrowUp':
+                    listNode.scrollTop = Math.max(scrollTop - 40, 0);
+                    break;
+            }
         }
 
 

--- a/modules/ui/sections/raw_member_editor.js
+++ b/modules/ui/sections/raw_member_editor.js
@@ -145,9 +145,9 @@ export function uiSectionRawMemberEditor(context) {
             .append('ul')
             .attr('class', 'member-list')
             .attr('tabindex', '0')
-            .on('mousedown.memberlist', function() {
+            .on('mousedown.memberlist', function(event) {
                 this.focus();
-                d3_event.stopPropagation();
+                event.stopPropagation();
             })
             .on('keydown.memberlist', handleListKeydown)
             .merge(list);
@@ -398,12 +398,12 @@ export function uiSectionRawMemberEditor(context) {
         }
 
 
-        function handleListKeydown(d3_event) {
-            d3_event.preventDefault();
-            d3_event.stopImmediatePropagation();
+        function handleListKeydown(event) {
+            event.preventDefault();
+            event.stopImmediatePropagation();
 
             // Only handle navigation keys when list is focused
-            if (!['PageDown', 'PageUp', 'End', 'Home', 'ArrowDown', 'ArrowUp'].includes(d3_event.key)) {
+            if (!['PageDown', 'PageUp', 'End', 'Home', 'ArrowDown', 'ArrowUp'].includes(event.key)) {
                 return;
             }
 
@@ -414,7 +414,7 @@ export function uiSectionRawMemberEditor(context) {
             var scrollTop = listNode.scrollTop;
             var scrollHeight = listNode.scrollHeight;
 
-            switch(d3_event.key) {
+            switch (event.key) {
                 case 'PageDown':
                     listNode.scrollTop = Math.min(scrollTop + listHeight, scrollHeight - listHeight);
                     break;

--- a/modules/ui/sections/raw_membership_editor.js
+++ b/modules/ui/sections/raw_membership_editor.js
@@ -366,9 +366,9 @@ export function uiSectionRawMembershipEditor(context) {
             .append('ul')
             .attr('class', 'member-list')
             .attr('tabindex', '0')
-            .on('mousedown.memberlist', function() {
+            .on('mousedown.memberlist', function(event) {
                 this.focus();
-                d3_event.stopPropagation();
+                event.stopPropagation();
             })
             .on('keydown.memberlist', handleListKeydown)
             .merge(list);
@@ -665,12 +665,12 @@ export function uiSectionRawMembershipEditor(context) {
         }
 
 
-        function handleListKeydown(d3_event) {
-            d3_event.preventDefault();
-            d3_event.stopImmediatePropagation();
+        function handleListKeydown(event) {
+            event.preventDefault();
+            event.stopImmediatePropagation();
 
             // Only handle navigation keys when list is focused
-            if (!['PageDown', 'PageUp', 'End', 'Home', 'ArrowDown', 'ArrowUp'].includes(d3_event.key)) {
+            if (!['PageDown', 'PageUp', 'End', 'Home', 'ArrowDown', 'ArrowUp'].includes(event.key)) {
                 return;
             }
 
@@ -681,7 +681,7 @@ export function uiSectionRawMembershipEditor(context) {
             var scrollTop = listNode.scrollTop;
             var scrollHeight = listNode.scrollHeight;
 
-            switch(d3_event.key) {
+            switch (event.key) {
                 case 'PageDown':
                     listNode.scrollTop = Math.min(scrollTop + listHeight, scrollHeight - listHeight);
                     break;

--- a/modules/ui/sections/raw_membership_editor.js
+++ b/modules/ui/sections/raw_membership_editor.js
@@ -365,6 +365,12 @@ export function uiSectionRawMembershipEditor(context) {
         list = list.enter()
             .append('ul')
             .attr('class', 'member-list')
+            .attr('tabindex', '0')
+            .on('mousedown.memberlist', function() {
+                this.focus();
+                d3_event.stopPropagation();
+            })
+            .on('keydown.memberlist', handleListKeydown)
             .merge(list);
 
 
@@ -656,6 +662,45 @@ export function uiSectionRawMembershipEditor(context) {
                     role.property('value', origValue);
                 })
             );
+        }
+
+
+        function handleListKeydown(d3_event) {
+            d3_event.preventDefault();
+            d3_event.stopImmediatePropagation();
+
+            // Only handle navigation keys when list is focused
+            if (!['PageDown', 'PageUp', 'End', 'Home', 'ArrowDown', 'ArrowUp'].includes(d3_event.key)) {
+                return;
+            }
+
+            var listNode = d3_select(this).node();
+            if (!listNode) return;
+
+            var listHeight = listNode.clientHeight;
+            var scrollTop = listNode.scrollTop;
+            var scrollHeight = listNode.scrollHeight;
+
+            switch(d3_event.key) {
+                case 'PageDown':
+                    listNode.scrollTop = Math.min(scrollTop + listHeight, scrollHeight - listHeight);
+                    break;
+                case 'PageUp':
+                    listNode.scrollTop = Math.max(scrollTop - listHeight, 0);
+                    break;
+                case 'End':
+                    listNode.scrollTop = scrollHeight;
+                    break;
+                case 'Home':
+                    listNode.scrollTop = 0;
+                    break;
+                case 'ArrowDown':
+                    listNode.scrollTop = Math.min(scrollTop + 40, scrollHeight - listHeight);
+                    break;
+                case 'ArrowUp':
+                    listNode.scrollTop = Math.max(scrollTop - 40, 0);
+                    break;
+            }
         }
 
 


### PR DESCRIPTION
### Summary
Adds standard keyboard scrolling behavior to the member list so arrow and page navigation keys scroll the list instead of moving the map.

### Changes
- Enable keyboard focus on member list
- Handle ArrowUp / ArrowDown / PageUp / PageDown / Home / End
- Prevent map movement while list is focused
- Add visible focus outline for accessibility

### Before
- Arrow and page keys moved the map instead of scrolling the relations list.
<img width="410" height="860" alt="before" src="https://github.com/user-attachments/assets/5659a16f-8490-4c83-9e92-2945ee030870" />


### After
- Relations list captures keyboard focus and scrolls independently without moving the map.
<img width="410" height="860" alt="after" src="https://github.com/user-attachments/assets/555811fc-6f28-4e28-b9df-dcecd520555e" />

### Notes
Improves keyboard accessibility and aligns the member list with standard sidebar scrolling behavior.