### PR TITLE
Improve zoom/pan performance by avoiding redundant tag class and label width recomputation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,11 +58,8 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * When viewing the help information for tags or presets, use locale-specific properties if available ([#11760], thanks [@k-yle])
 * Show country names in your preferred language and country flag emoji in the Country field dropdown ([#11783], thanks [@Razen04])
 #### :hourglass: Performance
-
 * iD is now twice as fast during long editing sessions ([#11861], thanks [@k-yle])
-
 * Improve zoom/pan performance by avoiding redundant tag class recomputation ([#11834], thanks [@1-navneet])
-
 #### :mortar_board: Walkthrough / Help
 #### :rocket: Presets
 * Add dedicated styling for `highway=ladder` to make it distinguishable from `highway=steps` ([#11799], thanks [@bhavyaKhatri2703])
@@ -89,22 +86,16 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#11783]: https://github.com/openstreetmap/iD/pull/11783
 [#11861]: https://github.com/openstreetmap/iD/pull/11861
 [#11862]: https://github.com/openstreetmap/iD/pull/11862
-
 [#11870]: https://github.com/openstreetmap/iD/issues/11870
 [#11904]: https://github.com/openstreetmap/iD/issues/11904
-
 [#11834]: https://github.com/openstreetmap/iD/pull/11834
-
 [@ilias52730]: https://github.com/ilias52730
 [@Razen04]: https://github.com/Razen04
 [@homersimpsons]: https://github.com/homersimpsons
 [@omsaraykar]: https://github.com/omsaraykar
 [@Kaushik4141]: https://github.com/Kaushik4141
-
 [@Kayd-06]: https://github.com/Kayd-06
 [@JaiswalShivang]: https://github.com/JaiswalShivang
-
-
 [@1-navneet]: https://github.com/1-navneet 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,6 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#11784]: https://github.com/openstreetmap/iD/pull/11784
 [#11794]: https://github.com/openstreetmap/iD/pull/11794
 [#11799]: https://github.com/openstreetmap/iD/issues/11799
-
 [#11783]: https://github.com/openstreetmap/iD/pull/11783
 [#11861]: https://github.com/openstreetmap/iD/pull/11861
 [#11862]: https://github.com/openstreetmap/iD/pull/11862

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,11 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * When viewing the help information for tags or presets, use locale-specific properties if available ([#11760], thanks [@k-yle])
 * Show country names in your preferred language and country flag emoji in the Country field dropdown ([#11783], thanks [@Razen04])
 #### :hourglass: Performance
+
 * iD is now twice as fast during long editing sessions ([#11861], thanks [@k-yle])
+
+* Improve zoom/pan performance by avoiding redundant tag class recomputation ([#11834], thanks [@1-navneet])
+
 #### :mortar_board: Walkthrough / Help
 #### :rocket: Presets
 * Add dedicated styling for `highway=ladder` to make it distinguishable from `highway=steps` ([#11799], thanks [@bhavyaKhatri2703])
@@ -82,18 +86,27 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#11784]: https://github.com/openstreetmap/iD/pull/11784
 [#11794]: https://github.com/openstreetmap/iD/pull/11794
 [#11799]: https://github.com/openstreetmap/iD/issues/11799
+
 [#11783]: https://github.com/openstreetmap/iD/pull/11783
 [#11861]: https://github.com/openstreetmap/iD/pull/11861
 [#11862]: https://github.com/openstreetmap/iD/pull/11862
+
 [#11870]: https://github.com/openstreetmap/iD/issues/11870
 [#11904]: https://github.com/openstreetmap/iD/issues/11904
+
+[#11834]: https://github.com/openstreetmap/iD/pull/11834
+
 [@ilias52730]: https://github.com/ilias52730
 [@Razen04]: https://github.com/Razen04
 [@homersimpsons]: https://github.com/homersimpsons
 [@omsaraykar]: https://github.com/omsaraykar
 [@Kaushik4141]: https://github.com/Kaushik4141
+
 [@Kayd-06]: https://github.com/Kayd-06
 [@JaiswalShivang]: https://github.com/JaiswalShivang
+
+
+[@1-navneet]: https://github.com/1-navneet 
 
 
 # v2.37.3

--- a/modules/svg/labels.js
+++ b/modules/svg/labels.js
@@ -789,19 +789,31 @@ export function svgLabels(projection, context) {
 const _textWidthCache = {};
 export function textWidth(text, size, container) {
     let c = _textWidthCache[size];
-    if (!c) c = _textWidthCache[size] = {};
-
-    if (c[text]) {
-        return c[text];
+    if (!c) {
+        c = _textWidthCache[size] = { widths: {}, measurer: null };
     }
-    const elem = document.createElementNS('http://www.w3.org/2000/svg', 'text');
-    elem.style.fontSize = `${size}px`;
-    elem.style.fontWeight = 'bold';
+
+    if (c.widths[text]) {
+        return c.widths[text];
+    }
+
+    // Avoid repeated create/remove of SVG text nodes on every zoom/pan.
+    // The measured width depends only on text + font size/style, which
+    // are stable during zoom/pan, so caching is safe.
+    let elem = c.measurer;
+    if (!elem) {
+        elem = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+        elem.style.fontSize = `${size}px`;
+        elem.style.fontWeight = 'bold';
+        elem.style.visibility = 'hidden';
+        elem.style.pointerEvents = 'none';
+        container.appendChild(elem);
+        c.measurer = elem;
+    }
+
     elem.textContent = text;
-    container.appendChild(elem);
-    c[text] = elem.getComputedTextLength();
-    elem.remove();
-    return c[text];
+    c.widths[text] = elem.getComputedTextLength();
+    return c.widths[text];
 }
 
 

--- a/modules/svg/tag_classes.js
+++ b/modules/svg/tag_classes.js
@@ -17,6 +17,10 @@ export function svgTagClasses() {
         'man_made', 'indoor', 'construction', 'proposed'
     ];
     var _tags = function(entity) { return entity.tags; };
+    // Cache computed class strings by tag object identity + base class.
+    // Safe for zoom/pan because tags do not change, and if tags change
+    // the graph creates new tag objects (cache miss => recompute).
+    var _classCache = new WeakMap();
 
 
     var tagClasses = function(selection) {
@@ -29,7 +33,19 @@ export function svgTagClasses() {
 
             var t = _tags(entity);
 
-            var computed = tagClasses.getClassesString(t, value);
+            // Avoid recomputing tagClasses for unchanged tags during zoom/pan.
+            // Cache is keyed by tag object identity and base class string.
+            var byBase = _classCache.get(t);
+            if (!byBase) {
+                byBase = new Map();
+                _classCache.set(t, byBase);
+            }
+
+            var computed = byBase.get(value);
+            if (!computed) {
+                computed = tagClasses.getClassesString(t, value);
+                byBase.set(value, computed);
+            }
 
             if (computed !== value) {
                 d3_select(this).attr('class', computed);

--- a/modules/svg/tag_classes.js
+++ b/modules/svg/tag_classes.js
@@ -1,7 +1,7 @@
 import { select as d3_select } from 'd3-selection';
 import { osmPathHighwayTagValues, osmPavedTags, osmSemipavedTags, osmLifecyclePrefixes } from '../osm/tags';
 
-
+var _classCache = new WeakMap();
 export function svgTagClasses() {
     var primaries = [
         'building', 'highway', 'railway', 'waterway', 'aeroway', 'aerialway',
@@ -17,10 +17,7 @@ export function svgTagClasses() {
         'man_made', 'indoor', 'construction', 'proposed'
     ];
     var _tags = function(entity) { return entity.tags; };
-    // Cache computed class strings by tag object identity + base class.
-    // Safe for zoom/pan because tags do not change, and if tags change
-    // the graph creates new tag objects (cache miss => recompute).
-    var _classCache = new WeakMap();
+    // Cache tag-derived classes by tag object identity.
 
 
     var tagClasses = function(selection) {
@@ -33,7 +30,6 @@ export function svgTagClasses() {
 
             var t = _tags(entity);
 
-            // Avoid recomputing tagClasses for unchanged tags during zoom/pan.
             var computed = tagClasses.getClassesString(t, value);
 
             if (computed !== value) {
@@ -44,16 +40,6 @@ export function svgTagClasses() {
 
 
     tagClasses.getClassesString = function(t, value) {
-        // Fast path: return cached class string for identical tags + base class.
-        var byBase = _classCache.get(t);
-        if (!byBase) {
-            byBase = new Map();
-            _classCache.set(t, byBase);
-        }
-
-        var cached = byBase.get(value);
-        if (cached) return cached;
-
         var primary, status;
         var i, j, k, v;
 
@@ -66,13 +52,21 @@ export function svgTagClasses() {
         }
 
         // preserve base classes (nothing with `tag-`)
-        var classes = value.trim().split(/\s+/)
+        var baseClasses = value.trim().split(/\s+/)
             .filter(function(klass) {
                 return klass.length && !/^tag-/.test(klass);
             })
             .map(function(klass) {  // special overrides for some perimeter strokes
                 return (klass === 'line' || klass === 'area') ? (overrideGeometry || klass) : klass;
             });
+
+        // Fast path: return cached tag-derived classes if available
+        var tagDerivedClasses = _classCache.get(t);
+        if (tagDerivedClasses) {
+            return baseClasses.concat(tagDerivedClasses).join(' ').trim();
+        }
+
+        var classes = [];
 
         // pick at most one primary classification tag..
         for (i = 0; i < primaries.length; i++) {
@@ -176,13 +170,9 @@ export function svgTagClasses() {
 
         // ensure that classes for tags keys/values with special characters like spaces
         // are not added to the DOM, because it can cause bizarre issues (#9448)
-        var computed = classes
-            .filter(klass => /^[-_a-z0-9]+$/.test(klass))
-            .join(' ')
-            .trim();
-
-        byBase.set(value, computed);
-        return computed;
+        var tagDerived = classes.filter(klass => /^[-_a-z0-9]+$/.test(klass));
+        _classCache.set(t, tagDerived);
+        return baseClasses.concat(tagDerived).join(' ').trim();
     };
 
 

--- a/modules/svg/tag_classes.js
+++ b/modules/svg/tag_classes.js
@@ -34,18 +34,7 @@ export function svgTagClasses() {
             var t = _tags(entity);
 
             // Avoid recomputing tagClasses for unchanged tags during zoom/pan.
-            // Cache is keyed by tag object identity and base class string.
-            var byBase = _classCache.get(t);
-            if (!byBase) {
-                byBase = new Map();
-                _classCache.set(t, byBase);
-            }
-
-            var computed = byBase.get(value);
-            if (!computed) {
-                computed = tagClasses.getClassesString(t, value);
-                byBase.set(value, computed);
-            }
+            var computed = tagClasses.getClassesString(t, value);
 
             if (computed !== value) {
                 d3_select(this).attr('class', computed);
@@ -55,6 +44,16 @@ export function svgTagClasses() {
 
 
     tagClasses.getClassesString = function(t, value) {
+        // Fast path: return cached class string for identical tags + base class.
+        var byBase = _classCache.get(t);
+        if (!byBase) {
+            byBase = new Map();
+            _classCache.set(t, byBase);
+        }
+
+        var cached = byBase.get(value);
+        if (cached) return cached;
+
         var primary, status;
         var i, j, k, v;
 
@@ -177,10 +176,13 @@ export function svgTagClasses() {
 
         // ensure that classes for tags keys/values with special characters like spaces
         // are not added to the DOM, because it can cause bizarre issues (#9448)
-        return classes
+        var computed = classes
             .filter(klass => /^[-_a-z0-9]+$/.test(klass))
             .join(' ')
             .trim();
+
+        byBase.set(value, computed);
+        return computed;
     };
 
 

--- a/modules/svg/tag_classes.js
+++ b/modules/svg/tag_classes.js
@@ -16,8 +16,8 @@ export function svgTagClasses() {
         'public_transport', 'location', 'parking', 'golf', 'type', 'leisure',
         'man_made', 'indoor', 'construction', 'proposed'
     ];
-    var _tags = function(entity) { return entity.tags; };
     // Cache tag-derived classes by tag object identity.
+    var _tags = function(entity) { return entity.tags; };
 
 
     var tagClasses = function(selection) {


### PR DESCRIPTION
This PR addresses the zoom and pan performance issue described in #11832.

### Problem
Profiling during zoom/pan interactions showed significant time spent repeatedly:
- Computing SVG tag class strings for entities whose tags were unchanged
- Measuring SVG text widths during label redraws

These operations were executed on every redraw, even when the underlying data did not change.

### Solution
This change reduces redundant work during redraws by:
- Reusing cached tag class strings when entity tags are unchanged
- Reusing a persistent SVG text measurer per font size to avoid repeated DOM create/remove cycles

### Result
- Reduced time spent in drawEditable during zoom/pan interactions
- Hotspots such as `tagClasses.getClassesString` no longer dominate redraw time
- No visual or behavioral changes observed

### Testing
- Tested locally using Chrome DevTools Performance profiling
- Reproduced using the same location and zoom level as the issue report
  (zoom level 18 near 53.382847, -1.470167)
