### PR TITLE
Indicate applied and partially applied relations for multi-selection

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -6087,3 +6087,16 @@ textarea:focus:dir(rtl)::-webkit-resizer {
     width: 100px;
     color: var(--link-color);
 }
+
+.relation-badge {
+  display: inline-block;
+  margin-left: 4px;
+  padding: 2px 6px;
+  font-size: 11px;
+  line-height: 1.4;
+  border-radius: 999px;      
+  border: 1px solid #363e4d;
+  background-color: #1d2635;
+  color: #949caa;
+  font-weight: 500;
+}

--- a/modules/ui/sections/raw_membership_editor.js
+++ b/modules/ui/sections/raw_membership_editor.js
@@ -354,9 +354,8 @@ export function uiSectionRawMembershipEditor(context) {
                 if (q && (value + ' ' + entity.id).toLowerCase().indexOf(q.toLowerCase()) === -1) return;
 
                 const count = relationCounts.get(entity.id) || 0;
-                const isCommon = count === selectedEntities.length;
-                const isPartial = count > 0 && count < selectedEntities.length;
-
+                const isCommon = selectedEntities.length > 0 && count === selectedEntities.length;
+                const isPartial = selectedEntities.length > 0 && count > 0 && count < selectedEntities.length;
 
                 result.push({
                     relation: entity,

--- a/modules/ui/sections/raw_membership_editor.js
+++ b/modules/ui/sections/raw_membership_editor.js
@@ -284,7 +284,7 @@ export function uiSectionRawMembershipEditor(context) {
         var graph = context.graph();
 
         //select entities
-        var selectedEntities = _entityIDs
+        const selectedEntities = _entityIDs
             .map(function(id) {
                 return graph.hasEntity(id);
             })
@@ -293,7 +293,7 @@ export function uiSectionRawMembershipEditor(context) {
             });
 
         // Map relationID -> number of selected entities in that relation
-        var relationCounts = new Map();
+        const relationCounts = new Map();
 
         selectedEntities.forEach(function(ent) {
             graph.parentRelations(ent).forEach(function (rel) {
@@ -352,20 +352,18 @@ export function uiSectionRawMembershipEditor(context) {
                 var value = baseDisplayValue(entity);
                 if (q && (value + ' ' + entity.id).toLowerCase().indexOf(q.toLowerCase()) === -1) return;
 
-                var count = relationCounts.get(entity.id) || 0;
-                var flags = {
-                    isCommon: count === selectedEntities.length,
-                    isPartial: count > 0 && count < selectedEntities.length
-                };
+                const count = relationCounts.get(entity.id) || 0;
+                const isCommon = count === selectedEntities.length;
+                const isPartial = count > 0 && count < selectedEntities.length;
 
 
                 result.push({
                     relation: entity,
                     value,
-                    display: baseDisplayLabel(entity, flags),
+                    display: baseDisplayLabel(entity, { isCommon, isPartial }),
                     title: value,
-                    isCommon: flags.isCommon,
-                    isPartial: flags.isPartial
+                    isCommon,
+                    isPartial
                 });
             });
 

--- a/modules/ui/sections/raw_membership_editor.js
+++ b/modules/ui/sections/raw_membership_editor.js
@@ -309,17 +309,6 @@ export function uiSectionRawMembershipEditor(context) {
             var entityName = utilDisplayName(entity) || '';
 
             return function(selection) {
-                if (flags.isCommon) {
-                    selection.append('span')
-                        .attr('class', 'green')
-                        .text('(Applied)');
-                } else if (flags.isPartial) {
-                    selection.append('span')
-                        .attr('class', 'orange')
-                        .text('(Partially Applied)');
-
-                }
-
                 selection
                     .append('b')
                     .text(presetName + ' ');
@@ -328,6 +317,18 @@ export function uiSectionRawMembershipEditor(context) {
                     .classed('has-colour', entity.tags.colour && isColourValid(entity.tags.colour))
                     .style('border-color', entity.tags.colour)
                     .text(entityName);
+
+                if (flags.isCommon) {
+                    selection.append('span')
+                        .attr('class', 'relation-badge')
+                        .text('Already Applied');
+                } else if (flags.isPartial) {
+                    selection.append('span')
+                        .attr('class', 'relation-badge')
+                        .text('Partially Applied');
+
+                }
+
             };
         }
 

--- a/modules/ui/sections/raw_membership_editor.js
+++ b/modules/ui/sections/raw_membership_editor.js
@@ -283,12 +283,43 @@ export function uiSectionRawMembershipEditor(context) {
 
         var graph = context.graph();
 
-        function baseDisplayLabel(entity) {
+        //select entities
+        var selectedEntities = _entityIDs
+            .map(function(id) {
+                return graph.hasEntity(id);
+            })
+            .filter(function(entity) {
+                return entity;
+            });
+
+        // Map relationID -> number of selected entities in that relation
+        var relationCounts = new Map();
+
+        selectedEntities.forEach(function(ent) {
+            graph.parentRelations(ent).forEach(function (rel) {
+                relationCounts.set(rel.id, (relationCounts.get(rel.id) || 0) + 1);
+            });
+        });
+
+        function baseDisplayLabel(entity, flags) {
+            flags = flags || {};
+
             var matched = presetManager.match(entity, graph);
             var presetName = (matched && matched.name()) || t('inspector.relation');
             var entityName = utilDisplayName(entity) || '';
 
-            return selection => {
+            return function(selection) {
+                if (flags.isCommon) {
+                    selection.append('span')
+                        .attr('class', 'green')
+                        .text('(Applied)');
+                } else if (flags.isPartial) {
+                    selection.append('span')
+                        .attr('class', 'orange')
+                        .text('(Partially Applied)');
+
+                }
+
                 selection
                     .append('b')
                     .text(presetName + ' ');
@@ -310,6 +341,7 @@ export function uiSectionRawMembershipEditor(context) {
             result.push({
                 relation: explicitRelation,
                 value: baseDisplayValue(explicitRelation) + ' ' + explicitRelation.id,
+                title: baseDisplayValue(explicitRelation),
                 display: baseDisplayLabel(explicitRelation)
             });
         } else {
@@ -320,10 +352,20 @@ export function uiSectionRawMembershipEditor(context) {
                 var value = baseDisplayValue(entity);
                 if (q && (value + ' ' + entity.id).toLowerCase().indexOf(q.toLowerCase()) === -1) return;
 
+                var count = relationCounts.get(entity.id) || 0;
+                var flags = {
+                    isCommon: count === selectedEntities.length,
+                    isPartial: count > 0 && count < selectedEntities.length
+                };
+
+
                 result.push({
                     relation: entity,
                     value,
-                    display: baseDisplayLabel(entity)
+                    display: baseDisplayLabel(entity, flags),
+                    title: value,
+                    isCommon: flags.isCommon,
+                    isPartial: flags.isPartial
                 });
             });
 


### PR DESCRIPTION
### Summary

This PR improves the discoverability of applied relations in the relations dropdown. While the dropdown already lists nearby relations, it is not currently clear which of those relations are applied to the current selection.

This change surfaces that information directly in the UI.

### Behavior

- Relations applied to **all** selected entities are labeled “Applied”
- Relations applied to **some** selected entities are labeled “Partially Applied”

These labels reflect existing state only and do not alter how relations are created or managed.

### Scope / Non-goals

- No changes to relation or membership logic
- Does not prevent duplicate relation members
- Does not introduce warnings or blocking behavior

More invasive approaches (such as enforcing constraints or modifying actions) are intentionally left out of scope for this PR.

This PR addresses one aspect of issue #10981.

<img width="957" height="579" alt="Screenshot 2026-03-02 015423" src="https://github.com/user-attachments/assets/b2608555-280b-4c2f-b817-5984fad7fce9" />
<img width="982" height="576" alt="Screenshot 2026-03-02 015439" src="https://github.com/user-attachments/assets/11e72d00-a388-4a5d-9e48-7d681fc5d749" />

