### PR TITLE
Fix duplicate parking:left:capacity in osmSummableTags

### DIFF
--- a/modules/osm/tags.js
+++ b/modules/osm/tags.js
@@ -388,5 +388,5 @@ export var osmSummableTags = new Set([
     'step_count',
     'parking:both:capacity',
     'parking:left:capacity',
-    'parking:left:capacity'
+    'parking:right:capacity'
 ]);


### PR DESCRIPTION
Fixes #11819

Replaces the duplicated `parking:left:capacity` entry with
`parking:right:capacity` in osmSummableTags.
