### PR TITLE
add crossreferenced to valid words to stop linter from spamming about supposed error

### DIFF
--- a/.cspell/custom-dictionary.txt
+++ b/.cspell/custom-dictionary.txt
@@ -10,6 +10,7 @@ busway
 childs
 chipseal
 colour
+crossreferenced
 datavalue
 disconnectable
 dotp


### PR DESCRIPTION
<img width="330" height="84" alt="screen-2026-02-23-19-47-32" src="https://github.com/user-attachments/assets/8e7eac34-d48d-47dc-827c-2a395217c086" />
<img width="125" height="58" alt="screen-2026-02-23-19-47-28" src="https://github.com/user-attachments/assets/b31813c0-7b1c-4a1a-9489-c95649d5c805" />

it does not appear to be clearly wrong, and I do not want to keep seeing this prominent linter complaint

https://github.com/codespell-project/codespell/issues/3203 existed but was rejected as a borderline case