### PR TITLE
Fix: Prevent boundary relation members from rendering as areas

### DIFF
--- a/modules/svg/areas.js
+++ b/modules/svg/areas.js
@@ -1,8 +1,8 @@
 import deepEqual from 'fast-deep-equal';
 import { bisector as d3_bisector } from 'd3-array';
+import { svgPath, svgSegmentWay, svgRelationMemberTags } from './helpers';
 
 import { osmEntity } from '../osm';
-import { svgPath, svgSegmentWay } from './helpers';
 import { svgTagClasses } from './tag_classes';
 import { svgTagPattern } from './tag_pattern';
 
@@ -94,7 +94,19 @@ export function svgAreas(projection, context) {
 
         for (var i = 0; i < entities.length; i++) {
             var entity = entities[i];
-            if (entity.geometry(graph) !== 'area') continue;
+            // Skip non-area geometries
+        if (entity.geometry(graph) !== 'area') continue;
+
+        // Boundary relation members should render as lines
+        var parents = graph.parentRelations(entity);
+        var isBoundaryMember = parents.some(function(relation) {
+            return relation.tags && (
+                relation.tags.type === 'boundary' ||
+                relation.tags.boundary
+            );
+        });
+
+        if (isBoundaryMember) continue;
             if (!areas[entity.id]) {
                 areas[entity.id] = {
                     entity: entity,
@@ -192,7 +204,7 @@ export function svgAreas(projection, context) {
                     base.entities[d.id] &&
                     !deepEqual(graph.entities[d.id].tags, base.entities[d.id].tags);
             })
-            .call(svgTagClasses())
+            .call(svgTagClasses().tags(svgRelationMemberTags(graph)))
             .attr('d', path);
 
 


### PR DESCRIPTION
Fixes #11900

Boundary relation members were being rendered as filled areas.
This change excludes boundary members from the area layer so they render as lines.

Verified that buildings, landuse areas, and multipolygon relations are unaffected.