### PR TITLE
#11775 Validation: Remove layer fixes for building overlaps, encourage geometry fix instead

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1811,7 +1811,8 @@ en:
       aeroway-waterway:
         reference: "Aeroways crossing waterways should use tunnels."
       building-building:
-        reference: "Buildings should not intersect except on different layers."
+        message: "Buildings should not intersect. If they are vertically stacked, please use the level tag instead of layer."
+        reference: "Buildings should not intersect. If they are vertically stacked, please use the **level** tag instead of **layer**."
       building-highway:
         reference: "Highways crossing buildings should use bridges, tunnels, or different layers."
       building-railway:

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1811,8 +1811,7 @@ en:
       aeroway-waterway:
         reference: "Aeroways crossing waterways should use tunnels."
       building-building:
-        message: "Buildings should not intersect. If they are vertically stacked, please use the level tag instead of layer."
-        reference: "Buildings should not intersect. If they are vertically stacked, please use the **level** tag instead of **layer**."
+        reference: "Buildings should not intersect. Please fix the geometry of the overlapping buildings."
       building-highway:
         reference: "Highways crossing buildings should use bridges, tunnels, or different layers."
       building-railway:

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1811,7 +1811,7 @@ en:
       aeroway-waterway:
         reference: "Aeroways crossing waterways should use tunnels."
       building-building:
-        reference: "Buildings should not intersect. Please fix the geometry of the overlapping buildings."
+        reference: "Buildings should not intersect. Please fix the geometry of the overlapping buildings. In rare cases of actually overlapping buildings set layer= tags."
       building-highway:
         reference: "Highways crossing buildings should use bridges, tunnels, or different layers."
       building-railway:

--- a/modules/validations/crossing_ways.js
+++ b/modules/validations/crossing_ways.js
@@ -89,21 +89,36 @@ export function validationCrossingWays(context) {
             return true;
         }
 
+        // assume 0 by default; don't use way.layer() since we account for structures here
+        var layer1 = tags1.layer || '0';
+        var layer2 = tags2.layer || '0';
+
+        if (allowsBridge(featureType1) && allowsBridge(featureType2)) {
+            if (hasTag(tags1, 'bridge') && !hasTag(tags2, 'bridge')) return true;
+            if (!hasTag(tags1, 'bridge') && hasTag(tags2, 'bridge')) return true;
+            // crossing bridges must use different layers
+            if (hasTag(tags1, 'bridge') && hasTag(tags2, 'bridge') && layer1 !== layer2) return true;
+        } else if (allowsBridge(featureType1) && hasTag(tags1, 'bridge')) return true;
+        else if (allowsBridge(featureType2) && hasTag(tags2, 'bridge')) return true;
+
+        if (allowsTunnel(featureType1) && allowsTunnel(featureType2)) {
+            if (hasTag(tags1, 'tunnel') && !hasTag(tags2, 'tunnel')) return true;
+            if (!hasTag(tags1, 'tunnel') && hasTag(tags2, 'tunnel')) return true;
+            // crossing tunnels must use different layers
+            if (hasTag(tags1, 'tunnel') && hasTag(tags2, 'tunnel') && layer1 !== layer2) return true;
+        } else if (allowsTunnel(featureType1) && hasTag(tags1, 'tunnel')) return true;
+        else if (allowsTunnel(featureType2) && hasTag(tags2, 'tunnel')) return true;
+
         // don't flag crossing waterways and pier/highways
         if (featureType1 === 'waterway' && featureType2 === 'highway' && tags2.man_made === 'pier') return true;
         if (featureType2 === 'waterway' && featureType1 === 'highway' && tags1.man_made === 'pier') return true;
 
-        if (tags1.layer !== undefined && tags1.layer === tags2.layer) return false; // Warn if both have the same defined layer
-
-        const isElement1Bridge = allowsBridge(featureType1) && hasTag(tags1, 'bridge');
-        const isElement2Bridge = allowsBridge(featureType2) && hasTag(tags2, 'bridge');
-        if (isElement1Bridge !== isElement2Bridge) return true; // Either one is bridge, the other is not
-
-        const isElement1Tunnel = allowsTunnel(featureType1) && hasTag(tags1, 'tunnel');
-        const isElement2Tunnel = allowsTunnel(featureType2) && hasTag(tags2, 'tunnel');
-        if (isElement1Tunnel !== isElement2Tunnel ) return true; // Either one is tunnel, the other is not
-
-        return (tags1.layer || '0') !== (tags2.layer || '0');
+        if (featureType1 === 'building' || featureType2 === 'building' ||
+            taggedAsIndoor(tags1) || taggedAsIndoor(tags2)) {
+            // for building crossings, different layers are enough
+            if (layer1 !== layer2) return true;
+        }
+        return false;
     }
 
 
@@ -404,6 +419,7 @@ export function validationCrossingWays(context) {
                                 allowsTunnel(featureType2) && hasTag(entities[1].tags, 'tunnel');
         var isCrossingBridges = allowsBridge(featureType1) && hasTag(entities[0].tags, 'bridge') &&
                                 allowsBridge(featureType2) && hasTag(entities[1].tags, 'bridge');
+        var isBothBuildings = featureType1 === 'building' && featureType2 === 'building';
 
         var subtype = [featureType1, featureType2].sort().join('-');
 
@@ -475,8 +491,12 @@ export function validationCrossingWays(context) {
                     featureType1 === 'building' ||
                     featureType2 === 'building')  {
 
-                    fixes.push(makeChangeLayerFix('higher'));
-                    fixes.push(makeChangeLayerFix('lower'));
+                    // For overlapping buildings, do not suggest changing the `layer=*` tag.
+                    // Vertically stacked buildings should use `level=*` instead.
+                    if (!isBothBuildings) {
+                        fixes.push(makeChangeLayerFix('higher'));
+                        fixes.push(makeChangeLayerFix('lower'));
+                    }
 
                 // can only add bridge/tunnel if both features are lines
                 } else if (context.graph().geometry(this.entityIds[0]) === 'line' &&

--- a/modules/validations/crossing_ways.js
+++ b/modules/validations/crossing_ways.js
@@ -78,43 +78,49 @@ export function validationCrossingWays(context) {
     }
 
 
-    function isLegitCrossing(tags1, featureType1, tags2, featureType2) {
+    function isLegitCrossing(tags1, featureType1, tags2, featureType2, wayTags1, wayTags2) {
 
+        wayTags1 = wayTags1 || tags1;
+        wayTags2 = wayTags2 || tags2;
+        
         // assume 0 by default
-        var level1 = tags1.level || '0';
-        var level2 = tags2.level || '0';
+        var level1 =  wayTags1.level || '0';
+        var level2 =  wayTags2.level || '0';
 
-        if (taggedAsIndoor(tags1) && taggedAsIndoor(tags2) && level1 !== level2) {
+        if (taggedAsIndoor(wayTags1) && taggedAsIndoor( wayTags2) && level1 !== level2) {
             // assume features don't interact if they're indoor on different levels
             return true;
         }
 
         // assume 0 by default; don't use way.layer() since we account for structures here
-        var layer1 = tags1.layer || '0';
-        var layer2 = tags2.layer || '0';
+        var layer1 = wayTags1.layer || '0';
+        var layer2 = wayTags2.layer || '0';
 
-        if (allowsBridge(featureType1) && allowsBridge(featureType2)) {
-            if (hasTag(tags1, 'bridge') && !hasTag(tags2, 'bridge')) return true;
-            if (!hasTag(tags1, 'bridge') && hasTag(tags2, 'bridge')) return true;
-            // crossing bridges must use different layers
-            if (hasTag(tags1, 'bridge') && hasTag(tags2, 'bridge') && layer1 !== layer2) return true;
-        } else if (allowsBridge(featureType1) && hasTag(tags1, 'bridge')) return true;
-        else if (allowsBridge(featureType2) && hasTag(tags2, 'bridge')) return true;
+       if (allowsBridge(featureType1) && allowsBridge(featureType2)) {
+            if (hasTag(wayTags1, 'bridge') !== hasTag(wayTags2, 'bridge')) {
+                // allow for everything EXCEPT same-type roads on same layer
+                if (featureType1 !== 'highway' || featureType2 !== 'highway' || layer1 !== layer2) return true;
+            }
+            if (hasTag(wayTags1, 'bridge') && hasTag(wayTags2, 'bridge') && layer1 !== layer2) return true;
+        } else if (allowsBridge(featureType1) && hasTag(wayTags1, 'bridge')) return true;
+        else if (allowsBridge(featureType2) && hasTag(wayTags2, 'bridge')) return true;
 
-        if (allowsTunnel(featureType1) && allowsTunnel(featureType2)) {
-            if (hasTag(tags1, 'tunnel') && !hasTag(tags2, 'tunnel')) return true;
-            if (!hasTag(tags1, 'tunnel') && hasTag(tags2, 'tunnel')) return true;
-            // crossing tunnels must use different layers
-            if (hasTag(tags1, 'tunnel') && hasTag(tags2, 'tunnel') && layer1 !== layer2) return true;
-        } else if (allowsTunnel(featureType1) && hasTag(tags1, 'tunnel')) return true;
-        else if (allowsTunnel(featureType2) && hasTag(tags2, 'tunnel')) return true;
+       if (allowsTunnel(featureType1) && allowsTunnel(featureType2)) {
+            if (hasTag(wayTags1, 'tunnel') !== hasTag(wayTags2, 'tunnel')) {
+                if (featureType1 !== 'highway' || featureType2 !== 'highway' || layer1 !== layer2) return true;
+            }
+            if (hasTag(wayTags1, 'tunnel') && hasTag(wayTags2, 'tunnel') && layer1 !== layer2) return true;
+        } else if (allowsTunnel(featureType1) && hasTag(wayTags1, 'tunnel')) return true;
+        else if (allowsTunnel(featureType2) && hasTag(wayTags2, 'tunnel')) return true;
+
+        if (layer1 !== layer2) return true;
 
         // don't flag crossing waterways and pier/highways
         if (featureType1 === 'waterway' && featureType2 === 'highway' && tags2.man_made === 'pier') return true;
         if (featureType2 === 'waterway' && featureType1 === 'highway' && tags1.man_made === 'pier') return true;
 
         if (featureType1 === 'building' || featureType2 === 'building' ||
-            taggedAsIndoor(tags1) || taggedAsIndoor(tags2)) {
+            taggedAsIndoor(wayTags1) || taggedAsIndoor(wayTags2)) {
             // Buildings on different layers are genuinely stacked - this is valid
             if (layer1 !== layer2) return true;
             return false;  // else always warn, nothing resolves it
@@ -297,7 +303,8 @@ export function validationCrossingWays(context) {
                 way2FeatureType = getFeatureType(taggedFeature2, graph);
 
                 if (way2FeatureType === null ||
-                    isLegitCrossing(taggedFeature1.tags, way1FeatureType, taggedFeature2.tags, way2FeatureType)) {
+                    isLegitCrossing(taggedFeature1.tags, way1FeatureType, taggedFeature2.tags, way2FeatureType,
+                                    way1.tags, way2.tags)) {
                     continue;
                 }
 

--- a/modules/validations/crossing_ways.js
+++ b/modules/validations/crossing_ways.js
@@ -115,9 +115,9 @@ export function validationCrossingWays(context) {
 
         if (featureType1 === 'building' || featureType2 === 'building' ||
             taggedAsIndoor(tags1) || taggedAsIndoor(tags2)) {
-             // For overlapping buildings, layer=* is not a valid resolution.
-            // The geometry must be fixed instead.
-            return false;  // always warn, nothing resolves it
+            // Buildings on different layers are genuinely stacked - this is valid
+            if (layer1 !== layer2) return true;
+            return false;  // else always warn, nothing resolves it
         }
         return false;
     }

--- a/modules/validations/crossing_ways.js
+++ b/modules/validations/crossing_ways.js
@@ -115,8 +115,9 @@ export function validationCrossingWays(context) {
 
         if (featureType1 === 'building' || featureType2 === 'building' ||
             taggedAsIndoor(tags1) || taggedAsIndoor(tags2)) {
-            // for building crossings, different layers are enough
-            if (layer1 !== layer2) return true;
+             // For overlapping buildings, layer=* is not a valid resolution.
+            // The geometry must be fixed instead.
+            return false;  // always warn, nothing resolves it
         }
         return false;
     }
@@ -492,8 +493,10 @@ export function validationCrossingWays(context) {
                     featureType2 === 'building')  {
 
                     // For overlapping buildings, do not suggest changing the `layer=*` tag.
-                    // Vertically stacked buildings should use `level=*` instead.
-                    if (!isBothBuildings) {
+                    // The geometry of the overlapping buildings should be fixed instead.
+                    if (!isBothBuildings &&
+                        !taggedAsIndoor(entities[0].tags) &&
+                        !taggedAsIndoor(entities[1].tags)) {
                         fixes.push(makeChangeLayerFix('higher'));
                         fixes.push(makeChangeLayerFix('lower'));
                     }


### PR DESCRIPTION
This PR modifies the crossing_ways validation logic to prevent the iD Editor from suggesting "Tag as higher" or "Tag as lower" (which adds layer=*) when two building features overlap.

The Problem Currently, mappers often use the "Quick Fix" layer buttons to silence validation warnings for overlapping buildings. This creates "layer soup"—data where buildings are incorrectly marked as floating in the air. Per community best practices and my recommendation [2026-01-15], buildings should stay on layer=0. If they are physically stacked, the level tag is the correct way to map them.

The Fix

Logic: Updated modules/validations/crossing_ways.js to identify building-on-building overlaps and suppress the changeLayer fixes.

Education: Updated the validation message in core.yaml to explicitly guide mappers toward using the level tag instead of layer.

Validation

Verified that "Tag as higher/lower" buttons are hidden for building-building crossings.

Verified that these buttons still appear for valid cases, such as bridges or tunnels (non-building crossings)

Closes #11775