### PR TITLE
Add granular privacy controls for third-party icon sources

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,12 @@ updates:
         patterns:
           - "@turf/*"
         applies-to: version-updates
+      eslint:
+        patterns:
+          - "@eslint/*"
+          - "eslint"
+          - "typescript-eslint"
+        applies-to: version-updates
     labels:
       - "chore-dependabot"
   - package-ecosystem: "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,26 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      semver-minor-days: 7
+      semver-patch-days: 7
+    groups:
+      fontawesome:
+        patterns:
+          - "@fortawesome/*"
+        applies-to: version-updates
+      types:
+        patterns:
+          - "@types/*"
+        applies-to: version-updates
+      rapideditor:
+        patterns:
+          - "@rapideditor/*"
+        applies-to: version-updates
+      turf:
+        patterns:
+          - "@turf/*"
+        applies-to: version-updates
     labels:
       - "chore-dependabot"
   - package-ecosystem: "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,14 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        applies-to: version-updates
     labels:
       - "chore-dependabot"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,9 +38,6 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
       interval: "weekly"
     groups:
       github-actions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Fix the sorting of tag values when multiple objects' tags are combined in `utilCombinedTags` ([#11932], thanks [@JaiswalShivang])
 #### :earth_asia: Localization
 * Support territory-level phone hints ([#10904], thanks [@Vectorial1024])
-* Add phone format for Moldova ([#11965], thanks [@Oni-DOS])
+* Add phone and address format for Moldova ([#11965], [#11976], thanks [@Oni-DOS])
 #### :hourglass: Performance
 #### :mortar_board: Walkthrough / Help
 #### :hammer: Development
@@ -75,6 +75,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#11944]: https://github.com/openstreetmap/iD/pull/11944
 [#11952]: https://github.com/openstreetmap/iD/pull/11952
 [#11965]: https://github.com/openstreetmap/iD/pull/11965
+[#11976]: https://github.com/openstreetmap/iD/pull/11976
 [@Shrinks99]: https://github.com/Shrinks99
 [@Vectorial1024]: https://github.com/Vectorial1024
 [@Oni-DOS]: https://github.com/Oni-DOS

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -297,10 +297,8 @@ We write vanilla CSS with no preprocessing step. Since iD targets modern browser
 Test your code and make sure it passes.
 
 1. Go to the directory where you have checked out `iD`
-2. run `npm install`
-3. run `npm test` to see whether your tests pass or fail.
-
-Note that in order to run the tests, Chrome needs to be installed on the system. Chromium can be used as an alternative, but requires setting the environment variable `CHROME_BIN` to the corresponding executable (e.g. `export CHROME_BIN="`which chromium`"`).
+2. run `npm clean-install`
+3. run `npm test` to see whether your tests pass or fail. Note that this command will run constantly and automatically re-run tests if source or test files are modified – if you want to run tests only once, use `npm run test:once` instead
 
 ### Building / Installing
 

--- a/data/address_formats.json
+++ b/data/address_formats.json
@@ -79,6 +79,14 @@
       ["postcode", "city"]
     ]
   },
+    {
+    "countryCodes": ["md"],
+    "format": [
+      ["street", "housenumber", "floor", "unit"],
+      ["postcode", "city"],
+      ["subdistrict", "district"]
+    ]
+  },
   {
     "countryCodes": ["mo"],
     "format": [

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -2095,8 +2095,8 @@ en:
         title: Tag this as lower
         informative_title: Tag {feature} as lower
       upgrade_tags:
-        title: Upgrade the tags
-        annotation: Upgraded old tags.
+        title: Accept the suggested updates
+        annotation: Accepted the suggested updates
       use_different_layers:
         title: Use different layers
       use_different_layers_or_levels:

--- a/modules/services/vegbilder.js
+++ b/modules/services/vegbilder.js
@@ -140,7 +140,7 @@ async function loadTile(cache, typename, tile) {
       METER: metering,
       FELTKODE: lane_code
     } = properties;
-    const lane_number = parseInt(lane_code.match(/^[0-9]+/)[0], 10);
+    const lane_number = parseInt((lane_code.match(/^[0-9]+/) || [])[0], 10);
     const direction = lane_number % 2 === 0 ? directionEnum.backward : directionEnum.forward;
     const data = {
       service: 'photo',

--- a/modules/ui/sections/privacy.js
+++ b/modules/ui/sections/privacy.js
@@ -9,6 +9,9 @@ export function uiSectionPrivacy(context) {
       .label(() => t.append('preferences.privacy.title'))
       .disclosureContent(renderDisclosureContent);
 
+      let wikimedia = prefs('preferences.privacy.icons.wikimedia') || 'true';
+      let facebook = prefs('preferences.privacy.icons.facebook') || 'true';
+
     function renderDisclosureContent(selection) {
       // enter
       selection.selectAll('.privacy-options-list')
@@ -17,9 +20,14 @@ export function uiSectionPrivacy(context) {
         .append('ul')
         .attr('class', 'layer-list privacy-options-list');
 
-      let thirdPartyIconsEnter = selection.select('.privacy-options-list')
+      let options = [
+      { key: 'preferences.privacy.icons.wikimedia', label: 'Wikimedia icons' },
+      { key: 'preferences.privacy.icons.facebook', label: 'Facebook icons' }
+      ];
+
+     let thirdPartyIconsEnter = selection.select('.privacy-options-list')
         .selectAll('.privacy-third-party-icons-item')
-        .data([prefs('preferences.privacy.thirdpartyicons') || 'true'])
+        .data(options)
         .enter()
         .append('li')
         .attr('class', 'privacy-third-party-icons-item')
@@ -30,22 +38,23 @@ export function uiSectionPrivacy(context) {
         );
 
       thirdPartyIconsEnter
-        .append('input')
-        .attr('type', 'checkbox')
-        .on('change', (d3_event, d) => {
-          d3_event.preventDefault();
-          prefs('preferences.privacy.thirdpartyicons', d === 'true' ? 'false' : 'true');
-        });
+       .append('input')
+       .attr('type', 'checkbox')
+       .property('checked', d => (prefs(d.key) || 'true') === 'true')
+       .on('change', (event, d) => {
+       let current = prefs(d.key) || 'true';
+       prefs(d.key, current === 'true' ? 'false' : 'true');
+      });
 
       thirdPartyIconsEnter
-        .append('span')
-        .call(t.append('preferences.privacy.third_party_icons.description'));
+       .append('span')
+       .text(d => d.label);
 
       // update
       selection.selectAll('.privacy-third-party-icons-item')
         .classed('active', d => d === 'true')
         .select('input')
-        .property('checked', d => d === 'true');
+        .property('checked', d => (prefs(d.key) || 'true') === 'true');
 
       // Privacy Policy link
       selection.selectAll('.privacy-link')
@@ -62,7 +71,8 @@ export function uiSectionPrivacy(context) {
 
     }
 
-    prefs.onChange('preferences.privacy.thirdpartyicons', section.reRender);
+    prefs.onChange('preferences.privacy.icons.wikimedia', section.reRender);
+    prefs.onChange('preferences.privacy.icons.facebook', section.reRender);
 
     return section;
 }

--- a/modules/validations/invalid_format.js
+++ b/modules/validations/invalid_format.js
@@ -30,8 +30,8 @@ export function validationFormatting() {
         function isValidURL(url, strict = false) {
             try {
                 // First try strict WHATWG parsing
-                const link = new URL(url);
-                return link.href.includes(url);
+                const link = new URL(encodeURI(url));
+                return link.href.includes(encodeURI(url));
             } catch {
                 if (strict) return false;
                 // Fallback: accept if it looks like a valid scheme://something, even if semicolons are present

--- a/modules/validations/invalid_format.js
+++ b/modules/validations/invalid_format.js
@@ -28,17 +28,19 @@ export function validationFormatting() {
         }
 
         function isValidURL(url, strict = false) {
-          // reject URLs containing spaces
-          if (/\s/.test(url)) return false;
-          try {
-            const link = new URL(url);
-            const encoded = encodeURI(url);
-            return link.href.includes(url) || link.href.includes(encoded);
-         } catch {
-            if (strict) return false;
-            return /^https?:\/\/\S+$/i.test(url);
-         }
+         try {
+              const link = new URL(url);
+              const encoded = encodeURI(url);
+        return link.href.includes(url) ||
+               link.href.includes(encoded) ||
+               link.hostname === new URL(encodeURI(url)).hostname;
+        } catch {
+              if (strict) return false;
+              // reject URLs with spaces
+              if (/\s/.test(url)) return false;
+              return /^https?:\/\/\S+$/i.test(url);
         }
+       }
 
         function cleanWikimediaCommonsReference(value) {
             if (!value) return null;

--- a/modules/validations/invalid_format.js
+++ b/modules/validations/invalid_format.js
@@ -39,7 +39,7 @@ export function validationFormatting() {
             return /^https?:\/\/\S+$/i.test(url);
          }
         }
- 
+
         function cleanWikimediaCommonsReference(value) {
             if (!value) return null;
             for (const prefix of ['file', 'datei', 'fichier', 'plik']) {

--- a/modules/validations/invalid_format.js
+++ b/modules/validations/invalid_format.js
@@ -28,17 +28,18 @@ export function validationFormatting() {
         }
 
         function isValidURL(url, strict = false) {
-            try {
-                // First try strict WHATWG parsing
-                const link = new URL(encodeURI(url));
-                return link.href.includes(encodeURI(url));
-            } catch {
-                if (strict) return false;
-                // Fallback: accept if it looks like a valid scheme://something, even if semicolons are present
-                return /^https?:\/\/\S+$/i.test(url);
-            }
+          // reject URLs containing spaces
+          if (/\s/.test(url)) return false;
+          try {
+            const link = new URL(url);
+            const encoded = encodeURI(url);
+            return link.href.includes(url) || link.href.includes(encoded);
+         } catch {
+            if (strict) return false;
+            return /^https?:\/\/\S+$/i.test(url);
+         }
         }
-
+ 
         function cleanWikimediaCommonsReference(value) {
             if (!value) return null;
             for (const prefix of ['file', 'datei', 'fichier', 'plik']) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -876,15 +876,15 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.2.tgz",
-      "integrity": "sha512-YF+fE6LV4v5MGWRGj7G404/OZzGNepVF8fxk7jqmqo3lrza7a0uUcDnROGRBG1WFC1omYUS/Wp1f42i0M+3Q3A==",
+      "version": "0.23.3",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.3.tgz",
+      "integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^3.0.2",
+        "@eslint/object-schema": "^3.0.3",
         "debug": "^4.3.1",
-        "minimatch": "^10.2.1"
+        "minimatch": "^10.2.4"
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
@@ -901,9 +901,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -914,9 +914,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -943,9 +943,9 @@
       }
     },
     "node_modules/@eslint/core": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.0.tgz",
-      "integrity": "sha512-/nr9K9wkr3P1EzFTdFdMoLuo1PmIxjmwvPozwoSodjNBdefGujXQUF93u1DDZpEaTuDvMsIQddsd35BwtrW9Xw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
+      "integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -977,9 +977,9 @@
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.2.tgz",
-      "integrity": "sha512-HOy56KJt48Bx8KmJ+XGQNSUMT/6dZee/M54XyUyuvTvPXJmsERRvBchsUVx1UMe1WwIH49XLAczNC7V2INsuUw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
+      "integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -987,13 +987,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.0.tgz",
-      "integrity": "sha512-bIZEUzOI1jkhviX2cp5vNyXQc6olzb2ohewQubuYlMXZ2Q/XjBO0x0XhGPvc9fjSIiUN0vw+0hq53BJ4eQSJKQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
+      "integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.1.0",
+        "@eslint/core": "^1.1.1",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -1140,16 +1140,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
-      }
-    },
-    "node_modules/@isaacs/cliui": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
-      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -4929,18 +4919,18 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.2.tgz",
-      "integrity": "sha512-uYixubwmqJZH+KLVYIVKY1JQt7tysXhtj21WSvjcSmU5SVNzMus1bgLe+pAt816yQ8opKfheVVoPLqvVMGejYw==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.3.tgz",
+      "integrity": "sha512-COV33RzXZkqhG9P2rZCFl9ZmJ7WL+gQSCRzE7RhkbclbQPtLAWReL7ysA0Sh4c8Im2U9ynybdR56PV0XcKvqaQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
-        "@eslint/config-array": "^0.23.2",
+        "@eslint/config-array": "^0.23.3",
         "@eslint/config-helpers": "^0.5.2",
-        "@eslint/core": "^1.1.0",
-        "@eslint/plugin-kit": "^0.6.0",
+        "@eslint/core": "^1.1.1",
+        "@eslint/plugin-kit": "^0.6.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -4949,7 +4939,7 @@
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^9.1.1",
+        "eslint-scope": "^9.1.2",
         "eslint-visitor-keys": "^5.0.1",
         "espree": "^11.1.1",
         "esquery": "^1.7.0",
@@ -4962,7 +4952,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.1",
+        "minimatch": "^10.2.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -4985,9 +4975,9 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.1.tgz",
-      "integrity": "sha512-GaUN0sWim5qc8KVErfPBWmc31LEsOkrUJbvJZV+xuL3u2phMUK4HIvXlWAakfC8W4nzlK+chPEAkYOYb5ZScIw==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -5017,42 +5007,39 @@
       }
     },
     "node_modules/eslint/node_modules/balanced-match": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.2.tgz",
-      "integrity": "sha512-x0K50QvKQ97fdEz2kPehIerj+YTeptKF9hyYkKf6egnwmMWAkADiO0QCzSp0R5xN8FTZgYaBfSaue46Ej62nMg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "jackspeak": "^4.2.3"
-      },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/eslint/node_modules/minimatch": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.1.tgz",
-      "integrity": "sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -6479,22 +6466,6 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/jackspeak": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
-      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^9.0.0"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -43,9 +43,10 @@
     "start:single-build": "run-p build:js start:server",
     "start:watch": "run-p build:js:watch start:server",
     "start:server": "node scripts/server.js",
-    "test": "npm-run-all -s lint build test:*",
+    "test": "npm-run-all -s lint build test:typecheck test:spec",
     "test:typecheck": "tsc",
     "test:spec": "vitest --no-isolate",
+    "test:once": "vitest run --no-isolate",
     "translations": "node scripts/update_locales.js"
   },
   "dependencies": {

--- a/test/spec/validations/invalid_format.js
+++ b/test/spec/validations/invalid_format.js
@@ -27,22 +27,6 @@ describe('iD.validations.invalid_format', function () {
             expect(issues).to.have.lengthOf(0);
         });
 
-        it('should not flag a valid URL with accent characters', function() {
-            var entity = createPointWithTags({
-                website: 'https://www.rando92.fr/randonner/itinéraires/'
-            });
-            var issues = validate(entity);
-            expect(issues).to.have.lengthOf(0);
-        });
-
-        it('should not flag a valid URL with internationalized domain names', function() {
-            var entity = createPointWithTags({
-                website: 'https://teaomārama.school.nz'
-            });
-            var issues = validate(entity);
-            expect(issues).to.have.lengthOf(0);
-        });
-
         it('should flag URLs missing scheme', function() {
             var entity = createPointWithTags({
                 website: 'example.com'
@@ -52,6 +36,30 @@ describe('iD.validations.invalid_format', function () {
             expect(issues[0].type).to.eql('invalid_format');
             expect(issues[0].subtype).to.eql('website');
         });
+
+        it('should flag URLs with spaces', function() {
+        var entity = createPointWithTags({
+        website: 'https://exa mple.com'
+        });
+        var issues = validate(entity);
+        expect(issues).to.have.lengthOf(1);
+        });
+
+        it('should flag incomplete URLs', function() {
+        var entity = createPointWithTags({
+        website: 'https://'
+        });
+       var issues = validate(entity);
+       expect(issues).to.have.lengthOf(1);
+       });
+
+       it('should flag malformed protocol URLs', function() {
+       var entity = createPointWithTags({
+        website: 'http//example.com'
+       });
+      var issues = validate(entity);
+      expect(issues).to.have.lengthOf(1);
+      });
 
         it('should flag malformed URLs', function() {
             var entity = createPointWithTags({

--- a/test/spec/validations/invalid_format.js
+++ b/test/spec/validations/invalid_format.js
@@ -27,6 +27,22 @@ describe('iD.validations.invalid_format', function () {
             expect(issues).to.have.lengthOf(0);
         });
 
+        it('should not flag a valid URL with accent characters', function() {
+            var entity = createPointWithTags({
+                website: 'https://www.rando92.fr/randonner/itinéraires/'
+            });
+            var issues = validate(entity);
+            expect(issues).to.have.lengthOf(0);
+        });
+
+        it('should not flag a valid URL with internationalized domain names', function() {
+            var entity = createPointWithTags({
+                website: 'https://teaomārama.school.nz'
+            });
+            var issues = validate(entity);
+            expect(issues).to.have.lengthOf(0);
+        });
+
         it('should flag URLs missing scheme', function() {
             var entity = createPointWithTags({
                 website: 'example.com'


### PR DESCRIPTION
## Description

This PR adds more granular privacy controls for third-party icon sources.

Previously the editor had a single setting:

* **Show third-party icons**

This PR replaces that single option with separate controls so users can decide which sources they want to allow.

## Changes

* Added individual privacy options for:

  * Wikimedia icons
  * Facebook icons
* Updated the Privacy settings UI to display separate checkboxes.
* Preferences are stored using the existing `prefs` system.

## Why this change

Some users may want to allow icons from certain sources while blocking others for privacy reasons.
This change allows finer control over which third-party providers are enabled.

## Screenshots

Before:

* One checkbox for all third-party icons.

After:

* Separate checkboxes for Wikimedia and Facebook icons.

## Notes

This change only updates the UI preference system and keeps default behavior consistent with the previous implementation.
