### PR TITLE
Fix TypeError in renderValue() for unrecognized ISO country codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#11783]: https://github.com/openstreetmap/iD/pull/11783
 [#11861]: https://github.com/openstreetmap/iD/pull/11861
 [#11862]: https://github.com/openstreetmap/iD/pull/11862
+[#11870]: https://github.com/openstreetmap/iD/issues/11870
+[#11904]: https://github.com/openstreetmap/iD/issues/11904
 [@ilias52730]: https://github.com/ilias52730
 [@Razen04]: https://github.com/Razen04
 [@homersimpsons]: https://github.com/homersimpsons

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Change package name to `@openstreetmap/id` to be able to publish releases on npm
 * Use Röntgen icon set directly from upstream npm package ([#11784], thanks [@tordans])
 * Replace deprecated `document.createEvent`/`initEvent` with modern [Event] constructor ([#11870], thanks [@JaiswalShivang])
+* Fix crash in country combo field when entering unrecognized ISO country codes ([#XXXX], thanks [@JaiswalShivang])
 
 
 [#8464]: https://github.com/openstreetmap/iD/issues/8464

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Change package name to `@openstreetmap/id` to be able to publish releases on npm
 * Use Röntgen icon set directly from upstream npm package ([#11784], thanks [@tordans])
 * Replace deprecated `document.createEvent`/`initEvent` with modern [Event] constructor ([#11870], thanks [@JaiswalShivang])
-* Fix crash in country combo field when entering unrecognized ISO country codes ([#XXXX], thanks [@JaiswalShivang])
+* Fix crash in country combo field when entering unrecognized ISO country codes ([#11904], thanks [@JaiswalShivang])
 
 
 [#8464]: https://github.com/openstreetmap/iD/issues/8464

--- a/modules/ui/fields/combo.js
+++ b/modules/ui/fields/combo.js
@@ -225,7 +225,7 @@ export function uiFieldCombo(field, context) {
       if (osmIsoCountryKeys.has(field.key) && tval) {
         const data = buildCountry()[tval];
         if (data) return selection => addFlagIcon(selection, data.name, data.flag);
-        return selection => selection(tval);
+        return selection => selection.text(tval);
       }
 
       var stringsField = field.resolveReference('stringsCrossReference');


### PR DESCRIPTION
## Fixes #11904 

## Summary

Fixes a TypeError crash in [modules/ui/fields/combo.js] where [renderValue()] calls a d3 selection object as a function when encountering an unrecognized ISO country code.

## Bug

When a country-related field (e.g., `addr:country`) has a value not found in the [buildCountry()] map, the fallback path executes:

```js
return selection => selection(tval);