### PR TITLE
feat: Allow multiple custom background layers with names , added crud…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 
 # Unreleased (2.38.0-dev)
 
+#### :tada: New Features
+* Allow users to save multiple custom background layers with custom names ([#10044], thanks [@JaiswalShivang])
+
 #### :sparkles: Usability & Accessibility
 * Show warning when attempting to paste but nothing has been copied ([#9401], thanks [@omsaraykar])
 * Don't suggest values from Taginfo for `addr:*` tags ([#11733], thanks [@k-yle])
@@ -80,6 +83,8 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [@homersimpsons]: https://github.com/homersimpsons
 [@omsaraykar]: https://github.com/omsaraykar
 [@Kaushik4141]: https://github.com/Kaushik4141
+[#10044]: https://github.com/openstreetmap/iD/issues/10044
+[@JaiswalShivang]: https://github.com/JaiswalShivang
 
 
 # v2.37.3

--- a/modules/renderer/background.js
+++ b/modules/renderer/background.js
@@ -77,10 +77,34 @@ export function rendererBackground(context) {
         // Add 'None'
         _imageryIndex.backgrounds.unshift(rendererBackgroundSource.None());
 
-        // Add 'Custom'
-        let template = prefs('background-custom-template') || '';
-        const custom = rendererBackgroundSource.Custom(template);
-        _imageryIndex.backgrounds.unshift(custom);
+        // Add Custom backgrounds (support multiple)
+        const oldTemplate = prefs('background-custom-template');
+        let customTemplates = [];
+        try {
+          customTemplates = JSON.parse(prefs('background-custom-templates') || '[]');
+        } catch {
+          customTemplates = [];
+        }
+
+        if (oldTemplate && !customTemplates.some(c => c.template === oldTemplate)) {
+          customTemplates.unshift({ id: 'custom-0', template: oldTemplate, name: 'Custom (Migrated)' });
+          prefs('background-custom-templates', JSON.stringify(customTemplates));
+          // Clear old single-template pref after migration to prevent re-migration
+          prefs('background-custom-template', null);
+        }
+
+        customTemplates.forEach((customData, index) => {
+          const customId = customData.id || `custom-${index}`;
+          const customName = customData.name || `Custom ${index + 1}`;
+          const custom = rendererBackgroundSource.Custom(customData.template, customName);
+          custom.id = customId;
+          _imageryIndex.backgrounds.unshift(custom);
+        });
+
+        const emptyCustom = rendererBackgroundSource.Custom('');
+        emptyCustom.id = 'custom';
+        emptyCustom.isEmptyCustomSlot = true;
+        _imageryIndex.backgrounds.unshift(emptyCustom);
 
         return _imageryIndex;
       });
@@ -187,7 +211,7 @@ export function rendererBackground(context) {
   }
 
 
-  background.updateImagery = function() {
+  background.updateImagery = function () {
     let currSource = baseLayer.source();
     if (context.inIntro() || !currSource) return;
 
@@ -307,7 +331,7 @@ export function rendererBackground(context) {
   };
 
 
-  background.baseLayerSource = function(d) {
+  background.baseLayerSource = function (d) {
     if (!arguments.length) return baseLayer.source();
 
     // test source against OSM imagery blocklists..
@@ -379,7 +403,7 @@ export function rendererBackground(context) {
       .source(d)
       .projection(context.projection)
       .dimensions(baseLayer.dimensions()
-    );
+      );
 
     _overlayLayers.push(layer);
     dispatch.call('change');
@@ -398,7 +422,7 @@ export function rendererBackground(context) {
   };
 
 
-  background.offset = function(d) {
+  background.offset = function (d) {
     const currSource = baseLayer.source();
     if (!arguments.length) {
       return (currSource && currSource.offset()) || [0, 0];
@@ -412,7 +436,7 @@ export function rendererBackground(context) {
   };
 
 
-  background.brightness = function(d) {
+  background.brightness = function (d) {
     if (!arguments.length) return _brightness;
     _brightness = d;
     if (context.mode()) dispatch.call('change');
@@ -420,7 +444,7 @@ export function rendererBackground(context) {
   };
 
 
-  background.contrast = function(d) {
+  background.contrast = function (d) {
     if (!arguments.length) return _contrast;
     _contrast = d;
     if (context.mode()) dispatch.call('change');
@@ -428,7 +452,7 @@ export function rendererBackground(context) {
   };
 
 
-  background.saturation = function(d) {
+  background.saturation = function (d) {
     if (!arguments.length) return _saturation;
     _saturation = d;
     if (context.mode()) dispatch.call('change');
@@ -436,7 +460,7 @@ export function rendererBackground(context) {
   };
 
 
-  background.sharpness = function(d) {
+  background.sharpness = function (d) {
     if (!arguments.length) return _sharpness;
     _sharpness = d;
     if (context.mode()) dispatch.call('change');
@@ -470,9 +494,9 @@ export function rendererBackground(context) {
         best = validBackgrounds.find(s => {
           if (!s.best() || s.overlay) return false;
           let bbox = turf_bbox(turf_bboxClip(
-                { type: 'MultiPolygon', coordinates: [ s.polygon || [extent.polygon()] ] },
-                extent.rectangle()));
-          let area = geoExtent(bbox.slice(0,2), bbox.slice(2,4)).area();
+            { type: 'MultiPolygon', coordinates: [s.polygon || [extent.polygon()]] },
+            extent.rectangle()));
+          let area = geoExtent(bbox.slice(0, 2), bbox.slice(2, 4)).area();
           return area / viewArea > 0.5; // min visible size: 50% of viewport area
         });
       }
@@ -525,11 +549,11 @@ export function rendererBackground(context) {
         }
       }
     })
-    .catch(err => {
-      /* eslint-disable no-console */
-      console.error(err);
-      /* eslint-enable no-console */
-    });
+      .catch(err => {
+        /* eslint-disable no-console */
+        console.error(err);
+        /* eslint-enable no-console */
+      });
   };
 
 

--- a/modules/renderer/background_source.js
+++ b/modules/renderer/background_source.js
@@ -14,7 +14,7 @@ window.matchMedia?.(`
         (-webkit-min-device-pixel-ratio: 2), /* Safari */
         (min-resolution: 2dppx),             /* standard */
         (min-resolution: 192dpi)             /* fallback */
-    `).addListener(function() {
+    `).addListener(function () {
 
     isRetina = window.devicePixelRatio && window.devicePixelRatio >= 2;
 });
@@ -52,72 +52,72 @@ export function rendererBackgroundSource(data) {
     source.zoomExtent = data.zoomExtent || [0, 22];
     source.overzoom = data.overzoom !== false;
 
-    source.offset = function(val) {
+    source.offset = function (val) {
         if (!arguments.length) return _offset;
         _offset = val;
         return source;
     };
 
 
-    source.nudge = function(val, zoomlevel) {
+    source.nudge = function (val, zoomlevel) {
         _offset[0] += val[0] / Math.pow(2, zoomlevel);
         _offset[1] += val[1] / Math.pow(2, zoomlevel);
         return source;
     };
 
 
-    source.name = function() {
+    source.name = function () {
         var id_safe = source.id.replace(/\./g, '<TX_DOT>');
         return t('imagery.' + id_safe + '.name', { default: _name });
     };
 
 
-    source.label = function() {
+    source.label = function () {
         var id_safe = source.id.replace(/\./g, '<TX_DOT>');
         return t.append('imagery.' + id_safe + '.name', { default: _name });
     };
 
 
-    source.hasDescription = function() {
+    source.hasDescription = function () {
         var id_safe = source.id.replace(/\./g, '<TX_DOT>');
         var descriptionText = localizer.tInfo('imagery.' + id_safe + '.description', { default: _description }).text;
         return descriptionText !== '';
     };
 
 
-    source.description = function() {
+    source.description = function () {
         var id_safe = source.id.replace(/\./g, '<TX_DOT>');
         return t.append('imagery.' + id_safe + '.description', { default: _description });
     };
 
 
-    source.best = function() {
+    source.best = function () {
         return _best;
     };
 
 
-    source.area = function() {
+    source.area = function () {
         if (!data.polygon) return Number.MAX_VALUE;  // worldwide
-        var area = d3_geoArea({ type: 'MultiPolygon', coordinates: [ data.polygon ] });
+        var area = d3_geoArea({ type: 'MultiPolygon', coordinates: [data.polygon] });
         return isNaN(area) ? 0 : area;
     };
 
 
-    source.imageryUsed = function() {
+    source.imageryUsed = function () {
         return _name || source.id;
     };
 
 
-    source.template = function(val) {
+    source.template = function (val) {
         if (!arguments.length) return _template;
-        if (source.id === 'custom' || source.id === 'Bing') {
+        if (source.id === 'custom' || source.id?.startsWith('custom-') || source.id === 'Bing') {
             _template = val;
         }
         return source;
     };
 
 
-    source.url = function(coord) {
+    source.url = function (coord) {
         var result = _template.replace(/#[\s\S]*/u, ''); // strip hash part of URL
         if (result === '') return result;   // source 'none'
 
@@ -137,7 +137,7 @@ export function rendererBackgroundSource(data) {
 
 
         if (source.type === 'wms') {
-            var tileToProjectedCoords = (function(x, y, z) {
+            var tileToProjectedCoords = (function (x, y, z) {
                 var zoomSize = Math.pow(2, z);
                 var lon = x / zoomSize * Math.PI * 2 - Math.PI;
                 var lat = Math.atan(Math.sinh(Math.PI * (1 - 2 * y / zoomSize)));
@@ -160,37 +160,37 @@ export function rendererBackgroundSource(data) {
             var tileSize = source.tileSize;
             var projection = source.projection;
             var minXmaxY = tileToProjectedCoords(coord[0], coord[1], coord[2]);
-            var maxXminY = tileToProjectedCoords(coord[0]+1, coord[1]+1, coord[2]);
+            var maxXminY = tileToProjectedCoords(coord[0] + 1, coord[1] + 1, coord[2]);
 
             result = result.replace(/\{(\w+)\}/g, function (token, key) {
-              switch (key) {
-                case 'width':
-                case 'height':
-                    return tileSize;
-                case 'proj':
-                    return projection;
-                case 'wkid':
-                    return projection.replace(/^EPSG:/, '');
-                case 'bbox':
-                    // WMS 1.3 flips x/y for some coordinate systems including EPSG:4326 - #7557
-                    if (projection === 'EPSG:4326' &&
-                        // The CRS parameter implies version 1.3 (prior versions use SRS)
-                        /VERSION=1.3|CRS={proj}/.test(source.template().toUpperCase())) {
-                        return maxXminY.y + ',' + minXmaxY.x + ',' + minXmaxY.y + ',' + maxXminY.x;
-                    } else {
-                        return minXmaxY.x + ',' + maxXminY.y + ',' + maxXminY.x + ',' + minXmaxY.y;
-                    }
-                case 'w':
-                    return minXmaxY.x;
-                case 's':
-                    return maxXminY.y;
-                case 'n':
-                    return maxXminY.x;
-                case 'e':
-                    return minXmaxY.y;
-                default:
-                    return token;
-              }
+                switch (key) {
+                    case 'width':
+                    case 'height':
+                        return tileSize;
+                    case 'proj':
+                        return projection;
+                    case 'wkid':
+                        return projection.replace(/^EPSG:/, '');
+                    case 'bbox':
+                        // WMS 1.3 flips x/y for some coordinate systems including EPSG:4326 - #7557
+                        if (projection === 'EPSG:4326' &&
+                            // The CRS parameter implies version 1.3 (prior versions use SRS)
+                            /VERSION=1.3|CRS={proj}/.test(source.template().toUpperCase())) {
+                            return maxXminY.y + ',' + minXmaxY.x + ',' + minXmaxY.y + ',' + maxXminY.x;
+                        } else {
+                            return minXmaxY.x + ',' + maxXminY.y + ',' + maxXminY.x + ',' + minXmaxY.y;
+                        }
+                    case 'w':
+                        return minXmaxY.x;
+                    case 's':
+                        return maxXminY.y;
+                    case 'n':
+                        return maxXminY.x;
+                    case 'e':
+                        return minXmaxY.y;
+                    default:
+                        return token;
+                }
             });
 
         } else if (source.type === 'tms') {
@@ -205,7 +205,7 @@ export function rendererBackgroundSource(data) {
 
         } else if (source.type === 'bing') {
             result = result
-                .replace('{u}', function() {
+                .replace('{u}', function () {
                     var u = '';
                     for (var zoom = coord[2]; zoom > 0; zoom--) {
                         var b = 0;
@@ -219,7 +219,7 @@ export function rendererBackgroundSource(data) {
         }
 
         // these apply to any type..
-        result = result.replace(/\{switch:([^}]+)\}/, function(s, r) {
+        result = result.replace(/\{switch:([^}]+)\}/, function (s, r) {
             var subdomains = r.split(',');
             return subdomains[(coord[0] + coord[1]) % subdomains.length];
         });
@@ -229,28 +229,28 @@ export function rendererBackgroundSource(data) {
     };
 
 
-    source.validZoom = function(z, underzoom) {
+    source.validZoom = function (z, underzoom) {
         if (underzoom === undefined) underzoom = 0;
         return source.zoomExtent[0] - underzoom <= z &&
             (source.overzoom || source.zoomExtent[1] > z);
     };
 
 
-    source.isLocatorOverlay = function() {
+    source.isLocatorOverlay = function () {
         return source.id === 'mapbox_locator_overlay';
     };
 
 
     /* hides a source from the list, but leaves it available for use */
-    source.isHidden = function() {
+    source.isHidden = function () {
         return false; // currently there are no hidden layers
     };
 
 
-    source.copyrightNotices = function() {};
+    source.copyrightNotices = function () { };
 
 
-    source.getMetadata = function(center, tileCoord, callback) {
+    source.getMetadata = function (center, tileCoord, callback) {
         var vintage = {
             start: localeDateString(source.startDate),
             end: localeDateString(source.endDate)
@@ -266,7 +266,7 @@ export function rendererBackgroundSource(data) {
 }
 
 
-rendererBackgroundSource.Bing = function(data, dispatch) {
+rendererBackgroundSource.Bing = function (data, dispatch) {
     // https://docs.microsoft.com/en-us/bingmaps/rest-services/imagery/get-imagery-metadata
     // https://docs.microsoft.com/en-us/bingmaps/rest-services/directly-accessing-the-bing-maps-tiles
 
@@ -291,7 +291,7 @@ rendererBackgroundSource.Bing = function(data, dispatch) {
     var metadataLastZoom = -1;
 
     d3_json(url)
-        .then(function(json) {
+        .then(function (json) {
             let imageryResource = json.resourceSets[0].resources[0];
 
             //retrieve and prepare up to date imagery template
@@ -299,18 +299,18 @@ rendererBackgroundSource.Bing = function(data, dispatch) {
             let subDomains = imageryResource.imageUrlSubdomains; //["t0, t1, t2, t3"]
             let subDomainNumbers = subDomains.map((subDomain) => {
                 return subDomain.substring(1);
-            } ).join(',');
+            }).join(',');
 
             template = template.replace('{subdomain}', `t{switch:${subDomainNumbers}}`).replace('{quadkey}', '{u}');
-            if (!new URLSearchParams(template).has(strictParam)){
+            if (!new URLSearchParams(template).has(strictParam)) {
                 template += `&${strictParam}=z`;
             }
             bing.template(template);
 
-            providers = imageryResource.imageryProviders.map(function(provider) {
+            providers = imageryResource.imageryProviders.map(function (provider) {
                 return {
                     attribution: provider.attribution,
-                    areas: provider.coverageAreas.map(function(area) {
+                    areas: provider.coverageAreas.map(function (area) {
                         return {
                             zoom: [area.zoomMin, area.zoomMax],
                             extent: geoExtent([area.bbox[1], area.bbox[0]], [area.bbox[3], area.bbox[2]])
@@ -320,31 +320,31 @@ rendererBackgroundSource.Bing = function(data, dispatch) {
             });
             dispatch.call('change');
         })
-        .catch(function() {
+        .catch(function () {
             /* ignore */
         });
 
 
-    bing.copyrightNotices = function(zoom, extent) {
+    bing.copyrightNotices = function (zoom, extent) {
         zoom = Math.min(zoom, 21);
-        return providers.filter(function(provider) {
-            return provider.areas.some(function(area) {
+        return providers.filter(function (provider) {
+            return provider.areas.some(function (area) {
                 return extent.intersects(area.extent) &&
                     area.zoom[0] <= zoom &&
                     area.zoom[1] >= zoom;
             });
-        }).map(function(provider) {
+        }).map(function (provider) {
             return provider.attribution;
         }).join(', ');
     };
 
 
-    bing.getMetadata = function(center, tileCoord, callback) {
+    bing.getMetadata = function (center, tileCoord, callback) {
         var tileID = tileCoord.slice(0, 3).join('/');
         var zoom = Math.min(tileCoord[2], 21);
         var centerPoint = center[1] + ',' + center[0];  // lat,lng
         var url = 'https://dev.virtualearth.net/REST/v1/Imagery/BasicMetadata/AerialOSM/' + centerPoint +
-                '?zl=' + zoom + '&key=' + key;
+            '?zl=' + zoom + '&key=' + key;
 
         if (inflight[tileID]) return;
 
@@ -357,7 +357,7 @@ rendererBackgroundSource.Bing = function(data, dispatch) {
 
         inflight[tileID] = true;
 
-        if (metadataLastZoom !== tileCoord[2]){
+        if (metadataLastZoom !== tileCoord[2]) {
             metadataLastZoom = tileCoord[2];
             taskQueue.clear();
         }
@@ -395,7 +395,7 @@ rendererBackgroundSource.Bing = function(data, dispatch) {
 
 
 
-rendererBackgroundSource.Esri = function(data) {
+rendererBackgroundSource.Esri = function (data) {
     // in addition to using the tilemap at zoom level 20, overzoom real tiles - #4327 (deprecated technique, but it works)
     if (data.template.match(/blankTile/) === null) {
         data.template = data.template + '?blankTile=false';
@@ -408,7 +408,7 @@ rendererBackgroundSource.Esri = function(data) {
 
     // use a tilemap service to set maximum zoom for esri tiles dynamically
     // https://developers.arcgis.com/documentation/tiled-elevation-service/
-    esri.fetchTilemap = function(center) {
+    esri.fetchTilemap = function (center) {
         // skip if we have already fetched a tilemap within 5km
         if (_prevCenter && geoSphericalDistance(center, _prevCenter) < 5000) return;
         _prevCenter = center;
@@ -417,7 +417,7 @@ rendererBackgroundSource.Esri = function(data) {
         var z = 20;
 
         // first generate a random url using the template
-        var dummyUrl = esri.url([1,2,3]);
+        var dummyUrl = esri.url([1, 2, 3]);
 
         // calculate url z/y/x from the lat/long of the center of the map
         var x = (Math.floor((center[0] + 180) / 360 * Math.pow(2, z)));
@@ -428,7 +428,7 @@ rendererBackgroundSource.Esri = function(data) {
 
         // make the request and introspect the response from the tilemap server
         d3_json(tilemapUrl)
-            .then(function(tilemap) {
+            .then(function (tilemap) {
                 if (!tilemap) {
                     throw new Error('Unknown Error');
                 }
@@ -444,13 +444,13 @@ rendererBackgroundSource.Esri = function(data) {
                 // if any tiles are missing at level 20 we restrict maxZoom to 19
                 esri.zoomExtent[1] = (hasTiles ? 22 : 19);
             })
-            .catch(function() {
+            .catch(function () {
                 /* ignore */
             });
     };
 
 
-    esri.getMetadata = function(center, tileCoord, callback) {
+    esri.getMetadata = function (center, tileCoord, callback) {
         if (esri.id !== 'EsriWorldImagery') {
             // rest endpoint is not available for ESRI's "clarity" imagery
             return callback(null, {});
@@ -477,7 +477,7 @@ rendererBackgroundSource.Esri = function(data) {
 
         inflight[tileID] = true;
         d3_json(url)
-            .then(function(result) {
+            .then(function (result) {
                 delete inflight[tileID];
 
                 result = result.features.map(f => f.attributes)
@@ -517,7 +517,7 @@ rendererBackgroundSource.Esri = function(data) {
                 cache[tileID].metadata = metadata;
                 if (callback) callback(null, metadata);
             })
-            .catch(function(err) {
+            .catch(function (err) {
                 delete inflight[tileID];
                 if (callback) callback(err.message);
             });
@@ -532,26 +532,26 @@ rendererBackgroundSource.Esri = function(data) {
 };
 
 
-rendererBackgroundSource.None = function() {
+rendererBackgroundSource.None = function () {
     var source = rendererBackgroundSource({ id: 'none', template: '' });
 
 
-    source.name = function() {
+    source.name = function () {
         return t('background.none');
     };
 
 
-    source.label = function() {
+    source.label = function () {
         return t.append('background.none');
     };
 
 
-    source.imageryUsed = function() {
+    source.imageryUsed = function () {
         return null;
     };
 
 
-    source.area = function() {
+    source.area = function () {
         return -1;  // sources in background pane are sorted by area
     };
 
@@ -560,20 +560,22 @@ rendererBackgroundSource.None = function() {
 };
 
 
-rendererBackgroundSource.Custom = function(template) {
+rendererBackgroundSource.Custom = function (template, customName) {
     var source = rendererBackgroundSource({ id: 'custom', template: template });
 
-
-    source.name = function() {
-        return t('background.custom');
+    source.name = function () {
+        return customName || t('background.custom');
     };
 
-    source.label = function() {
+    source.label = function () {
+        if (customName) {
+            return (selection) => selection.text(customName);
+        }
         return t.append('background.custom');
     };
 
 
-    source.imageryUsed = function() {
+    source.imageryUsed = function () {
         // sanitize personal connection tokens - #6801
         var cleaned = source.template();
 
@@ -582,7 +584,7 @@ rendererBackgroundSource.Custom = function(template) {
             var parts = cleaned.split('?', 2);
             var qs = utilStringQs(parts[1]);
 
-            ['access_token', 'connectId', 'token', 'Signature'].forEach(function(param) {
+            ['access_token', 'connectId', 'token', 'Signature'].forEach(function (param) {
                 if (qs[param]) {
                     qs[param] = '{apikey}';
                 }
@@ -598,7 +600,7 @@ rendererBackgroundSource.Custom = function(template) {
     };
 
 
-    source.area = function() {
+    source.area = function () {
         return -2;  // sources in background pane are sorted by area
     };
 

--- a/modules/ui/sections/background_list.js
+++ b/modules/ui/sections/background_list.js
@@ -15,11 +15,6 @@ export function uiSectionBackgroundList(context) {
 
     var _backgroundList = d3_select(null);
 
-    var _customSource = context.background().findSource('custom');
-
-    var _settingsCustomBackground = uiSettingsCustomBackground(context)
-        .on('change', customChanged);
-
     var section = uiSection('background-list', context)
         .label(() => t.append('background.backgrounds'))
         .disclosureContent(renderDisclosureContent);
@@ -61,7 +56,7 @@ export function uiSectionBackgroundList(context) {
         minimapLabelEnter
             .append('input')
             .attr('type', 'checkbox')
-            .on('change', function(d3_event) {
+            .on('change', function (d3_event) {
                 d3_event.preventDefault();
                 uiMapInMap.toggle();
             });
@@ -84,7 +79,7 @@ export function uiSectionBackgroundList(context) {
         panelLabelEnter
             .append('input')
             .attr('type', 'checkbox')
-            .on('change', function(d3_event) {
+            .on('change', function (d3_event) {
                 d3_event.preventDefault();
                 context.ui().info.toggle('background');
             });
@@ -106,7 +101,7 @@ export function uiSectionBackgroundList(context) {
         locPanelLabelEnter
             .append('input')
             .attr('type', 'checkbox')
-            .on('change', function(d3_event) {
+            .on('change', function (d3_event) {
                 d3_event.preventDefault();
                 context.ui().info.toggle('location');
             });
@@ -130,15 +125,15 @@ export function uiSectionBackgroundList(context) {
             .call(t.append('background.imagery_problem_faq'));
 
         _backgroundList
-            .call(drawListItems, 'radio', function(d3_event, d) {
+            .call(drawListItems, 'radio', function (d3_event, d) {
                 chooseBackground(d);
-            }, function(d) {
+            }, function (d) {
                 return !d.isHidden() && !d.overlay;
             });
     }
 
     function setTooltips(selection) {
-        selection.each(function(d, i, nodes) {
+        selection.each(function (d, i, nodes) {
             var item = d3_select(this).select('label');
             var span = item.select('span');
             var placement = (i < nodes.length / 2) ? 'bottom' : 'top';
@@ -166,25 +161,25 @@ export function uiSectionBackgroundList(context) {
         var sources = context.background()
             .sources(context.map().extent(), context.map().zoom(), true)
             .filter(filter)
-            .sort(function(a, b) {
+            .sort(function (a, b) {
                 return a.best() && !b.best() ? -1
                     : b.best() && !a.best() ? 1
-                    : d3_descending(a.area(), b.area()) || d3_ascending(a.name(), b.name()) || 0;
+                        : d3_descending(a.area(), b.area()) || d3_ascending(a.name(), b.name()) || 0;
             });
 
         var layerLinks = layerList.selectAll('li')
             // We have to be a bit inefficient about reordering the list since
             // arrow key navigation of radio values likes to work in the order
             // they were added, not the display document order.
-            .data(sources, function(d, i) { return d.id + '---' + i; });
+            .data(sources, function (d, i) { return d.id + '---' + i; });
 
         layerLinks.exit()
             .remove();
 
         var enter = layerLinks.enter()
             .append('li')
-            .classed('layer-custom', function(d) { return d.id === 'custom'; })
-            .classed('best', function(d) { return d.best(); });
+            .classed('layer-custom', function (d) { return d.id === 'custom'; })
+            .classed('best', function (d) { return d.best(); });
 
         var label = enter
             .append('label');
@@ -193,29 +188,47 @@ export function uiSectionBackgroundList(context) {
             .append('input')
             .attr('type', type)
             .attr('name', 'background-layer')
-            .attr('value', function(d) {
+            .attr('value', function (d) {
                 return d.id;
             })
             .on('change', change);
 
         label
             .append('span')
-            .each(function(d) { d.label()(d3_select(this)); });
+            .each(function (d) { d.label()(d3_select(this)); });
 
-        enter.filter(function(d) { return d.id === 'custom'; })
+        enter.filter(function (d) { return d.id === 'custom' || d.id?.startsWith('custom-'); })
             .append('button')
             .attr('class', 'layer-browse')
+            .each(function (d) {
+                d3_select(this).call(uiTooltip()
+                    .title(() => d.id === 'custom' ? t.append('settings.custom_background.tooltip') : t.append('settings.custom_background.edit'))
+                    .placement((localizer.textDirection() === 'rtl') ? 'right' : 'left')
+                );
+            })
+            .on('click', function (d3_event, d) {
+                d3_event.preventDefault();
+                editCustom(d.id);
+            })
+            .each(function (d) {
+                d3_select(this).call(svgIcon(d.id === 'custom' ? '#iD-icon-plus' : '#iD-icon-more'));
+            });
+
+        enter.filter(function (d) { return d.id?.startsWith('custom-'); })
+            .append('button')
+            .attr('class', 'layer-delete')
             .call(uiTooltip()
-                .title(() => t.append('settings.custom_background.tooltip'))
+                .title(() => t.append('icons.remove'))
                 .placement((localizer.textDirection() === 'rtl') ? 'right' : 'left')
             )
-            .on('click', function(d3_event) {
+            .on('click', function (d3_event, d) {
                 d3_event.preventDefault();
-                editCustom();
+                d3_event.stopPropagation();
+                deleteCustom(d.id);
             })
-            .call(svgIcon('#iD-icon-more'));
+            .call(svgIcon('#iD-icon-close'));
 
-        enter.filter(function(d) { return d.best(); })
+        enter.filter(function (d) { return d.best(); })
             .append('div')
             .attr('class', 'best')
             .call(uiTooltip()
@@ -236,7 +249,7 @@ export function uiSectionBackgroundList(context) {
 
         selection.selectAll('li')
             .classed('active', active)
-            .classed('switch', function(d) { return d.id === previousBackgroundID(); })
+            .classed('switch', function (d) { return d.id === previousBackgroundID(); })
             .call(setTooltips)
             .selectAll('input')
             .property('checked', active);
@@ -255,31 +268,97 @@ export function uiSectionBackgroundList(context) {
     }
 
 
-    function customChanged(d) {
+    function customChanged(d, customId) {
         if (d && d.template) {
-            _customSource.template(d.template);
-            chooseBackground(_customSource);
-        } else {
-            _customSource.template('');
-            chooseBackground(context.background().findSource('none'));
+            let customTemplates = [];
+            try {
+                customTemplates = JSON.parse(prefs('background-custom-templates') || '[]');
+            } catch {
+                customTemplates = [];
+            }
+
+            if (customId === 'custom') {
+                const newId = `custom-${Date.now()}`;
+                const customName = d.name || `Custom ${customTemplates.length + 1}`;
+                customTemplates.push({ id: newId, template: d.template, name: customName });
+                prefs('background-custom-templates', JSON.stringify(customTemplates));
+                window.location.reload();
+            } else {
+                const existing = customTemplates.find(c => c.id === customId);
+                if (existing) {
+                    existing.template = d.template;
+                    if (d.name) {
+                        existing.name = d.name;
+                    }
+                    prefs('background-custom-templates', JSON.stringify(customTemplates));
+                }
+                const source = context.background().findSource(customId);
+                if (source) {
+                    source.template(d.template);
+                    chooseBackground(source);
+                }
+            }
+        } else if (customId !== 'custom') {
+            deleteCustom(customId);
         }
     }
 
 
-    function editCustom() {
+    function editCustom(customId) {
+        const settingsCustom = uiSettingsCustomBackground(context)
+            .on('change', (d) => customChanged(d, customId));
+
+        if (customId && customId !== 'custom') {
+            const source = context.background().findSource(customId);
+            if (source) {
+                prefs('background-custom-template', source.template());
+                // Also set the name pref for editing
+                let customTemplates = [];
+                try {
+                    customTemplates = JSON.parse(prefs('background-custom-templates') || '[]');
+                } catch {
+                    customTemplates = [];
+                }
+                const existing = customTemplates.find(c => c.id === customId);
+                prefs('background-custom-name', existing?.name || '');
+            }
+        } else {
+            prefs('background-custom-template', '');
+            prefs('background-custom-name', '');
+        }
+
         context.container()
-            .call(_settingsCustomBackground);
+            .call(settingsCustom);
+    }
+
+
+    function deleteCustom(customId) {
+        if (!customId || customId === 'custom') return;
+
+        let customTemplates = [];
+        try {
+            const stored = localStorage.getItem('background-custom-templates');
+            customTemplates = stored ? JSON.parse(stored) : [];
+        } catch {
+            customTemplates = [];
+        }
+
+        customTemplates = customTemplates.filter(c => c.id !== customId);
+        localStorage.setItem('background-custom-templates', JSON.stringify(customTemplates));
+        localStorage.removeItem('background-custom-template');
+        localStorage.removeItem('background-custom-name');
+        window.location.reload();
     }
 
 
     context.background()
-        .on('change.background_list', function() {
+        .on('change.background_list', function () {
             _backgroundList.call(updateLayerSelections);
         });
 
     context.map()
         .on('move.background_list',
-            _debounce(function() {
+            _debounce(function () {
                 // layers in-view may have changed due to map move
                 window.requestIdleCallback(section.reRender);
             }, 1000)

--- a/modules/ui/settings/custom_background.js
+++ b/modules/ui/settings/custom_background.js
@@ -13,10 +13,12 @@ export function uiSettingsCustomBackground() {
     function render(selection) {
         // keep separate copies of original and current settings
         var _origSettings = {
-            template: prefs('background-custom-template')
+            template: prefs('background-custom-template'),
+            name: prefs('background-custom-name') || ''
         };
         var _currSettings = {
-            template: prefs('background-custom-template')
+            template: prefs('background-custom-template'),
+            name: prefs('background-custom-name') || ''
         };
 
         var example = 'https://tile.openstreetmap.org/{zoom}/{x}/{y}.png';
@@ -55,6 +57,14 @@ export function uiSettingsCustomBackground() {
             .append('div')
             .attr('class', 'instructions-template')
             .html(marked(instructions));
+
+        textSection
+            .append('input')
+            .attr('type', 'text')
+            .attr('class', 'field-name')
+            .attr('placeholder', 'Custom name (optional)')
+            .call(utilNoAuto)
+            .property('value', _currSettings.name || '');
 
         textSection
             .append('textarea')
@@ -97,7 +107,9 @@ export function uiSettingsCustomBackground() {
         // accept the current template
         function clickSave() {
             _currSettings.template = textSection.select('.field-template').property('value');
+            _currSettings.name = textSection.select('.field-name').property('value');
             prefs('background-custom-template', _currSettings.template);
+            prefs('background-custom-name', _currSettings.name);
             this.blur();
             modal.close();
             dispatch.call('change', this, _currSettings);


### PR DESCRIPTION
fixes #8874 

# Description
This PR addresses issue #8874 by allowing users to add, edit, and persist multiple custom background layers. Previously, iD only supported a single custom background layer.

# Features
- **Multiple Custom Backgrounds**: Users can now add multiple custom tile layers.
- **Custom Naming**: Added a name input field to the custom background modal. Users can name their layers (e.g., "My Drone Imagery", "Local Gov Map").
- **Persistence**: Custom layers are saved in `localStorage` as an array and persist across page reloads.
- **Management UI**: 
  - **Add**: Button to add a new custom layer.
  - **Edit**: Edit existing custom layers (name and URL).
  - **Delete**: Remove custom layers using the 'X' button.
- **Migration**: Automatically migrates existing single custom background settings to the new format.


# Video

https://github.com/user-attachments/assets/d00687ad-c59a-43c5-9c38-d2d7842a76b7


