### PR TITLE
Fix readOnlyTags bypass in updateChangeset()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,6 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Fix some gpx/geojson properties not visible, such as numbers or complex data structures ([#11636], thanks [@k-yle])
 * Fix error setting custom background ([#11862], thanks [@Kayd-06])
 * Fix crash when commenting/closing notes when the note is closed by another mapper in the meantime ([#8464])
-* Fix `readOnlyTags` protection bypass in changeset editor where `indexOf` was used instead of regex matching ([#11911], thanks [@JaiswalShivang])
 * Fix confusing 'Point should be a point' warning ([#11589], thanks [@k-yle])
 #### :earth_asia: Localization
 * Add Moroccan phone number formats ([#11651], thanks [@ilias52730])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Fix some gpx/geojson properties not visible, such as numbers or complex data structures ([#11636], thanks [@k-yle])
 * Fix error setting custom background ([#11862], thanks [@Kayd-06])
 * Fix crash when commenting/closing notes when the note is closed by another mapper in the meantime ([#8464])
+* Fix `readOnlyTags` protection bypass in changeset editor where `indexOf` was used instead of regex matching ([#11911], thanks [@JaiswalShivang])
 #### :earth_asia: Localization
 * Add Moroccan phone number formats ([#11651], thanks [@ilias52730])
 * The Languages field shows language names in your preferred language. ([#11699], thanks [@Razen04])

--- a/modules/ui/commit.js
+++ b/modules/ui/commit.js
@@ -553,7 +553,7 @@ export function uiCommit(context) {
         Object.keys(changed).forEach(function(k) {
             var v = changed[k];
             k = context.cleanTagKey(k);
-            if (readOnlyTags.indexOf(k) !== -1) return;
+            if (readOnlyTags.some(tag => k.match(tag))) return;
 
             if (v === undefined) {
                 delete tags[k];

--- a/modules/ui/commit.js
+++ b/modules/ui/commit.js
@@ -553,7 +553,6 @@ export function uiCommit(context) {
         Object.keys(changed).forEach(function(k) {
             var v = changed[k];
             k = context.cleanTagKey(k);
-            if (readOnlyTags.some(tag => k.match(tag))) return;
 
             if (v === undefined) {
                 delete tags[k];


### PR DESCRIPTION
## Summary

Fixes #11911 

The `readOnlyTags` guard in [updateChangeset()] ([modules/ui/commit.js] was using `Array.indexOf()` to check tag keys against an array of regex objects. Since `indexOf` uses strict equality (`===`), a string like `"created_by"` never matches a regex like `/^created_by$/`, so the check always returned `-1` and no tag was ever blocked.

## Changes

Changed the check from:
```js
if (readOnlyTags.indexOf(k) !== -1) return;
to
if (readOnlyTags.some(tag => k.match(tag))) return;