### PR TITLE
Add Select all members button for relations (fixes #9982)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 ##### 2026-03-02
 
 #### :sparkles: Usability & Accessibility
+* Add "Select all members" link and Ctrl+↓ shortcut for relations ([#11873], fixes [#9982], thanks [@FaisalMisbah23])
 * Show warning when attempting to paste but nothing has been copied ([#9401], thanks [@omsaraykar])
 * Don't suggest values from Taginfo for `addr:*` tags ([#11733], thanks [@k-yle])
 * Don't suggest values from Taginfo for tags with less than 100 uses, even if they're documented on the wiki ([#11794], thanks [@Kaushik4141])
@@ -154,6 +155,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#11819]: https://github.com/openstreetmap/iD/pull/11819
 [#11861]: https://github.com/openstreetmap/iD/pull/11861
 [#11862]: https://github.com/openstreetmap/iD/pull/11862
+<<<<<<< HEAD
 [#11869]: https://github.com/openstreetmap/iD/pull/11869
 [#11871]: https://github.com/openstreetmap/iD/pull/11871
 [#11904]: https://github.com/openstreetmap/iD/issues/11904
@@ -162,6 +164,11 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [be0a20e59]: https://github.com/openstreetmap/iD/commit/be0a20e59
 [b06496780]: https://github.com/openstreetmap/iD/commit/b06496780
 [#id-tagging-schema/pull/1507]: https://github.com/openstreetmap/id-tagging-schema/pull/1507
+=======
+[#11873]: https://github.com/openstreetmap/iD/pull/11873
+[#9982]: https://github.com/openstreetmap/iD/issues/9982
+[@FaisalMisbah23]: https://github.com/FaisalMisbah23
+>>>>>>> 5b96d6551d (Add Select all members for relations (fixes #9982))
 [@ilias52730]: https://github.com/ilias52730
 [@Razen04]: https://github.com/Razen04
 [@homersimpsons]: https://github.com/homersimpsons

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -2994,6 +2994,27 @@ img.tag-reference-wiki-image {
     */
 }
 
+.section-raw-member-editor .member-select-all-wrap {
+    margin-bottom: 4px;
+}
+.section-raw-member-editor .member-select-all {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+    color: var(--link-color, #06c);
+    cursor: pointer;
+}
+.section-raw-member-editor .member-select-all:hover {
+    text-decoration: underline;
+}
+.section-raw-member-editor .member-select-all .icon {
+    flex-shrink: 0;
+}
+.section-raw-member-editor .member-select-all.loading .icon use {
+    opacity: 0.5;
+}
+
 /* add tag, add relation buttons */
 .add-row {
     display: flex;

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -716,6 +716,8 @@ en:
     fields: Fields
     tags: Tags
     members: Members
+    select_all_members: Select all members
+    select_all_members_tooltip: Load and select all relation members
     relations: Relations
     features: Features
     title_count: "{title} ({count})"

--- a/modules/modes/select.js
+++ b/modules/modes/select.js
@@ -628,6 +628,27 @@ export function modeSelect(context, selectedIDs) {
 
             var currentSelectedIds = mode.selectedIDs();
 
+            // When a single relation is selected, Ctrl+↓ selects all its members (like way → nodes)
+            if (currentSelectedIds.length === 1) {
+                var entity = context.hasEntity(currentSelectedIds[0]);
+                if (entity && entity.type === 'relation' && entity.members.length > 0) {
+                    var memberIds = entity.members.map(function(m) { return m.id; });
+                    var missing = memberIds.filter(function(id) { return !context.hasEntity(id); });
+                    if (missing.length > 0) {
+                        context.loadEntity(entity.id, function(err) {
+                            if (err) return;
+                            var rel = context.entity(entity.id);
+                            if (!rel || !rel.members.length) return;
+                            var ids = rel.members.map(function(m) { return m.id; });
+                            context.enter(mode.selectedIDs(ids));
+                        });
+                        return;
+                    }
+                    context.enter(mode.selectedIDs(memberIds));
+                    return;
+                }
+            }
+
             var childIds = _focusedVertexIds ? _focusedVertexIds.filter(id => context.hasEntity(id)) : childNodeIdsOfSelection(true);
             if (!childIds || !childIds.length) return;
 

--- a/modules/ui/sections/raw_member_editor.js
+++ b/modules/ui/sections/raw_member_editor.js
@@ -139,6 +139,39 @@ export function uiSectionRawMemberEditor(context) {
             });
         });
 
+        const selectAllWrap = selection.selectAll('.member-select-all-wrap')
+            .data([0]);
+        selectAllWrap.enter()
+            .append('div')
+            .attr('class', 'member-select-all-wrap form-field')
+            .merge(selectAllWrap)
+            .style('display', entity.members.length === 0 ? 'none' : null)
+            .each(function() {
+                const wrap = d3_select(this);
+                wrap.selectAll('*').remove();
+                const link = wrap
+                    .append('a')
+                    .attr('class', 'member-select-all')
+                    .attr('href', '#')
+                    .attr('title', t('inspector.select_all_members_tooltip'));
+                link.call(svgIcon('#iD-icon-layers', 'inline'));
+                link.append('span').text(t('inspector.select_all_members'));
+                link.on('click', function(d3_event) {
+                    d3_event.preventDefault();
+                    const linkEl = d3_select(this);
+                    if (linkEl.classed('loading')) return;
+                    linkEl.classed('loading', true);
+                    context.loadEntity(entity.id, function(err) {
+                        linkEl.classed('loading', false);
+                        if (err) return;
+                        const updated = context.entity(entity.id);
+                        if (!updated || !updated.members.length) return;
+                        const ids = updated.members.map(function(m) { return m.id; });
+                        context.enter(modeSelect(context, ids));
+                    });
+                });
+            });
+
         var list = selection.selectAll('.member-list')
             .data([0]);
 


### PR DESCRIPTION
Adds a button in the Members section when a relation is selected. Clicking it loads any unloaded members, then switches to multiselection of all members so users can apply tags (e.g. toll) to each.

- Button in Members section switches to multiselection of all relation members
- Loads unloaded members first, then selects only loaded IDs
- Empty state message when relation has no members
- Promise error handling so loading state is always cleared