### PR TITLE
Fix custom background crash due to early source capture

### DIFF
--- a/modules/ui/sections/background_list.js
+++ b/modules/ui/sections/background_list.js
@@ -167,7 +167,7 @@ export function uiSectionBackgroundList(context) {
             .sort(function(a, b) {
                 return a.best() && !b.best() ? -1
                     : b.best() && !a.best() ? 1
-                        : d3_descending(a.area(), b.area()) || d3_ascending(a.name(), b.name()) || 0;
+                    : d3_descending(a.area(), b.area()) || d3_ascending(a.name(), b.name()) || 0;
             });
 
         var layerLinks = layerList.selectAll('li')

--- a/modules/ui/sections/background_list.js
+++ b/modules/ui/sections/background_list.js
@@ -15,8 +15,6 @@ export function uiSectionBackgroundList(context) {
 
     var _backgroundList = d3_select(null);
 
-    var _customSource = context.background().findSource('custom');
-
     var _settingsCustomBackground = uiSettingsCustomBackground(context)
         .on('change', customChanged);
 
@@ -169,7 +167,7 @@ export function uiSectionBackgroundList(context) {
             .sort(function(a, b) {
                 return a.best() && !b.best() ? -1
                     : b.best() && !a.best() ? 1
-                    : d3_descending(a.area(), b.area()) || d3_ascending(a.name(), b.name()) || 0;
+                        : d3_descending(a.area(), b.area()) || d3_ascending(a.name(), b.name()) || 0;
             });
 
         var layerLinks = layerList.selectAll('li')
@@ -256,12 +254,19 @@ export function uiSectionBackgroundList(context) {
 
 
     function customChanged(d) {
+        var background = context.background();
+        var customSource = background.findSource('custom');
+        if (!customSource) return;
+
         if (d && d.template) {
-            _customSource.template(d.template);
-            chooseBackground(_customSource);
+            customSource.template(d.template);
+            chooseBackground(customSource);
         } else {
-            _customSource.template('');
-            chooseBackground(context.background().findSource('none'));
+            customSource.template('');
+            var noneSource = background.findSource('none');
+            if (noneSource) {
+                chooseBackground(noneSource);
+            }
         }
     }
 

--- a/test/spec/ui/sections/background_list.js
+++ b/test/spec/ui/sections/background_list.js
@@ -1,0 +1,98 @@
+describe('iD.uiSectionBackgroundList', function () {
+    let context, container;
+
+    beforeEach(function () {
+        container = d3.select('body').append('div').attr('class', 'id-container');
+        context = iD.coreContext().assetPath('../dist/').init();
+        context.container(container);
+    });
+
+    afterEach(function () {
+        container.remove();
+    });
+
+    it('does not crash during initialization if custom source is missing', function () {
+        const originalFindSource = context.background().findSource;
+        context.background().findSource = (id) => {
+            if (id === 'custom') return null;
+            return originalFindSource(id);
+        };
+
+        try {
+            expect(() => {
+                iD.uiSectionBackgroundList(context);
+            }).not.to.throw();
+        } finally {
+            context.background().findSource = originalFindSource;
+        }
+    });
+
+    it('customChanged handles missing custom source gracefully', function () {
+        const section = iD.uiSectionBackgroundList(context);
+        const selection = container.append('div').call(section.render);
+
+        // Find the browse button for the custom layer
+        const browseButton = selection.selectAll('.layer-custom button.layer-browse');
+        expect(browseButton.size()).to.equal(1);
+
+        // Click it to open the settings modal
+        iD.utilTriggerEvent(browseButton, 'click');
+
+        // The modal should now be in the container
+        const modal = container.select('.modal');
+        expect(modal.size()).to.equal(1);
+
+        // Mock findSource to return null right before we "save"
+        const originalFindSource = context.background().findSource;
+        context.background().findSource = (id) => {
+            if (id === 'custom') return null;
+            return originalFindSource(id);
+        };
+
+        try {
+            // Find and click the "OK" (save) button in the modal
+            const okButton = modal.select('.modal-section.buttons .ok-button');
+            expect(okButton.size()).to.equal(1);
+
+            expect(() => {
+                iD.utilTriggerEvent(okButton, 'click');
+            }).not.to.throw();
+
+        } finally {
+            context.background().findSource = originalFindSource;
+        }
+    });
+
+    it('customChanged fallback to "none" handles missing "none" source gracefully', function () {
+        const section = iD.uiSectionBackgroundList(context);
+        const selection = container.append('div').call(section.render);
+
+        // Find the browse button for the custom layer and click it
+        const browseButton = selection.selectAll('.layer-custom button.layer-browse');
+        iD.utilTriggerEvent(browseButton, 'click');
+
+        const modal = container.select('.modal');
+        expect(modal.size()).to.equal(1);
+
+        // Clear the template field to simulate falling back to 'none'
+        modal.select('textarea.field-template').property('value', '');
+
+        // Mock findSource to return null for 'none'
+        const originalFindSource = context.background().findSource;
+        context.background().findSource = (id) => {
+            if (id === 'none') return null;
+            return originalFindSource(id);
+        };
+
+        try {
+            const okButton = modal.select('.modal-section.buttons .ok-button');
+            expect(okButton.size()).to.equal(1);
+
+            expect(() => {
+                iD.utilTriggerEvent(okButton, 'click');
+            }).not.to.throw();
+        } finally {
+            context.background().findSource = originalFindSource;
+        }
+    });
+});


### PR DESCRIPTION
## Problem
The iD editor crashes with a `TypeError` when a user attempts to set a custom background URL before the "Custom" imagery source is fully initialized. 

### Root Cause
In [background_list.js], the `_customSource` variable was initialized once when the UI section was first created. Because background sources load asynchronously, `context.background().findSource('custom')` could return `null` at that moment. When [customChanged()] was later called to update a URL, it attempted to access `.template()` on that null reference, causing the crash.

## Solution
- Removed the static `_customSource` initialization.
- Modified [customChanged(d)] to resolve both the [custom] and `none` imagery sources dynamically at the time they are needed.
- Added defensive null-guards to safely handle cases where the background sources might still be unavailable, preventing any potential crash paths.

## Testing
- Added a new specification file [test/spec/ui/sections/background_list.js] with 3 regression tests covering:
  - Safe initialization when sources are missing.
  - Safe handling of custom URL changes.
  - Safe fallback to the "none" source.
- Verified that all tests pass and that the code adheres to iD's formatting style.

Fixes #11855