### PR TITLE
Restore dblclick zoom on add-way behavior

### DIFF
--- a/modules/behavior/add_way.js
+++ b/modules/behavior/add_way.js
@@ -25,14 +25,11 @@ export function behaviorAddWay(context) {
 
     behavior.off = function(surface) {
         surface.call(draw.off);
+        context.map().dblclickZoomEnable(true);
     };
 
 
     behavior.cancel = function() {
-        window.setTimeout(function() {
-            context.map().dblclickZoomEnable(true);
-        }, 1000);
-
         context.enter(modeBrowse(context));
     };
 


### PR DESCRIPTION
### Description

This PR addresses the issue described in #11373
`behaviorAddWay` disables double-click zoom when the behavior is installed, but restores it only through a delayed timer in the cancel path. If the mode exits before the timer fires (for example when cancelling quickly or switching modes), the cleanup may not run and double-click zoom can remain disabled.

### Fix

Restore double-click zoom synchronously in behavior.off() so that the cleanup runs whenever the behavior is removed.
This ensures double-click zoom is consistently restored on all exit paths, including:
- finishing a way
- cancelling the operation
- switching modes

### Result

Double-click zoom is reliably restored after leaving **Add Way** mode.

This was verified by finishing a way, cancelling the operation, and switching modes to ensure zoom behavior is restored consistently (see clip below).

### Fixes

Fixes #11373

### Clips

**Before**

https://github.com/user-attachments/assets/f250c740-253d-4232-b320-c73fa2598110

**After**

https://github.com/user-attachments/assets/fa5c415e-d641-43ba-94e6-c43a43ccd322



