### PR TITLE
Add inline validation for preset fields with regex pattern

### DIFF
--- a/modules/ui/fields/input.js
+++ b/modules/ui/fields/input.js
@@ -108,6 +108,15 @@ export function uiFieldText(field, context) {
 
         wrap.call(_lengthIndicator);
 
+        if (wrap.select('.field-validation-message').empty()) {
+            wrap.append('div')
+                .attr('class', 'field-validation-message')
+                .style('display', 'none')
+                .style('font-size', '12px')
+                .style('margin-top', '4px')
+                .style('color', '#888');
+        }
+
         if (field.type === 'tel') {
             updatePhonePlaceholder();
 
@@ -435,6 +444,28 @@ export function uiFieldText(field, context) {
         return function() {
             var t = {};
             var val = utilGetSetValue(input);
+            const validationMessage = wrap.select('.field-validation-message');
+
+            if (field.pattern && val) {
+                let regex = null;
+
+                try {
+                    regex = new RegExp(field.pattern);
+                } catch (e) {
+                    regex = null;
+                }
+
+                if (regex && !regex.test(val)) {
+                    validationMessage
+                        .style('display', 'block')
+                        .text('Value does not match expected format');
+                } else {
+                    validationMessage.style('display', 'none');
+                }
+
+            } else {
+                validationMessage.style('display', 'none');
+            }
             if (!onInput) val = context.cleanTagValue(val);
 
             // don't override multiple values with blank string

--- a/modules/ui/fields/input.js
+++ b/modules/ui/fields/input.js
@@ -442,9 +442,6 @@ export function uiFieldText(field, context) {
             var t = {};
             var val = utilGetSetValue(input);
             const validationMessage = wrap.select('.field-validation-message');
-            if (!field.pattern && field.key === 'website') {
-                field.pattern = '^https?://.+';
-            }
             if (!onInput && field.pattern && val) {
                 let regex = null;
 

--- a/modules/ui/fields/input.js
+++ b/modules/ui/fields/input.js
@@ -442,8 +442,10 @@ export function uiFieldText(field, context) {
             var t = {};
             var val = utilGetSetValue(input);
             const validationMessage = wrap.select('.field-validation-message');
-
-            if (field.pattern && val) {
+            if (!field.pattern && field.key === 'website') {
+                field.pattern = '^https?://.+';
+            }
+            if (!onInput && field.pattern && val) {
                 let regex = null;
 
                 try {
@@ -454,14 +456,14 @@ export function uiFieldText(field, context) {
 
                 if (regex && !regex.test(val)) {
                     validationMessage
-                        .style('display', 'block')
-                        .text(localizer.t('validation.value_does_not_match_expected_format'));
+                        .classed('hide', false)
+                        .text(localizer.t('inspector.invalid_format'));
                 } else {
-                    validationMessage.style('display', 'none');
+                    validationMessage.classed('hide', true);
                 }
 
-            } else {
-                validationMessage.style('display', 'none');
+            } else if(!onInput) {
+                validationMessage.classed('hide', true);
             }
             if (!onInput) val = context.cleanTagValue(val);
 

--- a/modules/ui/fields/input.js
+++ b/modules/ui/fields/input.js
@@ -110,11 +110,7 @@ export function uiFieldText(field, context) {
 
         if (wrap.select('.field-validation-message').empty()) {
             wrap.append('div')
-                .attr('class', 'field-validation-message')
-                .style('display', 'none')
-                .style('font-size', '12px')
-                .style('margin-top', '4px')
-                .style('color', '#888');
+                .attr('class', 'field-validation-message hide');
         }
 
         if (field.type === 'tel') {
@@ -441,6 +437,7 @@ export function uiFieldText(field, context) {
 
 
     function change(onInput) {
+        
         return function() {
             var t = {};
             var val = utilGetSetValue(input);
@@ -458,7 +455,7 @@ export function uiFieldText(field, context) {
                 if (regex && !regex.test(val)) {
                     validationMessage
                         .style('display', 'block')
-                        .text('Value does not match expected format');
+                        .text(localizer.t('validation.value_does_not_match_expected_format'));
                 } else {
                     validationMessage.style('display', 'none');
                 }


### PR DESCRIPTION

<img width="1920" height="1080" alt="valid" src="https://github.com/user-attachments/assets/c93b7715-a3fd-412d-8d3b-d523d1595dcc" />

## Add inline validation for fields that define a regex pattern

### Summary

This PR adds inline validation support for preset fields that define a `pattern` (regex).

If a field includes a regex pattern and the entered value does not match it, an informational message is displayed directly below the input field.

### Behavior

- Validation runs on **blur / change**, not while typing.
- The message appears only after the user finishes editing the field.
- If the value becomes valid, the message disappears.
- This does **not** block saving.
- This does **not** create or modify issues in the issues panel.
- It only applies to fields that define a `pattern`.

### Why

Some fields may define a regex pattern but currently provide no direct feedback when the value does not match the expected format.

This change improves UX by giving contextual, field-level feedback after editing is complete, while staying consistent with iD’s existing interaction model (no validation on every keystroke).

### Scope

- Changes limited to `uiFieldText`.
- No changes to the validation engine.
- No preset/schema changes.

Closes #10769 