### PR TITLE
Replace deprecated document.createEvent/initEvent with modern Event constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :hammer: Development
 * Change package name to `@openstreetmap/id` to be able to publish releases on npm
 * Use Röntgen icon set directly from upstream npm package ([#11784], thanks [@tordans])
+* Replace deprecated `document.createEvent`/`initEvent` with modern [Event] constructor ([#11870], thanks [@JaiswalShivang])
 
 
 [#11522]: https://github.com/openstreetmap/iD/issues/11522
@@ -85,6 +86,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [@omsaraykar]: https://github.com/omsaraykar
 [@Kaushik4141]: https://github.com/Kaushik4141
 [@Kayd-06]: https://github.com/Kayd-06
+[@JaiswalShivang]: https://github.com/JaiswalShivang
 
 
 # v2.37.3

--- a/modules/renderer/map.js
+++ b/modules/renderer/map.js
@@ -302,7 +302,9 @@ export function rendererMap(context) {
                 }
             }
             if (hasOrphan) {
-                var event = new Event('mouseup', { view: window });
+                var event = new Event('mouseup');
+                // Event needs to be dispatched with an event.view property.
+                event.view = window;
                 window.dispatchEvent(event);
             }
         }

--- a/modules/renderer/map.js
+++ b/modules/renderer/map.js
@@ -302,7 +302,7 @@ export function rendererMap(context) {
                 }
             }
             if (hasOrphan) {
-                var event = new Event('mouseup');
+                const event = new Event('mouseup');
                 // Event needs to be dispatched with an event.view property.
                 event.view = window;
                 window.dispatchEvent(event);

--- a/modules/renderer/map.js
+++ b/modules/renderer/map.js
@@ -302,15 +302,7 @@ export function rendererMap(context) {
                 }
             }
             if (hasOrphan) {
-                var event = window.CustomEvent;
-                if (event) {
-                    event = new event('mouseup');
-                } else {
-                    event = window.document.createEvent('Event');
-                    event.initEvent('mouseup', false, false);
-                }
-                // Event needs to be dispatched with an event.view property.
-                event.view = window;
+                var event = new Event('mouseup', { view: window });
                 window.dispatchEvent(event);
             }
         }

--- a/modules/ui/init.js
+++ b/modules/ui/init.js
@@ -549,12 +549,7 @@ export function uiInit(context) {
         ui.checkOverflow('.top-toolbar');
         ui.checkOverflow('.map-footer-bar');
 
-        // Use outdated code so it works on Explorer
-        var resizeWindowEvent = document.createEvent('Event');
-
-        resizeWindowEvent.initEvent('resizeWindow', true, true);
-
-        document.dispatchEvent(resizeWindowEvent);
+        document.dispatchEvent(new Event('resizeWindow', { bubbles: true, cancelable: true }));
     };
 
 

--- a/modules/ui/init.js
+++ b/modules/ui/init.js
@@ -549,7 +549,11 @@ export function uiInit(context) {
         ui.checkOverflow('.top-toolbar');
         ui.checkOverflow('.map-footer-bar');
 
-        document.dispatchEvent(new Event('resizeWindow', { bubbles: true, cancelable: true }));
+        const event = new Event('resizeWindow', {
+            bubbles: true,
+            cancelable: true
+        });
+        document.dispatchEvent(event);
     };
 
 

--- a/modules/util/trigger_event.js
+++ b/modules/util/trigger_event.js
@@ -1,10 +1,7 @@
 export function utilTriggerEvent(target, type, eventProperties) {
     target.each(function() {
-        var evt = document.createEvent('HTMLEvents');
-        evt.initEvent(type, true, true);
-        for (var prop in eventProperties) {
-            evt[prop] = eventProperties[prop];
-        }
+        var evt = new Event(type, { bubbles: true, cancelable: true });
+        Object.assign(evt, eventProperties);
         this.dispatchEvent(evt);
     });
 }

--- a/modules/util/trigger_event.js
+++ b/modules/util/trigger_event.js
@@ -1,7 +1,10 @@
 export function utilTriggerEvent(target, type, eventProperties) {
     target.each(function() {
-        var evt = new Event(type, { bubbles: true, cancelable: true });
-        Object.assign(evt, eventProperties);
-        this.dispatchEvent(evt);
+        const event = new Event(type, {
+            bubbles: true,
+            cancelable: true
+        });
+        Object.assign(event, eventProperties);
+        this.dispatchEvent(event);
     });
 }


### PR DESCRIPTION
## Summary

Replaces all usages of the deprecated `document.createEvent()` and `initEvent()` methods with the modern [Event()] constructor across the codebase.

Closes #11870 

## Problem

The codebase uses `document.createEvent()` and `initEvent()` in 3 files. These methods are [deprecated by MDN](https://developer.mozilla.org/en-US/docs/Web/API/Document/createEvent) and have been superseded by the [[Event()] constructor](https://developer.mozilla.org/en-US/docs/Web/API/Event/Event).

Notably, [modules/ui/init.js] contains the comment:
> "Use outdated code so it works on Explorer"

Since iD no longer supports Internet Explorer, this legacy code can be safely modernized.

## Changes

### 1. [modules/util/trigger_event.js]
Core utility function used by [combobox.js]
[address.js] and [changeset_editor.js]

- Replaced `document.createEvent('HTMLEvents')` + `initEvent()` with `new Event()`
- Replaced manual property loop with `Object.assign()`

### 2. [modules/ui/init.js](line 552-557)
- Removed outdated IE compatibility comment and 3-line event creation
- Replaced with single-line `new Event()` call

### 3. [modules/renderer/map.js](line 304-314)
- Removed unnecessary `CustomEvent` existence check and `createEvent` fallback
- Simplified to direct `new Event()` constructor

## Browser Support

The [Event()] constructor is supported by all browsers that iD currently targets:
- Chrome 15+ ✅
- Firefox 11+ ✅  
- Safari 6+ ✅
- Edge 12+ ✅

[caniuse: Event constructor](https://caniuse.com/mdn-api_event_event)

## Testing

- [x] Existing tests pass (`npm test`)
- [x] Manual testing: combobox interactions, address field changes, window resizing, and map zoom all work correctly