### PR TITLE
fixing false positive for emergency=* on highways (fix#11806)

### DIFF
--- a/modules/validations/mismatched_geometry.js
+++ b/modules/validations/mismatched_geometry.js
@@ -267,6 +267,10 @@ export function validationMismatchedGeometry() {
             // special case: buildings-as-points are discouraged by iD, but common in OSM, so ignore them
             if (primaryKey === 'building') return false;
 
+            //special case: emergency=* works like an access tag on highways and railways
+            //treat it as valid and don’t flag it as a mismatch with highway or railway.
+            if (primaryKey === 'emergency' && (entity.tags.highway || entity.tags.railway)) return false;
+
             if (asTarget.tags[primaryKey] === '*') return false;
 
             return asSource.isFallback() || asSource.tags[primaryKey] === '*';


### PR DESCRIPTION
fixes #11806


the validator was incorrectly flagging emergency=* on highway=* and railway=* features
this PR adds a special case so emergency=yes/no/designated is treated as a valid access tag instead of a mismatch

<img width="1380" height="875" alt="image" src="https://github.com/user-attachments/assets/92d6b83f-028a-4cb6-af0e-ad241fff1e1b" />
<img width="1223" height="318" alt="image" src="https://github.com/user-attachments/assets/36365ef5-52d8-464b-ab20-c84a064f02fd" />
<img width="1217" height="835" alt="image" src="https://github.com/user-attachments/assets/987f4568-9442-46bc-8547-874ea00fdf69" />
