### PR TITLE
PoC: Automatically split geographically distant edits into linked changesets\

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -5483,6 +5483,16 @@ a.user-info {
     opacity: 0.5;
 }
 
+.changeset-group + .changeset-group {
+    margin-top: 10px;
+}
+
+.changeset-group-title {
+    margin: 0 0 4px 2px;
+    font-size: 12px;
+    font-weight: 600;
+}
+
 
 /* Conflict resolution
 ------------------------------------------------------- */

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -611,6 +611,8 @@ en:
     save: Upload
     cancel: Cancel
     changes: Changes
+    multiple_changesets_info: "Some edits are too far apart and will be uploaded separately as {count} changesets. Review each group below."
+    changeset_group: "Changeset {num}"
     download_changes: Download osmChange file
     errors: Errors
     warnings: Warnings

--- a/modules/core/changeset_splitter.js
+++ b/modules/core/changeset_splitter.js
@@ -1,0 +1,323 @@
+import { geoExtent } from '../geo/extent';
+
+
+function UnionFind() {
+    this.parent = {};
+    this.rank = {};
+}
+
+UnionFind.prototype.find = function(x) {
+    if (this.parent[x] === undefined) {
+        this.parent[x] = x;
+        this.rank[x] = 0;
+    }
+    if (this.parent[x] !== x) {
+        this.parent[x] = this.find(this.parent[x]);
+    }
+    return this.parent[x];
+};
+
+UnionFind.prototype.union = function(a, b) {
+    var ra = this.find(a);
+    var rb = this.find(b);
+    if (ra === rb) return;
+    if (this.rank[ra] < this.rank[rb]) { var tmp = ra; ra = rb; rb = tmp; }
+    this.parent[rb] = ra;
+    if (this.rank[ra] === this.rank[rb]) this.rank[ra]++;
+};
+
+
+/**
+ * Split a set of changes into geographically coherent groups,
+ * preserving referential integrity (ways stay with their nodes,
+ * relations stay with their members).
+ *
+ * @param {Object} changes - { created: Entity[], modified: Entity[], deleted: Entity[] }
+ * @param {import('./graph').coreGraph} graph - The current graph for resolving entity relationships
+ * @param {number} [threshold=0.25] - Maximum bbox area in degrees^2 before splitting
+ * @returns {Object[]} Array of { created, modified, deleted } groups
+ */
+export function coreChangesetSplitter(changes, graph, threshold) {
+    if (threshold === undefined) threshold = 0.25;
+
+    var allEntities = changes.created.concat(changes.modified).concat(changes.deleted);
+
+    // Early exit for empty changes
+    if (allEntities.length === 0) {
+        return [{ created: [], modified: [], deleted: [] }];
+    }
+
+    // Build entity map first (needed by extent computation and centroid)
+    var entityMap = {};
+    for (var e = 0; e < allEntities.length; e++) {
+        entityMap[allEntities[e].id] = allEntities[e];
+    }
+
+    // Early exit if overall bbox is under threshold
+    var overallExtent = computeOverallExtent(allEntities, graph, entityMap);
+    if (overallExtent.area() <= threshold) {
+        return [changes];
+    }
+
+    // Build union-find from structural dependencies
+    var uf = new UnionFind();
+
+    for (var i = 0; i < allEntities.length; i++) {
+        var entity = allEntities[i];
+        uf.find(entity.id);  // ensure entity exists in union-find
+
+        if (entity.type === 'way' && entity.nodes) {
+            for (var j = 0; j < entity.nodes.length; j++) {
+                if (entityMap[entity.nodes[j]] || hasChangedEntity(allEntities, entity.nodes[j])) {
+                    uf.union(entity.id, entity.nodes[j]);
+                }
+            }
+        } else if (entity.type === 'relation' && entity.members) {
+            for (var k = 0; k < entity.members.length; k++) {
+                var memberId = entity.members[k].id;
+                if (entityMap[memberId] || hasChangedEntity(allEntities, memberId)) {
+                    uf.union(entity.id, memberId);
+                }
+            }
+        }
+    }
+
+    // Extract connected components
+    var components = {};
+    for (var m = 0; m < allEntities.length; m++) {
+        var root = uf.find(allEntities[m].id);
+        if (!components[root]) components[root] = [];
+        components[root].push(allEntities[m]);
+    }
+
+    var componentKeys = Object.keys(components);
+
+    // If only one component, no split possible
+    if (componentKeys.length <= 1) {
+        return [changes];
+    }
+
+    // Compute centroid for each component
+    var componentCentroids = {};
+    for (var c = 0; c < componentKeys.length; c++) {
+        componentCentroids[componentKeys[c]] = computeComponentCentroid(components[componentKeys[c]], graph, entityMap);
+    }
+
+    // Grid-based clustering
+    var cellSize = 0.5;
+    var gridGroups = {};
+
+    for (var g = 0; g < componentKeys.length; g++) {
+        var key = componentKeys[g];
+        var centroid = componentCentroids[key];
+        var gridKey;
+
+        if (centroid) {
+            gridKey = Math.floor(centroid[0] / cellSize) + ',' + Math.floor(centroid[1] / cellSize);
+        } else {
+            gridKey = '_orphan';
+        }
+
+        if (!gridGroups[gridKey]) {
+            gridGroups[gridKey] = [];
+        }
+        gridGroups[gridKey].push(key);
+    }
+
+    // Merge adjacent grid cells whose combined extent is under threshold
+    mergeAdjacentCells(gridGroups, components, graph, entityMap, threshold);
+
+    // Handle orphan components: attach to the largest group
+    if (gridGroups._orphan) {
+        var orphanComponents = gridGroups._orphan;
+        delete gridGroups._orphan;
+
+        var largestKey = findLargestGroupKey(gridGroups, components);
+        if (largestKey) {
+            gridGroups[largestKey] = gridGroups[largestKey].concat(orphanComponents);
+        } else {
+            // Everything is orphan; put in single group
+            gridGroups._all = orphanComponents;
+        }
+    }
+
+    // Build output groups
+    return buildOutputGroups(gridGroups, components, changes);
+}
+
+function hasChangedEntity(allEntities, id) {
+    for (var i = 0; i < allEntities.length; i++) {
+        if (allEntities[i].id === id) return true;
+    }
+    return false;
+}
+
+
+function computeOverallExtent(allEntities, graph, entityMap) {
+    var extent = geoExtent();
+    for (var i = 0; i < allEntities.length; i++) {
+        var locs = getEntityLocations(allEntities[i], graph, entityMap);
+        for (var j = 0; j < locs.length; j++) {
+            extent._extend(geoExtent(locs[j]));
+        }
+    }
+    return extent;
+}
+
+
+// Returns ALL resolvable locations for an entity (not just the first one).
+// This is critical for ways that span large areas.
+function getEntityLocations(entity, graph, entityMap, seen) {
+    var locs = [];
+    if (!entity) return locs;
+
+    // Guard against relation cycles, e.g. r1 -> r2 -> r1.
+    if (!seen) seen = {};
+    if (seen[entity.id]) return locs;
+    seen[entity.id] = true;
+
+    if (entity.type === 'node' && entity.loc) {
+        locs.push(entity.loc);
+    } else if (entity.type === 'way' && entity.nodes) {
+        for (var i = 0; i < entity.nodes.length; i++) {
+            var node = graph.hasEntity(entity.nodes[i]);
+            if (!node && entityMap) node = entityMap[entity.nodes[i]];
+            if (node && node.loc) locs.push(node.loc);
+        }
+    } else if (entity.type === 'relation' && entity.members) {
+        for (var j = 0; j < entity.members.length; j++) {
+            var member = graph.hasEntity(entity.members[j].id);
+            if (!member && entityMap) member = entityMap[entity.members[j].id];
+            if (member) {
+                var memberLocs = getEntityLocations(member, graph, entityMap, seen);
+                for (var k = 0; k < memberLocs.length; k++) {
+                    locs.push(memberLocs[k]);
+                }
+            }
+        }
+    }
+
+    delete seen[entity.id];
+    return locs;
+}
+
+
+function computeComponentCentroid(entities, graph, entityMap) {
+    var sumLon = 0;
+    var sumLat = 0;
+    var count = 0;
+
+    for (var i = 0; i < entities.length; i++) {
+        var locs = getEntityLocations(entities[i], graph, entityMap);
+        for (var j = 0; j < locs.length; j++) {
+            sumLon += locs[j][0];
+            sumLat += locs[j][1];
+            count++;
+        }
+    }
+
+    if (count === 0) return null;
+    return [sumLon / count, sumLat / count];
+}
+
+
+function parseGridKey(key) {
+    var parts = key.split(',');
+    return [parseInt(parts[0], 10), parseInt(parts[1], 10)];
+}
+
+
+function mergeAdjacentCells(gridGroups, components, graph, entityMap, threshold) {
+    var merged = true;
+    while (merged) {
+        merged = false;
+        var keys = Object.keys(gridGroups).filter(function(k) { return k !== '_orphan'; });
+
+        for (var i = 0; i < keys.length && !merged; i++) {
+            for (var j = i + 1; j < keys.length && !merged; j++) {
+                var a = parseGridKey(keys[i]);
+                var b = parseGridKey(keys[j]);
+
+                // Check grid adjacency in 8-neighborhood (including diagonal neighbors).
+                if (Math.abs(a[0] - b[0]) <= 1 && Math.abs(a[1] - b[1]) <= 1) {
+                    // Compute combined extent
+                    var combinedEntities = [];
+                    var compKeysA = gridGroups[keys[i]];
+                    var compKeysB = gridGroups[keys[j]];
+
+                    for (var m = 0; m < compKeysA.length; m++) {
+                        combinedEntities = combinedEntities.concat(components[compKeysA[m]]);
+                    }
+                    for (var n = 0; n < compKeysB.length; n++) {
+                        combinedEntities = combinedEntities.concat(components[compKeysB[n]]);
+                    }
+
+                    var combinedExtent = computeOverallExtent(combinedEntities, graph, entityMap);
+
+                    if (combinedExtent.area() <= threshold) {
+                        // Merge j into i
+                        gridGroups[keys[i]] = compKeysA.concat(compKeysB);
+                        delete gridGroups[keys[j]];
+                        merged = true;
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+function findLargestGroupKey(gridGroups, components) {
+    var largestKey = null;
+    var largestCount = 0;
+
+    var keys = Object.keys(gridGroups);
+    for (var i = 0; i < keys.length; i++) {
+        var count = 0;
+        var compKeys = gridGroups[keys[i]];
+        for (var j = 0; j < compKeys.length; j++) {
+            count += components[compKeys[j]].length;
+        }
+        if (count > largestCount) {
+            largestCount = count;
+            largestKey = keys[i];
+        }
+    }
+
+    return largestKey;
+}
+
+
+function buildOutputGroups(gridGroups, components, changes) {
+    var groups = [];
+    var groupKeys = Object.keys(gridGroups);
+
+    // Build a set of entity IDs per change type for fast lookup
+    var createdIds = new Set(changes.created.map(function(e) { return e.id; }));
+    var modifiedIds = new Set(changes.modified.map(function(e) { return e.id; }));
+    var deletedIds = new Set(changes.deleted.map(function(e) { return e.id; }));
+
+    for (var i = 0; i < groupKeys.length; i++) {
+        var group = { created: [], modified: [], deleted: [] };
+        var compKeys = gridGroups[groupKeys[i]];
+
+        for (var j = 0; j < compKeys.length; j++) {
+            var entities = components[compKeys[j]];
+
+            for (var k = 0; k < entities.length; k++) {
+                var entity = entities[k];
+                if (createdIds.has(entity.id)) {
+                    group.created.push(entity);
+                } else if (modifiedIds.has(entity.id)) {
+                    group.modified.push(entity);
+                } else if (deletedIds.has(entity.id)) {
+                    group.deleted.push(entity);
+                }
+            }
+        }
+
+        groups.push(group);
+    }
+
+    return groups;
+}

--- a/modules/core/index.js
+++ b/modules/core/index.js
@@ -1,3 +1,4 @@
+export { coreChangesetSplitter } from './changeset_splitter';
 export { coreContext } from './context';
 export { coreFileFetcher, fileFetcher } from './file_fetcher';
 export { coreDifference } from './difference';

--- a/modules/core/uploader.js
+++ b/modules/core/uploader.js
@@ -8,6 +8,7 @@ import { actionNoop } from '../actions/noop';
 import { actionRevert } from '../actions/revert';
 import { coreGraph } from '../core/graph';
 import { t } from '../core/localizer';
+import { coreChangesetSplitter } from './changeset_splitter';
 import { utilArrayUnion, utilArrayUniq, utilDisplayName, utilDisplayType, utilRebind } from '../util';
 
 
@@ -35,6 +36,11 @@ export function coreUploader(context) {
     var _conflicts = [];
     var _errors = [];
     var _origChanges;
+    var _uploadedEntityIDs = {};
+    var _splitBaseComment = null;
+    var _splitTotalParts = null;
+    var _splitUploadedParts = 0;
+    var _splitReferenceChangesetID = null;
 
     var _discardTags = {};
     fileFetcher.get('discarded')
@@ -77,6 +83,13 @@ export function coreUploader(context) {
         _anyConflictsAutomaticallyResolved = false;
         _conflicts = [];
         _errors = [];
+        if (!tryAgain) {
+            _uploadedEntityIDs = {};
+            _splitBaseComment = null;
+            _splitTotalParts = null;
+            _splitUploadedParts = 0;
+            _splitReferenceChangesetID = null;
+        }
 
         // Store original changes, in case user wants to download them as an .osc file
         _origChanges = history.changes(actionDiscardTags(history.difference(), _discardTags));
@@ -301,9 +314,29 @@ export function coreUploader(context) {
             var changes = history.changes(actionDiscardTags(history.difference(), _discardTags));
             if (changes.modified.length || changes.created.length || changes.deleted.length) {
 
+                var groups = coreChangesetSplitter(changes, context.graph());
+
                 dispatch.call('willAttemptUpload', this);
 
-                osm.putChangeset(changeset, changes, uploadCallback);
+                if (groups.length > 1) {
+                    if (_splitTotalParts === null) {
+                        _splitTotalParts = groups.length;
+                    }
+                    if (_splitBaseComment === null) {
+                        _splitBaseComment = (changeset.tags.comment || '').trim();
+                    }
+                    uploadGroupsSequentially(changeset, groups, 0);
+                } else {
+                    // If we are resuming a split upload and only one part remains,
+                    // preserve split metadata for the final part.
+                    if (_splitTotalParts && _splitTotalParts > 1) {
+                        var finalPartNumber = _splitUploadedParts + 1;
+                        var taggedChangeset = withSplitComment(changeset, finalPartNumber, _splitTotalParts);
+                        osm.putChangeset(taggedChangeset, groups[0], uploadCallback);
+                    } else {
+                        osm.putChangeset(changeset, groups[0], uploadCallback);
+                    }
+                }
 
             } else {
                 // changes were insignificant or reverted by user
@@ -330,6 +363,89 @@ export function coreUploader(context) {
         }
     }
 
+    function uploadGroupsSequentially(changeset, groups, index) {
+        var osm = context.connection();
+        if (!osm) {
+            _errors.push({ msg: 'No OSM Service' });
+            didResultInErrors();
+            return;
+        }
+
+        var partNumber = _splitUploadedParts + 1;
+        var totalParts = _splitTotalParts || groups.length;
+        var taggedChangeset = withSplitComment(changeset, partNumber, totalParts);
+        var group = groups[index];
+        osm.putChangeset(taggedChangeset, group, function(err, updatedChangeset) {
+            if (err) {
+                uploadCallback(err, updatedChangeset);
+                return;
+            }
+
+            if (!_splitReferenceChangesetID && updatedChangeset && updatedChangeset.id) {
+                _splitReferenceChangesetID = updatedChangeset.id;
+            }
+            _splitUploadedParts++;
+            markGroupAsUploaded(group);
+
+            if (index < groups.length - 1) {
+                uploadGroupsSequentially(changeset, groups, index + 1);
+            } else {
+                didResultInSuccess(updatedChangeset);
+            }
+        });
+    }
+
+    function withSplitComment(changeset, partNumber, totalParts) {
+        var tags = Object.assign({}, changeset.tags);
+        tags.comment = splitComment(partNumber, totalParts);
+        return changeset.update({ tags: tags });
+    }
+
+    function splitComment(partNumber, totalParts) {
+        var baseComment = _splitBaseComment || '';
+        var suffix = 'part ' + partNumber + '/' + totalParts;
+
+        if (partNumber > 1 && _splitReferenceChangesetID) {
+            var osm = context.connection();
+            var ref = osm && osm.changesetURL ?
+                osm.changesetURL(_splitReferenceChangesetID) :
+                String(_splitReferenceChangesetID);
+            suffix += ', ref: ' + ref;
+        }
+
+        if (baseComment) {
+            return baseComment + ' (' + suffix + ')';
+        }
+        return suffix.charAt(0).toUpperCase() + suffix.slice(1);
+    }
+
+    function markGroupAsUploaded(group) {
+        var history = context.history();
+        var entities = group.created.concat(group.modified).concat(group.deleted);
+        var ids = utilArrayUniq(entities.map(function(entity) { return entity.id; }));
+
+        if (!ids.length) return;
+
+        history.pauseChangeDispatch();
+        for (var i = 0; i < ids.length; i++) {
+            _uploadedEntityIDs[ids[i]] = true;
+            history.replace(actionRevert(ids[i]));
+        }
+        history.resumeChangeDispatch();
+    }
+
+    function applyUploadedReverts() {
+        var history = context.history();
+        var ids = Object.keys(_uploadedEntityIDs);
+        if (!ids.length) return;
+
+        history.pauseChangeDispatch();
+        for (var i = 0; i < ids.length; i++) {
+            history.replace(actionRevert(ids[i]));
+        }
+        history.resumeChangeDispatch();
+    }
+
     function didResultInNoChanges() {
 
         dispatch.call('resultNoChanges', this);
@@ -340,8 +456,9 @@ export function coreUploader(context) {
     }
 
     function didResultInErrors() {
-
-        context.history().pop();
+        var history = context.history();
+        history.pop();
+        applyUploadedReverts();
 
         dispatch.call('resultErrors', this, _errors);
 
@@ -381,6 +498,11 @@ export function coreUploader(context) {
 
     function endSave() {
         _isSaving = false;
+        _uploadedEntityIDs = {};
+        _splitBaseComment = null;
+        _splitTotalParts = null;
+        _splitUploadedParts = 0;
+        _splitReferenceChangesetID = null;
 
         dispatch.call('saveEnded', this);
     }

--- a/modules/ui/sections/changes.js
+++ b/modules/ui/sections/changes.js
@@ -2,6 +2,7 @@ import { select as d3_select } from 'd3-selection';
 
 import { presetManager } from '../../presets';
 import { fileFetcher } from '../../core/file_fetcher';
+import { coreChangesetSplitter } from '../../core/changeset_splitter';
 import { t } from '../../core/localizer';
 import { JXON } from '../../util/jxon';
 import { actionDiscardTags } from '../../actions/discard_tags';
@@ -33,6 +34,9 @@ export function uiSectionChanges(context) {
     function renderDisclosureContent(selection) {
         var history = context.history();
         var summary = history.difference().summary();
+        var changes = history.changes(actionDiscardTags(history.difference(), _discardTags));
+        var groups = coreChangesetSplitter(changes, context.graph());
+        var groupedSummary = splitSummaryIntoGroups(summary, groups);
 
         var container = selection.selectAll('.commit-section')
             .data([0]);
@@ -42,15 +46,65 @@ export function uiSectionChanges(context) {
             .attr('class', 'commit-section');
 
         containerEnter
-            .append('ul')
-            .attr('class', 'changeset-list');
+            .append('p')
+            .attr('class', 'changeset-multi-message field-warning hide');
+
+        containerEnter
+            .append('div')
+            .attr('class', 'changeset-groups');
+
+        containerEnter
+            .append('a')
+            .attr('class', 'download-changes');
 
         container = containerEnter
             .merge(container);
 
+        var splitMessage = container.select('.changeset-multi-message');
+        splitMessage
+            .classed('hide', groups.length <= 1)
+            .text(groups.length > 1 ? getSplitMessage(groups.length) : '');
 
-        var items = container.select('ul').selectAll('li')
-            .data(summary);
+        var groupContainers = container.select('.changeset-groups')
+            .selectAll('.changeset-group')
+            .data(groupedSummary);
+
+        var groupEnter = groupContainers.enter()
+            .append('div')
+            .attr('class', 'changeset-group');
+
+        groupEnter
+            .append('h4')
+            .attr('class', 'changeset-group-title');
+
+        groupEnter
+            .append('ul')
+            .attr('class', 'changeset-list');
+
+        groupContainers.exit()
+            .remove();
+
+        groupContainers = groupEnter
+            .merge(groupContainers);
+
+        groupContainers.select('.changeset-group-title')
+            .classed('hide', groups.length <= 1)
+            .text(function(d, i) {
+                var groupLabel = t('commit.changeset_group', {
+                    num: i + 1,
+                    default: ''
+                });
+                if (!groupLabel) {
+                    groupLabel = 'Changeset ' + (i + 1);
+                }
+                return t('inspector.title_count', {
+                    title: groupLabel,
+                    count: d.length
+                });
+            });
+
+        var items = groupContainers.select('ul').selectAll('li')
+            .data(function(d) { return d; }, function(d) { return d.changeType + '-' + d.entity.id; });
 
         var itemsEnter = items.enter()
             .append('li')
@@ -85,35 +139,30 @@ export function uiSectionChanges(context) {
             .append('span')
             .attr('class', 'entity-name')
             .text(function(d) {
-                var name = utilDisplayName(d.entity) || '',
-                    string = '';
-                if (name !== '') {
-                    string += ':';
-                }
-                return string += ' ' + name;
+                var name = utilDisplayName(d.entity) || '';
+                return (name !== '' ? ':' : '') + ' ' + name;
             });
 
-        items = itemsEnter
-            .merge(items);
+        items.exit()
+            .remove();
 
 
         // Download changeset link
         var changeset = new osmChangeset().update({ id: undefined });
-        var changes = history.changes(actionDiscardTags(history.difference(), _discardTags));
-
-        delete changeset.id;  // Export without chnageset_id
 
         var data = JXON.stringify(changeset.osmChangeJXON(changes));
         var blob = new Blob([data], {type: 'text/xml;charset=utf-8;'});
         var fileName = 'changes.osc';
 
-        var linkEnter = container.selectAll('.download-changes')
-            .data([0])
-            .enter()
+        var link = container.selectAll('.download-changes')
+            .data([0]);
+
+        var linkEnter = link.enter()
             .append('a')
             .attr('class', 'download-changes');
 
-        linkEnter
+        link = linkEnter
+            .merge(link)
             .attr('href', window.URL.createObjectURL(blob))
             .attr('download', fileName);
 
@@ -146,6 +195,38 @@ export function uiSectionChanges(context) {
                     .classed('hover', true);
             }
         }
+    }
+
+    function getSplitMessage(groupCount) {
+        var message = t('commit.multiple_changesets_info', {
+            count: groupCount,
+            default: ''
+        });
+        if (!message) {
+            message = 'Some edits are too far apart and will be uploaded separately as ' + groupCount + ' changesets. Review each group below.';
+        }
+        return message;
+    }
+
+    function splitSummaryIntoGroups(summary, groups) {
+        var indexByEntityID = {};
+        for (var i = 0; i < groups.length; i++) {
+            var entities = groups[i].created.concat(groups[i].modified).concat(groups[i].deleted);
+            for (var j = 0; j < entities.length; j++) {
+                indexByEntityID[entities[j].id] = i;
+            }
+        }
+
+        var grouped = groups.map(function() { return []; });
+        for (var k = 0; k < summary.length; k++) {
+            var change = summary[k];
+            var index = indexByEntityID[change.entity.id];
+            if (index === undefined) index = 0;
+            if (!grouped[index]) grouped[index] = [];
+            grouped[index].push(change);
+        }
+
+        return grouped.filter(function(group) { return group.length; });
     }
 
     return section;

--- a/test/spec/core/changeset_splitter.js
+++ b/test/spec/core/changeset_splitter.js
@@ -1,0 +1,504 @@
+describe('iD.coreChangesetSplitter', function() {
+
+    describe('early exit', function() {
+        it('returns single group for empty changes', function() {
+            // Scenario: User opens the editor, makes no edits, and hits save.
+            // The changeset is empty.
+            var graph = iD.coreGraph([]);
+            var changes = { created: [], modified: [], deleted: [] };
+            var groups = iD.coreChangesetSplitter(changes, graph, 0.25);
+
+            expect(groups).to.have.length(1);
+            expect(groups[0].created).to.have.length(0);
+            expect(groups[0].modified).to.have.length(0);
+            expect(groups[0].deleted).to.have.length(0);
+        });
+
+        it('handles a single entity', function() {
+            // Scenario: User adds just one bench in a park and saves.
+            // Should always return a single group.
+            var n1 = iD.osmNode({ id: 'n1', loc: [0, 0] });
+            var graph = iD.coreGraph([n1]);
+
+            var changes = { created: [n1], modified: [], deleted: [] };
+            var groups = iD.coreChangesetSplitter(changes, graph, 0.25);
+
+            expect(groups).to.have.length(1);
+            expect(groups[0].created).to.have.length(1);
+        });
+
+        it('does not split when overall bbox is under threshold', function() {
+            // Scenario: User adds two benches in the same park (~10 meters apart).
+            // Both edits are well within the threshold, so no split is needed.
+            //
+            //   n1 ---10m--- n2
+            //      (same park)
+            var n1 = iD.osmNode({ id: 'n1', loc: [0, 0] });
+            var n2 = iD.osmNode({ id: 'n2', loc: [0.1, 0.1] });
+            var graph = iD.coreGraph([n1, n2]);
+
+            var changes = { created: [n1, n2], modified: [], deleted: [] };
+            var groups = iD.coreChangesetSplitter(changes, graph, 0.25);
+
+            expect(groups).to.have.length(1);
+            expect(groups[0].created).to.have.length(2);
+        });
+    });
+
+
+    describe('geographic splitting', function() {
+        it('splits distant unrelated nodes into separate groups', function() {
+            // Scenario: User adds a restaurant in London, then pans across the
+            // globe and adds a bus stop in Mongolia. These are completely
+            // unrelated edits that should become two separate changesets.
+            //
+            //   n1 (London)                    n2 (Mongolia)
+            //     [0,0] --------- 8000km --------- [100,50]
+            var n1 = iD.osmNode({ id: 'n1', loc: [0, 0] });
+            var n2 = iD.osmNode({ id: 'n2', loc: [100, 50] });
+            var graph = iD.coreGraph([n1, n2]);
+
+            var changes = { created: [n1, n2], modified: [], deleted: [] };
+            var groups = iD.coreChangesetSplitter(changes, graph, 0.25);
+
+            expect(groups).to.have.length(2);
+            expect(groups[0].created).to.have.length(1);
+            expect(groups[1].created).to.have.length(1);
+        });
+
+        it('correctly distributes entities across created/modified/deleted in each group', function() {
+            // Scenario: User does a mixed editing session in two distant areas:
+            //
+            //   Area A (London):       Area B (Mongolia):
+            //   - adds cafe n1         - adds shop n3
+            //   - retags bench n2      - deletes old POI n4
+            //
+            // Each group should preserve the correct change type per entity.
+            var n1 = iD.osmNode({ id: 'n1', loc: [0, 0] });
+            var n2 = iD.osmNode({ id: 'n2', loc: [0.001, 0.001] });
+            var n3 = iD.osmNode({ id: 'n3', loc: [100, 50] });
+            var n4 = iD.osmNode({ id: 'n4', loc: [100.001, 50.001] });
+            var graph = iD.coreGraph([n1, n2, n3]);
+
+            var changes = { created: [n1, n3], modified: [n2], deleted: [n4] };
+            var groups = iD.coreChangesetSplitter(changes, graph, 0.25);
+
+            expect(groups).to.have.length(2);
+            groups.forEach(function(g) {
+                expect(g).to.have.property('created').that.is.an('array');
+                expect(g).to.have.property('modified').that.is.an('array');
+                expect(g).to.have.property('deleted').that.is.an('array');
+            });
+
+            var totalCreated = groups.reduce(function(sum, g) { return sum + g.created.length; }, 0);
+            var totalModified = groups.reduce(function(sum, g) { return sum + g.modified.length; }, 0);
+            var totalDeleted = groups.reduce(function(sum, g) { return sum + g.deleted.length; }, 0);
+            expect(totalCreated).to.equal(2);
+            expect(totalModified).to.equal(1);
+            expect(totalDeleted).to.equal(1);
+        });
+    });
+
+
+    describe('referential integrity', function() {
+        it('keeps a way and its child nodes in the same group', function() {
+            // Scenario: User draws a new road (w1) with two nodes in London,
+            // then also adds an unrelated POI (n3) in Mongolia.
+            // The road and its nodes must stay together.
+            //
+            //   n1 ---w1--- n2                   n3
+            //   [London road]        8000km       [Mongolia POI]
+            //   \___ group A ___/                 \_ group B _/
+            var n1 = iD.osmNode({ id: 'n1', loc: [0, 0] });
+            var n2 = iD.osmNode({ id: 'n2', loc: [0.001, 0.001] });
+            var n3 = iD.osmNode({ id: 'n3', loc: [100, 50] });
+            var w1 = iD.osmWay({ id: 'w1', nodes: ['n1', 'n2'] });
+            var graph = iD.coreGraph([n1, n2, n3, w1]);
+
+            var changes = { created: [n1, n2, n3, w1], modified: [], deleted: [] };
+            var groups = iD.coreChangesetSplitter(changes, graph, 0.25);
+
+            expect(groups).to.have.length(2);
+
+            var wayGroup = groups.find(function(g) {
+                return g.created.some(function(e) { return e.id === 'w1'; });
+            });
+            var wayGroupIds = wayGroup.created.map(function(e) { return e.id; });
+            expect(wayGroupIds).to.include('n1');
+            expect(wayGroupIds).to.include('n2');
+            expect(wayGroupIds).to.include('w1');
+            expect(wayGroupIds).to.not.include('n3');
+        });
+
+        it('keeps a relation and its members in the same group', function() {
+            // Scenario: User creates a multipolygon building (r1) with an
+            // outer way (w1 with nodes n1, n2) in London, and separately
+            // adds a POI (n3) in Mongolia.
+            // The entire building relation must stay in one group.
+            //
+            //   n1 ---w1--- n2
+            //   \____r1____/                     n3
+            //   [London building]                [Mongolia POI]
+            //   \_____ group A _____/            \_ group B _/
+            var n1 = iD.osmNode({ id: 'n1', loc: [0, 0] });
+            var n2 = iD.osmNode({ id: 'n2', loc: [0.01, 0.01] });
+            var w1 = iD.osmWay({ id: 'w1', nodes: ['n1', 'n2'] });
+            var r1 = iD.osmRelation({ id: 'r1', members: [{ id: 'w1', type: 'way', role: 'outer' }] });
+            var n3 = iD.osmNode({ id: 'n3', loc: [100, 50] });
+            var graph = iD.coreGraph([n1, n2, w1, r1, n3]);
+
+            var changes = { created: [n1, n2, w1, r1, n3], modified: [], deleted: [] };
+            var groups = iD.coreChangesetSplitter(changes, graph, 0.25);
+
+            expect(groups).to.have.length(2);
+
+            var relGroup = groups.find(function(g) {
+                return g.created.some(function(e) { return e.id === 'r1'; });
+            });
+            var relGroupIds = relGroup.created.map(function(e) { return e.id; });
+            expect(relGroupIds).to.include('w1');
+            expect(relGroupIds).to.include('n1');
+            expect(relGroupIds).to.include('n2');
+        });
+
+        it('keeps nested relations in the same group', function() {
+            // Scenario: User creates a route relation (r2) that contains a
+            // sub-relation (r1), which contains a way (w1) and node (n1).
+            // Then they also add a separate POI (n2) far away.
+            // The entire nested structure must stay as one group.
+            //
+            //   n1 ---w1
+            //   \__r1__/
+            //   \___r2__/                        n2
+            //   [nested route]                   [distant POI]
+            //   \_____ group A _____/            \_ group B _/
+            var n1 = iD.osmNode({ id: 'n1', loc: [0, 0] });
+            var w1 = iD.osmWay({ id: 'w1', nodes: ['n1'] });
+            var r1 = iD.osmRelation({ id: 'r1', members: [{ id: 'w1', type: 'way', role: '' }] });
+            var r2 = iD.osmRelation({ id: 'r2', members: [{ id: 'r1', type: 'relation', role: '' }] });
+            var n2 = iD.osmNode({ id: 'n2', loc: [100, 50] });
+            var graph = iD.coreGraph([n1, w1, r1, r2, n2]);
+
+            var changes = { created: [n1, w1, r1, r2, n2], modified: [], deleted: [] };
+            var groups = iD.coreChangesetSplitter(changes, graph, 0.25);
+
+            expect(groups).to.have.length(2);
+
+            var nestedGroup = groups.find(function(g) {
+                return g.created.some(function(e) { return e.id === 'r2'; });
+            });
+            var ids = nestedGroup.created.map(function(e) { return e.id; });
+            expect(ids).to.include('r1');
+            expect(ids).to.include('w1');
+            expect(ids).to.include('n1');
+            expect(ids).to.not.include('n2');
+        });
+    });
+
+
+    describe('deleted entities', function() {
+        it('groups deleted entities with related entities', function() {
+            // Scenario: User deletes a road (w1) but its nodes (n1, n2)
+            // remain because they're shared with other features. User also
+            // retags node n1. The deleted way should group with the modified
+            // node since they share a structural dependency.
+            //
+            //   n1 ---w1--- n2         (w1 deleted, n1 retagged)
+            //   \___ same group ___/
+            var n1 = iD.osmNode({ id: 'n1', loc: [0, 0] });
+            var n2 = iD.osmNode({ id: 'n2', loc: [0.001, 0.001] });
+            var w1 = iD.osmWay({ id: 'w1', nodes: ['n1', 'n2'] });
+            var graph = iD.coreGraph([n1, n2]);
+
+            var changes = { created: [], modified: [n1], deleted: [w1] };
+            var groups = iD.coreChangesetSplitter(changes, graph, 0.25);
+
+            expect(groups).to.have.length(1);
+            var ids = groups[0].modified.map(function(e) { return e.id; })
+                .concat(groups[0].deleted.map(function(e) { return e.id; }));
+            expect(ids).to.include('n1');
+            expect(ids).to.include('w1');
+        });
+
+        it('resolves location from deleted nodes not in graph via entityMap', function() {
+            // Scenario: User bulk-deletes an entire building (way + nodes)
+            // in London, and also deletes an unrelated POI in Mongolia.
+            // All entities are gone from the head graph, but their base
+            // versions still carry location data.
+            //
+            //   n1 ---w1--- n2  (all deleted)     n3 (deleted)
+            //   [London building]                  [Mongolia POI]
+            //   \_____ group A _____/              \_ group B _/
+            var n1 = iD.osmNode({ id: 'n1', loc: [0, 0] });
+            var n2 = iD.osmNode({ id: 'n2', loc: [0.001, 0.001] });
+            var w1 = iD.osmWay({ id: 'w1', nodes: ['n1', 'n2'] });
+            var n3 = iD.osmNode({ id: 'n3', loc: [100, 50] });
+            var graph = iD.coreGraph([]);
+
+            var changes = { created: [], modified: [], deleted: [n1, n2, w1, n3] };
+            var groups = iD.coreChangesetSplitter(changes, graph, 0.25);
+
+            expect(groups).to.have.length(2);
+            var wayGroup = groups.find(function(g) {
+                return g.deleted.some(function(e) { return e.id === 'w1'; });
+            });
+            var wayGroupIds = wayGroup.deleted.map(function(e) { return e.id; });
+            expect(wayGroupIds).to.include('n1');
+            expect(wayGroupIds).to.include('n2');
+            expect(wayGroupIds).to.not.include('n3');
+        });
+    });
+
+
+    describe('edge cases', function() {
+        it('handles only modified entities', function() {
+            // Scenario: User retags a cafe in London, then pans to Mongolia
+            // and retags a bus stop there. No new features or deletions,
+            // just tag edits in two distant places.
+            //
+            //   n1 (retagged)                    n2 (retagged)
+            //   [London cafe]      8000km        [Mongolia bus stop]
+            //   \_ group A _/                    \_ group B _/
+            var n1 = iD.osmNode({ id: 'n1', loc: [0, 0] });
+            var n2 = iD.osmNode({ id: 'n2', loc: [100, 50] });
+            var graph = iD.coreGraph([n1, n2]);
+
+            var changes = { created: [], modified: [n1, n2], deleted: [] };
+            var groups = iD.coreChangesetSplitter(changes, graph, 0.25);
+
+            expect(groups).to.have.length(2);
+            expect(groups[0].modified).to.have.length(1);
+            expect(groups[1].modified).to.have.length(1);
+            expect(groups[0].created).to.have.length(0);
+            expect(groups[0].deleted).to.have.length(0);
+        });
+
+        it('links two ways sharing a common node in the changes', function() {
+            // Scenario: User draws two connected streets (w1 and w2) that
+            // share an intersection node (n3), plus an unrelated POI (n4)
+            // far away. The two streets must stay together because they
+            // share node n3 which is also being created.
+            //
+            //   n1 ---w1--- n3 ---w2--- n2       n4
+            //               (shared)              [distant POI]
+            //   \_______ group A ______/          \_ group B _/
+            var n1 = iD.osmNode({ id: 'n1', loc: [0, 0] });
+            var n2 = iD.osmNode({ id: 'n2', loc: [0.001, 0] });
+            var nShared = iD.osmNode({ id: 'n3', loc: [0.0005, 0] });
+            var n4 = iD.osmNode({ id: 'n4', loc: [100, 50] });
+            var w1 = iD.osmWay({ id: 'w1', nodes: ['n1', 'n3'] });
+            var w2 = iD.osmWay({ id: 'w2', nodes: ['n3', 'n2'] });
+            var graph = iD.coreGraph([n1, n2, nShared, n4, w1, w2]);
+
+            var changes = { created: [n1, n2, nShared, n4, w1, w2], modified: [], deleted: [] };
+            var groups = iD.coreChangesetSplitter(changes, graph, 0.25);
+
+            expect(groups).to.have.length(2);
+            var wayGroup = groups.find(function(g) {
+                return g.created.some(function(e) { return e.id === 'w1'; });
+            });
+            var ids = wayGroup.created.map(function(e) { return e.id; });
+            expect(ids).to.include('w1');
+            expect(ids).to.include('w2');
+            expect(ids).to.include('n3');
+            expect(ids).to.not.include('n4');
+        });
+
+        it('does not link two ways sharing a node that is NOT in the changes', function() {
+            // Scenario: User retags two existing roads (w1 and w2) that
+            // share an intersection node (n1), but the node itself is
+            // unchanged. Since the shared node won't be uploaded, there's
+            // no conflict risk, so the ways can safely go in separate changesets.
+            //
+            //   n2 ---w1--- n1 ---w2--- n3
+            //   (retagged)  (unchanged)  (retagged)
+            //   [London]                 [Mongolia]
+            //   \_ group A _/            \_ group B _/
+            var nShared = iD.osmNode({ id: 'n1', loc: [5, 5] });
+            var n2 = iD.osmNode({ id: 'n2', loc: [0, 0] });
+            var n3 = iD.osmNode({ id: 'n3', loc: [100, 50] });
+            var w1 = iD.osmWay({ id: 'w1', nodes: ['n1', 'n2'] });
+            var w2 = iD.osmWay({ id: 'w2', nodes: ['n1', 'n3'] });
+            var graph = iD.coreGraph([nShared, n2, n3, w1, w2]);
+
+            var changes = { created: [], modified: [w1, w2], deleted: [] };
+            var groups = iD.coreChangesetSplitter(changes, graph, 0.25);
+
+            expect(groups).to.have.length(2);
+        });
+
+        it('keeps a way with geographically distant nodes as one component', function() {
+            // Scenario: User draws a very long power line (w1) that stretches
+            // from London to Istanbul. The way and its endpoint nodes must
+            // stay together; you can't upload half a way.
+            //
+            //   n1 ============w1============ n2
+            //   [London]      5000km          [Istanbul]
+            //   \__________ group A __________/
+            var n1 = iD.osmNode({ id: 'n1', loc: [0, 0] });
+            var n2 = iD.osmNode({ id: 'n2', loc: [50, 40] });
+            var w1 = iD.osmWay({ id: 'w1', nodes: ['n1', 'n2'] });
+            var graph = iD.coreGraph([n1, n2, w1]);
+
+            var changes = { created: [n1, n2, w1], modified: [], deleted: [] };
+            var groups = iD.coreChangesetSplitter(changes, graph, 0.25);
+
+            expect(groups).to.have.length(1);
+            expect(groups[0].created).to.have.length(3);
+        });
+
+        it('handles negative coordinates correctly', function() {
+            // Scenario: User adds two POIs in Buenos Aires (southern/western
+            // hemisphere with negative lat/lon), plus one POI in Mongolia.
+            // The two Buenos Aires nodes should cluster together despite
+            // negative coordinates.
+            //
+            //   n1, n2 (Buenos Aires)            n3 (Mongolia)
+            //   [-73, -33]        ~15000km       [100, 50]
+            //   \_ group A _/                    \_ group B _/
+            var n1 = iD.osmNode({ id: 'n1', loc: [-73, -33] });
+            var n2 = iD.osmNode({ id: 'n2', loc: [-73.001, -33.001] });
+            var n3 = iD.osmNode({ id: 'n3', loc: [100, 50] });
+            var graph = iD.coreGraph([n1, n2, n3]);
+
+            var changes = { created: [n1, n2, n3], modified: [], deleted: [] };
+            var groups = iD.coreChangesetSplitter(changes, graph, 0.25);
+
+            expect(groups).to.have.length(2);
+            var southAmericaGroup = groups.find(function(g) {
+                return g.created.some(function(e) { return e.id === 'n1'; });
+            });
+            var ids = southAmericaGroup.created.map(function(e) { return e.id; });
+            expect(ids).to.include('n2');
+            expect(ids).to.not.include('n3');
+        });
+
+        it('merges nearby nodes in adjacent grid cells', function() {
+            // Scenario: User adds two trees on opposite sides of a street.
+            // They happen to fall on different sides of an internal grid
+            // cell boundary (at lon=0.5). The splitter should still merge
+            // them since their combined extent is small.
+            //
+            //        grid boundary
+            //             |
+            //   n1 (0.49) | n2 (0.51)            n3 (100)
+            //     [tree]  |  [tree]               [distant POI]
+            //   \____ group A ___/                \_ group B _/
+            var n1 = iD.osmNode({ id: 'n1', loc: [0.49, 0] });
+            var n2 = iD.osmNode({ id: 'n2', loc: [0.51, 0] });
+            var n3 = iD.osmNode({ id: 'n3', loc: [100, 50] });
+            var graph = iD.coreGraph([n1, n2, n3]);
+
+            var changes = { created: [n1, n2, n3], modified: [], deleted: [] };
+            var groups = iD.coreChangesetSplitter(changes, graph, 0.25);
+
+            expect(groups).to.have.length(2);
+            var nearGroup = groups.find(function(g) {
+                return g.created.some(function(e) { return e.id === 'n1'; });
+            });
+            var ids = nearGroup.created.map(function(e) { return e.id; });
+            expect(ids).to.include('n2');
+        });
+
+        it('preserves entity count across all groups', function() {
+            // Scenario: User performs a mix of actions across three cities:
+            // creates a cafe and road in London, retags a shop in Cairo,
+            // and deletes a POI in Mongolia.
+            // All 4 entities must appear exactly once across all groups.
+            //
+            //   n1+w1 (London)  n2 (Cairo)  n3 (Mongolia)
+            //   [created]       [modified]   [deleted]
+            var n1 = iD.osmNode({ id: 'n1', loc: [0, 0] });
+            var n2 = iD.osmNode({ id: 'n2', loc: [50, 30] });
+            var n3 = iD.osmNode({ id: 'n3', loc: [100, 50] });
+            var w1 = iD.osmWay({ id: 'w1', nodes: ['n1'] });
+            var graph = iD.coreGraph([n1, n2, n3, w1]);
+
+            var changes = { created: [n1, w1], modified: [n2], deleted: [n3] };
+            var groups = iD.coreChangesetSplitter(changes, graph, 0.25);
+
+            var totalEntities = groups.reduce(function(sum, g) {
+                return sum + g.created.length + g.modified.length + g.deleted.length;
+            }, 0);
+            expect(totalEntities).to.equal(4);
+        });
+
+        it('handles a relation whose members are not in the changes', function() {
+            // Scenario: User retags an existing bus route relation (r1)
+            // without modifying its member ways/nodes, and also adds a
+            // new POI (n2) far away. Since the relation's members aren't
+            // being changed, there's no structural link to keep r1 and n2
+            // together.
+            //
+            //   n1 ---w1   (unchanged, in graph only)
+            //   \__r1__/   (retagged)            n2 (new POI)
+            //   [London]                         [Mongolia]
+            //   \_ group A _/                    \_ group B _/
+            var n1 = iD.osmNode({ id: 'n1', loc: [0, 0] });
+            var w1 = iD.osmWay({ id: 'w1', nodes: ['n1'] });
+            var r1 = iD.osmRelation({ id: 'r1', members: [{ id: 'w1', type: 'way', role: '' }] });
+            var n2 = iD.osmNode({ id: 'n2', loc: [100, 50] });
+            var graph = iD.coreGraph([n1, w1]);
+
+            var changes = { created: [], modified: [r1, n2], deleted: [] };
+            var groups = iD.coreChangesetSplitter(changes, graph, 0.25);
+
+            expect(groups).to.have.length(2);
+        });
+
+        it('handles cyclic relation membership without infinite recursion', function() {
+            // Scenario: Two relations reference each other, and one relation
+            // also contains a node with location. The traversal should not
+            // recurse forever.
+            //
+            //   r1 -> r2 -> r1 (cycle), plus r1 -> n1
+            //   and an unrelated far-away node n2.
+            var n1 = iD.osmNode({ id: 'n1', loc: [0, 0] });
+            var n2 = iD.osmNode({ id: 'n2', loc: [100, 50] });
+            var r1 = iD.osmRelation({
+                id: 'r1',
+                members: [
+                    { id: 'r2', type: 'relation', role: '' },
+                    { id: 'n1', type: 'node', role: '' }
+                ]
+            });
+            var r2 = iD.osmRelation({ id: 'r2', members: [{ id: 'r1', type: 'relation', role: '' }] });
+            var graph = iD.coreGraph([n1, n2, r1, r2]);
+
+            var changes = { created: [n1, n2, r1, r2], modified: [], deleted: [] };
+            var groups = iD.coreChangesetSplitter(changes, graph, 0.25);
+
+            expect(groups).to.have.length(2);
+            var cyclicGroup = groups.find(function(g) {
+                return g.created.some(function(e) { return e.id === 'r1'; });
+            });
+            var ids = cyclicGroup.created.map(function(e) { return e.id; });
+            expect(ids).to.include('r2');
+            expect(ids).to.include('n1');
+            expect(ids).to.not.include('n2');
+        });
+
+        it('merges diagonal neighboring grid cells when extent remains small', function() {
+            // Scenario: n1 and n2 are in diagonal neighboring cells, while n3
+            // is far away. Diagonal neighbors should still merge if the
+            // combined extent is under threshold.
+            var n1 = iD.osmNode({ id: 'n1', loc: [0.10, 0.10] });   // cell (0,0)
+            var n2 = iD.osmNode({ id: 'n2', loc: [0.60, 0.60] });   // cell (1,1), diagonal from n1
+            var n3 = iD.osmNode({ id: 'n3', loc: [100, 50] });
+            var graph = iD.coreGraph([n1, n2, n3]);
+
+            var changes = { created: [n1, n2, n3], modified: [], deleted: [] };
+            var groups = iD.coreChangesetSplitter(changes, graph, 0.25);
+
+            expect(groups).to.have.length(2);
+
+            var nearGroup = groups.find(function(g) {
+                return g.created.some(function(e) { return e.id === 'n1'; });
+            });
+            var ids = nearGroup.created.map(function(e) { return e.id; });
+            expect(ids).to.include('n2');
+            expect(ids).to.not.include('n3');
+        });
+    });
+
+});

--- a/test/spec/core/uploader.js
+++ b/test/spec/core/uploader.js
@@ -1,0 +1,93 @@
+describe('iD.coreUploader', function() {
+
+    function makeDifference(changes) {
+        return {
+            created: function() { return changes.created; },
+            modified: function() { return changes.modified; },
+            summary: function() { return []; }
+        };
+    }
+
+    function makeContext(changes, graph, connection) {
+        var history = {
+            perform: sinon.spy(),
+            replace: sinon.spy(),
+            pop: sinon.spy(),
+            pauseChangeDispatch: sinon.spy(),
+            resumeChangeDispatch: sinon.spy(),
+            clearSaved: sinon.spy(),
+            base: function() { return graph; },
+            difference: function() { return makeDifference(changes); },
+            changes: function() { return changes; }
+        };
+
+        return {
+            connection: function() { return connection; },
+            history: function() { return history; },
+            graph: function() { return graph; },
+            flush: sinon.spy()
+        };
+    }
+
+    function makeConnection() {
+        return {
+            authenticated: function() { return true; },
+            authenticate: sinon.spy(),
+            putChangeset: sinon.spy(),
+            changesetURL: function(id) { return 'https://www.openstreetmap.org/changeset/' + id; },
+            updateChangesetTags: sinon.stub().resolves()
+        };
+    }
+
+    it('uploads each split group sequentially', function() {
+        var n1 = iD.osmNode({ id: 'n1', loc: [0, 0] });
+        var n2 = iD.osmNode({ id: 'n2', loc: [100, 50] });
+        var graph = iD.coreGraph([n1, n2]);
+        var changes = { created: [n1, n2], modified: [], deleted: [] };
+        var connection = makeConnection();
+        connection.putChangeset = sinon.stub().callsFake(function(changeset, uploadChanges, callback) {
+            callback(null, changeset);
+        });
+        var context = makeContext(changes, graph, connection);
+        var uploader = iD.coreUploader(context);
+
+        uploader.save(iD.osmChangeset({ tags: { comment: 'real upload' } }));
+
+        expect(connection.putChangeset).to.have.been.calledTwice;
+        expect(connection.putChangeset.firstCall.args[1].created).to.have.length(1);
+        expect(connection.putChangeset.secondCall.args[1].created).to.have.length(1);
+        var uploadedIds = [
+            connection.putChangeset.firstCall.args[1].created[0].id,
+            connection.putChangeset.secondCall.args[1].created[0].id
+        ];
+        expect(uploadedIds).to.include('n1');
+        expect(uploadedIds).to.include('n2');
+    });
+
+    it('adds part markers and references first split changeset in later comments', function() {
+        var n1 = iD.osmNode({ id: 'n1', loc: [0, 0] });
+        var n2 = iD.osmNode({ id: 'n2', loc: [100, 50] });
+        var graph = iD.coreGraph([n1, n2]);
+        var changes = { created: [n1, n2], modified: [], deleted: [] };
+        var connection = makeConnection();
+        var seenComments = [];
+        var ids = ['111', '222'];
+        var call = 0;
+
+        connection.putChangeset = sinon.stub().callsFake(function(changeset, uploadChanges, callback) {
+            seenComments.push(changeset.tags.comment);
+            var updated = changeset.update({ id: ids[call++] });
+            callback(null, updated);
+        });
+
+        var context = makeContext(changes, graph, connection);
+        var uploader = iD.coreUploader(context);
+
+        uploader.save(iD.osmChangeset({ tags: { comment: 'Split upload test' } }));
+
+        expect(connection.putChangeset).to.have.been.calledTwice;
+        expect(seenComments[0]).to.equal('Split upload test (part 1/2)');
+        expect(seenComments[1]).to.equal('Split upload test (part 2/2, ref: https://www.openstreetmap.org/changeset/111)');
+    });
+
+});

--- a/test/spec/ui/sections/changes.js
+++ b/test/spec/ui/sections/changes.js
@@ -1,0 +1,49 @@
+describe('iD.uiSectionChanges', function() {
+    var context, element;
+
+    function render() {
+        var section = iD.uiSectionChanges(context).expandedByDefault(true);
+        element.call(section.render);
+    }
+
+    beforeEach(function() {
+        context = iD.coreContext().assetPath('../dist/').init();
+        element = d3.select('body')
+            .append('div')
+            .attr('class', 'ui-wrap');
+    });
+
+    afterEach(function() {
+        d3.selectAll('.ui-wrap').remove();
+    });
+
+    it('shows split notice and grouped change lists for multi-changeset uploads', function() {
+        var n1 = iD.osmNode({ id: 'n1', loc: [0, 0] });
+        var n2 = iD.osmNode({ id: 'n2', loc: [100, 50] });
+
+        context.history().perform(iD.actionAddEntity(n1), iD.actionAddEntity(n2), 'add distant nodes');
+        render();
+
+        expect(element.select('.changeset-multi-message').classed('hide')).to.equal(false);
+        expect(element.select('.changeset-multi-message').text()).to.contain('too far apart');
+        expect(element.selectAll('.changeset-group').size()).to.equal(2);
+
+        var listCounts = element.selectAll('.changeset-group .changeset-list')
+            .nodes()
+            .map(function(node) { return node.querySelectorAll('li').length; });
+
+        expect(listCounts).to.eql([1, 1]);
+    });
+
+    it('hides split notice and keeps a single changes list when not splitting', function() {
+        var n1 = iD.osmNode({ id: 'n1', loc: [0, 0] });
+        var n2 = iD.osmNode({ id: 'n2', loc: [0.001, 0.001] });
+
+        context.history().perform(iD.actionAddEntity(n1), iD.actionAddEntity(n2), 'add nearby nodes');
+        render();
+
+        expect(element.select('.changeset-multi-message').classed('hide')).to.equal(true);
+        expect(element.selectAll('.changeset-group').size()).to.equal(1);
+        expect(element.selectAll('.changeset-group .changeset-list li').size()).to.equal(2);
+    });
+});


### PR DESCRIPTION
This change starts from one practical problem that is most visible with new users: a single editing session can contain unrelated edits spread far apart, and uploading them as one changeset makes review noisy, confusing, and harder to trust. New mappers often make exploratory edits in multiple places before saving, so they are the group most likely to run into this.

The goal here was to let iD separate those edits automatically, while still keeping dependent objects together so uploads remain valid.

The core of that work is a new splitter in `modules/core/changeset_splitter.js`, exported from `modules/core/index.js` as `coreChangesetSplitter`. It builds connected components from the changed entities with union-find, linking ways to their nodes and relations to their members. After that, it uses location data and extent checks to cluster components geographically. It keeps an early return for small local edits, handles deleted entities by resolving locations from changed data when graph entities are missing, and includes cycle-safe traversal for relation membership.

`modules/core/uploader.js` now uses that splitter before upload. Instead of one `putChangeset` call with everything, it uploads groups sequentially. It tracks split state and uploaded entity IDs so local history can be reverted group by group as each part succeeds. Comment text is also annotated with part information, and later parts reference the first uploaded changeset URL. This gives clearer auditability when one editing session becomes multiple uploads.

On the Save screen, `modules/ui/sections/changes.js` now renders grouped change lists when splitting occurs, rather than a single flat list. The warning message was updated to explicitly tell the mapper that edits are too far apart and will be uploaded separately. Related strings were added in `data/core.yaml`, and `css/80_app.css` adds spacing and titles for grouped sections so the layout stays readable.

The test coverage for this feature was built out in three new files: `test/spec/core/changeset_splitter.js`, `test/spec/core/uploader.js`, and `test/spec/ui/sections/changes.js`. The splitter tests cover structural integrity, geographic partitioning, deleted-entity behavior, cycle handling, and edge cases. The uploader tests cover sequential multi-group behavior and split comment linking. The UI tests cover split messaging and grouped rendering behavior.

ref: #5424
