### PR TITLE
Fix buggy non-global string replacements

### DIFF
--- a/modules/ui/fields/wikidata.js
+++ b/modules/ui/fields/wikidata.js
@@ -207,7 +207,7 @@ export function uiFieldWikidata(field, context) {
                 var foundPreferred;
                 for (var i in langs) {
                     var lang = langs[i];
-                    var siteID = lang.replace('-', '_') + 'wiki';
+                    var siteID = lang.replaceAll('-', '_') + 'wiki';
                     if (entity.sitelinks[siteID]) {
                         foundPreferred = true;
                         newWikipediaValue = lang + ':' + entity.sitelinks[siteID].title;
@@ -228,7 +228,7 @@ export function uiFieldWikidata(field, context) {
                         // if no wikipedia pages are linked to this wikidata entity, delete that tag
                         newWikipediaValue = null;
                     } else {
-                        var wikiLang = wikiSiteKeys[0].slice(0, -4).replace('_', '-');
+                        var wikiLang = wikiSiteKeys[0].slice(0, -4).replaceAll('_', '-');
                         var wikiTitle = entity.sitelinks[wikiSiteKeys[0]].title;
                         newWikipediaValue = wikiLang + ':' + wikiTitle;
                     }

--- a/modules/ui/preset_list.js
+++ b/modules/ui/preset_list.js
@@ -180,7 +180,7 @@ export function uiPresetList(context) {
 
         items.enter()
             .append('div')
-            .attr('class', function(item) { return 'preset-list-item preset-' + item.preset.id.replace('/', '-'); })
+            .attr('class', function(item) { return 'preset-list-item preset-' + item.preset.id.replaceAll('/', '-'); })
             .classed('current', function(item) { return _currentPresets.indexOf(item.preset) !== -1; })
             .each(function(item) { d3_select(this).call(item); })
             .style('opacity', 0)

--- a/modules/ui/top_toolbar.js
+++ b/modules/ui/top_toolbar.js
@@ -68,7 +68,7 @@ export function uiTopToolbar(context) {
                 .enter()
                 .append('div')
                 .attr('class', function(d) {
-                    var classes = 'toolbar-item ' + (d.id || d).replace('_', '-');
+                    var classes = 'toolbar-item ' + (d.id || d).replaceAll('_', '-');
                     if (d.klass) classes += ' ' + d.klass;
                     return classes;
                 });


### PR DESCRIPTION
## Summary

Fix non-global `String.prototype.replace()` calls that only replace the first occurrence of a character, causing bugs when the input contains multiple instances of the target character.

## Changes

- **[modules/ui/preset_list.js](cci:7://file:///c:/Users/kunal/iD/modules/ui/preset_list.js:0:0-0:0)**: [replace('/', '-')](cci:1://file:///c:/Users/kunal/iD/cleanly_replace.cjs:2:0-6:1) → [replace(/\//g, '-')](cci:1://file:///c:/Users/kunal/iD/cleanly_replace.cjs:2:0-6:1)
  - Preset IDs like `amenity/vending_machine/sweets` generated invalid CSS class names with unescaped slashes (e.g. `preset-amenity-vending_machine/sweets`).

- **[modules/ui/fields/wikidata.js](cci:7://file:///c:/Users/kunal/iD/modules/ui/fields/wikidata.js:0:0-0:0)**: [replace('-', '_')](cci:1://file:///c:/Users/kunal/iD/cleanly_replace.cjs:2:0-6:1) → [replace(/-/g, '_')](cci:1://file:///c:/Users/kunal/iD/cleanly_replace.cjs:2:0-6:1) and [replace('_', '-')](cci:1://file:///c:/Users/kunal/iD/cleanly_replace.cjs:2:0-6:1) → [replace(/_/g, '-')](cci:1://file:///c:/Users/kunal/iD/cleanly_replace.cjs:2:0-6:1)
  - Wikipedia language codes with multiple hyphens (e.g. `zh-min-nan`) were not fully converted, breaking sitelink lookups.

- **[modules/ui/top_toolbar.js](cci:7://file:///c:/Users/kunal/iD/modules/ui/top_toolbar.js:0:0-0:0)**: [replace('_', '-')](cci:1://file:///c:/Users/kunal/iD/cleanly_replace.cjs:2:0-6:1) → [replace(/_/g, '-')](cci:1://file:///c:/Users/kunal/iD/cleanly_replace.cjs:2:0-6:1)
  - Toolbar item IDs with multiple underscores only had the first one replaced.

## Testing

All existing unit tests pass (`npm run test:spec`).
