### PR TITLE
Fix 50k bbox spinner

### DIFF
--- a/modules/services/osm.js
+++ b/modules/services/osm.js
@@ -1,40 +1,71 @@
-import _throttle from 'lodash-es/throttle';
+import _throttle from "lodash-es/throttle";
 
-import { dispatch as d3_dispatch } from 'd3-dispatch';
-import { json as d3_json, xml as d3_xml } from 'd3-fetch';
-import { osmAuth } from 'osm-auth';
-import RBush from 'rbush';
+import { dispatch as d3_dispatch } from "d3-dispatch";
+import { json as d3_json, xml as d3_xml } from "d3-fetch";
+import { osmAuth } from "osm-auth";
+import RBush from "rbush";
 
-import { JXON } from '../util/jxon';
-import { geoExtent, geoRawMercator, geoVecAdd, geoZoomToScale } from '../geo';
-import { osmEntity, osmNode, osmNote, osmRelation, osmWay } from '../osm';
-import { utilArrayChunk, utilArrayGroupBy, utilArrayUniq, utilObjectOmit, utilRebind, utilTiler, utilQsString } from '../util';
-import { localizer } from '../core/localizer.js';
-import { utilGzip } from '../util/util';
-import { osmApiConnections } from '../../config/id.js';
-
+import { JXON } from "../util/jxon";
+import { geoExtent, geoRawMercator, geoVecAdd, geoZoomToScale } from "../geo";
+import { osmEntity, osmNode, osmNote, osmRelation, osmWay } from "../osm";
+import {
+  utilArrayChunk,
+  utilArrayGroupBy,
+  utilArrayUniq,
+  utilObjectOmit,
+  utilRebind,
+  utilTiler,
+  utilQsString,
+} from "../util";
+import { localizer } from "../core/localizer.js";
+import { utilGzip } from "../util/util";
+import { osmApiConnections } from "../../config/id.js";
 
 var tiler = utilTiler();
-var dispatch = d3_dispatch('apiStatusChange', 'authLoading', 'authDone', 'change', 'loading', 'loaded', 'loadedNotes');
+var dispatch = d3_dispatch(
+  "apiStatusChange",
+  "authLoading",
+  "authDone",
+  "change",
+  "loading",
+  "loaded",
+  "loadedNotes",
+);
 
 var urlroot = osmApiConnections[0].url;
 var apiUrlroot = osmApiConnections[0].apiUrl || urlroot;
 var redirectPath = window.location.origin + window.location.pathname;
 var oauth = osmAuth({
-    url: urlroot,
-    apiUrl: apiUrlroot,
-    client_id: osmApiConnections[0].client_id,
-    scope: 'read_prefs write_prefs write_api read_gpx write_notes',
-    redirect_uri: redirectPath + 'land.html',
-    loading: authLoading,
-    done: authDone
+  url: urlroot,
+  apiUrl: apiUrlroot,
+  client_id: osmApiConnections[0].client_id,
+  scope: "read_prefs write_prefs write_api read_gpx write_notes",
+  redirect_uri: redirectPath + "land.html",
+  loading: authLoading,
+  done: authDone,
 });
 var _apiConnections = osmApiConnections;
 
 // hardcode default block of Google Maps
-var _imageryBlocklists = [/.*\.google(apis)?\..*\/(vt|kh)[\?\/].*([xyz]=.*){3}.*/];
-var _tileCache = { toLoad: {}, loaded: {}, inflight: {}, seen: {}, rtree: new RBush() };
-var _noteCache = { toLoad: {}, loaded: {}, inflight: {}, inflightPost: {}, note: {}, closed: {}, rtree: new RBush() };
+var _imageryBlocklists = [
+  /.*\.google(apis)?\..*\/(vt|kh)[\?\/].*([xyz]=.*){3}.*/,
+];
+var _tileCache = {
+  toLoad: {},
+  loaded: {},
+  inflight: {},
+  seen: {},
+  rtree: new RBush(),
+};
+var _noteCache = {
+  toLoad: {},
+  loaded: {},
+  inflight: {},
+  inflightPost: {},
+  note: {},
+  closed: {},
+  rtree: new RBush(),
+};
 var _userCache = { toLoad: {}, user: {} };
 var _cachedApiStatus;
 var _changeset = {};
@@ -47,1481 +78,1607 @@ var _rateLimitError;
 var _userChangesets;
 var _userDetails;
 var _off;
+var MAX_SUBDIVISION_DEPTH = 3;
+var _isLoading = false;
 
 // set a default but also load this from the API status
 var _maxWayNodes = 2000;
 
-
 function authLoading() {
-    dispatch.call('authLoading');
+  dispatch.call("authLoading");
 }
-
 
 function authDone() {
-    dispatch.call('authDone');
+  dispatch.call("authDone");
 }
-
 
 function abortRequest(controllerOrXHR) {
-    if (controllerOrXHR) {
-        controllerOrXHR.abort();
-    }
+  if (controllerOrXHR) {
+    controllerOrXHR.abort();
+  }
 }
-
 
 function hasInflightRequests(cache) {
-    return Object.keys(cache.inflight).length;
+  return Object.keys(cache.inflight).length;
 }
-
 
 function abortUnwantedRequests(cache, visibleTiles) {
-    Object.keys(cache.inflight).forEach(function(k) {
-        if (cache.toLoad[k]) return;
-        if (visibleTiles.find(function(tile) { return k === tile.id; })) return;
+  Object.keys(cache.inflight).forEach(function (k) {
+    if (cache.toLoad[k]) return;
+    if (
+      visibleTiles.find(function (tile) {
+        return k === tile.id;
+      })
+    )
+      return;
 
-        abortRequest(cache.inflight[k]);
-        delete cache.inflight[k];
-    });
+    abortRequest(cache.inflight[k]);
+    delete cache.inflight[k];
+  });
 }
-
 
 function getLoc(attrs) {
-    var lon = attrs.lon && attrs.lon.value;
-    var lat = attrs.lat && attrs.lat.value;
-    return [Number(lon), Number(lat)];
+  var lon = attrs.lon && attrs.lon.value;
+  var lat = attrs.lat && attrs.lat.value;
+  return [Number(lon), Number(lat)];
 }
 
-
 function getNodes(obj) {
-    var elems = obj.getElementsByTagName('nd');
-    var nodes = new Array(elems.length);
-    for (var i = 0, l = elems.length; i < l; i++) {
-        nodes[i] = 'n' + elems[i].attributes.ref.value;
-    }
-    return nodes;
+  var elems = obj.getElementsByTagName("nd");
+  var nodes = new Array(elems.length);
+  for (var i = 0, l = elems.length; i < l; i++) {
+    nodes[i] = "n" + elems[i].attributes.ref.value;
+  }
+  return nodes;
 }
 
 function getNodesJSON(obj) {
-    var elems = obj.nodes;
-    var nodes = new Array(elems.length);
-    for (var i = 0, l = elems.length; i < l; i++) {
-        nodes[i] = 'n' + elems[i];
-    }
-    return nodes;
+  var elems = obj.nodes;
+  var nodes = new Array(elems.length);
+  for (var i = 0, l = elems.length; i < l; i++) {
+    nodes[i] = "n" + elems[i];
+  }
+  return nodes;
 }
 
 function getTags(obj) {
-    var elems = obj.getElementsByTagName('tag');
-    var tags = {};
-    for (var i = 0, l = elems.length; i < l; i++) {
-        var attrs = elems[i].attributes;
-        tags[attrs.k.value] = attrs.v.value;
-    }
+  var elems = obj.getElementsByTagName("tag");
+  var tags = {};
+  for (var i = 0, l = elems.length; i < l; i++) {
+    var attrs = elems[i].attributes;
+    tags[attrs.k.value] = attrs.v.value;
+  }
 
-    return tags;
+  return tags;
 }
 
-
 function getMembers(obj) {
-    var elems = obj.getElementsByTagName('member');
-    var members = new Array(elems.length);
-    for (var i = 0, l = elems.length; i < l; i++) {
-        var attrs = elems[i].attributes;
-        members[i] = {
-            id: attrs.type.value[0] + attrs.ref.value,
-            type: attrs.type.value,
-            role: attrs.role.value
-        };
-    }
-    return members;
+  var elems = obj.getElementsByTagName("member");
+  var members = new Array(elems.length);
+  for (var i = 0, l = elems.length; i < l; i++) {
+    var attrs = elems[i].attributes;
+    members[i] = {
+      id: attrs.type.value[0] + attrs.ref.value,
+      type: attrs.type.value,
+      role: attrs.role.value,
+    };
+  }
+  return members;
 }
 
 function getMembersJSON(obj) {
-    var elems = obj.members;
-    var members = new Array(elems.length);
-    for (var i = 0, l = elems.length; i < l; i++) {
-        var attrs = elems[i];
-        members[i] = {
-            id: attrs.type[0] + attrs.ref,
-            type: attrs.type,
-            role: attrs.role
-        };
-    }
-    return members;
+  var elems = obj.members;
+  var members = new Array(elems.length);
+  for (var i = 0, l = elems.length; i < l; i++) {
+    var attrs = elems[i];
+    members[i] = {
+      id: attrs.type[0] + attrs.ref,
+      type: attrs.type,
+      role: attrs.role,
+    };
+  }
+  return members;
 }
 
 function getVisible(attrs) {
-    return (!attrs.visible || attrs.visible.value !== 'false');
+  return !attrs.visible || attrs.visible.value !== "false";
 }
-
 
 function parseComments(comments) {
-    var parsedComments = [];
+  var parsedComments = [];
 
-    // for each comment
-    for (var i = 0; i < comments.length; i++) {
-        var comment = comments[i];
-        if (comment.nodeName === 'comment') {
-            var childNodes = comment.childNodes;
-            var parsedComment = {};
+  // for each comment
+  for (var i = 0; i < comments.length; i++) {
+    var comment = comments[i];
+    if (comment.nodeName === "comment") {
+      var childNodes = comment.childNodes;
+      var parsedComment = {};
 
-            for (var j = 0; j < childNodes.length; j++) {
-                var node = childNodes[j];
-                var nodeName = node.nodeName;
-                if (nodeName === '#text') continue;
-                parsedComment[nodeName] = node.textContent;
+      for (var j = 0; j < childNodes.length; j++) {
+        var node = childNodes[j];
+        var nodeName = node.nodeName;
+        if (nodeName === "#text") continue;
+        parsedComment[nodeName] = node.textContent;
 
-                if (nodeName === 'uid') {
-                    var uid = node.textContent;
-                    if (uid && !_userCache.user[uid]) {
-                        _userCache.toLoad[uid] = true;
-                    }
-                }
-            }
-
-            if (parsedComment) {
-                parsedComments.push(parsedComment);
-            }
+        if (nodeName === "uid") {
+          var uid = node.textContent;
+          if (uid && !_userCache.user[uid]) {
+            _userCache.toLoad[uid] = true;
+          }
         }
-    }
-    return parsedComments;
-}
+      }
 
+      if (parsedComment) {
+        parsedComments.push(parsedComment);
+      }
+    }
+  }
+  return parsedComments;
+}
 
 function encodeNoteRtree(note) {
-    return {
-        minX: note.loc[0],
-        minY: note.loc[1],
-        maxX: note.loc[0],
-        maxY: note.loc[1],
-        data: note
-    };
+  return {
+    minX: note.loc[0],
+    minY: note.loc[1],
+    maxX: note.loc[0],
+    maxY: note.loc[1],
+    data: note,
+  };
 }
 
-
 var jsonparsers = {
+  node: function nodeData(obj, uid) {
+    return new osmNode({
+      id: uid,
+      visible: typeof obj.visible === "boolean" ? obj.visible : true,
+      version: obj.version && obj.version.toString(),
+      changeset: obj.changeset && obj.changeset.toString(),
+      timestamp: obj.timestamp,
+      user: obj.user,
+      uid: obj.uid && obj.uid.toString(),
+      loc: [Number(obj.lon), Number(obj.lat)],
+      tags: obj.tags,
+    });
+  },
 
-    node: function nodeData(obj, uid) {
-        return new osmNode({
-            id:  uid,
-            visible: typeof obj.visible === 'boolean' ? obj.visible : true,
-            version: obj.version && obj.version.toString(),
-            changeset: obj.changeset && obj.changeset.toString(),
-            timestamp: obj.timestamp,
-            user: obj.user,
-            uid: obj.uid && obj.uid.toString(),
-            loc: [Number(obj.lon), Number(obj.lat)],
-            tags: obj.tags
-        });
-    },
+  way: function wayData(obj, uid) {
+    return new osmWay({
+      id: uid,
+      visible: typeof obj.visible === "boolean" ? obj.visible : true,
+      version: obj.version && obj.version.toString(),
+      changeset: obj.changeset && obj.changeset.toString(),
+      timestamp: obj.timestamp,
+      user: obj.user,
+      uid: obj.uid && obj.uid.toString(),
+      tags: obj.tags,
+      nodes: getNodesJSON(obj),
+    });
+  },
 
-    way: function wayData(obj, uid) {
-        return new osmWay({
-            id:  uid,
-            visible: typeof obj.visible === 'boolean' ? obj.visible : true,
-            version: obj.version && obj.version.toString(),
-            changeset: obj.changeset && obj.changeset.toString(),
-            timestamp: obj.timestamp,
-            user: obj.user,
-            uid: obj.uid && obj.uid.toString(),
-            tags: obj.tags,
-            nodes: getNodesJSON(obj)
-        });
-    },
+  relation: function relationData(obj, uid) {
+    return new osmRelation({
+      id: uid,
+      visible: typeof obj.visible === "boolean" ? obj.visible : true,
+      version: obj.version && obj.version.toString(),
+      changeset: obj.changeset && obj.changeset.toString(),
+      timestamp: obj.timestamp,
+      user: obj.user,
+      uid: obj.uid && obj.uid.toString(),
+      tags: obj.tags,
+      members: getMembersJSON(obj),
+    });
+  },
 
-    relation: function relationData(obj, uid) {
-        return new osmRelation({
-            id:  uid,
-            visible: typeof obj.visible === 'boolean' ? obj.visible : true,
-            version: obj.version && obj.version.toString(),
-            changeset: obj.changeset && obj.changeset.toString(),
-            timestamp: obj.timestamp,
-            user: obj.user,
-            uid: obj.uid && obj.uid.toString(),
-            tags: obj.tags,
-            members: getMembersJSON(obj)
-        });
-    },
-
-    user: function parseUser(obj, uid) {
-        return {
-            id: uid,
-            display_name: obj.display_name,
-            account_created: obj.account_created,
-            image_url: obj.img && obj.img.href,
-            changesets_count: obj.changesets && obj.changesets.count && obj.changesets.count.toString() || '0',
-            active_blocks: obj.blocks && obj.blocks.received && obj.blocks.received.active && obj.blocks.received.active.toString() || '0'
-        };
-    }
+  user: function parseUser(obj, uid) {
+    return {
+      id: uid,
+      display_name: obj.display_name,
+      account_created: obj.account_created,
+      image_url: obj.img && obj.img.href,
+      changesets_count:
+        (obj.changesets &&
+          obj.changesets.count &&
+          obj.changesets.count.toString()) ||
+        "0",
+      active_blocks:
+        (obj.blocks &&
+          obj.blocks.received &&
+          obj.blocks.received.active &&
+          obj.blocks.received.active.toString()) ||
+        "0",
+    };
+  },
 };
 
 function parseJSON(payload, callback, options) {
-    options = Object.assign({ skipSeen: true }, options);
-    if (!payload)  {
-        return callback({ message: 'No JSON', status: -1 });
+  options = Object.assign({ skipSeen: true }, options);
+  if (!payload) {
+    return callback({ message: "No JSON", status: -1 });
+  }
+
+  var json = payload;
+  if (typeof json !== "object") json = JSON.parse(payload);
+
+  if (!json.elements) return callback({ message: "No JSON", status: -1 });
+
+  var children = json.elements;
+
+  var handle = window.requestIdleCallback(function () {
+    _deferred.delete(handle);
+    var results = [];
+    var result;
+    for (var i = 0; i < children.length; i++) {
+      result = parseChild(children[i]);
+      if (result) results.push(result);
+    }
+    callback(null, results);
+  });
+  _deferred.add(handle);
+
+  function parseChild(child) {
+    var parser = jsonparsers[child.type];
+    if (!parser) return null;
+
+    var uid;
+
+    uid = osmEntity.id.fromOSM(child.type, child.id);
+    if (options.skipSeen) {
+      if (_tileCache.seen[uid]) return null; // avoid reparsing a "seen" entity
+      _tileCache.seen[uid] = true;
     }
 
-    var json = payload;
-    if (typeof json !== 'object') json = JSON.parse(payload);
-
-    if (!json.elements) return callback({ message: 'No JSON', status: -1 });
-
-    var children = json.elements;
-
-    var handle = window.requestIdleCallback(function() {
-        _deferred.delete(handle);
-        var results = [];
-        var result;
-        for (var i = 0; i < children.length; i++) {
-            result = parseChild(children[i]);
-            if (result) results.push(result);
-        }
-        callback(null, results);
-    });
-    _deferred.add(handle);
-
-    function parseChild(child) {
-        var parser = jsonparsers[child.type];
-        if (!parser) return null;
-
-        var uid;
-
-        uid = osmEntity.id.fromOSM(child.type, child.id);
-        if (options.skipSeen) {
-            if (_tileCache.seen[uid]) return null;  // avoid reparsing a "seen" entity
-            _tileCache.seen[uid] = true;
-        }
-
-        return parser(child, uid);
-    }
+    return parser(child, uid);
+  }
 }
 
 function parseUserJSON(payload, callback, options) {
-    options = Object.assign({ skipSeen: true }, options);
-    if (!payload)  {
-        return callback({ message: 'No JSON', status: -1 });
+  options = Object.assign({ skipSeen: true }, options);
+  if (!payload) {
+    return callback({ message: "No JSON", status: -1 });
+  }
+
+  var json = payload;
+  if (typeof json !== "object") json = JSON.parse(payload);
+
+  if (!json.users && !json.user)
+    return callback({ message: "No JSON", status: -1 });
+
+  var objs = json.users || [json];
+
+  var handle = window.requestIdleCallback(function () {
+    _deferred.delete(handle);
+    var results = [];
+    var result;
+    for (var i = 0; i < objs.length; i++) {
+      result = parseObj(objs[i]);
+      if (result) results.push(result);
     }
+    callback(null, results);
+  });
+  _deferred.add(handle);
 
-    var json = payload;
-    if (typeof json !== 'object') json = JSON.parse(payload);
-
-    if (!json.users && !json.user) return callback({ message: 'No JSON', status: -1 });
-
-    var objs = json.users || [json];
-
-    var handle = window.requestIdleCallback(function() {
-        _deferred.delete(handle);
-        var results = [];
-        var result;
-        for (var i = 0; i < objs.length; i++) {
-            result = parseObj(objs[i]);
-            if (result) results.push(result);
-        }
-        callback(null, results);
-    });
-    _deferred.add(handle);
-
-    function parseObj(obj) {
-        var uid = obj.user.id && obj.user.id.toString();
-        if (options.skipSeen && _userCache.user[uid]) {
-            delete _userCache.toLoad[uid];
-            return null;
-        }
-        var user = jsonparsers.user(obj.user, uid);
-        _userCache.user[uid] = user;
-        delete _userCache.toLoad[uid];
-        return user;
+  function parseObj(obj) {
+    var uid = obj.user.id && obj.user.id.toString();
+    if (options.skipSeen && _userCache.user[uid]) {
+      delete _userCache.toLoad[uid];
+      return null;
     }
+    var user = jsonparsers.user(obj.user, uid);
+    _userCache.user[uid] = user;
+    delete _userCache.toLoad[uid];
+    return user;
+  }
 }
 
 var parsers = {
-    node: function nodeData(obj, uid) {
-        var attrs = obj.attributes;
-        return new osmNode({
-            id: uid,
-            visible: getVisible(attrs),
-            version: attrs.version.value,
-            changeset: attrs.changeset && attrs.changeset.value,
-            timestamp: attrs.timestamp && attrs.timestamp.value,
-            user: attrs.user && attrs.user.value,
-            uid: attrs.uid && attrs.uid.value,
-            loc: getLoc(attrs),
-            tags: getTags(obj)
-        });
-    },
+  node: function nodeData(obj, uid) {
+    var attrs = obj.attributes;
+    return new osmNode({
+      id: uid,
+      visible: getVisible(attrs),
+      version: attrs.version.value,
+      changeset: attrs.changeset && attrs.changeset.value,
+      timestamp: attrs.timestamp && attrs.timestamp.value,
+      user: attrs.user && attrs.user.value,
+      uid: attrs.uid && attrs.uid.value,
+      loc: getLoc(attrs),
+      tags: getTags(obj),
+    });
+  },
 
-    way: function wayData(obj, uid) {
-        var attrs = obj.attributes;
-        return new osmWay({
-            id: uid,
-            visible: getVisible(attrs),
-            version: attrs.version.value,
-            changeset: attrs.changeset && attrs.changeset.value,
-            timestamp: attrs.timestamp && attrs.timestamp.value,
-            user: attrs.user && attrs.user.value,
-            uid: attrs.uid && attrs.uid.value,
-            tags: getTags(obj),
-            nodes: getNodes(obj),
-        });
-    },
+  way: function wayData(obj, uid) {
+    var attrs = obj.attributes;
+    return new osmWay({
+      id: uid,
+      visible: getVisible(attrs),
+      version: attrs.version.value,
+      changeset: attrs.changeset && attrs.changeset.value,
+      timestamp: attrs.timestamp && attrs.timestamp.value,
+      user: attrs.user && attrs.user.value,
+      uid: attrs.uid && attrs.uid.value,
+      tags: getTags(obj),
+      nodes: getNodes(obj),
+    });
+  },
 
-    relation: function relationData(obj, uid) {
-        var attrs = obj.attributes;
-        return new osmRelation({
-            id: uid,
-            visible: getVisible(attrs),
-            version: attrs.version.value,
-            changeset: attrs.changeset && attrs.changeset.value,
-            timestamp: attrs.timestamp && attrs.timestamp.value,
-            user: attrs.user && attrs.user.value,
-            uid: attrs.uid && attrs.uid.value,
-            tags: getTags(obj),
-            members: getMembers(obj)
-        });
-    },
+  relation: function relationData(obj, uid) {
+    var attrs = obj.attributes;
+    return new osmRelation({
+      id: uid,
+      visible: getVisible(attrs),
+      version: attrs.version.value,
+      changeset: attrs.changeset && attrs.changeset.value,
+      timestamp: attrs.timestamp && attrs.timestamp.value,
+      user: attrs.user && attrs.user.value,
+      uid: attrs.uid && attrs.uid.value,
+      tags: getTags(obj),
+      members: getMembers(obj),
+    });
+  },
 
-    note: function parseNote(obj, uid) {
-        var attrs = obj.attributes;
-        var childNodes = obj.childNodes;
-        var props = {};
+  note: function parseNote(obj, uid) {
+    var attrs = obj.attributes;
+    var childNodes = obj.childNodes;
+    var props = {};
 
-        props.id = uid;
-        props.loc = getLoc(attrs);
+    props.id = uid;
+    props.loc = getLoc(attrs);
 
-        // if notes are coincident, move them apart slightly
-        if (!_noteCache.note[uid]) {
-            let coincident = false;
-            const epsilon = 0.00001;
-            do {
-                if (coincident) {
-                    props.loc = geoVecAdd(props.loc, [epsilon, epsilon]);
-                }
-                const bbox = geoExtent(props.loc).bbox();
-                coincident = _noteCache.rtree.search(bbox).length;
-            } while (coincident);
-        } else {
-            // we already saw this note: don't change its location again
-            props.loc = _noteCache.note[uid].loc;
+    // if notes are coincident, move them apart slightly
+    if (!_noteCache.note[uid]) {
+      let coincident = false;
+      const epsilon = 0.00001;
+      do {
+        if (coincident) {
+          props.loc = geoVecAdd(props.loc, [epsilon, epsilon]);
         }
-
-        // parse note contents
-        for (var i = 0; i < childNodes.length; i++) {
-            var node = childNodes[i];
-            var nodeName = node.nodeName;
-            if (nodeName === '#text') continue;
-
-            // if the element is comments, parse the comments
-            if (nodeName === 'comments') {
-                props[nodeName] = parseComments(node.childNodes);
-            } else {
-                props[nodeName] = node.textContent;
-            }
-        }
-
-        var note = new osmNote(props);
-        var item = encodeNoteRtree(note);
-        _noteCache.note[note.id] = note;
-        updateRtree(item, true);
-
-        return note;
-    },
-
-    user: function parseUser(obj, uid) {
-        var attrs = obj.attributes;
-        var user = {
-            id: uid,
-            display_name: attrs.display_name && attrs.display_name.value,
-            account_created: attrs.account_created && attrs.account_created.value,
-            changesets_count: '0',
-            active_blocks: '0'
-        };
-
-        var img = obj.getElementsByTagName('img');
-        if (img && img[0] && img[0].getAttribute('href')) {
-            user.image_url = img[0].getAttribute('href');
-        }
-
-        var changesets = obj.getElementsByTagName('changesets');
-        if (changesets && changesets[0] && changesets[0].getAttribute('count')) {
-            user.changesets_count = changesets[0].getAttribute('count');
-        }
-
-        var blocks = obj.getElementsByTagName('blocks');
-        if (blocks && blocks[0]) {
-            var received = blocks[0].getElementsByTagName('received');
-            if (received && received[0] && received[0].getAttribute('active')) {
-                user.active_blocks = received[0].getAttribute('active');
-            }
-        }
-
-        _userCache.user[uid] = user;
-        delete _userCache.toLoad[uid];
-        return user;
+        const bbox = geoExtent(props.loc).bbox();
+        coincident = _noteCache.rtree.search(bbox).length;
+      } while (coincident);
+    } else {
+      // we already saw this note: don't change its location again
+      props.loc = _noteCache.note[uid].loc;
     }
+
+    // parse note contents
+    for (var i = 0; i < childNodes.length; i++) {
+      var node = childNodes[i];
+      var nodeName = node.nodeName;
+      if (nodeName === "#text") continue;
+
+      // if the element is comments, parse the comments
+      if (nodeName === "comments") {
+        props[nodeName] = parseComments(node.childNodes);
+      } else {
+        props[nodeName] = node.textContent;
+      }
+    }
+
+    var note = new osmNote(props);
+    var item = encodeNoteRtree(note);
+    _noteCache.note[note.id] = note;
+    updateRtree(item, true);
+
+    return note;
+  },
+
+  user: function parseUser(obj, uid) {
+    var attrs = obj.attributes;
+    var user = {
+      id: uid,
+      display_name: attrs.display_name && attrs.display_name.value,
+      account_created: attrs.account_created && attrs.account_created.value,
+      changesets_count: "0",
+      active_blocks: "0",
+    };
+
+    var img = obj.getElementsByTagName("img");
+    if (img && img[0] && img[0].getAttribute("href")) {
+      user.image_url = img[0].getAttribute("href");
+    }
+
+    var changesets = obj.getElementsByTagName("changesets");
+    if (changesets && changesets[0] && changesets[0].getAttribute("count")) {
+      user.changesets_count = changesets[0].getAttribute("count");
+    }
+
+    var blocks = obj.getElementsByTagName("blocks");
+    if (blocks && blocks[0]) {
+      var received = blocks[0].getElementsByTagName("received");
+      if (received && received[0] && received[0].getAttribute("active")) {
+        user.active_blocks = received[0].getAttribute("active");
+      }
+    }
+
+    _userCache.user[uid] = user;
+    delete _userCache.toLoad[uid];
+    return user;
+  },
 };
 
-
 function parseXML(xml, callback, options) {
-    options = Object.assign({ skipSeen: true }, options);
-    if (!xml || !xml.childNodes) {
-        return callback({ message: 'No XML', status: -1 });
+  options = Object.assign({ skipSeen: true }, options);
+  if (!xml || !xml.childNodes) {
+    return callback({ message: "No XML", status: -1 });
+  }
+
+  var root = xml.childNodes[0];
+  var children = root.childNodes;
+
+  var handle = window.requestIdleCallback(function () {
+    _deferred.delete(handle);
+    var results = [];
+    var result;
+    for (var i = 0; i < children.length; i++) {
+      result = parseChild(children[i]);
+      if (result) results.push(result);
+    }
+    callback(null, results);
+  });
+  _deferred.add(handle);
+
+  function parseChild(child) {
+    var parser = parsers[child.nodeName];
+    if (!parser) return null;
+
+    var uid;
+    if (child.nodeName === "user") {
+      uid = child.attributes.id.value;
+      if (options.skipSeen && _userCache.user[uid]) {
+        delete _userCache.toLoad[uid];
+        return null;
+      }
+    } else if (child.nodeName === "note") {
+      uid = child.getElementsByTagName("id")[0].textContent;
+    } else {
+      uid = osmEntity.id.fromOSM(child.nodeName, child.attributes.id.value);
+      if (options.skipSeen) {
+        if (_tileCache.seen[uid]) return null; // avoid reparsing a "seen" entity
+        _tileCache.seen[uid] = true;
+      }
     }
 
-    var root = xml.childNodes[0];
-    var children = root.childNodes;
-
-    var handle = window.requestIdleCallback(function() {
-        _deferred.delete(handle);
-        var results = [];
-        var result;
-        for (var i = 0; i < children.length; i++) {
-            result = parseChild(children[i]);
-            if (result) results.push(result);
-        }
-        callback(null, results);
-    });
-    _deferred.add(handle);
-
-
-    function parseChild(child) {
-        var parser = parsers[child.nodeName];
-        if (!parser) return null;
-
-        var uid;
-        if (child.nodeName === 'user') {
-            uid = child.attributes.id.value;
-            if (options.skipSeen && _userCache.user[uid]) {
-                delete _userCache.toLoad[uid];
-                return null;
-            }
-
-        } else if (child.nodeName === 'note') {
-            uid = child.getElementsByTagName('id')[0].textContent;
-
-        } else {
-            uid = osmEntity.id.fromOSM(child.nodeName, child.attributes.id.value);
-            if (options.skipSeen) {
-                if (_tileCache.seen[uid]) return null;  // avoid reparsing a "seen" entity
-                _tileCache.seen[uid] = true;
-            }
-        }
-
-        return parser(child, uid);
-    }
+    return parser(child, uid);
+  }
 }
-
 
 // replace or remove note from rtree
 function updateRtree(item, replace) {
-    _noteCache.rtree.remove(item, function isEql(a, b) { return a.data.id === b.data.id; });
+  _noteCache.rtree.remove(item, function isEql(a, b) {
+    return a.data.id === b.data.id;
+  });
 
-    if (replace) {
-        _noteCache.rtree.insert(item);
-    }
+  if (replace) {
+    _noteCache.rtree.insert(item);
+  }
 }
-
 
 function wrapcb(thisArg, callback, cid) {
-    return function(err, result) {
-        if (err) {
-            return callback.call(thisArg, err);
-
-        } else if (thisArg.getConnectionId() !== cid) {
-            return callback.call(thisArg, { message: 'Connection Switched', status: -1 });
-
-        } else {
-            return callback.call(thisArg, err, result);
-        }
-    };
+  return function (err, result) {
+    if (err) {
+      return callback.call(thisArg, err);
+    } else if (thisArg.getConnectionId() !== cid) {
+      return callback.call(thisArg, {
+        message: "Connection Switched",
+        status: -1,
+      });
+    } else {
+      return callback.call(thisArg, err, result);
+    }
+  };
 }
 
-
 export default {
+  init: function () {
+    utilRebind(this, dispatch, "on");
+  },
 
-    init: function() {
-        utilRebind(this, dispatch, 'on');
-    },
+  reset: function () {
+    _isLoading = false;
+    Array.from(_deferred).forEach(function (handle) {
+      window.cancelIdleCallback(handle);
+      _deferred.delete(handle);
+    });
 
+    _connectionID++;
+    _userChangesets = undefined;
+    _userDetails = undefined;
+    _rateLimitError = undefined;
 
-    reset: function() {
-        Array.from(_deferred).forEach(function(handle) {
-            window.cancelIdleCallback(handle);
-            _deferred.delete(handle);
-        });
+    Object.values(_tileCache.inflight).forEach(abortRequest);
+    Object.values(_noteCache.inflight).forEach(abortRequest);
+    Object.values(_noteCache.inflightPost).forEach(abortRequest);
+    if (_changeset.inflight) abortRequest(_changeset.inflight);
 
-        _connectionID++;
-        _userChangesets = undefined;
-        _userDetails = undefined;
-        _rateLimitError = undefined;
+    _tileCache = {
+      toLoad: {},
+      loaded: {},
+      inflight: {},
+      seen: {},
+      rtree: new RBush(),
+    };
+    _noteCache = {
+      toLoad: {},
+      loaded: {},
+      inflight: {},
+      inflightPost: {},
+      note: {},
+      closed: {},
+      rtree: new RBush(),
+    };
+    _userCache = { toLoad: {}, user: {} };
+    _cachedApiStatus = undefined;
+    _changeset = {};
 
-        Object.values(_tileCache.inflight).forEach(abortRequest);
-        Object.values(_noteCache.inflight).forEach(abortRequest);
-        Object.values(_noteCache.inflightPost).forEach(abortRequest);
-        if (_changeset.inflight) abortRequest(_changeset.inflight);
+    return this;
+  },
 
-        _tileCache = { toLoad: {}, loaded: {}, inflight: {}, seen: {}, rtree: new RBush() };
-        _noteCache = { toLoad: {}, loaded: {}, inflight: {}, inflightPost: {}, note: {}, closed: {}, rtree: new RBush() };
-        _userCache = { toLoad: {}, user: {} };
-        _cachedApiStatus = undefined;
-        _changeset = {};
+  getConnectionId: function () {
+    return _connectionID;
+  },
 
-        return this;
-    },
+  getUrlRoot: function () {
+    return urlroot;
+  },
 
+  getApiUrlRoot: function () {
+    return apiUrlroot;
+  },
 
-    getConnectionId: function() {
-        return _connectionID;
-    },
+  changesetURL: function (changesetID) {
+    return urlroot + "/changeset/" + changesetID;
+  },
 
+  changesetsURL: function (center, zoom) {
+    var precision = Math.max(0, Math.ceil(Math.log(zoom) / Math.LN2));
+    return (
+      urlroot +
+      "/history#map=" +
+      Math.floor(zoom) +
+      "/" +
+      center[1].toFixed(precision) +
+      "/" +
+      center[0].toFixed(precision)
+    );
+  },
 
-    getUrlRoot: function() {
-        return urlroot;
-    },
+  entityURL: function (entity) {
+    return urlroot + "/" + entity.type + "/" + entity.osmId();
+  },
 
+  historyURL: function (entity) {
+    return urlroot + "/" + entity.type + "/" + entity.osmId() + "/history";
+  },
 
-    getApiUrlRoot: function() {
-        return apiUrlroot;
-    },
+  userURL: function (username) {
+    return urlroot + "/user/" + encodeURIComponent(username);
+  },
 
+  noteURL: function (note) {
+    return urlroot + "/note/" + note.id;
+  },
 
-    changesetURL: function(changesetID) {
-        return urlroot + '/changeset/' + changesetID;
-    },
+  noteReportURL: function (note) {
+    return (
+      urlroot + "/reports/new?reportable_type=Note&reportable_id=" + note.id
+    );
+  },
 
+  // Generic method to load data from the OSM API
+  // Can handle either auth or unauth calls.
+  loadFromAPI: function (path, callback, options) {
+    options = Object.assign({ skipSeen: true }, options);
+    var that = this;
+    var cid = _connectionID;
 
-    changesetsURL: function(center, zoom) {
-        var precision = Math.max(0, Math.ceil(Math.log(zoom) / Math.LN2));
-        return urlroot + '/history#map=' +
-            Math.floor(zoom) + '/' +
-            center[1].toFixed(precision) + '/' +
-            center[0].toFixed(precision);
-    },
+    function done(err, payload) {
+      if (that.getConnectionId() !== cid) {
+        if (callback) callback({ message: "Connection Switched", status: -1 });
+        return;
+      }
 
+      if (
+        (err && _cachedApiStatus === "online") ||
+        (!err && _cachedApiStatus !== "online")
+      ) {
+        // If the response's error state doesn't match the status,
+        // it's likely we lost or gained the connection so reload the status
+        that.reloadApiStatus();
+      }
 
-    entityURL: function(entity) {
-        return urlroot + '/' + entity.type + '/' + entity.osmId();
-    },
-
-
-    historyURL: function(entity) {
-        return urlroot + '/' + entity.type + '/' + entity.osmId() + '/history';
-    },
-
-
-    userURL: function(username) {
-        return urlroot + '/user/' + encodeURIComponent(username);
-    },
-
-
-    noteURL: function(note) {
-        return urlroot + '/note/' + note.id;
-    },
-
-
-    noteReportURL: function(note) {
-        return urlroot + '/reports/new?reportable_type=Note&reportable_id=' + note.id;
-    },
-
-
-    // Generic method to load data from the OSM API
-    // Can handle either auth or unauth calls.
-    loadFromAPI: function(path, callback, options) {
-        options = Object.assign({ skipSeen: true }, options);
-        var that = this;
-        var cid = _connectionID;
-
-        function done(err, payload) {
-            if (that.getConnectionId() !== cid) {
-                if (callback) callback({ message: 'Connection Switched', status: -1 });
-                return;
-            }
-
-            if ((err && _cachedApiStatus === 'online') ||
-                (!err && _cachedApiStatus !== 'online')) {
-                // If the response's error state doesn't match the status,
-                // it's likely we lost or gained the connection so reload the status
-                that.reloadApiStatus();
-            }
-
-            if (callback) {
-                if (err) {
-                    // eslint-disable-next-line no-console
-                    console.error('API error:', err);
-                    return callback(err);
-                } else {
-                    if (path.indexOf('.json') !== -1) {
-                        return parseJSON(payload, callback, options);
-                    } else {
-                        return parseXML(payload, callback, options);
-                    }
-                }
-            }
-        }
-
-        if (this.authenticated()) {
-            return oauth.xhr({
-                method: 'GET',
-                path
-            }, done);
+      if (callback) {
+        if (err) {
+          // eslint-disable-next-line no-console
+          console.error("API error:", err);
+          return callback(err);
         } else {
-            var url = apiUrlroot + path;
-            var controller = new AbortController();
-            var fn;
-            if (path.indexOf('.json') !== -1) {
-                fn = d3_json;
-            } else {
-                fn = d3_xml;
-            }
-
-            fn(url, { signal: controller.signal })
-                .then(function(data) {
-                    done(null, data);
-                })
-                .catch(function(err) {
-                    if (err.name === 'AbortError') return;
-                    // d3-fetch includes status in the error message,
-                    // but we can't access the response itself
-                    // https://github.com/d3/d3-fetch/issues/27
-                    var match = err.message.match(/^\d{3}/);
-                    if (match) {
-                        done({ status: +match[0], statusText: err.message });
-                    } else {
-                        done(err.message);
-                    }
-                });
-            return controller;
+          if (path.indexOf(".json") !== -1) {
+            return parseJSON(payload, callback, options);
+          } else {
+            return parseXML(payload, callback, options);
+          }
         }
-    },
-
-
-    // Load a single entity by id (ways and relations use the `/full` call to include
-    // nodes and members). Parent relations are not included, see `loadEntityRelations`.
-    // GET /api/0.6/node/#id
-    // GET /api/0.6/[way|relation]/#id/full
-    loadEntity: function(id, callback) {
-        var type = osmEntity.id.type(id);
-        var osmID = osmEntity.id.toOSM(id);
-        var options = { skipSeen: false };
-
-        this.loadFromAPI(
-            '/api/0.6/' + type + '/' + osmID + (type !== 'node' ? '/full' : '') + '.json',
-            function(err, entities) {
-                if (callback) callback(err, { data: entities });
-            },
-            options
-        );
-    },
-
-    // Load a single note by id , XML format
-    // GET /api/0.6/notes/#id
-    loadEntityNote: function(id, callback) {
-        var options = { skipSeen: false };
-        this.loadFromAPI(
-            '/api/0.6/notes/' + id ,
-            function(err, entities) {
-                if (callback) callback(err, { data: entities });
-            },
-            options
-        );
-    },
-
-
-    // Load a single entity with a specific version
-    // GET /api/0.6/[node|way|relation]/#id/#version
-    loadEntityVersion: function(id, version, callback) {
-        var type = osmEntity.id.type(id);
-        var osmID = osmEntity.id.toOSM(id);
-        var options = { skipSeen: false };
-
-        this.loadFromAPI(
-            '/api/0.6/' + type + '/' + osmID + '/' + version + '.json',
-            function(err, entities) {
-                if (callback) callback(err, { data: entities });
-            },
-            options
-        );
-    },
-
-
-    // Load the relations of a single entity with the given.
-    // GET /api/0.6/[node|way|relation]/#id/relations
-    loadEntityRelations: function(id, callback) {
-        var type = osmEntity.id.type(id);
-        var osmID = osmEntity.id.toOSM(id);
-        var options = { skipSeen: false };
-
-        this.loadFromAPI(
-            '/api/0.6/' + type + '/' + osmID + '/relations.json',
-            function(err, entities) {
-                if (callback) callback(err, { data: entities });
-            },
-            options
-        );
-    },
-
-
-    // Load multiple entities in chunks
-    // (note: callback may be called multiple times)
-    // Unlike `loadEntity`, child nodes and members are not fetched
-    // GET /api/0.6/[nodes|ways|relations]?#parameters
-    loadMultiple: function(ids, callback) {
-        var that = this;
-        var groups = utilArrayGroupBy(utilArrayUniq(ids), osmEntity.id.type);
-
-        Object.keys(groups).forEach(function(k) {
-            var type = k + 's';   // nodes, ways, relations
-            var osmIDs = groups[k].map(function(id) { return osmEntity.id.toOSM(id); });
-            var options = { skipSeen: false };
-
-            utilArrayChunk(osmIDs, 150).forEach(function(arr) {
-                that.loadFromAPI(
-                    '/api/0.6/' + type + '.json?' + type + '=' + arr.join(),
-                    function(err, entities) {
-                        if (callback) callback(err, { data: entities });
-                    },
-                    options
-                );
-            });
-        });
-    },
-
-
-    // Create, upload, and close a changeset
-    // PUT /api/0.6/changeset/create
-    // POST /api/0.6/changeset/#id/upload
-    // PUT /api/0.6/changeset/#id/close
-    putChangeset: function(changeset, changes, callback) {
-        var cid = _connectionID;
-
-        if (_changeset.inflight) {
-            return callback({ message: 'Changeset already inflight', status: -2 }, changeset);
-
-        } else if (_changeset.open) {   // reuse existing open changeset..
-            return createdChangeset.call(this, null, _changeset.open);
-
-        } else {   // Open a new changeset..
-            var options = {
-                method: 'PUT',
-                path: '/api/0.6/changeset/create',
-                headers: { 'Content-Type': 'text/xml' },
-                content: JXON.stringify(changeset.asJXON())
-            };
-            _changeset.inflight = oauth.xhr(
-                options,
-                wrapcb(this, createdChangeset, cid)
-            );
-        }
-
-
-        async function createdChangeset(err, changesetID) {
-            _changeset.inflight = null;
-            if (err) { return callback(err, changeset); }
-
-            _changeset.open = changesetID;
-            changeset = changeset.update({ id: changesetID });
-
-            // Upload the changeset..
-            const xml = JXON.stringify(changeset.osmChangeJXON(changes));
-            const compressed = await utilGzip(xml);
-
-            const headers = { 'Content-Type': 'text/xml' };
-            if (compressed) headers['Content-Encoding'] = 'gzip';
-
-            var options = {
-                method: 'POST',
-                path: '/api/0.6/changeset/' + changesetID + '/upload',
-                headers,
-                content: compressed || xml,
-            };
-            _changeset.inflight = oauth.xhr(
-                options,
-                wrapcb(this, uploadedChangeset, cid)
-            );
-        }
-
-
-        function uploadedChangeset(err) {
-            _changeset.inflight = null;
-            if (err) return callback(err, changeset);
-
-            // Upload was successful, safe to call the callback.
-            // Add delay to allow for postgres replication #1646 #2678
-            window.setTimeout(function() { callback(null, changeset); }, 2500);
-            _changeset.open = null;
-
-            // At this point, we don't really care if the connection was switched..
-            // Only try to close the changeset if we're still talking to the same server.
-            if (this.getConnectionId() === cid) {
-                // Still attempt to close changeset, but ignore response because #2667
-                oauth.xhr({
-                    method: 'PUT',
-                    path: '/api/0.6/changeset/' + changeset.id + '/close',
-                    headers: { 'Content-Type': 'text/xml' }
-                }, function() { return true; });
-            }
-        }
-    },
-
-    /** updates the tags on an existing unclosed changeset */
-    // PUT /api/0.6/changeset/#id
-    updateChangesetTags: (changeset) => {
-        return oauth.fetch(`${oauth.options().apiUrl}/api/0.6/changeset/${changeset.id}`, {
-            method: 'PUT',
-            headers: { 'Content-Type': 'text/xml' },
-            body: JXON.stringify(changeset.asJXON())
-        });
-    },
-
-
-    // Load multiple users in chunks
-    // (note: callback may be called multiple times)
-    // GET /api/0.6/users?users=#id1,#id2,...,#idn
-    loadUsers: function(uids, callback) {
-        var toLoad = [];
-        var cached = [];
-
-        utilArrayUniq(uids).forEach(function(uid) {
-            if (_userCache.user[uid]) {
-                delete _userCache.toLoad[uid];
-                cached.push(_userCache.user[uid]);
-            } else {
-                toLoad.push(uid);
-            }
-        });
-
-        if (cached.length || !this.authenticated()) {
-            callback(undefined, cached);
-            if (!this.authenticated()) return;  // require auth
-        }
-
-        utilArrayChunk(toLoad, 150).forEach(function(arr) {
-            oauth.xhr({
-                method: 'GET',
-                path: '/api/0.6/users.json?users=' + arr.join()
-            }, wrapcb(this, done, _connectionID));
-        }.bind(this));
-
-        function done(err, payload) {
-            if (err) return callback(err);
-
-            var options = { skipSeen: true };
-            return parseUserJSON(payload, function(err, results) {
-                if (err) return callback(err);
-                return callback(undefined, results);
-            }, options);
-        }
-    },
-
-
-    // Load a given user by id
-    // GET /api/0.6/user/#id
-    loadUser: function(uid, callback) {
-        if (_userCache.user[uid] || !this.authenticated()) {   // require auth
-            delete _userCache.toLoad[uid];
-            return callback(undefined, _userCache.user[uid]);
-        }
-
-        oauth.xhr({
-            method: 'GET',
-            path: '/api/0.6/user/' + uid + '.json'
-        }, wrapcb(this, done, _connectionID));
-
-        function done(err, payload) {
-            if (err) return callback(err);
-
-            var options = { skipSeen: true };
-            return parseUserJSON(payload, function(err, results) {
-                if (err) return callback(err);
-                return callback(undefined, results[0]);
-            }, options);
-        }
-    },
-
-
-    // Load the details of the logged-in user
-    // GET /api/0.6/user/details
-    userDetails: function(callback) {
-        if (_userDetails) {    // retrieve cached
-            return callback(undefined, _userDetails);
-        }
-
-        oauth.xhr({
-            method: 'GET',
-            path: '/api/0.6/user/details.json'
-        }, wrapcb(this, done, _connectionID));
-
-        function done(err, payload) {
-            if (err) return callback(err);
-
-            var options = { skipSeen: false };
-            return parseUserJSON(payload, function(err, results) {
-                if (err) return callback(err);
-                _userDetails = results[0];
-                return callback(undefined, _userDetails);
-            }, options);
-        }
-    },
-
-
-    // Load previous changesets for the logged in user
-    // GET /api/0.6/changesets?user=#id
-    userChangesets: function(callback) {
-        if (_userChangesets) {    // retrieve cached
-            return callback(undefined, _userChangesets);
-        }
-
-        this.userDetails(
-            wrapcb(this, gotDetails, _connectionID)
-        );
-
-
-        function gotDetails(err, user) {
-            if (err) { return callback(err); }
-
-            oauth.xhr({
-                method: 'GET',
-                path: '/api/0.6/changesets?user=' + user.id
-            }, wrapcb(this, done, _connectionID));
-        }
-
-        function done(err, xml) {
-            if (err) { return callback(err); }
-
-            _userChangesets = Array.prototype.map.call(
-                xml.getElementsByTagName('changeset'),
-                function (changeset) { return { tags: getTags(changeset) }; }
-            ).filter(function (changeset) {
-                var comment = changeset.tags.comment;
-                return comment && comment !== '';
-            });
-
-            return callback(undefined, _userChangesets);
-        }
-    },
-
-
-    // Fetch the status of the OSM API
-    // GET /api/capabilities
-    status: function(callback) {
-        var url = apiUrlroot + '/api/capabilities';
-        var errback = wrapcb(this, done, _connectionID);
-        d3_xml(url)
-            .then(function(data) { errback(null, data); })
-            .catch(function(err) { errback(err.message); });
-
-        function done(err, xml) {
-            if (err) {
-                // the status is null if no response could be retrieved
-                return callback(err, null);
-            }
-
-            // update blocklists
-            var elements = xml.getElementsByTagName('blacklist');
-            var regexes = [];
-            for (var i = 0; i < elements.length; i++) {
-                var regexString = elements[i].getAttribute('regex');  // needs unencode?
-                if (regexString) {
-                    try {
-                        var regex = new RegExp(regexString, 'i');
-                        regexes.push(regex);
-                    } catch {
-                        /* noop */
-                    }
-                }
-            }
-            if (regexes.length) {
-                _imageryBlocklists = regexes;
-            }
-
-            if (_rateLimitError) {
-                return callback(_rateLimitError, 'rateLimited');
-            } else {
-                var waynodes = xml.getElementsByTagName('waynodes');
-                var maxWayNodes = waynodes.length && parseInt(waynodes[0].getAttribute('maximum'), 10);
-                if (maxWayNodes && isFinite(maxWayNodes)) _maxWayNodes = maxWayNodes;
-
-                var apiStatus = xml.getElementsByTagName('status');
-                var val = apiStatus[0].getAttribute('api');
-                return callback(undefined, val);
-            }
-        }
-    },
-
-    // Calls `status` and dispatches an `apiStatusChange` event if the returned
-    // status differs from the cached status.
-    reloadApiStatus: function() {
-        // throttle to avoid unnecessary API calls
-        if (!this.throttledReloadApiStatus) {
-            var that = this;
-            this.throttledReloadApiStatus = _throttle(function() {
-                that.status(function(err, status) {
-                    if (status !== _cachedApiStatus) {
-                        _cachedApiStatus = status;
-                        dispatch.call('apiStatusChange', that, err, status);
-                    }
-                });
-            }, 500);
-        }
-        this.throttledReloadApiStatus();
-    },
-
-
-    // Returns the maximum number of nodes a single way can have
-    maxWayNodes: function() {
-        return _maxWayNodes;
-    },
-
-
-    // Load data (entities) from the API in tiles
-    // GET /api/0.6/map?bbox=
-    loadTiles: function(projection, callback) {
-        if (_off) return;
-
-        // determine the needed tiles to cover the view
-        var tiles = tiler.zoomExtent([_tileZoom, _tileZoom]).getTiles(projection);
-
-        // abort inflight requests that are no longer needed
-        var hadRequests = hasInflightRequests(_tileCache);
-        abortUnwantedRequests(_tileCache, tiles);
-        if (hadRequests && !hasInflightRequests(_tileCache)) {
-            if (_rateLimitError) {
-                // was rate limited, but has settled
-                _rateLimitError = undefined;
-                dispatch.call('change');
-                this.reloadApiStatus();
-            }
-            dispatch.call('loaded');    // stop the spinner
-        }
-
-        // issue new requests..
-        tiles.forEach(function(tile) {
-            this.loadTile(tile, callback);
-        }, this);
-    },
-
-
-    // Load a single data tile
-    // GET /api/0.6/map?bbox=
-    loadTile: function(tile, callback) {
-        if (_off) return;
-        if (_tileCache.loaded[tile.id] || _tileCache.inflight[tile.id]) return;
-
-        if (!hasInflightRequests(_tileCache)) {
-            dispatch.call('loading');   // start the spinner
-        }
-
-        var path = '/api/0.6/map.json?bbox=';
-        var options = { skipSeen: true };
-
-        _tileCache.inflight[tile.id] = this.loadFromAPI(
-            path + tile.extent.toParam(),
-            tileCallback.bind(this),
-            options
-        );
-
-        function tileCallback(err, parsed) {
-            if (!err) {
-                delete _tileCache.inflight[tile.id];
-                delete _tileCache.toLoad[tile.id];
-                _tileCache.loaded[tile.id] = true;
-                var bbox = tile.extent.bbox();
-                bbox.id = tile.id;
-                _tileCache.rtree.insert(bbox);
-            } else {
-                // map tile loading error: e.g. network connection error,
-                // 509 Bandwidth Limit Exceeded, 429 Too Many Requests
-                if (!_rateLimitError && err.status === 509 || err.status === 429) {
-                    // show "API rate limiting" warning
-                    _rateLimitError = err;
-                    dispatch.call('change');
-                    this.reloadApiStatus();
-                }
-                setTimeout(() => {
-                    // retry loading the tiles
-                    delete _tileCache.inflight[tile.id];
-                    this.loadTile(tile, callback);
-                }, 8000);
-            }
-            if (callback) {
-                callback(err, Object.assign({ data: parsed }, tile));
-            }
-            if (!hasInflightRequests(_tileCache)) {
-                if (_rateLimitError) {
-                    // was rate limited, but has settled
-                    _rateLimitError = undefined;
-                    dispatch.call('change');
-                    this.reloadApiStatus();
-                }
-                dispatch.call('loaded');     // stop the spinner
-            }
-        }
-    },
-
-
-    isDataLoaded: function(loc) {
-        var bbox = { minX: loc[0], minY: loc[1], maxX: loc[0], maxY: loc[1] };
-        return _tileCache.rtree.collides(bbox);
-    },
-
-
-    // load the tile that covers the given `loc`
-    loadTileAtLoc: function(loc, callback) {
-        // Back off if the toLoad queue is filling up.. re #6417
-        // (Currently `loadTileAtLoc` requests are considered low priority - used by operations to
-        // let users safely edit geometries which extend to unloaded tiles.  We can drop some.)
-        if (Object.keys(_tileCache.toLoad).length > 50) return;
-
-        var k = geoZoomToScale(_tileZoom + 1);
-        var offset = geoRawMercator().scale(k)(loc);
-        var projection = geoRawMercator().transform({ k: k, x: -offset[0], y: -offset[1] });
-        var tiles = tiler.zoomExtent([_tileZoom, _tileZoom]).getTiles(projection);
-
-        tiles.forEach(function(tile) {
-            if (_tileCache.toLoad[tile.id] || _tileCache.loaded[tile.id] || _tileCache.inflight[tile.id]) return;
-
-            _tileCache.toLoad[tile.id] = true;
-            this.loadTile(tile, callback);
-        }, this);
-    },
-
-
-    // Load notes from the API in tiles
-    // GET /api/0.6/notes?bbox=
-    loadNotes: function(projection, noteOptions) {
-        noteOptions = Object.assign({ limit: 10000, closed: 7 }, noteOptions);
-        if (_off) return;
-
-        var that = this;
-        var path = '/api/0.6/notes?limit=' + noteOptions.limit + '&closed=' + noteOptions.closed + '&bbox=';
-        var throttleLoadUsers = _throttle(function() {
-            var uids = Object.keys(_userCache.toLoad);
-            if (!uids.length) return;
-            that.loadUsers(uids, function() {});  // eagerly load user details
-        }, 750);
-
-        // determine the needed tiles to cover the view
-        var tiles = tiler.zoomExtent([_noteZoom, _noteZoom]).getTiles(projection);
-
-        // abort inflight requests that are no longer needed
-        abortUnwantedRequests(_noteCache, tiles);
-
-        // issue new requests..
-        tiles.forEach(function(tile) {
-            if (_noteCache.loaded[tile.id] || _noteCache.inflight[tile.id]) return;
-
-            var options = { skipSeen: false };
-            _noteCache.inflight[tile.id] = that.loadFromAPI(
-                path + tile.extent.toParam(),
-                function(err) {
-                    delete _noteCache.inflight[tile.id];
-                    if (!err) {
-                        _noteCache.loaded[tile.id] = true;
-                    }
-                    throttleLoadUsers();
-                    dispatch.call('loadedNotes');
-                },
-                options
-            );
-        });
-    },
-
-
-    // Create a note
-    // POST /api/0.6/notes?params
-    postNoteCreate: function(note, callback) {
-        if (!this.authenticated()) {
-            return callback({ message: 'Not Authenticated', status: -3 }, note);
-        }
-        if (_noteCache.inflightPost[note.id]) {
-            return callback({ message: 'Note update already inflight', status: -2 }, note);
-        }
-
-        if (!note.loc[0] || !note.loc[1] || !note.newComment) return; // location & description required
-
-        var comment = note.newComment;
-        if (note.newCategory && note.newCategory !== 'None') { comment += ' #' + note.newCategory; }
-
-        var path = '/api/0.6/notes?' + utilQsString({ lon: note.loc[0], lat: note.loc[1], text: comment });
-
-        _noteCache.inflightPost[note.id] = oauth.xhr({
-            method: 'POST',
-            path: path
-        }, wrapcb(this, done, _connectionID));
-
-
-        function done(err, xml) {
-            delete _noteCache.inflightPost[note.id];
-            if (err) { return callback(err); }
-
-            // we get the updated note back, remove from caches and reparse..
-            this.removeNote(note);
-
-            var options = { skipSeen: false };
-            return parseXML(xml, function(err, results) {
-                if (err) {
-                    return callback(err);
-                } else {
-                    return callback(undefined, results[0]);
-                }
-            }, options);
-        }
-    },
-
-
-    // Update a note
-    // POST /api/0.6/notes/#id/comment?text=comment
-    // POST /api/0.6/notes/#id/close?text=comment
-    // POST /api/0.6/notes/#id/reopen?text=comment
-    postNoteUpdate: function(note, newStatus, callback) {
-        if (!this.authenticated()) {
-            return callback({ message: 'Not Authenticated', status: -3 }, note);
-        }
-        if (_noteCache.inflightPost[note.id]) {
-            return callback({ message: 'Note update already inflight', status: -2 }, note);
-        }
-
-        var action;
-        if (note.status !== 'closed' && newStatus === 'closed') {
-            action = 'close';
-        } else if (note.status !== 'open' && newStatus === 'open') {
-            action = 'reopen';
-        } else {
-            action = 'comment';
-            if (!note.newComment) return; // when commenting, comment required
-        }
-
-        var path = '/api/0.6/notes/' + note.id + '/' + action;
-        if (note.newComment) {
-            path += '?' + utilQsString({ text: note.newComment });
-        }
-
-        _noteCache.inflightPost[note.id] = oauth.xhr({
-            method: 'POST',
-            path: path
-        }, wrapcb(this, done, _connectionID));
-
-
-        function done(err, xml) {
-            delete _noteCache.inflightPost[note.id];
-            if (err) { return callback(err); }
-
-            // we get the updated note back, remove from caches and reparse..
-            this.removeNote(note);
-
-            // update closed note cache - used to populate `closed:note` changeset tag
-            if (action === 'close') {
-                _noteCache.closed[note.id] = true;
-            } else if (action === 'reopen') {
-                delete _noteCache.closed[note.id];
-            }
-
-            var options = { skipSeen: false };
-            return parseXML(xml, function(err, results) {
-                if (err) {
-                    return callback(err);
-                } else {
-                    return callback(undefined, results[0]);
-                }
-            }, options);
-        }
-    },
-
-
-    /* connection options for source switcher (optional) */
-    apiConnections: function(val) {
-        if (!arguments.length) return _apiConnections;
-        _apiConnections = val;
-        return this;
-    },
-
-
-    switch: function(newOptions) {
-        urlroot = newOptions.url;
-        apiUrlroot = newOptions.apiUrl || urlroot;
-        if (newOptions.url && !newOptions.apiUrl) {
-            newOptions = {
-                ...newOptions,
-                apiUrl: newOptions.url
-            };
-        }
-
-        // Copy the existing options, but omit 'access_token'.
-        // (if we did preauth, access_token won't work on a different server)
-        const oldOptions = utilObjectOmit(oauth.options(), 'access_token');
-        oauth.options({...oldOptions, ...newOptions});
-
-        this.reset();
-        this.userChangesets(function() {});  // eagerly load user details/changesets
-        dispatch.call('change');
-        return this;
-    },
-
-
-    toggle: function(val) {
-        _off = !val;
-        return this;
-    },
-
-
-    isChangesetInflight: function() {
-        return !!_changeset.inflight;
-    },
-
-
-    // get/set cached data
-    // This is used to save/restore the state when entering/exiting the walkthrough
-    // Also used for testing purposes.
-    caches: function(obj) {
-        function cloneCache(source) {
-            var target = {};
-            Object.keys(source).forEach(function(k) {
-                if (k === 'rtree') {
-                    target.rtree = new RBush().fromJSON(source.rtree.toJSON());  // clone rbush
-                } else if (k === 'note') {
-                    target.note = {};
-                    Object.keys(source.note).forEach(function(id) {
-                        target.note[id] = osmNote(source.note[id]);   // copy notes
-                    });
-                } else {
-                    target[k] = JSON.parse(JSON.stringify(source[k]));   // clone deep
-                }
-            });
-            return target;
-        }
-
-        if (!arguments.length) {
-            return {
-                tile: cloneCache(_tileCache),
-                note: cloneCache(_noteCache),
-                user: cloneCache(_userCache)
-            };
-        }
-
-        // access caches directly for testing (e.g., loading notes rtree)
-        if (obj === 'get') {
-            return {
-                tile: _tileCache,
-                note: _noteCache,
-                user: _userCache
-            };
-        }
-
-        if (obj.tile) {
-            _tileCache = obj.tile;
-            _tileCache.inflight = {};
-        }
-        if (obj.note) {
-            _noteCache = obj.note;
-            _noteCache.inflight = {};
-            _noteCache.inflightPost = {};
-        }
-        if (obj.user) {
-            _userCache = obj.user;
-        }
-
-        return this;
-    },
-
-
-    logout: function() {
-        _userChangesets = undefined;
-        _userDetails = undefined;
-        oauth.logout();
-        dispatch.call('change');
-        return this;
-    },
-
-
-    authenticated: function() {
-        return oauth.authenticated();
-    },
-
-
-    /** @param {import('osm-auth').LoginOptions} options */
-    authenticate: function(callback, options) {
-        var that = this;
-        var cid = _connectionID;
-        _userChangesets = undefined;
-        _userDetails = undefined;
-
-        function done(err, res) {
-            if (err) {
-                if (callback) callback(err);
-                return;
-            }
-            if (that.getConnectionId() !== cid) {
-                if (callback) callback({ message: 'Connection Switched', status: -1 });
-                return;
-            }
-            _rateLimitError = undefined;
-            dispatch.call('change');
-            if (callback) callback(err, res);
-            that.userChangesets(function() {});  // eagerly load user details/changesets
-        }
-
-        // ensure the locale is correctly set before opening the popup
-        oauth.options({
-            ...oauth.options(),
-            locale: localizer.localeCode(),
-        });
-
-        oauth.authenticate(done, options);
-    },
-
-
-    imageryBlocklists: function() {
-        return _imageryBlocklists;
-    },
-
-
-    tileZoom: function(val) {
-        if (!arguments.length) return _tileZoom;
-        _tileZoom = val;
-        return this;
-    },
-
-
-    // get all cached notes covering the viewport
-    notes: function(projection) {
-        var viewport = projection.clipExtent();
-        var min = [viewport[0][0], viewport[1][1]];
-        var max = [viewport[1][0], viewport[0][1]];
-        var bbox = geoExtent(projection.invert(min), projection.invert(max)).bbox();
-
-        return _noteCache.rtree.search(bbox)
-            .map(function(d) { return d.data; });
-    },
-
-
-    // get a single note from the cache
-    getNote: function(id) {
-        return _noteCache.note[id];
-    },
-
-
-    // remove a single note from the cache
-    removeNote: function(note) {
-        if (!(note instanceof osmNote) || !note.id) return;
-
-        delete _noteCache.note[note.id];
-        updateRtree(encodeNoteRtree(note), false);  // false = remove
-    },
-
-
-    // replace a single note in the cache
-    replaceNote: function(note) {
-        if (!(note instanceof osmNote) || !note.id) return;
-
-        _noteCache.note[note.id] = note;
-        updateRtree(encodeNoteRtree(note), true);  // true = replace
-        return note;
-    },
-
-
-    // Get an array of note IDs closed during this session.
-    // Used to populate `closed:note` changeset tag
-    getClosedIDs: function() {
-        return Object.keys(_noteCache.closed).sort();
+      }
     }
 
+    if (this.authenticated()) {
+      return oauth.xhr(
+        {
+          method: "GET",
+          path,
+        },
+        done,
+      );
+    } else {
+      var url = apiUrlroot + path;
+      var controller = new AbortController();
+      var fn;
+      if (path.indexOf(".json") !== -1) {
+        fn = d3_json;
+      } else {
+        fn = d3_xml;
+      }
+
+      fn(url, { signal: controller.signal })
+        .then(function (data) {
+          done(null, data);
+        })
+        .catch(function (err) {
+          if (err.name === "AbortError") return;
+          // d3-fetch includes status in the error message,
+          // but we can't access the response itself
+          // https://github.com/d3/d3-fetch/issues/27
+          var match = err.message.match(/^\d{3}/);
+          if (match) {
+            done({ status: +match[0], statusText: err.message });
+          } else {
+            done(err.message);
+          }
+        });
+      return controller;
+    }
+  },
+
+  // Load a single entity by id (ways and relations use the `/full` call to include
+  // nodes and members). Parent relations are not included, see `loadEntityRelations`.
+  // GET /api/0.6/node/#id
+  // GET /api/0.6/[way|relation]/#id/full
+  loadEntity: function (id, callback) {
+    var type = osmEntity.id.type(id);
+    var osmID = osmEntity.id.toOSM(id);
+    var options = { skipSeen: false };
+
+    this.loadFromAPI(
+      "/api/0.6/" +
+        type +
+        "/" +
+        osmID +
+        (type !== "node" ? "/full" : "") +
+        ".json",
+      function (err, entities) {
+        if (callback) callback(err, { data: entities });
+      },
+      options,
+    );
+  },
+
+  // Load a single note by id , XML format
+  // GET /api/0.6/notes/#id
+  loadEntityNote: function (id, callback) {
+    var options = { skipSeen: false };
+    this.loadFromAPI(
+      "/api/0.6/notes/" + id,
+      function (err, entities) {
+        if (callback) callback(err, { data: entities });
+      },
+      options,
+    );
+  },
+
+  // Load a single entity with a specific version
+  // GET /api/0.6/[node|way|relation]/#id/#version
+  loadEntityVersion: function (id, version, callback) {
+    var type = osmEntity.id.type(id);
+    var osmID = osmEntity.id.toOSM(id);
+    var options = { skipSeen: false };
+
+    this.loadFromAPI(
+      "/api/0.6/" + type + "/" + osmID + "/" + version + ".json",
+      function (err, entities) {
+        if (callback) callback(err, { data: entities });
+      },
+      options,
+    );
+  },
+
+  // Load the relations of a single entity with the given.
+  // GET /api/0.6/[node|way|relation]/#id/relations
+  loadEntityRelations: function (id, callback) {
+    var type = osmEntity.id.type(id);
+    var osmID = osmEntity.id.toOSM(id);
+    var options = { skipSeen: false };
+
+    this.loadFromAPI(
+      "/api/0.6/" + type + "/" + osmID + "/relations.json",
+      function (err, entities) {
+        if (callback) callback(err, { data: entities });
+      },
+      options,
+    );
+  },
+
+  // Load multiple entities in chunks
+  // (note: callback may be called multiple times)
+  // Unlike `loadEntity`, child nodes and members are not fetched
+  // GET /api/0.6/[nodes|ways|relations]?#parameters
+  loadMultiple: function (ids, callback) {
+    var that = this;
+    var groups = utilArrayGroupBy(utilArrayUniq(ids), osmEntity.id.type);
+
+    Object.keys(groups).forEach(function (k) {
+      var type = k + "s"; // nodes, ways, relations
+      var osmIDs = groups[k].map(function (id) {
+        return osmEntity.id.toOSM(id);
+      });
+      var options = { skipSeen: false };
+
+      utilArrayChunk(osmIDs, 150).forEach(function (arr) {
+        that.loadFromAPI(
+          "/api/0.6/" + type + ".json?" + type + "=" + arr.join(),
+          function (err, entities) {
+            if (callback) callback(err, { data: entities });
+          },
+          options,
+        );
+      });
+    });
+  },
+
+  // Create, upload, and close a changeset
+  // PUT /api/0.6/changeset/create
+  // POST /api/0.6/changeset/#id/upload
+  // PUT /api/0.6/changeset/#id/close
+  putChangeset: function (changeset, changes, callback) {
+    var cid = _connectionID;
+
+    if (_changeset.inflight) {
+      return callback(
+        { message: "Changeset already inflight", status: -2 },
+        changeset,
+      );
+    } else if (_changeset.open) {
+      // reuse existing open changeset..
+      return createdChangeset.call(this, null, _changeset.open);
+    } else {
+      // Open a new changeset..
+      var options = {
+        method: "PUT",
+        path: "/api/0.6/changeset/create",
+        headers: { "Content-Type": "text/xml" },
+        content: JXON.stringify(changeset.asJXON()),
+      };
+      _changeset.inflight = oauth.xhr(
+        options,
+        wrapcb(this, createdChangeset, cid),
+      );
+    }
+
+    async function createdChangeset(err, changesetID) {
+      _changeset.inflight = null;
+      if (err) {
+        return callback(err, changeset);
+      }
+
+      _changeset.open = changesetID;
+      changeset = changeset.update({ id: changesetID });
+
+      // Upload the changeset..
+      const xml = JXON.stringify(changeset.osmChangeJXON(changes));
+      const compressed = await utilGzip(xml);
+
+      const headers = { "Content-Type": "text/xml" };
+      if (compressed) headers["Content-Encoding"] = "gzip";
+
+      var options = {
+        method: "POST",
+        path: "/api/0.6/changeset/" + changesetID + "/upload",
+        headers,
+        content: compressed || xml,
+      };
+      _changeset.inflight = oauth.xhr(
+        options,
+        wrapcb(this, uploadedChangeset, cid),
+      );
+    }
+
+    function uploadedChangeset(err) {
+      _changeset.inflight = null;
+      if (err) return callback(err, changeset);
+
+      // Upload was successful, safe to call the callback.
+      // Add delay to allow for postgres replication #1646 #2678
+      window.setTimeout(function () {
+        callback(null, changeset);
+      }, 2500);
+      _changeset.open = null;
+
+      // At this point, we don't really care if the connection was switched..
+      // Only try to close the changeset if we're still talking to the same server.
+      if (this.getConnectionId() === cid) {
+        // Still attempt to close changeset, but ignore response because #2667
+        oauth.xhr(
+          {
+            method: "PUT",
+            path: "/api/0.6/changeset/" + changeset.id + "/close",
+            headers: { "Content-Type": "text/xml" },
+          },
+          function () {
+            return true;
+          },
+        );
+      }
+    }
+  },
+
+  /** updates the tags on an existing unclosed changeset */
+  // PUT /api/0.6/changeset/#id
+  updateChangesetTags: (changeset) => {
+    return oauth.fetch(
+      `${oauth.options().apiUrl}/api/0.6/changeset/${changeset.id}`,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "text/xml" },
+        body: JXON.stringify(changeset.asJXON()),
+      },
+    );
+  },
+
+  // Load multiple users in chunks
+  // (note: callback may be called multiple times)
+  // GET /api/0.6/users?users=#id1,#id2,...,#idn
+  loadUsers: function (uids, callback) {
+    var toLoad = [];
+    var cached = [];
+
+    utilArrayUniq(uids).forEach(function (uid) {
+      if (_userCache.user[uid]) {
+        delete _userCache.toLoad[uid];
+        cached.push(_userCache.user[uid]);
+      } else {
+        toLoad.push(uid);
+      }
+    });
+
+    if (cached.length || !this.authenticated()) {
+      callback(undefined, cached);
+      if (!this.authenticated()) return; // require auth
+    }
+
+    utilArrayChunk(toLoad, 150).forEach(
+      function (arr) {
+        oauth.xhr(
+          {
+            method: "GET",
+            path: "/api/0.6/users.json?users=" + arr.join(),
+          },
+          wrapcb(this, done, _connectionID),
+        );
+      }.bind(this),
+    );
+
+    function done(err, payload) {
+      if (err) return callback(err);
+
+      var options = { skipSeen: true };
+      return parseUserJSON(
+        payload,
+        function (err, results) {
+          if (err) return callback(err);
+          return callback(undefined, results);
+        },
+        options,
+      );
+    }
+  },
+
+  // Load a given user by id
+  // GET /api/0.6/user/#id
+  loadUser: function (uid, callback) {
+    if (_userCache.user[uid] || !this.authenticated()) {
+      // require auth
+      delete _userCache.toLoad[uid];
+      return callback(undefined, _userCache.user[uid]);
+    }
+
+    oauth.xhr(
+      {
+        method: "GET",
+        path: "/api/0.6/user/" + uid + ".json",
+      },
+      wrapcb(this, done, _connectionID),
+    );
+
+    function done(err, payload) {
+      if (err) return callback(err);
+
+      var options = { skipSeen: true };
+      return parseUserJSON(
+        payload,
+        function (err, results) {
+          if (err) return callback(err);
+          return callback(undefined, results[0]);
+        },
+        options,
+      );
+    }
+  },
+
+  // Load the details of the logged-in user
+  // GET /api/0.6/user/details
+  userDetails: function (callback) {
+    if (_userDetails) {
+      // retrieve cached
+      return callback(undefined, _userDetails);
+    }
+
+    oauth.xhr(
+      {
+        method: "GET",
+        path: "/api/0.6/user/details.json",
+      },
+      wrapcb(this, done, _connectionID),
+    );
+
+    function done(err, payload) {
+      if (err) return callback(err);
+
+      var options = { skipSeen: false };
+      return parseUserJSON(
+        payload,
+        function (err, results) {
+          if (err) return callback(err);
+          _userDetails = results[0];
+          return callback(undefined, _userDetails);
+        },
+        options,
+      );
+    }
+  },
+
+  // Load previous changesets for the logged in user
+  // GET /api/0.6/changesets?user=#id
+  userChangesets: function (callback) {
+    if (_userChangesets) {
+      // retrieve cached
+      return callback(undefined, _userChangesets);
+    }
+
+    this.userDetails(wrapcb(this, gotDetails, _connectionID));
+
+    function gotDetails(err, user) {
+      if (err) {
+        return callback(err);
+      }
+
+      oauth.xhr(
+        {
+          method: "GET",
+          path: "/api/0.6/changesets?user=" + user.id,
+        },
+        wrapcb(this, done, _connectionID),
+      );
+    }
+
+    function done(err, xml) {
+      if (err) {
+        return callback(err);
+      }
+
+      _userChangesets = Array.prototype.map
+        .call(xml.getElementsByTagName("changeset"), function (changeset) {
+          return { tags: getTags(changeset) };
+        })
+        .filter(function (changeset) {
+          var comment = changeset.tags.comment;
+          return comment && comment !== "";
+        });
+
+      return callback(undefined, _userChangesets);
+    }
+  },
+
+  // Fetch the status of the OSM API
+  // GET /api/capabilities
+  status: function (callback) {
+    var url = apiUrlroot + "/api/capabilities";
+    var errback = wrapcb(this, done, _connectionID);
+    d3_xml(url)
+      .then(function (data) {
+        errback(null, data);
+      })
+      .catch(function (err) {
+        errback(err.message);
+      });
+
+    function done(err, xml) {
+      if (err) {
+        // the status is null if no response could be retrieved
+        return callback(err, null);
+      }
+
+      // update blocklists
+      var elements = xml.getElementsByTagName("blacklist");
+      var regexes = [];
+      for (var i = 0; i < elements.length; i++) {
+        var regexString = elements[i].getAttribute("regex"); // needs unencode?
+        if (regexString) {
+          try {
+            var regex = new RegExp(regexString, "i");
+            regexes.push(regex);
+          } catch {
+            /* noop */
+          }
+        }
+      }
+      if (regexes.length) {
+        _imageryBlocklists = regexes;
+      }
+
+      if (_rateLimitError) {
+        return callback(_rateLimitError, "rateLimited");
+      } else {
+        var waynodes = xml.getElementsByTagName("waynodes");
+        var maxWayNodes =
+          waynodes.length && parseInt(waynodes[0].getAttribute("maximum"), 10);
+        if (maxWayNodes && isFinite(maxWayNodes)) _maxWayNodes = maxWayNodes;
+
+        var apiStatus = xml.getElementsByTagName("status");
+        var val = apiStatus[0].getAttribute("api");
+        return callback(undefined, val);
+      }
+    }
+  },
+
+  // Calls `status` and dispatches an `apiStatusChange` event if the returned
+  // status differs from the cached status.
+  reloadApiStatus: function () {
+    // throttle to avoid unnecessary API calls
+    if (!this.throttledReloadApiStatus) {
+      var that = this;
+      this.throttledReloadApiStatus = _throttle(function () {
+        that.status(function (err, status) {
+          if (status !== _cachedApiStatus) {
+            _cachedApiStatus = status;
+            dispatch.call("apiStatusChange", that, err, status);
+          }
+        });
+      }, 500);
+    }
+    this.throttledReloadApiStatus();
+  },
+
+  // Returns the maximum number of nodes a single way can have
+  maxWayNodes: function () {
+    return _maxWayNodes;
+  },
+
+  // Load data (entities) from the API in tiles
+  // GET /api/0.6/map?bbox=
+  loadTiles: function (projection, callback) {
+    if (_off) return;
+
+    // determine the needed tiles to cover the view
+    var tiles = tiler.zoomExtent([_tileZoom, _tileZoom]).getTiles(projection);
+
+    // abort inflight requests that are no longer needed
+    var hadRequests = hasInflightRequests(_tileCache);
+    abortUnwantedRequests(_tileCache, tiles);
+    if (hadRequests && !hasInflightRequests(_tileCache)) {
+      if (_rateLimitError) {
+        // was rate limited, but has settled
+        _rateLimitError = undefined;
+        dispatch.call("change");
+        this.reloadApiStatus();
+      }
+      dispatch.call("loaded"); // stop the spinner
+    }
+
+    // issue new requests..
+    tiles.forEach(function (tile) {
+      this.loadTile(tile, callback);
+    }, this);
+  },
+
+  // Load a single data tile
+  // GET /api/0.6/map?bbox=
+  loadTile: function (tile, callback, depth = 0) {
+    if (_off) return;
+    if (_tileCache.loaded[tile.id] || _tileCache.inflight[tile.id]) return;
+
+    if (!hasInflightRequests(_tileCache) && !_isLoading) {
+      _isLoading = true;
+      dispatch.call("loading");
+    }
+
+    var path = "/api/0.6/map.json?bbox=";
+    var options = { skipSeen: true };
+
+    _tileCache.inflight[tile.id] = this.loadFromAPI(
+      path + tile.extent.toParam(),
+      tileCallback.bind(this),
+      options,
+    );
+
+    function tileCallback(err, parsed) {
+      if (err && err.status === 400) {
+        if (depth < MAX_SUBDIVISION_DEPTH) {
+          delete _tileCache.inflight[tile.id];
+          delete _tileCache.toLoad[tile.id];
+
+          var extentObj = tile.extent.bbox();
+
+          var minLon = extentObj.minX;
+          var minLat = extentObj.minY;
+          var maxLon = extentObj.maxX;
+          var maxLat = extentObj.maxY;
+
+          var midLon = (minLon + maxLon) / 2;
+          var midLat = (minLat + maxLat) / 2;
+
+          var boxes = [
+            [minLon, minLat, midLon, midLat],
+            [midLon, minLat, maxLon, midLat],
+            [minLon, midLat, midLon, maxLat],
+            [midLon, midLat, maxLon, maxLat],
+          ];
+
+          boxes.forEach((bboxArr, i) => {
+            var childTile = {
+              id: tile.id + "-" + depth + "-" + i,
+              extent: {
+                toParam: () => bboxArr.join(","),
+                bbox: () => ({
+                  minX: bboxArr[0],
+                  minY: bboxArr[1],
+                  maxX: bboxArr[2],
+                  maxY: bboxArr[3],
+                }),
+              },
+            };
+
+            this.loadTile(childTile, callback, depth + 1);
+          });
+
+          return;
+        }
+        console.warn("Max subdivision depth reached, skipping:", tile.id);
+
+        delete _tileCache.inflight[tile.id];
+        delete _tileCache.toLoad[tile.id];
+
+        if (!hasInflightRequests(_tileCache) && _isLoading) {
+          _isLoading = false;
+          dispatch.call("loaded");
+        }
+
+        return;
+      }
+      if (!err) {
+        delete _tileCache.inflight[tile.id];
+        delete _tileCache.toLoad[tile.id];
+        _tileCache.loaded[tile.id] = true;
+
+        var bboxObj = tile.extent.bbox();
+        _tileCache.rtree.insert({
+          minX: bboxObj.minX,
+          minY: bboxObj.minY,
+          maxX: bboxObj.maxX,
+          maxY: bboxObj.maxY,
+        });
+      } else {
+        delete _tileCache.inflight[tile.id];
+
+        setTimeout(() => {
+          this.loadTile(tile, callback, depth);
+        }, 8000);
+
+        return;
+      }
+      if (callback) {
+        callback(null, Object.assign({ data: parsed }, tile));
+      }
+
+      if (!hasInflightRequests(_tileCache)) {
+        dispatch.call("loaded");
+      }
+    }
+  },
+
+  isDataLoaded: function (loc) {
+    var bbox = { minX: loc[0], minY: loc[1], maxX: loc[0], maxY: loc[1] };
+    return _tileCache.rtree.collides(bbox);
+  },
+
+  // load the tile that covers the given `loc`
+  loadTileAtLoc: function (loc, callback) {
+    // Back off if the toLoad queue is filling up.. re #6417
+    // (Currently `loadTileAtLoc` requests are considered low priority - used by operations to
+    // let users safely edit geometries which extend to unloaded tiles.  We can drop some.)
+    if (Object.keys(_tileCache.toLoad).length > 50) return;
+
+    var k = geoZoomToScale(_tileZoom + 1);
+    var offset = geoRawMercator().scale(k)(loc);
+    var projection = geoRawMercator().transform({
+      k: k,
+      x: -offset[0],
+      y: -offset[1],
+    });
+    var tiles = tiler.zoomExtent([_tileZoom, _tileZoom]).getTiles(projection);
+
+    tiles.forEach(function (tile) {
+      if (
+        _tileCache.toLoad[tile.id] ||
+        _tileCache.loaded[tile.id] ||
+        _tileCache.inflight[tile.id]
+      )
+        return;
+
+      _tileCache.toLoad[tile.id] = true;
+      this.loadTile(tile, callback);
+    }, this);
+  },
+
+  // Load notes from the API in tiles
+  // GET /api/0.6/notes?bbox=
+  loadNotes: function (projection, noteOptions) {
+    noteOptions = Object.assign({ limit: 10000, closed: 7 }, noteOptions);
+    if (_off) return;
+
+    var that = this;
+    var path =
+      "/api/0.6/notes?limit=" +
+      noteOptions.limit +
+      "&closed=" +
+      noteOptions.closed +
+      "&bbox=";
+    var throttleLoadUsers = _throttle(function () {
+      var uids = Object.keys(_userCache.toLoad);
+      if (!uids.length) return;
+      that.loadUsers(uids, function () {}); // eagerly load user details
+    }, 750);
+
+    // determine the needed tiles to cover the view
+    var tiles = tiler.zoomExtent([_noteZoom, _noteZoom]).getTiles(projection);
+
+    // abort inflight requests that are no longer needed
+    abortUnwantedRequests(_noteCache, tiles);
+
+    // issue new requests..
+    tiles.forEach(function (tile) {
+      if (_noteCache.loaded[tile.id] || _noteCache.inflight[tile.id]) return;
+
+      var options = { skipSeen: false };
+      _noteCache.inflight[tile.id] = that.loadFromAPI(
+        path + tile.extent.toParam(),
+        function (err) {
+          delete _noteCache.inflight[tile.id];
+          if (!err) {
+            _noteCache.loaded[tile.id] = true;
+          }
+          throttleLoadUsers();
+          dispatch.call("loadedNotes");
+        },
+        options,
+      );
+    });
+  },
+
+  // Create a note
+  // POST /api/0.6/notes?params
+  postNoteCreate: function (note, callback) {
+    if (!this.authenticated()) {
+      return callback({ message: "Not Authenticated", status: -3 }, note);
+    }
+    if (_noteCache.inflightPost[note.id]) {
+      return callback(
+        { message: "Note update already inflight", status: -2 },
+        note,
+      );
+    }
+
+    if (!note.loc[0] || !note.loc[1] || !note.newComment) return; // location & description required
+
+    var comment = note.newComment;
+    if (note.newCategory && note.newCategory !== "None") {
+      comment += " #" + note.newCategory;
+    }
+
+    var path =
+      "/api/0.6/notes?" +
+      utilQsString({ lon: note.loc[0], lat: note.loc[1], text: comment });
+
+    _noteCache.inflightPost[note.id] = oauth.xhr(
+      {
+        method: "POST",
+        path: path,
+      },
+      wrapcb(this, done, _connectionID),
+    );
+
+    function done(err, xml) {
+      delete _noteCache.inflightPost[note.id];
+      if (err) {
+        return callback(err);
+      }
+
+      // we get the updated note back, remove from caches and reparse..
+      this.removeNote(note);
+
+      var options = { skipSeen: false };
+      return parseXML(
+        xml,
+        function (err, results) {
+          if (err) {
+            return callback(err);
+          } else {
+            return callback(undefined, results[0]);
+          }
+        },
+        options,
+      );
+    }
+  },
+
+  // Update a note
+  // POST /api/0.6/notes/#id/comment?text=comment
+  // POST /api/0.6/notes/#id/close?text=comment
+  // POST /api/0.6/notes/#id/reopen?text=comment
+  postNoteUpdate: function (note, newStatus, callback) {
+    if (!this.authenticated()) {
+      return callback({ message: "Not Authenticated", status: -3 }, note);
+    }
+    if (_noteCache.inflightPost[note.id]) {
+      return callback(
+        { message: "Note update already inflight", status: -2 },
+        note,
+      );
+    }
+
+    var action;
+    if (note.status !== "closed" && newStatus === "closed") {
+      action = "close";
+    } else if (note.status !== "open" && newStatus === "open") {
+      action = "reopen";
+    } else {
+      action = "comment";
+      if (!note.newComment) return; // when commenting, comment required
+    }
+
+    var path = "/api/0.6/notes/" + note.id + "/" + action;
+    if (note.newComment) {
+      path += "?" + utilQsString({ text: note.newComment });
+    }
+
+    _noteCache.inflightPost[note.id] = oauth.xhr(
+      {
+        method: "POST",
+        path: path,
+      },
+      wrapcb(this, done, _connectionID),
+    );
+
+    function done(err, xml) {
+      delete _noteCache.inflightPost[note.id];
+      if (err) {
+        return callback(err);
+      }
+
+      // we get the updated note back, remove from caches and reparse..
+      this.removeNote(note);
+
+      // update closed note cache - used to populate `closed:note` changeset tag
+      if (action === "close") {
+        _noteCache.closed[note.id] = true;
+      } else if (action === "reopen") {
+        delete _noteCache.closed[note.id];
+      }
+
+      var options = { skipSeen: false };
+      return parseXML(
+        xml,
+        function (err, results) {
+          if (err) {
+            return callback(err);
+          } else {
+            return callback(undefined, results[0]);
+          }
+        },
+        options,
+      );
+    }
+  },
+
+  /* connection options for source switcher (optional) */
+  apiConnections: function (val) {
+    if (!arguments.length) return _apiConnections;
+    _apiConnections = val;
+    return this;
+  },
+
+  switch: function (newOptions) {
+    urlroot = newOptions.url;
+    apiUrlroot = newOptions.apiUrl || urlroot;
+    if (newOptions.url && !newOptions.apiUrl) {
+      newOptions = {
+        ...newOptions,
+        apiUrl: newOptions.url,
+      };
+    }
+
+    // Copy the existing options, but omit 'access_token'.
+    // (if we did preauth, access_token won't work on a different server)
+    const oldOptions = utilObjectOmit(oauth.options(), "access_token");
+    oauth.options({ ...oldOptions, ...newOptions });
+
+    this.reset();
+    this.userChangesets(function () {}); // eagerly load user details/changesets
+    dispatch.call("change");
+    return this;
+  },
+
+  toggle: function (val) {
+    _off = !val;
+    return this;
+  },
+
+  isChangesetInflight: function () {
+    return !!_changeset.inflight;
+  },
+
+  // get/set cached data
+  // This is used to save/restore the state when entering/exiting the walkthrough
+  // Also used for testing purposes.
+  caches: function (obj) {
+    function cloneCache(source) {
+      var target = {};
+      Object.keys(source).forEach(function (k) {
+        if (k === "rtree") {
+          target.rtree = new RBush().fromJSON(source.rtree.toJSON()); // clone rbush
+        } else if (k === "note") {
+          target.note = {};
+          Object.keys(source.note).forEach(function (id) {
+            target.note[id] = osmNote(source.note[id]); // copy notes
+          });
+        } else {
+          target[k] = JSON.parse(JSON.stringify(source[k])); // clone deep
+        }
+      });
+      return target;
+    }
+
+    if (!arguments.length) {
+      return {
+        tile: cloneCache(_tileCache),
+        note: cloneCache(_noteCache),
+        user: cloneCache(_userCache),
+      };
+    }
+
+    // access caches directly for testing (e.g., loading notes rtree)
+    if (obj === "get") {
+      return {
+        tile: _tileCache,
+        note: _noteCache,
+        user: _userCache,
+      };
+    }
+
+    if (obj.tile) {
+      _tileCache = obj.tile;
+      _tileCache.inflight = {};
+    }
+    if (obj.note) {
+      _noteCache = obj.note;
+      _noteCache.inflight = {};
+      _noteCache.inflightPost = {};
+    }
+    if (obj.user) {
+      _userCache = obj.user;
+    }
+
+    return this;
+  },
+
+  logout: function () {
+    _userChangesets = undefined;
+    _userDetails = undefined;
+    oauth.logout();
+    dispatch.call("change");
+    return this;
+  },
+
+  authenticated: function () {
+    return oauth.authenticated();
+  },
+
+  /** @param {import('osm-auth').LoginOptions} options */
+  authenticate: function (callback, options) {
+    var that = this;
+    var cid = _connectionID;
+    _userChangesets = undefined;
+    _userDetails = undefined;
+
+    function done(err, res) {
+      if (err) {
+        if (callback) callback(err);
+        return;
+      }
+      if (that.getConnectionId() !== cid) {
+        if (callback) callback({ message: "Connection Switched", status: -1 });
+        return;
+      }
+      _rateLimitError = undefined;
+      dispatch.call("change");
+      if (callback) callback(err, res);
+      that.userChangesets(function () {}); // eagerly load user details/changesets
+    }
+
+    // ensure the locale is correctly set before opening the popup
+    oauth.options({
+      ...oauth.options(),
+      locale: localizer.localeCode(),
+    });
+
+    oauth.authenticate(done, options);
+  },
+
+  imageryBlocklists: function () {
+    return _imageryBlocklists;
+  },
+
+  tileZoom: function (val) {
+    if (!arguments.length) return _tileZoom;
+    _tileZoom = val;
+    return this;
+  },
+
+  // get all cached notes covering the viewport
+  notes: function (projection) {
+    var viewport = projection.clipExtent();
+    var min = [viewport[0][0], viewport[1][1]];
+    var max = [viewport[1][0], viewport[0][1]];
+    var bbox = geoExtent(projection.invert(min), projection.invert(max)).bbox();
+
+    return _noteCache.rtree.search(bbox).map(function (d) {
+      return d.data;
+    });
+  },
+
+  // get a single note from the cache
+  getNote: function (id) {
+    return _noteCache.note[id];
+  },
+
+  // remove a single note from the cache
+  removeNote: function (note) {
+    if (!(note instanceof osmNote) || !note.id) return;
+
+    delete _noteCache.note[note.id];
+    updateRtree(encodeNoteRtree(note), false); // false = remove
+  },
+
+  // replace a single note in the cache
+  replaceNote: function (note) {
+    if (!(note instanceof osmNote) || !note.id) return;
+
+    _noteCache.note[note.id] = note;
+    updateRtree(encodeNoteRtree(note), true); // true = replace
+    return note;
+  },
+
+  // Get an array of note IDs closed during this session.
+  // Used to populate `closed:note` changeset tag
+  getClosedIDs: function () {
+    return Object.keys(_noteCache.closed).sort();
+  },
 };

--- a/modules/services/osm.js
+++ b/modules/services/osm.js
@@ -1211,12 +1211,11 @@ export default {
 
     function tileCallback(err, parsed) {
       if (err && err.status === 400) {
+        delete _tileCache.inflight[tile.id];
+        delete _tileCache.toLoad[tile.id];
+
         if (depth < MAX_SUBDIVISION_DEPTH) {
-          delete _tileCache.inflight[tile.id];
-          delete _tileCache.toLoad[tile.id];
-
           var extentObj = tile.extent.bbox();
-
           var minLon = extentObj.minX;
           var minLat = extentObj.minY;
           var maxLon = extentObj.maxX;
@@ -1251,10 +1250,8 @@ export default {
 
           return;
         }
-        console.warn("Max subdivision depth reached, skipping:", tile.id);
 
-        delete _tileCache.inflight[tile.id];
-        delete _tileCache.toLoad[tile.id];
+        console.warn("Max subdivision depth reached, skipping:", tile.id);
 
         if (!hasInflightRequests(_tileCache) && _isLoading) {
           _isLoading = false;
@@ -1263,6 +1260,7 @@ export default {
 
         return;
       }
+
       if (!err) {
         delete _tileCache.inflight[tile.id];
         delete _tileCache.toLoad[tile.id];
@@ -1275,6 +1273,9 @@ export default {
           maxX: bboxObj.maxX,
           maxY: bboxObj.maxY,
         });
+      } else if (err.status === 429 || err.status === 509) {
+        delete _tileCache.inflight[tile.id];
+        _rateLimitError = err;
       } else {
         delete _tileCache.inflight[tile.id];
 
@@ -1284,11 +1285,13 @@ export default {
 
         return;
       }
+
       if (callback) {
         callback(null, Object.assign({ data: parsed }, tile));
       }
 
-      if (!hasInflightRequests(_tileCache)) {
+      if (!hasInflightRequests(_tileCache) && _isLoading) {
+        _isLoading = false;
         dispatch.call("loaded");
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -104,7 +104,7 @@
       "version": "0.9.31",
       "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
       "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@actions/core": {
@@ -207,7 +207,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.1.tgz",
       "integrity": "sha512-B0Hv6G3gWGMn0xKJ0txEi/jM5iFpT3MfDxmhZFb4W047GvytCf1DHQ1D69W3zHI4yWe2aTZAA0JnbMZ7Xc8DuQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@csstools/css-calc": "^2.1.4",
@@ -221,7 +221,7 @@
       "version": "6.7.6",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.7.6.tgz",
       "integrity": "sha512-hBaJER6A9MpdG3WgdlOolHmbOYvSk46y7IQN/1+iqiCuUu6iWdQrs9DGKF8ocqsEqWujWf/V7b7vaDgiUmIvUg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/nwsapi": "^2.3.9",
@@ -235,7 +235,7 @@
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@colors/colors": {
@@ -252,7 +252,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
       "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -272,7 +272,7 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
       "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -296,7 +296,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
       "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -324,7 +324,7 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
       "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -347,7 +347,7 @@
       "version": "1.0.23",
       "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.23.tgz",
       "integrity": "sha512-YEmgyklR6l/oKUltidNVYdjSmLSW88vMsKx0pmiS3r71s8ZZRpd8A0Yf0U+6p/RzElmMnPBv27hNWjDQMSZRtQ==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -367,7 +367,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
       "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -966,7 +966,7 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.11.0.tgz",
       "integrity": "sha512-wO3vd8nsEHdumsXrjGO/v4p6irbg7hy9kvIeR6i2AwylZSk4HJdWgL0FNaVquW1+AweJcdvU1IEpuIWk/WaPnA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -2577,7 +2577,7 @@
       "version": "25.2.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.0.tgz",
       "integrity": "sha512-DZ8VwRFUNzuqJ5khrvwMXHmvPe+zGayJhr2CDNiKB1WBE1ST8Djl00D0IC4vvNmHMdj6DlbYRIaFE7WHjlDl5w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -3082,7 +3082,7 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -3289,7 +3289,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
@@ -3796,7 +3796,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
       "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mdn-data": "2.12.2",
@@ -3864,7 +3864,7 @@
       "version": "5.3.7",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
       "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/css-color": "^4.1.1",
@@ -4312,7 +4312,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
       "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-mimetype": "^5.0.0",
@@ -4380,7 +4380,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4398,7 +4398,7 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/deep-is": {
@@ -4648,7 +4648,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -5758,7 +5758,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
       "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@exodus/bytes": "^1.6.0"
@@ -5771,7 +5771,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -5785,7 +5785,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -6236,7 +6236,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-regex": {
@@ -6448,7 +6448,7 @@
       "version": "28.0.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.0.0.tgz",
       "integrity": "sha512-KDYJgZ6T2TKdU8yBfYueq5EPG/EylMsBvCaenWMJb2OXmjgczzwveRCoJ+Hgj1lXPDyasvrgneSn4GBuR1hYyA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
@@ -6488,7 +6488,7 @@
       "version": "7.20.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.20.0.tgz",
       "integrity": "sha512-MJZrkjyd7DeC+uPZh+5/YaMDxFiiEEaDgbUSVMXayofAkDWF1088CDo+2RPg7B1BuS1qf1vgNE7xqwPxE0DuSQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -6664,7 +6664,7 @@
       "version": "11.2.4",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
       "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
-      "devOptional": true,
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -6789,7 +6789,7 @@
       "version": "2.12.2",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
       "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
-      "devOptional": true,
+      "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/memorystream": {
@@ -6928,7 +6928,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/mustache": {
@@ -11884,6 +11884,270 @@
         }
       }
     },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.2.tgz",
+      "integrity": "sha512-o3pcKzJgSGt4d74lSZ+OCnHwkKBeAbFDmbEm5gg70eA8VkyCuC/zV9TwBnmw6VjDlRdF4Pshfb+WE9E6XY1PoQ==",
+      "cpu": [
+        "arm"
+      ],
+      "extraneous": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.2.tgz",
+      "integrity": "sha512-cqFSWO5tX2vhC9hJTK8WAiPIm4Q8q/cU8j2HQA0L3E1uXvBYbOZMhE2oFL8n2pKB5sOCHY6bBuHaRwG7TkfJyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "extraneous": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.2.tgz",
+      "integrity": "sha512-vngduywkkv8Fkh3wIZf5nFPXzWsNsVu1kvtLETWxTFf/5opZmflgVSeLgdHR56RQh71xhPhWoOkEBvbehwTlVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "extraneous": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.2.tgz",
+      "integrity": "sha512-h11KikYrUCYTrDj6h939hhMNlqU2fo/X4NB0OZcys3fya49o1hmFaczAiJWVAFgrM1NCP6RrO7lQKeVYSKBPSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "extraneous": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.2.tgz",
+      "integrity": "sha512-/eg4CI61ZUkLXxMHyVlmlGrSQZ34xqWlZNW43IAU4RmdzWEx0mQJ2mN/Cx4IHLVZFL6UBGAh+/GXhgvGb+nVxw==",
+      "cpu": [
+        "arm64"
+      ],
+      "extraneous": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.2.tgz",
+      "integrity": "sha512-QOWgFH5X9+p+S1NAfOqc0z8qEpJIoUHf7OWjNUGOeW18Mx22lAUOiA9b6r2/vpzLdfxi/f+VWsYjUOMCcYh0Ng==",
+      "cpu": [
+        "x64"
+      ],
+      "extraneous": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.2.tgz",
+      "integrity": "sha512-kDWSPafToDd8LcBYd1t5jw7bD5Ojcu12S3uT372e5HKPzQt532vW+rGFFOaiR0opxePyUkHrwz8iWYEyH1IIQA==",
+      "cpu": [
+        "arm"
+      ],
+      "extraneous": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.2.tgz",
+      "integrity": "sha512-gKm7Mk9wCv6/rkzwCiUC4KnevYhlf8ztBrDRT9g/u//1fZLapSRc+eDZj2Eu2wpJ+0RzUKgtNijnVIB4ZxyL+w==",
+      "cpu": [
+        "arm"
+      ],
+      "extraneous": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.2.tgz",
+      "integrity": "sha512-66lA8vnj5mB/rtDNwPgrrKUOtCLVQypkyDa2gMfOefXK6rcZAxKLO9Fy3GkW8VkPnENv9hBkNOFfGLf6rNKGUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "extraneous": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.2.tgz",
+      "integrity": "sha512-s+OPucLNdJHvuZHuIz2WwncJ+SfWHFEmlC5nKMUgAelUeBUnlB4wt7rXWiyG4Zn07uY2Dd+SGyVa9oyLkVGOjA==",
+      "cpu": [
+        "arm64"
+      ],
+      "extraneous": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.2.tgz",
+      "integrity": "sha512-8wTRM3+gVMDLLDdaT6tKmOE3lJyRy9NpJUS/ZRWmLCmOPIJhVyXwjBo+XbrrwtV33Em1/eCTd5TuGJm4+DmYjw==",
+      "cpu": [
+        "loong64"
+      ],
+      "extraneous": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.2.tgz",
+      "integrity": "sha512-6yqEfgJ1anIeuP2P/zhtfBlDpXUb80t8DpbYwXQ3bQd95JMvUaqiX+fKqYqUwZXqdJDd8xdilNtsHM2N0cFm6A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "extraneous": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.2.tgz",
+      "integrity": "sha512-sshYUiYVSEI2B6dp4jMncwxbrUqRdNApF2c3bhtLAU0qA8Lrri0p0NauOsTWh3yCCCDyBOjESHMExonp7Nzc0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "extraneous": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.2.tgz",
+      "integrity": "sha512-duBLgd+3pqC4MMwBrKkFxaZerUxZcYApQVC5SdbF5/e/589GwVvlRUnyqMFbM8iUSb1BaoX/3fRL7hB9m2Pj8Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "extraneous": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.2.tgz",
+      "integrity": "sha512-tzhYJJidDUVGMgVyE+PmxENPHlvvqm1KILjjZhB8/xHYqAGeizh3GBGf9u6WdJpZrz1aCpIIHG0LgJgH9rVjHQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "extraneous": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.2.tgz",
+      "integrity": "sha512-opH8GSUuVcCSSyHHcl5hELrmnk4waZoVpgn/4FDao9iyE4WpQhyWJ5ryl5M3ocp4qkRuHfyXnGqg8M9oKCEKRA==",
+      "cpu": [
+        "x64"
+      ],
+      "extraneous": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.2.tgz",
+      "integrity": "sha512-LSeBHnGli1pPKVJ79ZVJgeZWWZXkEe/5o8kcn23M8eMKCUANejchJbF/JqzM4RRjOJfNRhKJk8FuqL1GKjF5oQ==",
+      "cpu": [
+        "x64"
+      ],
+      "extraneous": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.2.tgz",
+      "integrity": "sha512-uPj7MQ6/s+/GOpolavm6BPo+6CbhbKYyZHUDvZ/SmJM7pfDBgdGisFX3bY/CBDMg2ZO4utfhlApkSfZ92yXw7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "extraneous": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.2.tgz",
+      "integrity": "sha512-Z9MUCrSgIaUeeHAiNkm3cQyst2UhzjPraR3gYYfOjAuZI7tcFRTOD+4cHLPoS/3qinchth+V56vtqz1Tv+6KPA==",
+      "cpu": [
+        "arm64"
+      ],
+      "extraneous": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.2.tgz",
+      "integrity": "sha512-+GnYBmpjldD3XQd+HMejo+0gJGwYIOfFeoBQv32xF/RUIvccUz20/V6Otdv+57NE70D5pa8W/jVGDoGq0oON4A==",
+      "cpu": [
+        "ia32"
+      ],
+      "extraneous": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.2.tgz",
+      "integrity": "sha512-ApXFKluSB6kDQkAqZOKXBjiaqdF1BlKi+/eqnYe9Ee7U2K3pUDKsIyr8EYm/QDHTJIM+4X+lI0gJc3TTRhd+dA==",
+      "cpu": [
+        "x64"
+      ],
+      "extraneous": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.2.tgz",
+      "integrity": "sha512-ARz+Bs8kY6FtitYM96PqPEVvPXqEZmPZsSkXvyX19YzDqkCaIlhCieLLMI5hxO9SRZ2XtCtm8wxhy0iJ2jxNfw==",
+      "cpu": [
+        "x64"
+      ],
+      "extraneous": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/netlify-cli/node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
@@ -15948,6 +16212,19 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/netlify-cli/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "extraneous": true,
+      "hasInstallScript": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/netlify-cli/node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -20005,6 +20282,47 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/rollup": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.2.tgz",
+      "integrity": "sha512-I25/2QgoROE1vYV+NQ1En9T9UFB9Cmfm2CJ83zZOlaDpvz29wGQSZXWKw7MiNXau7wYgB/T9fVIdIuEQ+KbiiA==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.52.2",
+        "@rollup/rollup-android-arm64": "4.52.2",
+        "@rollup/rollup-darwin-arm64": "4.52.2",
+        "@rollup/rollup-darwin-x64": "4.52.2",
+        "@rollup/rollup-freebsd-arm64": "4.52.2",
+        "@rollup/rollup-freebsd-x64": "4.52.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.52.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.52.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.52.2",
+        "@rollup/rollup-linux-arm64-musl": "4.52.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.52.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.52.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.52.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.52.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.52.2",
+        "@rollup/rollup-linux-x64-gnu": "4.52.2",
+        "@rollup/rollup-linux-x64-musl": "4.52.2",
+        "@rollup/rollup-openharmony-arm64": "4.52.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.52.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.52.2",
+        "@rollup/rollup-win32-x64-gnu": "4.52.2",
+        "@rollup/rollup-win32-x64-msvc": "4.52.2",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/netlify-cli/node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -22761,7 +23079,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
       "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
@@ -23052,7 +23370,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -23239,7 +23557,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -23480,7 +23798,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "xmlchars": "^2.2.0"
@@ -24314,7 +24632,7 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/text-hex": {
@@ -24382,7 +24700,7 @@
       "version": "7.0.19",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.19.tgz",
       "integrity": "sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tldts-core": "^7.0.19"
@@ -24395,7 +24713,7 @@
       "version": "7.0.19",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.19.tgz",
       "integrity": "sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/to-regex-range": {
@@ -24415,7 +24733,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
       "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^7.0.5"
@@ -24428,7 +24746,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
       "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
@@ -24651,7 +24969,7 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/universal-user-agent": {
@@ -24921,7 +25239,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "xml-name-validator": "^5.0.0"
@@ -24934,7 +25252,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
       "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20"
@@ -24956,7 +25274,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
       "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -24966,7 +25284,7 @@
       "version": "16.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.0.tgz",
       "integrity": "sha512-9CcxtEKsf53UFwkSUZjG+9vydAsFO4lFHBpJUtjBcoJOCJpKnSJNwCw813zrYJHpCJ7sgfbtOe0V5Ku7Pa1XMQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@exodus/bytes": "^1.11.0",
@@ -25249,7 +25567,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -25259,7 +25577,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/xpath": {


### PR DESCRIPTION
## What this PR fixes #11459 

When the OSM API returns a `400 Bad Request` for `/map.json?bbox=...` 
(typically caused by the 50k node limit), the editor keeps retrying the same tile and the loading spinner never stops.

Even after API calls stop in the network tab, the spinner continues because the tile remains in `_tileCache.inflight`.

## Root cause

- Tiles were not always removed from `_tileCache.inflight` on 400 responses
- Subdivision logic did not fully clear loading state
- When maximum subdivision depth was reached, the tile was skipped but loading state was not cleaned up
- Spinner state depended only on inflight requests and was never safely reset

## What I changed

- Proper cleanup of:
  - `_tileCache.inflight`
  - `_tileCache.toLoad`

- Safe tile subdivision when 400 occurs:
  - Correct bbox extraction using `{minX, minY, maxX, maxY}`
  - Guard against invalid or degenerate extents
  - Stop subdivision after `MAX_SUBDIVISION_DEPTH`

- Restored rate-limit handling (429 / 509)

- Added `_isLoading` guard to:
  - Prevent duplicate `loading` dispatch
  - Ensure `loaded` dispatch only fires once all inflight requests are cleared

## Result

- No infinite spinner
- No repeated 400 calls
- API calls stop cleanly
- Editor returns to stable state

Tested by forcing a bbox that exceeds the 50k node limit.
