### PR TITLE
Fix: implement tag retention for Extract tool to prevent area validation errors

### DIFF
--- a/modules/actions/extract.js
+++ b/modules/actions/extract.js
@@ -9,11 +9,9 @@ export function actionExtract(entityID, projection) {
     /** @param {boolean} shiftKeyPressed */
     var action = function(graph, shiftKeyPressed) {
         var entity = graph.entity(entityID);
-
         if (entity.type === 'node') {
             return extractFromNode(entity, graph, shiftKeyPressed);
         }
-
         return extractFromWayOrRelation(entity, graph);
     };
 
@@ -49,10 +47,13 @@ export function actionExtract(entityID, projection) {
         var keysToCopyAndRetain = ['source', 'wheelchair'];
         var keysToRetain = ['area'];
         var buildingKeysToRetain = ['architect', 'building', 'height', 'layer', 'nycdoitt:bin', 'ref:GB:uprn', 'ref:linz:building_id'];
+        
+        // Comprehensive list of primary OSM categories to prevent "naked" areas
+        var primaryCategoryKeys = /^(amenity|shop|leisure|tourism|craft|office|landuse|natural|historic|military|place|power|railway|route|telecom|waterway|club|emergency|healthcare|boundary|highway|aeroway|man_made)$/;
 
         var extractedLoc = d3_geoPath(projection).centroid(entity.asGeoJSON(graph));
         extractedLoc = extractedLoc && projection.invert(extractedLoc);
-        if (!extractedLoc  || !isFinite(extractedLoc[0]) || !isFinite(extractedLoc[1])) {
+        if (!extractedLoc || !isFinite(extractedLoc[0]) || !isFinite(extractedLoc[1])) {
             extractedLoc = entity.extent(graph).center();
         }
 
@@ -69,15 +70,12 @@ export function actionExtract(entityID, projection) {
 
         var isIndoorArea = fromGeometry === 'area' && entity.tags.indoor && indoorAreaValues[entity.tags.indoor];
 
-        var entityTags = Object.assign({}, entity.tags);  // shallow copy
+        var entityTags = Object.assign({}, entity.tags);
         var pointTags = {};
         for (var key in entityTags) {
-
-            if (entity.type === 'relation' &&
-                key === 'type') {
+            if (entity.type === 'relation' && key === 'type') {
                 continue;
             }
-
             if (keysToRetain.indexOf(key) !== -1) {
                 continue;
             }
@@ -93,16 +91,23 @@ export function actionExtract(entityID, projection) {
                 continue;
             }
 
-            // copy the tag from the entity to the point
+            // Copy the tag to the new Point
             pointTags[key] = entityTags[key];
+            
+            // Retain 'level' on the area 
+            if (key === 'level' && fromGeometry === 'area') {
+                continue;
+            } 
 
             // leave addresses and some other tags so they're on both features
             if (keysToCopyAndRetain.indexOf(key) !== -1 ||
                 key.match(/^addr:.{1,}/)) {
                 continue;
-            } else if (isIndoorArea && key === 'level') {
-                // leave `level` on both features
-                continue;
+            }
+
+            // Keep the primary category if no other structural identity exists
+            if (key.match(primaryCategoryKeys) && !isBuilding && !isIndoorArea) {
+                continue; 
             }
 
             // remove the tag from the entity


### PR DESCRIPTION
I’ve been working on a fix for the Extract Tool to resolve the data integrity issues (Red Errors) that occur when extracting tags from independent objects. (After looking at all possible edge cases I have chosen this approach to resolve the issue)

The Problem :
In the current implementation, the Extract tool is "too aggressive" when handling standalone features like swimming pools. When a user extracts a label to a Point for better visibility, the tool often strips all descriptive tags from the original geometry, leaving behind only area=yes. This immediately triggers the "Area has no descriptive tags" validation error.

The Approach: "Tag" Retention
Instead of a total extraction, I’ve implemented a "Tag Retention" logic in modules/actions/extract.js. This approach ensures that the tool remains available everywhere while protecting the validity of the underlying geometry.

Key Logic Applied:

I introduced a regex for primaryCategoryKeys (e.g., amenity, shop, leisure, historic, etc.) to identify the core "Identity" of an object.

Context: The code now checks if the area has a structural fallback like building=yes.

Scenario A (Buildings): If it’s a building, the primary tag moves to the Point because the area remains valid as a "Building".

Scenario B (Standalone Objects): If there is no building tag, the logic refuses to delete the primary tag from the area. It copies the tag to the Point but leaves it on the Area as a "Shell," preventing the Red Error.

Handling Vertical Data (Level Tags)
I have also ensured that vertical data standards are maintained.

Level Retention: The extraction logic specifically identifies the level key and retains it on the area footprint. This ensures that even if a business name is moved to a Point (to resolve "Too Close" warnings), the physical structure doesn't lose its floor data.

Summary of Changes
extract.js (Action): Added conditional deletion logic based on building presence and primary category lists.

This fix allows for the high icon visibility mappers want without the data corruption that currently triggers the validator. I'd love to get some feedback on this approach!

#Before (When the "Extraction" tool used)
<img width="920" height="477" alt="imgpr#2" src="https://github.com/user-attachments/assets/aaef447b-d946-4658-8ad1-31a37109655d" />
<img width="863" height="592" alt="imgpr#off" src="https://github.com/user-attachments/assets/90604daa-0e56-42a8-b407-d81eba837b53" />



#After (When the "Extraction" tool used)
<img width="984" height="568" alt="imgpr#2testing" src="https://github.com/user-attachments/assets/5892b956-19cd-48bb-af70-383977718aaf" />
<img width="770" height="531" alt="imgpr#testing" src="https://github.com/user-attachments/assets/d7469405-58a9-49e7-9543-86d4d988e157" />



Fixes #11830

