### PR TITLE
make iD 2x faster during long edit sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * When viewing the help information for tags or presets, use locale-specific properties if available ([#11760], thanks [@k-yle])
 * Show country names in your preferred language and country flag emoji in the Country field dropdown ([#11783], thanks [@Razen04])
 #### :hourglass: Performance
+* iD is now twice as fast during long editing sessions ([#11861], thanks [@k-yle])
 #### :mortar_board: Walkthrough / Help
 #### :rocket: Presets
 * Add dedicated styling for `highway=ladder` to make it distinguishable from `highway=steps` ([#11799], thanks [@bhavyaKhatri2703])
@@ -78,6 +79,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#11794]: https://github.com/openstreetmap/iD/pull/11794
 [#11799]: https://github.com/openstreetmap/iD/issues/11799
 [#11783]: https://github.com/openstreetmap/iD/pull/11783
+[#11861]: https://github.com/openstreetmap/iD/pull/11861
 [#11862]: https://github.com/openstreetmap/iD/pull/11862
 [@ilias52730]: https://github.com/ilias52730
 [@Razen04]: https://github.com/Razen04

--- a/modules/core/history.js
+++ b/modules/core/history.js
@@ -655,7 +655,7 @@ export function coreHistory(context) {
                         .then(() => prefs('has_saved_history', null))
                         .catch(() => dispatch.call('storage_error'));
                 } else {
-                    asyncPrefs.set('saved_history', history.toJSON())
+                    asyncPrefs.set('saved_history', historyData)
                         .then(() => prefs('has_saved_history', true))
                         .catch(() => dispatch.call('storage_error'));
                 }


### PR DESCRIPTION
For changesets that last several hours and affect thousands of elements ([example](https://osmcha.org/changesets/177297256)), `coreHistory`'s stack quickly reaches >1GB of JSON, which makes `history.toJSON()` the perf bottleneck. 

Over 99% of time is spent inside this function after ever operation, and we call the function twice in a row for no good reason. We can just reuse the value from a few lines above