### PR TITLE
fix(validation): don't flag valid unicode URLs as invalid

### DIFF
--- a/modules/validations/invalid_format.js
+++ b/modules/validations/invalid_format.js
@@ -29,9 +29,9 @@ export function validationFormatting() {
 
         function isValidURL(url, strict = false) {
             try {
-                // First try strict WHATWG parsing
                 const link = new URL(url);
-                return link.href.includes(url);
+                // Accept normalized/encoded URLs as long as they are absolute http(s) URLs.
+                return /^https?:$/i.test(link.protocol) && !!link.hostname;
             } catch {
                 if (strict) return false;
                 // Fallback: accept if it looks like a valid scheme://something, even if semicolons are present

--- a/test/spec/validations/invalid_format.js
+++ b/test/spec/validations/invalid_format.js
@@ -27,6 +27,14 @@ describe('iD.validations.invalid_format', function () {
             expect(issues).to.have.lengthOf(0);
         });
 
+        it('should not flag valid URLs containing unicode path characters', function() {
+            var entity = createPointWithTags({
+                website: 'https://www.rando92.fr/randonner/itinéraires/'
+            });
+            var issues = validate(entity);
+            expect(issues).to.have.lengthOf(0);
+        });
+
         it('should flag URLs missing scheme', function() {
             var entity = createPointWithTags({
                 website: 'example.com'

--- a/test/spec/validations/invalid_format.js
+++ b/test/spec/validations/invalid_format.js
@@ -58,6 +58,19 @@ describe('iD.validations.invalid_format', function () {
             });
         });
 
+        it('should flag malformed protocol and incomplete URLs', function() {
+            var entity = createPointWithTags({
+                website: 'http//example.com',
+                url: 'https://'
+            });
+            var issues = validate(entity);
+            expect(issues).to.have.lengthOf(2);
+            issues.forEach(function(issue) {
+                expect(issue.type).to.eql('invalid_format');
+                expect(issue.subtype).to.eql('website');
+            });
+        });
+
         it('should handle multiple URLs separated by semicolons', function() {
             var entity = createPointWithTags({
                 website: 'https://example.com;invalid-url;http://valid.org'


### PR DESCRIPTION
## Summary
- fix URL validation to accept absolute `http(s)` URLs after WHATWG normalization/encoding instead of requiring the original raw string to be preserved
- add a regression test for a valid URL containing unicode path characters (`itinéraires`) so it is no longer incorrectly flagged

## Testing
- `npm run test:spec -- test/spec/validations/invalid_format.js`

## Related
Fixes #11983
