### PR TITLE
Fix potential TypeError parsing lane_number in vegbilder.js

### DIFF
--- a/modules/services/vegbilder.js
+++ b/modules/services/vegbilder.js
@@ -140,7 +140,8 @@ async function loadTile(cache, typename, tile) {
       METER: metering,
       FELTKODE: lane_code
     } = properties;
-    const lane_number = parseInt(lane_code.match(/^[0-9]+/)[0], 10);
+    const lane_match = lane_code.match(/^[0-9]+/);
+    const lane_number = parseInt(lane_match ? lane_match[0] : '0', 10);
     const direction = lane_number % 2 === 0 ? directionEnum.backward : directionEnum.forward;
     const data = {
       service: 'photo',

--- a/modules/services/vegbilder.js
+++ b/modules/services/vegbilder.js
@@ -140,8 +140,7 @@ async function loadTile(cache, typename, tile) {
       METER: metering,
       FELTKODE: lane_code
     } = properties;
-    const lane_match = lane_code.match(/^[0-9]+/);
-    const lane_number = parseInt(lane_match ? lane_match[0] : '0', 10);
+    const lane_number = parseInt((lane_code.match(/^[0-9]+/) || [])[0], 10);
     const direction = lane_number % 2 === 0 ? directionEnum.backward : directionEnum.forward;
     const data = {
       service: 'photo',


### PR DESCRIPTION
## Description
This PR fixes a bug in [modules/services/vegbilder.js](cci:7://file:///c:/Users/kunal/iD/modules/services/vegbilder.js:0:0-0:0) where `lane_code.match(/^[0-9]+/)[0]` is accessed directly without verifying if `lane_code.match` actually returned a match array. 

When the match returns `null` (if the string does not start with digits), parsing it causes a `TypeError: Cannot read properties of null (reading '0')`. 

### Changes:
- Used a fallback expression `lane_match ? lane_match[0] : '0'` to safely prevent accessing `[0]` on `null`, making the parsing logic more robust.
