### PR TITLE
Fix infinite spinner when 400 error occurs due to 50k node limit by s…

### DIFF
--- a/modules/services/osm.js
+++ b/modules/services/osm.js
@@ -1140,45 +1140,18 @@ export default {
                     delete _tileCache.inflight[tile.id];
                     delete _tileCache.toLoad[tile.id];
 
-                    if (depth < MAX_SUBDIVISION_DEPTH) {
-
-                        var extent = tile.extent.bbox();
-                        var minLon = extent.minX;
-                        var minLat = extent.minY;
-                        var maxLon = extent.maxX;
-                        var maxLat = extent.maxY;
-
-                        var midLon = (minLon + maxLon) / 2;
-                        var midLat = (minLat + maxLat) / 2;
-
-                        var boxes = [
-                            [minLon, minLat, midLon, midLat],
-                            [midLon, minLat, maxLon, midLat],
-                            [minLon, midLat, midLon, maxLat],
-                            [midLon, midLat, maxLon, maxLat]
-                        ];
-
-                        boxes.forEach(function(bboxArr, i) {
+                    if (depth < _maxSubdivisionDepth) {
+                        var quadrants = tile.extent.split();
+                        quadrants.forEach(function(extent, i) {
 
                             var childTile = {
                                 id: tile.id + '-' + depth + '-' + i,
-                                extent: {
-                                    toParam: function() { return bboxArr.join(','); },
-                                    bbox: function() {
-                                        return {
-                                            minX: bboxArr[0],
-                                            minY: bboxArr[1],
-                                            maxX: bboxArr[2],
-                                            maxY: bboxArr[3]
-                                        };
-                                    }
-                                }
+                                extent: extent
                             };
 
                             this.loadTile(childTile, callback, depth + 1);
 
                         }.bind(this));
-
                         return;
                     }
 

--- a/modules/services/osm.js
+++ b/modules/services/osm.js
@@ -47,6 +47,8 @@ var _rateLimitError;
 var _userChangesets;
 var _userDetails;
 var _off;
+var _isLoading = false;
+var MAX_SUBDIVISION_DEPTH = 3;
 
 // set a default but also load this from the API status
 var _maxWayNodes = 2000;
@@ -553,6 +555,7 @@ export default {
         _userChangesets = undefined;
         _userDetails = undefined;
         _rateLimitError = undefined;
+        _isLoading = false;
 
         Object.values(_tileCache.inflight).forEach(abortRequest);
         Object.values(_noteCache.inflight).forEach(abortRequest);
@@ -1102,11 +1105,13 @@ export default {
 
     // Load a single data tile
     // GET /api/0.6/map?bbox=
-    loadTile: function(tile, callback) {
+    loadTile: function(tile, callback, depth) {
+        depth = depth || 0;
         if (_off) return;
         if (_tileCache.loaded[tile.id] || _tileCache.inflight[tile.id]) return;
 
-        if (!hasInflightRequests(_tileCache)) {
+        if (!hasInflightRequests(_tileCache) && !_isLoading) {
+            _isLoading = true;
             dispatch.call('loading');   // start the spinner
         }
 
@@ -1128,19 +1133,67 @@ export default {
                 bbox.id = tile.id;
                 _tileCache.rtree.insert(bbox);
             } else {
-                // map tile loading error: e.g. network connection error,
-                // 509 Bandwidth Limit Exceeded, 429 Too Many Requests
-                if (!_rateLimitError && err.status === 509 || err.status === 429) {
-                    // show "API rate limiting" warning
+
+                // 400 → subdivision (50k node limit)
+                if (err && err.status === 400) {
+
+                    delete _tileCache.inflight[tile.id];
+                    delete _tileCache.toLoad[tile.id];
+
+                    if (depth < MAX_SUBDIVISION_DEPTH) {
+
+                        var extent = tile.extent.bbox();
+                        var minLon = extent.minX;
+                        var minLat = extent.minY;
+                        var maxLon = extent.maxX;
+                        var maxLat = extent.maxY;
+
+                        var midLon = (minLon + maxLon) / 2;
+                        var midLat = (minLat + maxLat) / 2;
+
+                        var boxes = [
+                            [minLon, minLat, midLon, midLat],
+                            [midLon, minLat, maxLon, midLat],
+                            [minLon, midLat, midLon, maxLat],
+                            [midLon, midLat, maxLon, maxLat]
+                        ];
+
+                        boxes.forEach(function(bboxArr, i) {
+
+                            var childTile = {
+                                id: tile.id + '-' + depth + '-' + i,
+                                extent: {
+                                    toParam: function() { return bboxArr.join(','); },
+                                    bbox: function() {
+                                        return {
+                                            minX: bboxArr[0],
+                                            minY: bboxArr[1],
+                                            maxX: bboxArr[2],
+                                            maxY: bboxArr[3]
+                                        };
+                                    }
+                                }
+                            };
+
+                            this.loadTile(childTile, callback, depth + 1);
+
+                        }.bind(this));
+
+                        return;
+                    }
+
+                } else if (!_rateLimitError && (err.status === 509 || err.status === 429)) {
+
                     _rateLimitError = err;
                     dispatch.call('change');
                     this.reloadApiStatus();
+
                 }
-                setTimeout(() => {
-                    // retry loading the tiles
+
+                setTimeout(function() {
                     delete _tileCache.inflight[tile.id];
-                    this.loadTile(tile, callback);
-                }, 8000);
+                    this.loadTile(tile, callback, depth);
+                }.bind(this), 8000);
             }
             if (callback) {
                 callback(err, Object.assign({ data: parsed }, tile));
@@ -1152,6 +1205,7 @@ export default {
                     dispatch.call('change');
                     this.reloadApiStatus();
                 }
+                _isLoading = false;
                 dispatch.call('loaded');     // stop the spinner
             }
         }

--- a/modules/services/osm.js
+++ b/modules/services/osm.js
@@ -48,7 +48,7 @@ var _userChangesets;
 var _userDetails;
 var _off;
 var _isLoading = false;
-var MAX_SUBDIVISION_DEPTH = 3;
+var _maxSubdivisionDepth = 3;
 
 // set a default but also load this from the API status
 var _maxWayNodes = 2000;

--- a/modules/services/osm.js
+++ b/modules/services/osm.js
@@ -1143,14 +1143,11 @@ export default {
                     if (depth < _maxSubdivisionDepth) {
                         var quadrants = tile.extent.split();
                         quadrants.forEach(function(extent, i) {
-
                             var childTile = {
                                 id: tile.id + '-' + depth + '-' + i,
                                 extent: extent
                             };
-
                             this.loadTile(childTile, callback, depth + 1);
-
                         }.bind(this));
                         return;
                     }

--- a/test/spec/services/osm_subdivision.js
+++ b/test/spec/services/osm_subdivision.js
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import osmService from '../../../modules/services/osm.js';
+import { geoExtent } from '../../../modules/geo/index.js';
+
+describe('OSM 400 tile subdivision', () => {
+
+  let service;
+  let fakeTile;
+
+  beforeEach(() => {
+    service = osmService;
+    service.reset();
+
+    fakeTile = {
+      id: '0,0,16',
+      extent: geoExtent([[0, 0], [1, 1]])
+    };
+  });
+
+
+  it('subdivides only once on initial 400', () => {
+
+    let callCount = 0;
+
+    vi.spyOn(service, 'loadFromAPI').mockImplementation((path, cb) => {
+
+      callCount++;
+
+      // Only first call returns 400
+      if (callCount === 1) {
+        cb({
+          status: 400,
+          statusText: 'You requested too many nodes (limit is 50000)'
+        });
+      } else {
+        cb(null, []); // children succeed
+      }
+
+      return { abort: () => {} }; // important
+    });
+
+    const spy = vi.spyOn(service, 'loadTile');
+
+    service.loadTile(fakeTile, () => {});
+
+    // 1 original + 4 children
+    expect(spy).toHaveBeenCalledTimes(5);
+
+    spy.mockRestore();
+  });
+
+
+  it('does not subdivide beyond max depth', () => {
+
+    vi.spyOn(service, 'loadFromAPI').mockImplementation((path, cb) => {
+      cb({
+        status: 400,
+        statusText: 'You requested too many nodes (limit is 50000)'
+      });
+      return { abort: () => {} };
+    });
+
+    const spy = vi.spyOn(service, 'loadTile');
+
+    service.loadTile(fakeTile, () => {}, 3);
+
+    // should not create children
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    spy.mockRestore();
+  });
+
+
+  it('retries for non-400 errors', () => {
+
+    vi.useFakeTimers();
+
+    let retryTriggered = false;
+
+    vi.spyOn(service, 'loadFromAPI').mockImplementation((path, cb) => {
+      cb({ status: 429 });
+      return { abort: () => {} };
+    });
+
+    const spy = vi.spyOn(service, 'loadTile');
+
+    service.loadTile(fakeTile, () => {});
+
+    vi.runAllTimers();
+
+    expect(spy).toHaveBeenCalled();
+
+    spy.mockRestore();
+    vi.useRealTimers();
+  });
+
+});


### PR DESCRIPTION
## Fix infinite spinner when OSM API returns 400 for large bbox #11459 

### What this fixes

When the OSM API returns a `400 Bad Request` for `/map.json?bbox=...` (typically caused by the 50k node limit), the editor keeps retrying the same tile and the loading spinner never stops.

Even after API requests stop in the network tab, the tile remains in `_tileCache.inflight`, so the spinner continues indefinitely.

### What was changed

- Added safe handling for `400` responses  
- Subdivide tiles when possible (up to a max depth)  
- Properly clear `_tileCache.inflight` and `_tileCache.toLoad`  
- Ensure the spinner stops once all inflight requests are resolved  

### Result

Please take a look of vedio: https://drive.google.com/file/d/1-3UsnZWG6jUg05__sEQULTYYidnYVkZg/view?usp=drive_link

- No infinite spinner  
- No repeated 400 requests  
- Editor returns to a stable state  

Tested by forcing a bbox that exceeds the 50k node limit.
I have added a vedio in comment of this issue if want please you can check for fixes.
Thanks