### PR TITLE
Prevent unused slots in the recent preset list.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Replace deprecated `document.createEvent`/`initEvent` with modern Event constructor ([#11871], thanks [@JaiswalShivang])
 * Fix crash in country combo field when entering unrecognized ISO country codes ([#11904], thanks [@JaiswalShivang])
 * Upgrade clipboard functionality with modern Clipboard API ([#11869], thanks [@tulavamsidheeraj])
+* Ensure the recent presets list is always full by filtering for location before limiting the count. ([#11405], thanks [@Razen04])
 
 
 [#8464]: https://github.com/openstreetmap/iD/issues/8464
@@ -190,6 +191,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [ffc7e2135]: https://github.com/openstreetmap/iD/commit/ffc7e2135
 [be0a20e59]: https://github.com/openstreetmap/iD/commit/be0a20e59
 [b06496780]: https://github.com/openstreetmap/iD/commit/b06496780
+[#11405]: https://github.com/openstreetmap/iD/issues/11405
 [#id-tagging-schema/pull/1507]: https://github.com/openstreetmap/id-tagging-schema/pull/1507
 [@ilias52730]: https://github.com/ilias52730
 [@Razen04]: https://github.com/Razen04

--- a/modules/presets/index.js
+++ b/modules/presets/index.js
@@ -410,9 +410,14 @@ export function presetIndex() {
 
 
   _this.defaults = (geometry, n, startWithRecents, loc, extraPresets) => {
+    const validHere = Array.isArray(loc) ? locationManager.locationSetsAt(loc) : null;
+
     let recents = [];
     if (startWithRecents) {
-      recents = _this.recent().matchGeometry(geometry).collection.slice(0, MAX_RECENTS_TO_SHOW);
+        // filtering before slicing to prevent unused slots in the recent preset list, issue #11405
+        recents = _this.recent().matchGeometry(geometry).collection
+        .filter(a => !a.locationSetID || (validHere && validHere[a.locationSetID]))
+        .slice(0, MAX_RECENTS_TO_SHOW);
     }
 
     let defaults;
@@ -421,7 +426,9 @@ export function presetIndex() {
         var preset = _this.item(id);
         if (preset && preset.matchGeometry(geometry)) return preset;
         return null;
-      }).filter(Boolean);
+      })
+        .filter(Boolean)
+        .filter(a => !a.locationSetID || validHere[a.locationSetID]);
     } else {
       defaults = _defaults[geometry].collection.concat(_this.fallback(geometry));
     }
@@ -429,11 +436,6 @@ export function presetIndex() {
     let result = presetCollection(
       utilArrayUniq(recents.concat(defaults).concat(extraPresets || [])).slice(0, n - 1)
     );
-
-    if (Array.isArray(loc)) {
-      const validHere = locationManager.locationSetsAt(loc);
-      result.collection = result.collection.filter(a => !a.locationSetID || validHere[a.locationSetID]);
-    }
 
     return result;
   };

--- a/test/spec/presets/index.js
+++ b/test/spec/presets/index.js
@@ -428,7 +428,7 @@ describe('iD.presetIndex', function () {
     });
 
     describe('PresetIndex.recents', () => {
-        it('fills all recent slots by filtering before slicing (#11405)', () => {
+        it('fills all recent slots even when some remembered presets are not available in the current region (#11405)', () => {
             const testIndex = presetIndex();
 
             locationManager.locationSetsAt = () => ({ 'world': true, 'us_only': false });

--- a/test/spec/presets/index.js
+++ b/test/spec/presets/index.js
@@ -1,3 +1,5 @@
+import { locationManager, presetIndex } from '../../../modules';
+
 describe('iD.presetIndex', function () {
     var _savedPresets, _savedAreaKeys;
 
@@ -422,6 +424,36 @@ describe('iD.presetIndex', function () {
                 [200, { 'Content-Type': 'application/json' }, JSON.stringify(presetData)]
             );
             _server.respond();
+        });
+    });
+
+    describe('PresetIndex.recents', () => {
+        it('fills all recent slots by filtering before slicing (#11405)', () => {
+            const testIndex = presetIndex();
+
+            locationManager.locationSetsAt = () => ({ 'world': true, 'us_only': false });
+
+            const p1 = { id: 'p1', matchGeometry: () => true, locationSetID: 'world' };
+            const p2 = { id: 'p2', matchGeometry: () => true, locationSetID: 'us_only' }; // Invalid
+            const p3 = { id: 'p3', matchGeometry: () => true, locationSetID: 'world' };
+            const p4 = { id: 'p4', matchGeometry: () => true, locationSetID: 'us_only' }; // Invalid
+            const p5 = { id: 'p5', matchGeometry: () => true, locationSetID: 'world' };
+
+            testIndex.recent = () => ({
+                matchGeometry: () => ({
+                    collection: [p1, p2, p3, p4, p5]
+                })
+            });
+
+            const locCoords = [0, 51];
+            const result = testIndex.defaults('point', 10, true, locCoords);
+
+            const ids = result.collection.map(p => p.id);
+
+            expect(ids).to.include('p5');
+            expect(ids).to.not.include('p2');
+            expect(ids).to.not.include('p4');
+            expect(ids.slice(0, 3)).to.eql(['p1', 'p3', 'p5']);
         });
     });
 


### PR DESCRIPTION
Fixes #11405 

Filtering before slicing prevents the unused slots in the recent preset list, more detail about this in #11405 

If we wish to show the Motorway Link and others in the US and CA in the recent list, we can just prevent filtering the recent list based on location, I have already commented in the issue everything [here](https://github.com/openstreetmap/iD/issues/11405#issuecomment-3796540428).
