### PR TITLE
Fix: Add onClick handler to remove_proprietary_data button .The incom…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Don't error on features with a sole `note` tag ([#11522])
 * Warn when two features cross each other on same `layer`, regardless of `bridge` / `tunnel` tags ([#10999], thanks [@homersimpsons])
 #### :bug: Bugfixes
+* Fix "Remove proprietary data" button not working in incompatible_source validation (thanks [@JaiswalShivang])
 * Fix some gpx/geojson properties not visible, such as numbers or complex data structures ([#11636], thanks [@k-yle])
 #### :earth_asia: Localization
 * Add Moroccan phone number formats ([#11651], thanks [@ilias52730])
@@ -80,6 +81,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [@homersimpsons]: https://github.com/homersimpsons
 [@omsaraykar]: https://github.com/omsaraykar
 [@Kaushik4141]: https://github.com/Kaushik4141
+[@JaiswalShivang]: https://github.com/JaiswalShivang
 
 
 # v2.37.3

--- a/modules/validations/incompatible_source.js
+++ b/modules/validations/incompatible_source.js
@@ -1,3 +1,4 @@
+import { actionChangeTags } from '../actions/change_tags';
 import { t } from '../core/localizer';
 import { utilDisplayLabel } from '../util/utilDisplayLabel';
 import { validationIssue, validationIssueFix } from '../core/validation';
@@ -56,25 +57,54 @@ export function validationIncompatibleSource() {
           hash: source,
           dynamicFixes: () => {
             return [
-              new validationIssueFix({ title: t.append('issues.fix.remove_proprietary_data.title') })
+              new validationIssueFix({
+                icon: 'iD-operation-delete',
+                title: t.append('issues.fix.remove_proprietary_data.title'),
+                onClick: (context) => {
+                  const entity = context.hasEntity(entityID);
+                  if (!entity) return;
+
+                  let newTags = Object.assign({}, entity.tags);
+
+                  // If source has multiple values (semicolon-separated), remove only the bad ones
+                  if (entity.tags.source && entity.tags.source.includes(';')) {
+                    const sources = entity.tags.source.split(';').map(s => s.trim());
+                    const filteredSources = sources.filter(s => !getIncompatibleSources(s).length);
+
+                    if (filteredSources.length) {
+                      newTags.source = filteredSources.join(';');
+                    } else {
+                      delete newTags.source;
+                    }
+                  } else {
+                    // Single source value - just remove the tag
+                    delete newTags.source;
+                  }
+
+                  context.perform(
+                    actionChangeTags(entityID, newTags),
+                    t('issues.fix.remove_proprietary_data.annotation')
+                  );
+                }
+              })
             ];
           }
         }))
       );
 
-      function getReference(id) {
-        return function showReference(selection) {
-          selection.selectAll('.issue-reference')
-            .data([0])
-            .enter()
-            .append('div')
-            .attr('class', 'issue-reference')
-            .call(t.append(`issues.incompatible_source.reference.${id}`));
-        };
-      }
-    };
+    function getReference(id) {
+      return function showReference(selection) {
+        selection.selectAll('.issue-reference')
+          .data([0])
+          .enter()
+          .append('div')
+          .attr('class', 'issue-reference')
+          .call(t.append(`issues.incompatible_source.reference.${id}`));
+      };
+    }
+  };
 
-    validation.type = type;
+  validation.type = type;
 
-    return validation;
+  return validation;
 }


### PR DESCRIPTION
Fixes #11826
## Summary
The `incompatible_source` validation correctly detects when features have incompatible data sources (Google, Baidu, Amap) in their `source` tag. However, the "Remove proprietary data" fix button was non-functional because it was missing an [onClick](cci:1://file:///c:/Users/jaisw/OneDrive/Desktop/simmy/iD/modules/validations/outdated_tags.js:179:14-181:15) handler.
## Problem
Users would see the warning about incompatible sources, but clicking the "Remove proprietary data" button did nothing. They had to manually find and delete the `source` tag.
**Before:**
```javascript
new validationIssueFix({ 
  title: t.append('issues.fix.remove_proprietary_data.title') 
})
// Missing: onClick handler and icon

**After:**
```javascript
new validationIssueFix({
  icon: 'iD-operation-delete',
  title: t.append('issues.fix.remove_proprietary_data.title'),
  onClick: (context) => {
    // Removes incompatible source from tags
  }
})

---

https://github.com/user-attachments/assets/9f118eca-e7f0-4465-9132-c501680acc61


