### PR TITLE
Ensure XML elements are created without namespace in JXON

### DIFF
--- a/modules/util/jxon.js
+++ b/modules/util/jxon.js
@@ -110,12 +110,12 @@ export var JXON = new (function () {
         oParentEl.setAttribute(sName.slice(1), vValue);
       } else if (vValue.constructor === Array) {
         for (var nItem = 0; nItem < vValue.length; nItem++) {
-          oChild = oXMLDoc.createElement(sName);
+          oChild = oXMLDoc.createElementNS(null, sName);
           loadObjTree(oXMLDoc, oChild, vValue[nItem]);
           oParentEl.appendChild(oChild);
         }
       } else {
-        oChild = oXMLDoc.createElement(sName);
+        oChild = oXMLDoc.createElementNS(null, sName);
         if (vValue instanceof Object) {
           loadObjTree(oXMLDoc, oChild, vValue);
         } else if (vValue !== null && vValue !== true) {


### PR DESCRIPTION
### Description

This PR fixes a bug where Safari users were unable to save edits in the iD editor (#11842).

When saving in Safari, the browser was injecting the XHTML namespace (`xmlns="http://www.w3.org/1999/xhtml"`) into the root `<osm>` element. The OpenStreetMap API server fails to parse XML with this namespace, as it expects the elements to be in the null (default) namespace.

The error message reported by users was:
`Cannot parse valid changeset from xml string . XML doesn't contain an osm/changeset element.`

### Changes

- Modified [modules/util/jxon.js] to use `createElementNS(null, sName)` instead of `createElement(sName)`. This explicitly forces the elements into the null namespace, preventing browsers from adding their own defaults.

### Verification

- Verified that the generated XML for changesets does not contain the `xmlns` attribute.
- Ran all existing tests (`npm run test:spec`) to ensure no regressions in XML generation for other browsers.

Fixes #11842