### PR TITLE
Fix move (M/drag) not working after toggling Data panel with node selected (#9582)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Add `railway=crossing` tag when connecting two railways using the validation fix ([#9226], thanks [@paulklie])
 #### :bug: Bugfixes
 * Fix typo: `parking:left:capacity` duplicated in osmSummableTags, missing `parking:right:capacity` ([#11819], thanks [@JaiswalShivang])
+* Fix move (M / drag) not working after toggling Data panel layer or Map Features checkbox with a node selected; blur focus from checkbox so shortcuts work ([#9582])
 * Fix some gpx/geojson properties not visible, such as numbers or complex data structures ([#11636], thanks [@k-yle])
 * Fix error setting custom background ([#11862], thanks [@Kayd-06])
 * Fix crash when commenting/closing notes when the note is closed by another mapper in the meantime ([#8464])
@@ -130,6 +131,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#10935]: https://github.com/openstreetmap/iD/issues/10935
 [#10999]: https://github.com/openstreetmap/iD/pull/10999
 [#11327]: https://github.com/openstreetmap/iD/pull/11327
+[#9582]: https://github.com/openstreetmap/iD/issues/9582
 [#11522]: https://github.com/openstreetmap/iD/issues/11522
 [#11533]: https://github.com/openstreetmap/iD/pull/11533
 [#11589]: https://github.com/openstreetmap/iD/pull/11589

--- a/modules/ui/sections/data_layers.js
+++ b/modules/ui/sections/data_layers.js
@@ -65,6 +65,10 @@ export function uiSectionDataLayers(context) {
 
     function toggleLayer(which) {
         setLayer(which, !showsLayer(which));
+        // Release focus from the checkbox so keyboard shortcuts (e.g. M for move) work (fixes #9582)
+        if (document.activeElement && /^(INPUT|SELECT|TEXTAREA)$/.test(document.activeElement.tagName)) {
+            document.activeElement.blur();
+        }
     }
 
     function drawOsmItems(selection) {

--- a/modules/ui/sections/map_features.js
+++ b/modules/ui/sections/map_features.js
@@ -118,6 +118,10 @@ export function uiSectionMapFeatures(context) {
 
     function clickFeature(d3_event, d) {
         context.features().toggle(d);
+        // Release focus from the checkbox so keyboard shortcuts (e.g. M for move) work (fixes #9582)
+        if (document.activeElement && /^(INPUT|SELECT|TEXTAREA)$/.test(document.activeElement.tagName)) {
+            document.activeElement.blur();
+        }
     }
 
     function showsLayer(id) {


### PR DESCRIPTION
Fixes #9582

**Problem:** After toggling a layer or map-feature checkbox in the Data panel (e.g. enabling "Paths") with a node selected, moving the node via **M** or drag did not work—the map panned instead. Workaround was to click outside the checkbox so focus left the input.

**Cause:** Focus stayed on the checkbox (input element), so keyboard shortcuts were not handled and interaction was wrong.

**Fix:** Blur the active element after toggling in both Map Features (`map_features.js`) and Data layers (`data_layers.js`) so focus leaves the panel and M/drag work without an extra click.