### PR TITLE
Fix taxiway connection to runway centerline validation

### DIFF
--- a/modules/validations/crossing_ways.js
+++ b/modules/validations/crossing_ways.js
@@ -5,7 +5,7 @@ import { actionChangeTags } from '../actions/change_tags';
 import { actionMergeNodes } from '../actions/merge_nodes';
 import { actionSplit } from '../actions/split';
 import { modeSelect } from '../modes/select';
-import { geoAngle, geoExtent, geoLatToMeters, geoLonToMeters, geoLineIntersection,
+import { geoAngle, geoChooseEdge, geoExtent, geoLatToMeters, geoLonToMeters, geoLineIntersection,
     geoSphericalClosestNode, geoSphericalDistance, geoVecAngle, geoVecLength, geoMetersToLat, geoMetersToLon } from '../geo';
 import { osmNode } from '../osm/node';
 import { osmFlowingWaterwayTagValues, osmPathHighwayTagValues, osmRailwayTrackTagValues, osmRoutableAerowayTags, osmRoutableHighwayTagValues } from '../osm/tags';
@@ -226,6 +226,133 @@ export function validationCrossingWays(context) {
         return null;
     }
 
+    function pointOnSegment(point, segment) {
+        var x = point[0], y = point[1];
+        var x1 = segment[0][0], y1 = segment[0][1];
+        var x2 = segment[1][0], y2 = segment[1][1];
+        var dx = x2 - x1, dy = y2 - y1;
+        var epsilon = 1e-12;
+
+        var cross = (x - x1) * dy - (y - y1) * dx;
+        if (Math.abs(cross) > epsilon) return false;
+
+        var dot = (x - x1) * dx + (y - y1) * dy;
+        if (dot < -epsilon) return false;
+
+        var lenSq = dx * dx + dy * dy;
+        if (dot - lenSq > epsilon) return false;
+
+        return true;
+    }
+
+    function aerowayEndpointTouchIntersection(segment1, segment2) {
+        if (pointOnSegment(segment1[0], segment2)) return segment1[0];
+        if (pointOnSegment(segment1[1], segment2)) return segment1[1];
+        if (pointOnSegment(segment2[0], segment1)) return segment2[0];
+        if (pointOnSegment(segment2[1], segment1)) return segment2[1];
+        return null;
+    }
+
+    function runwayAreaTaxiwayConnectionInfo(wayInfos, crossPoint, graph) {
+        var runwayAreaInfo = wayInfos.find(function(info) {
+            return info.featureType === 'aeroway' &&
+                info.way.tags.aeroway === 'runway' &&
+                info.way.geometry(graph) === 'area';
+        });
+        var taxiwayInfo = wayInfos.find(function(info) {
+            return info.featureType === 'aeroway' &&
+                info.way.tags.aeroway === 'taxiway' &&
+                info.way.geometry(graph) === 'line';
+        });
+        if (!runwayAreaInfo || !taxiwayInfo) return null;
+
+        var tree = context.history().tree();
+        var runwayArea = runwayAreaInfo.way;
+        var taxiway = taxiwayInfo.way;
+        var runwayExtent = runwayArea.extent(graph);
+        var segmentInfos = tree.waySegments(runwayExtent, graph);
+        var centerlinesByID = {};
+        segmentInfos.forEach(function(segmentInfo) {
+            var way = graph.hasEntity(segmentInfo.wayId);
+            if (!way || way.id === runwayArea.id || way.type !== 'way') return;
+            if (way.tags.aeroway !== 'runway') return;
+            if (way.geometry(graph) !== 'line') return;
+            centerlinesByID[way.id] = way;
+        });
+        var centerlines = Object.values(centerlinesByID);
+        if (!centerlines.length) {
+            return { hasRunwayCenterline: false };
+        }
+
+        var taxiwayEndpointNodes = [graph.entity(taxiway.first()), graph.entity(taxiway.last())];
+        var isConnected = centerlines.some(function(centerline) {
+            return taxiwayEndpointNodes.some(function(endpointNode) {
+                return endpointNode && centerline.contains(endpointNode.id);
+            });
+        });
+        if (isConnected) {
+            return { isConnected: true };
+        }
+
+        var endpointToCrossing = taxiwayEndpointNodes
+            .filter(Boolean)
+            .map(function(node) {
+                return {
+                    node: node,
+                    distance: geoSphericalDistance(node.loc, crossPoint)
+                };
+            })
+            .sort(function(a, b) {
+                return a.distance - b.distance;
+            })[0];
+        if (!endpointToCrossing) {
+            return { hasRunwayCenterline: true };
+        }
+
+        // Only apply centerline snapping when the crossing is at the taxiway endpoint.
+        var endpointTouchThresholdMeters = 2;
+        if (endpointToCrossing.distance > endpointTouchThresholdMeters) {
+            return { hasRunwayCenterline: true };
+        }
+
+        var bestSnap = null;
+        centerlines.forEach(function(centerline) {
+            var centerlineNodes = graph.childNodes(centerline);
+            var snapInfo = geoChooseEdge(centerlineNodes, context.projection(endpointToCrossing.node.loc), context.projection, '');
+            if (!snapInfo || snapInfo.index === undefined) return;
+
+            var snapDistance = geoSphericalDistance(endpointToCrossing.node.loc, snapInfo.loc);
+            if (!bestSnap || snapDistance < bestSnap.distance) {
+                bestSnap = {
+                    distance: snapDistance,
+                    loc: snapInfo.loc,
+                    way: centerline,
+                    edge: [centerline.nodes[snapInfo.index - 1], centerline.nodes[snapInfo.index]]
+                };
+            }
+        });
+        if (!bestSnap) {
+            return { hasRunwayCenterline: true };
+        }
+
+        // Avoid snapping to a centerline that is implausibly far away.
+        var maxSnapDistanceMeters = 150;
+        if (bestSnap.distance > maxSnapDistanceMeters) {
+            return { hasRunwayCenterline: true };
+        }
+
+        return {
+            isConnected: false,
+            hasRunwayCenterline: true,
+            snap: {
+                taxiwayEndpointID: endpointToCrossing.node.id,
+                runwayCenterlineID: bestSnap.way.id,
+                runwayCenterlineEdge: bestSnap.edge,
+                loc: bestSnap.loc
+            }
+        };
+    }
+
 
     function findCrossingsByWay(way1, graph, tree) {
         var edgeCrossInfos = [];
@@ -305,6 +432,12 @@ export function validationCrossingWays(context) {
                 segment1 = [n1.loc, n2.loc];
                 segment2 = [nA.loc, nB.loc];
                 var point = geoLineIntersection(segment1, segment2);
+                if (!point &&
+                    way1FeatureType === 'aeroway' &&
+                    way2FeatureType === 'aeroway') {
+                    // Handle endpoint-to-segment touches that `geoLineIntersection` can miss.
+                    point = aerowayEndpointTouchIntersection(segment1, segment2);
+                }
                 if (point) {
                     edgeCrossInfos.push({
                         wayInfos: [
@@ -368,7 +501,10 @@ export function validationCrossingWays(context) {
         for (wayIndex in ways) {
             crossings = findCrossingsByWay(ways[wayIndex], graph, tree);
             for (crossingIndex in crossings) {
-                issues.push(createIssue(crossings[crossingIndex], graph));
+                var issue = createIssue(crossings[crossingIndex], graph);
+                if (issue) {
+                    issues.push(issue);
+                }
             }
         }
         return issues;
@@ -395,6 +531,11 @@ export function validationCrossingWays(context) {
         });
         var edges = [crossing.wayInfos[0].edge, crossing.wayInfos[1].edge];
         var featureTypes = [crossing.wayInfos[0].featureType, crossing.wayInfos[1].featureType];
+
+        var areaCenterlineConnectionInfo = runwayAreaTaxiwayConnectionInfo(crossing.wayInfos, crossing.crossPoint, graph);
+        if (areaCenterlineConnectionInfo && areaCenterlineConnectionInfo.isConnected) {
+            return null;
+        }
 
         var connectionTags = tagsForConnectionNodeIfAllowed(entities[0], entities[1], graph);
 
@@ -445,7 +586,8 @@ export function validationCrossingWays(context) {
             data: {
                 edges: edges,
                 featureTypes: featureTypes,
-                connectionTags: connectionTags
+                connectionTags: connectionTags,
+                runwayCenterlineSnap: areaCenterlineConnectionInfo && areaCenterlineConnectionInfo.snap
             },
             hash: uniqueID,
             loc: crossing.crossPoint,
@@ -460,10 +602,14 @@ export function validationCrossingWays(context) {
                 var fixes = [];
 
                 if (connectionTags) {
-                    fixes.push(makeConnectWaysFix(this.data.connectionTags));
-                    let lessLikelyConnectionTags = tagsForConnectionNodeIfAllowed(entities[0], entities[1], graph, true);
-                    if (lessLikelyConnectionTags && !isEqual(connectionTags, lessLikelyConnectionTags)) {
-                        fixes.push(makeConnectWaysFix(lessLikelyConnectionTags));
+                    if (this.data.runwayCenterlineSnap) {
+                        fixes.push(makeConnectTaxiwayToRunwayCenterlineFix(this.data.runwayCenterlineSnap));
+                    } else {
+                        fixes.push(makeConnectWaysFix(this.data.connectionTags));
+                        let lessLikelyConnectionTags = tagsForConnectionNodeIfAllowed(entities[0], entities[1], graph, true);
+                        if (lessLikelyConnectionTags && !isEqual(connectionTags, lessLikelyConnectionTags)) {
+                            fixes.push(makeConnectWaysFix(lessLikelyConnectionTags));
+                        }
                     }
                 }
 
@@ -720,6 +866,50 @@ export function validationCrossingWays(context) {
 
                 context.perform(action, t('issues.fix.' + fixTitleID + '.annotation'));
                 context.enter(modeSelect(context, resultWayIDs));
+            }
+        });
+    }
+
+    function makeConnectTaxiwayToRunwayCenterlineFix(snapInfo) {
+        return new validationIssueFix({
+            icon: 'iD-icon-crossing',
+            title: t.append('issues.fix.connect_features.title'),
+            onClick: function(context) {
+                context.perform(
+                    function actionConnectTaxiwayToRunwayCenterline(graph) {
+                        var endpointNode = graph.hasEntity(snapInfo.taxiwayEndpointID);
+                        if (!endpointNode || endpointNode.type !== 'node') return graph;
+
+                        var centerline = graph.hasEntity(snapInfo.runwayCenterlineID);
+                        if (!centerline || centerline.type !== 'way') return graph;
+
+                        var edge = snapInfo.runwayCenterlineEdge;
+                        var loc = snapInfo.loc;
+                        var edgeNodes = edge && [graph.hasEntity(edge[0]), graph.hasEntity(edge[1])];
+                        var edgeNeedsRefresh = !edgeNodes || !edgeNodes[0] || !edgeNodes[1];
+
+                        if (edgeNeedsRefresh) {
+                            var centerlineNodes = graph.childNodes(centerline);
+                            var refreshed = geoChooseEdge(centerlineNodes, context.projection(endpointNode.loc), context.projection, '');
+                            if (!refreshed || refreshed.index === undefined) return graph;
+                            edge = [centerline.nodes[refreshed.index - 1], centerline.nodes[refreshed.index]];
+                            loc = refreshed.loc;
+                            edgeNodes = [graph.hasEntity(edge[0]), graph.hasEntity(edge[1])];
+                            if (!edgeNodes[0] || !edgeNodes[1]) return graph;
+                        }
+
+                        var mergeThresholdInMeters = 0.75;
+                        var nearestCenterlineNode = geoSphericalClosestNode(graph.childNodes(centerline), loc);
+                        if (nearestCenterlineNode && nearestCenterlineNode.distance < mergeThresholdInMeters) {
+                            graph = actionMergeNodes([nearestCenterlineNode.node.id, endpointNode.id], nearestCenterlineNode.node.loc)(graph);
+                        } else {
+                            // Reuse the taxiway endpoint as the inserted midpoint so connectivity is guaranteed.
+                            graph = actionAddMidpoint({ loc: loc, edge: edge }, endpointNode)(graph);
+                        }
+                        return graph;
+                    },
+                    t('issues.fix.connect_crossing_features.annotation')
+                );
             }
         });
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11920,6 +11920,314 @@
         }
       }
     },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.2.tgz",
+      "integrity": "sha512-o3pcKzJgSGt4d74lSZ+OCnHwkKBeAbFDmbEm5gg70eA8VkyCuC/zV9TwBnmw6VjDlRdF4Pshfb+WE9E6XY1PoQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.2.tgz",
+      "integrity": "sha512-cqFSWO5tX2vhC9hJTK8WAiPIm4Q8q/cU8j2HQA0L3E1uXvBYbOZMhE2oFL8n2pKB5sOCHY6bBuHaRwG7TkfJyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.2.tgz",
+      "integrity": "sha512-vngduywkkv8Fkh3wIZf5nFPXzWsNsVu1kvtLETWxTFf/5opZmflgVSeLgdHR56RQh71xhPhWoOkEBvbehwTlVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.2.tgz",
+      "integrity": "sha512-h11KikYrUCYTrDj6h939hhMNlqU2fo/X4NB0OZcys3fya49o1hmFaczAiJWVAFgrM1NCP6RrO7lQKeVYSKBPSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.2.tgz",
+      "integrity": "sha512-/eg4CI61ZUkLXxMHyVlmlGrSQZ34xqWlZNW43IAU4RmdzWEx0mQJ2mN/Cx4IHLVZFL6UBGAh+/GXhgvGb+nVxw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.2.tgz",
+      "integrity": "sha512-QOWgFH5X9+p+S1NAfOqc0z8qEpJIoUHf7OWjNUGOeW18Mx22lAUOiA9b6r2/vpzLdfxi/f+VWsYjUOMCcYh0Ng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.2.tgz",
+      "integrity": "sha512-kDWSPafToDd8LcBYd1t5jw7bD5Ojcu12S3uT372e5HKPzQt532vW+rGFFOaiR0opxePyUkHrwz8iWYEyH1IIQA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.2.tgz",
+      "integrity": "sha512-gKm7Mk9wCv6/rkzwCiUC4KnevYhlf8ztBrDRT9g/u//1fZLapSRc+eDZj2Eu2wpJ+0RzUKgtNijnVIB4ZxyL+w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.2.tgz",
+      "integrity": "sha512-66lA8vnj5mB/rtDNwPgrrKUOtCLVQypkyDa2gMfOefXK6rcZAxKLO9Fy3GkW8VkPnENv9hBkNOFfGLf6rNKGUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.2.tgz",
+      "integrity": "sha512-s+OPucLNdJHvuZHuIz2WwncJ+SfWHFEmlC5nKMUgAelUeBUnlB4wt7rXWiyG4Zn07uY2Dd+SGyVa9oyLkVGOjA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.2.tgz",
+      "integrity": "sha512-8wTRM3+gVMDLLDdaT6tKmOE3lJyRy9NpJUS/ZRWmLCmOPIJhVyXwjBo+XbrrwtV33Em1/eCTd5TuGJm4+DmYjw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.2.tgz",
+      "integrity": "sha512-6yqEfgJ1anIeuP2P/zhtfBlDpXUb80t8DpbYwXQ3bQd95JMvUaqiX+fKqYqUwZXqdJDd8xdilNtsHM2N0cFm6A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.2.tgz",
+      "integrity": "sha512-sshYUiYVSEI2B6dp4jMncwxbrUqRdNApF2c3bhtLAU0qA8Lrri0p0NauOsTWh3yCCCDyBOjESHMExonp7Nzc0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.2.tgz",
+      "integrity": "sha512-duBLgd+3pqC4MMwBrKkFxaZerUxZcYApQVC5SdbF5/e/589GwVvlRUnyqMFbM8iUSb1BaoX/3fRL7hB9m2Pj8Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.2.tgz",
+      "integrity": "sha512-tzhYJJidDUVGMgVyE+PmxENPHlvvqm1KILjjZhB8/xHYqAGeizh3GBGf9u6WdJpZrz1aCpIIHG0LgJgH9rVjHQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.2.tgz",
+      "integrity": "sha512-opH8GSUuVcCSSyHHcl5hELrmnk4waZoVpgn/4FDao9iyE4WpQhyWJ5ryl5M3ocp4qkRuHfyXnGqg8M9oKCEKRA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.2.tgz",
+      "integrity": "sha512-LSeBHnGli1pPKVJ79ZVJgeZWWZXkEe/5o8kcn23M8eMKCUANejchJbF/JqzM4RRjOJfNRhKJk8FuqL1GKjF5oQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.2.tgz",
+      "integrity": "sha512-uPj7MQ6/s+/GOpolavm6BPo+6CbhbKYyZHUDvZ/SmJM7pfDBgdGisFX3bY/CBDMg2ZO4utfhlApkSfZ92yXw7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.2.tgz",
+      "integrity": "sha512-Z9MUCrSgIaUeeHAiNkm3cQyst2UhzjPraR3gYYfOjAuZI7tcFRTOD+4cHLPoS/3qinchth+V56vtqz1Tv+6KPA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.2.tgz",
+      "integrity": "sha512-+GnYBmpjldD3XQd+HMejo+0gJGwYIOfFeoBQv32xF/RUIvccUz20/V6Otdv+57NE70D5pa8W/jVGDoGq0oON4A==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.2.tgz",
+      "integrity": "sha512-ApXFKluSB6kDQkAqZOKXBjiaqdF1BlKi+/eqnYe9Ee7U2K3pUDKsIyr8EYm/QDHTJIM+4X+lI0gJc3TTRhd+dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
+    },
+    "node_modules/netlify-cli/node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.2.tgz",
+      "integrity": "sha512-ARz+Bs8kY6FtitYM96PqPEVvPXqEZmPZsSkXvyX19YzDqkCaIlhCieLLMI5hxO9SRZ2XtCtm8wxhy0iJ2jxNfw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
+    },
     "node_modules/netlify-cli/node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
@@ -15224,9 +15532,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/express/node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -15982,6 +16290,21 @@
       "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/netlify-cli/node_modules/function-bind": {
@@ -20040,6 +20363,49 @@
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true
+    },
+    "node_modules/netlify-cli/node_modules/rollup": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.2.tgz",
+      "integrity": "sha512-I25/2QgoROE1vYV+NQ1En9T9UFB9Cmfm2CJ83zZOlaDpvz29wGQSZXWKw7MiNXau7wYgB/T9fVIdIuEQ+KbiiA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.52.2",
+        "@rollup/rollup-android-arm64": "4.52.2",
+        "@rollup/rollup-darwin-arm64": "4.52.2",
+        "@rollup/rollup-darwin-x64": "4.52.2",
+        "@rollup/rollup-freebsd-arm64": "4.52.2",
+        "@rollup/rollup-freebsd-x64": "4.52.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.52.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.52.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.52.2",
+        "@rollup/rollup-linux-arm64-musl": "4.52.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.52.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.52.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.52.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.52.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.52.2",
+        "@rollup/rollup-linux-x64-gnu": "4.52.2",
+        "@rollup/rollup-linux-x64-musl": "4.52.2",
+        "@rollup/rollup-openharmony-arm64": "4.52.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.52.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.52.2",
+        "@rollup/rollup-win32-x64-gnu": "4.52.2",
+        "@rollup/rollup-win32-x64-msvc": "4.52.2",
+        "fsevents": "~2.3.2"
+      }
     },
     "node_modules/netlify-cli/node_modules/router": {
       "version": "2.2.0",

--- a/test/spec/validations/crossing_ways.js
+++ b/test/spec/validations/crossing_ways.js
@@ -32,6 +32,79 @@ describe('iD.validations.crossing_ways', function () {
         );
     }
 
+    function createAerowayEndpointTouchCrossing() {
+        var n1 = iD.osmNode({id: 'n-1', loc: [1, 1]});
+        var n2 = iD.osmNode({id: 'n-2', loc: [3, 1]});
+        var w1 = iD.osmWay({id: 'w-1', nodes: ['n-1', 'n-2'], tags: { aeroway: 'runway' }});
+
+        context.perform(
+            iD.actionAddEntity(n1),
+            iD.actionAddEntity(n2),
+            iD.actionAddEntity(w1)
+        );
+
+        // taxiway starts exactly on runway centerline but with a separate node id
+        var n3 = iD.osmNode({id: 'n-3', loc: [2, 1]});
+        var n4 = iD.osmNode({id: 'n-4', loc: [2, 2]});
+        var w2 = iD.osmWay({id: 'w-2', nodes: ['n-3', 'n-4'], tags: { aeroway: 'taxiway' }});
+
+        context.perform(
+            iD.actionAddEntity(n3),
+            iD.actionAddEntity(n4),
+            iD.actionAddEntity(w2)
+        );
+    }
+
+    function createRunwayAreaWithCenterlineAndTaxiway(connectedToCenterline) {
+        var a1 = iD.osmNode({ id: 'n-a1', loc: [0, 0] });
+        var a2 = iD.osmNode({ id: 'n-a2', loc: [0.00004, 0] });
+        var a3 = iD.osmNode({ id: 'n-a3', loc: [0.00004, 0.00002] });
+        var a4 = iD.osmNode({ id: 'n-a4', loc: [0, 0.00002] });
+        var runwayArea = iD.osmWay({
+            id: 'w-area',
+            nodes: ['n-a1', 'n-a2', 'n-a3', 'n-a4', 'n-a1'],
+            tags: { aeroway: 'runway', area: 'yes' }
+        });
+
+        var c1 = iD.osmNode({ id: 'n-c1', loc: [0.00001, 0.00001] });
+        var cMid = iD.osmNode({ id: 'n-cm', loc: [0.00002, 0.00001] });
+        var c2 = iD.osmNode({ id: 'n-c2', loc: [0.00003, 0.00001] });
+        var runwayCenterline = iD.osmWay({
+            id: 'w-center',
+            nodes: ['n-c1', 'n-cm', 'n-c2'],
+            tags: { aeroway: 'runway' }
+        });
+
+        var t1 = iD.osmNode({ id: 'n-t1', loc: [0.00002, -0.00001] });
+        var taxiwayNodes;
+        if (connectedToCenterline) {
+            taxiwayNodes = ['n-t1', 'n-cm'];
+        } else {
+            var t2 = iD.osmNode({ id: 'n-t2', loc: [0.00002, 0] });
+            taxiwayNodes = ['n-t1', 'n-t2'];
+            context.perform(iD.actionAddEntity(t2));
+        }
+        var taxiway = iD.osmWay({
+            id: 'w-taxi',
+            nodes: taxiwayNodes,
+            tags: { aeroway: 'taxiway' }
+        });
+
+        context.perform(
+            iD.actionAddEntity(a1),
+            iD.actionAddEntity(a2),
+            iD.actionAddEntity(a3),
+            iD.actionAddEntity(a4),
+            iD.actionAddEntity(c1),
+            iD.actionAddEntity(cMid),
+            iD.actionAddEntity(c2),
+            iD.actionAddEntity(t1),
+            iD.actionAddEntity(runwayArea),
+            iD.actionAddEntity(runwayCenterline),
+            iD.actionAddEntity(taxiway)
+        );
+    }
+
     function createWaysWithTwoCrossingPoint() {
       var n1 = iD.osmNode({id: 'n-1', loc: [1,1]});
       var n2 = iD.osmNode({id: 'n-2', loc: [3,3]});
@@ -553,6 +626,78 @@ describe('iD.validations.crossing_ways', function () {
     it('flags an aeroway crosing another aeroway', function() {
         createWaysWithOneCrossingPoint({ aeroway: 'runway' }, { aeroway: 'taxiway' });
         verifySingleCrossingIssue(validate(), {});
+    });
+
+    it('flags touching aeroway endpoint crossing runway centerline', function() {
+        createAerowayEndpointTouchCrossing();
+        var issues = validate();
+        expect(issues).to.have.lengthOf(2);
+        expect(issues[0].id).to.eql(issues[1].id);
+        expect(issues[0].data.connectionTags).to.eql({});
+        expect(issues[1].data.connectionTags).to.eql({});
+        expect(issues[0].loc).to.eql([2, 1]);
+    });
+
+    it('connect fix joins runway and taxiway with a shared node', function() {
+        createWaysWithOneCrossingPoint({ aeroway: 'runway' }, { aeroway: 'taxiway' });
+        var issues = validate();
+        context.enter(iD.modeSelect(context, ['w-2']));
+        var fixes = issues[0].fixes(context);
+        fixes[0].onClick(context);
+
+        var graph = context.graph();
+        var runway = graph.entity('w-1');
+        var taxiway = graph.entity('w-2');
+        var sharedNodes = runway.nodes.filter(function(nodeID) {
+            return taxiway.nodes.indexOf(nodeID) !== -1;
+        });
+
+        expect(sharedNodes.length).to.be.greaterThan(0);
+        var sharedNode = graph.entity(sharedNodes[0]);
+        expect(sharedNode.loc[0]).to.eql(1.5);
+        expect(sharedNode.loc[1]).to.eql(1.5);
+    });
+
+    it('flags taxiway touching runway area when runway has centerline but no centerline connection', function() {
+        createRunwayAreaWithCenterlineAndTaxiway(false);
+        var issues = validate();
+        var centerlineSnapIssues = issues.filter(function(issue) {
+            return issue.type === 'crossing_ways' && !!issue.data.runwayCenterlineSnap;
+        });
+        expect(centerlineSnapIssues).to.have.lengthOf(2);
+        expect(centerlineSnapIssues[0].subtype).to.eql('aeroway-aeroway');
+    });
+
+    it('ignores taxiway crossing runway area if taxiway is already connected to runway centerline', function() {
+        createRunwayAreaWithCenterlineAndTaxiway(true);
+        var issues = validate();
+        expect(issues).to.have.lengthOf(0);
+    });
+
+    it('runway area warning fix snaps taxiway endpoint to runway centerline', function() {
+        createRunwayAreaWithCenterlineAndTaxiway(false);
+        var issues = validate();
+        var snapIssue = issues.find(function(issue) {
+            return issue.type === 'crossing_ways' && !!issue.data.runwayCenterlineSnap;
+        });
+        expect(snapIssue).to.not.eql(undefined);
+        context.enter(iD.modeSelect(context, ['w-taxi']));
+        snapIssue.fixes(context)[0].onClick(context);
+
+        var graph = context.graph();
+        var taxiway = graph.entity('w-taxi');
+        var runwayCenterline = graph.entity('w-center');
+        var runwayArea = graph.entity('w-area');
+
+        var sharedCenterlineNodes = taxiway.nodes.filter(function(nodeID) {
+            return runwayCenterline.nodes.indexOf(nodeID) !== -1;
+        });
+        expect(sharedCenterlineNodes.length).to.be.greaterThan(0);
+
+        var sharedAreaNodes = taxiway.nodes.filter(function(nodeID) {
+            return runwayArea.nodes.indexOf(nodeID) !== -1;
+        });
+        expect(sharedAreaNodes.length).to.eql(0);
     });
 
     it('flags an aeroway crosing a major road', function() {


### PR DESCRIPTION
This PR fixes aeroway validation when runways are mapped as an area with a separate centerline.

Changes:
- Ensure taxiways connect to the runway centerline (aeroway=runway way), not just the runway area polygon.
- Prevent false “Crossing aeroways should be connected” warnings when the correct centerline connection exists.
- Update crossing aeroway validation logic to prefer runway centerlines for topology checks.
- Add/adjust tests to cover area runway + centerline cases.

Result:
- Correct topology for routing and validation.
- Area runways render visually, centerlines handle connections as intended.

Fixes #11169 