### PR TITLE
Add tag-based search to feature list (e.g. building=yes)

### DIFF
--- a/modules/ui/feature_list.js
+++ b/modules/ui/feature_list.js
@@ -22,6 +22,7 @@ import {
     utilHighlightEntities,
     utilNoAuto
 } from '../util';
+const tagRegex = /^([a-zA-Z0-9:_-]+)=([a-zA-Z0-9:_-]+)$/;
 
 
 export const idMatch = q => {
@@ -103,7 +104,7 @@ export function uiFeatureList(context) {
             if (d3_event.keyCode === 13 && // ↩ Return
                 q.length &&
                 items.size()) {
-                const tagMatch = q.match(/^([a-zA-Z0-9:_-]+)=([a-zA-Z0-9:_-]+)$/);
+                const tagMatch = q.match(tagRegex);
                 if (tagMatch) {
                     const ids = [];
 
@@ -145,7 +146,7 @@ export function uiFeatureList(context) {
             var graph = context.graph();
             var visibleCenter = context.map().extent().center();
             var q = search.property('value').toLowerCase().trim();
-            const tagMatch = q.match(/^([a-zA-Z0-9:_-]+)=([a-zA-Z0-9:_-]+)$/);
+            const tagMatch = q.match(tagRegex);
 
             if (!q) return [];
 

--- a/modules/ui/feature_list.js
+++ b/modules/ui/feature_list.js
@@ -98,31 +98,29 @@ export function uiFeatureList(context) {
 
 
         function keypress(d3_event) {
-          var q = search.property('value'),
-          items = list.selectAll('.feature-list-item');
+            var q = search.property('value'), 
+                items = list.selectAll('.feature-list-item');
+            if (d3_event.keyCode === 13 && // ↩ Return
+                q.length &&
+                items.size()) {
+                const tagMatch = q.match(/^([a-zA-Z0-9:_-]+)=([a-zA-Z0-9:_-]+)$/);
 
-          if (d3_event.keyCode === 13 && q.length && items.size()) {
+               if (tagMatch) {
+                const ids = [];
 
-          const tagMatch = q.match(/^([a-zA-Z0-9:_-]+)=([a-zA-Z0-9:_-]+)$/);
-
-          if (tagMatch) {
-            const ids = [];
-
-            items.each(function(d) {
+                items.each(function(d) {
                 if (d.entity) {
                     ids.push(d.entity.id);
                 }
-            });
+                });
 
-            if (ids.length) {
-                context.enter(modeSelect(context, ids));
-            }
-
-            return;
-          }
-
-          click(d3_event, items.datum());
-         }
+                if (ids.length) {
+                  context.enter(modeSelect(context, ids));
+                }
+                  return;
+                }
+                click(d3_event, items.datum());
+               }
         }
 
 
@@ -201,20 +199,18 @@ export function uiFeatureList(context) {
                 });
             }
 
-            var allEntities = graph.entities;
-            const tagResults = [];
+        var allEntities = graph.entities;
+        const tagResults = [];
 
-          if (tagMatch) {
+        if (tagMatch) {
           const key = tagMatch[1];
           const value = tagMatch[2];
           const extent = context.map().extent();
 
-         for (let entityID in allEntities) {
+        for (let entityID in allEntities) {
            let entity = allEntities[entityID];
            if (!entity || !entity.tags) continue;
-
-           if (entity.tags[key] === value) {
-
+         if (entity.tags[key] === value) {
            if (!extent.intersects(entity.extent(graph))) continue;
 
            tagResults.push({
@@ -223,12 +219,10 @@ export function uiFeatureList(context) {
             geometry: entity.geometry(graph),
             type: utilDisplayType(entity.id),
             name: utilDisplayName(entity) || key + '=' + value
-        });
-        }
+           } );}
 
-        if (tagResults.length > 100) break;
-       }
-       }
+         if (tagResults.length > 100) break;
+        }}
             const localResults = [];
             for (var id in allEntities) {
                 var entity = allEntities[id];

--- a/modules/ui/feature_list.js
+++ b/modules/ui/feature_list.js
@@ -98,13 +98,31 @@ export function uiFeatureList(context) {
 
 
         function keypress(d3_event) {
-            var q = search.property('value'),
-                items = list.selectAll('.feature-list-item');
-            if (d3_event.keyCode === 13 && // ↩ Return
-                q.length &&
-                items.size()) {
-                click(d3_event, items.datum());
+          var q = search.property('value'),
+          items = list.selectAll('.feature-list-item');
+
+          if (d3_event.keyCode === 13 && q.length && items.size()) {
+
+          const tagMatch = q.match(/^([a-zA-Z0-9:_-]+)=([a-zA-Z0-9:_-]+)$/);
+
+          if (tagMatch) {
+            const ids = [];
+
+            items.each(function(d) {
+                if (d.entity) {
+                    ids.push(d.entity.id);
+                }
+            });
+
+            if (ids.length) {
+                context.enter(modeSelect(context, ids));
             }
+
+            return;
+          }
+
+          click(d3_event, items.datum());
+         }
         }
 
 
@@ -131,6 +149,7 @@ export function uiFeatureList(context) {
             var graph = context.graph();
             var visibleCenter = context.map().extent().center();
             var q = search.property('value').toLowerCase().trim();
+            const tagMatch = q.match(/^([a-zA-Z0-9:_-]+)=([a-zA-Z0-9:_-]+)$/);
 
             if (!q) return [];
 
@@ -183,6 +202,33 @@ export function uiFeatureList(context) {
             }
 
             var allEntities = graph.entities;
+            const tagResults = [];
+
+          if (tagMatch) {
+          const key = tagMatch[1];
+          const value = tagMatch[2];
+          const extent = context.map().extent();
+
+         for (let entityID in allEntities) {
+           let entity = allEntities[entityID];
+           if (!entity || !entity.tags) continue;
+
+           if (entity.tags[key] === value) {
+
+           if (!extent.intersects(entity.extent(graph))) continue;
+
+           tagResults.push({
+            id: entity.id,
+            entity: entity,
+            geometry: entity.geometry(graph),
+            type: utilDisplayType(entity.id),
+            name: utilDisplayName(entity) || key + '=' + value
+        });
+        }
+
+        if (tagResults.length > 100) break;
+       }
+       }
             const localResults = [];
             for (var id in allEntities) {
                 var entity = allEntities[id];
@@ -269,7 +315,7 @@ export function uiFeatureList(context) {
                 });
             }
 
-            return [...idResult, ...localResults, ...coordResult, ...geocodeResults, ...extraResults];
+            return [...tagResults, ...idResult, ...localResults, ...coordResult, ...geocodeResults, ...extraResults];
         }
 
 

--- a/modules/ui/feature_list.js
+++ b/modules/ui/feature_list.js
@@ -224,8 +224,8 @@ export function uiFeatureList(context) {
                 }
             }
             const localResults = [];
-            for (var id in allEntities) {
-                var entity = allEntities[id];
+            for (const id in allEntities) {
+                const entity = allEntities[id];
                 if (!entity) continue;
 
                 var matched = presetManager.match(entity, graph);
@@ -254,19 +254,19 @@ export function uiFeatureList(context) {
 
                     // Make a temporary osmEntity so we can preset match
                     // and better localize the search result - #4725
-                    var id = osmEntity.id.fromOSM(d.osm_type, d.osm_id);
-                    var tags = {};
+                    const id = osmEntity.id.fromOSM(d.osm_type, d.osm_id);
+                    const tags = {};
                     tags[d.class] = d.type;
 
-                    var attrs = { id: id, type: d.osm_type, tags: tags };
+                    const attrs = { id: id, type: d.osm_type, tags: tags };
                     if (d.osm_type === 'way') {   // for ways, add some fake closed nodes
                         attrs.nodes = ['a','a'];  // so that geometry area is possible
                     }
 
-                    var tempEntity = osmEntity(attrs);
-                    var tempGraph = coreGraph([tempEntity]);
-                    var matched = presetManager.match(tempEntity, tempGraph);
-                    var type = (matched && matched.name()) || utilDisplayType(id);
+                    const tempEntity = osmEntity(attrs);
+                    const tempGraph = coreGraph([tempEntity]);
+                    const matched = presetManager.match(tempEntity, tempGraph);
+                    const type = (matched && matched.name()) || utilDisplayType(id);
 
                     geocodeResults.push({
                         id: tempEntity.id,

--- a/modules/ui/feature_list.js
+++ b/modules/ui/feature_list.js
@@ -98,25 +98,26 @@ export function uiFeatureList(context) {
 
 
         function keypress(d3_event) {
-            var q = search.property('value'), 
+            var q = search.property('value'),
                 items = list.selectAll('.feature-list-item');
             if (d3_event.keyCode === 13 && // ↩ Return
                 q.length &&
                 items.size()) {
                 const tagMatch = q.match(/^([a-zA-Z0-9:_-]+)=([a-zA-Z0-9:_-]+)$/);
+                if (tagMatch) {
+                    const ids = [];
 
-             if (tagMatch) {
-                const ids = [];
-                items.each(function(d) {
-                 if (d.entity) { 
-                    ids.push(d.entity.id);}
-                });
-                if (ids.length) {
-                  context.enter(modeSelect(context, ids));
+                    items.each(function(d) {
+                        if (d.entity) {
+                            ids.push(d.entity.id);
+                        }
+                    });
+                    if (ids.length) {
+                        context.enter(modeSelect(context, ids));
+                    }
+                    return;
                 }
-                return;
-             }
-            click(d3_event, items.datum());
+                click(d3_event, items.datum());
             }
         }
 
@@ -196,30 +197,31 @@ export function uiFeatureList(context) {
                 });
             }
 
-        var allEntities = graph.entities;
-        const tagResults = [];
+            var allEntities = graph.entities;
+            const tagResults = [];
+            if (tagMatch) {
+                 const key = tagMatch[1];
+                 const value = tagMatch[2];
+                 const extent = context.map().extent();
 
-        if (tagMatch) {
-          const key = tagMatch[1];
-          const value = tagMatch[2];
-          const extent = context.map().extent();
+                 for (var id in allEntities) {
+                    var entity = allEntities[id];
+                    if (!entity || !entity.tags) continue;
 
-        for (let entityID in allEntities) {
-         let entity = allEntities[entityID];
-         if (!entity || !entity.tags) continue;
-         if (entity.tags[key] === value) {
-           if (!extent.intersects(entity.extent(graph))) continue;
+                    if (entity.tags[key] === value) {
+                        if (!extent.intersects(entity.extent(graph))) continue;
 
-           tagResults.push({
-            id: entity.id,
-            entity: entity,
-            geometry: entity.geometry(graph),
-            type: utilDisplayType(entity.id),
-            name: utilDisplayName(entity) || key + '=' + value
-           });}
-
-         if (tagResults.length > 100) break;
-        }}
+                        tagResults.push({
+                            id: entity.id,
+                            entity: entity,
+                            geometry: entity.geometry(graph),
+                            type: utilDisplayType(entity.id),
+                            name: utilDisplayName(entity) || key + '=' + value
+                        });
+                    }
+                    if (tagResults.length > 100) break;
+                }
+            }
             const localResults = [];
             for (var id in allEntities) {
                 var entity = allEntities[id];

--- a/modules/ui/feature_list.js
+++ b/modules/ui/feature_list.js
@@ -105,22 +105,19 @@ export function uiFeatureList(context) {
                 items.size()) {
                 const tagMatch = q.match(/^([a-zA-Z0-9:_-]+)=([a-zA-Z0-9:_-]+)$/);
 
-               if (tagMatch) {
+             if (tagMatch) {
                 const ids = [];
-
                 items.each(function(d) {
-                if (d.entity) {
-                    ids.push(d.entity.id);
-                }
+                 if (d.entity) { 
+                    ids.push(d.entity.id);}
                 });
-
                 if (ids.length) {
                   context.enter(modeSelect(context, ids));
                 }
-                  return;
-                }
-                click(d3_event, items.datum());
-               }
+                return;
+             }
+            click(d3_event, items.datum());
+            }
         }
 
 
@@ -208,8 +205,8 @@ export function uiFeatureList(context) {
           const extent = context.map().extent();
 
         for (let entityID in allEntities) {
-           let entity = allEntities[entityID];
-           if (!entity || !entity.tags) continue;
+         let entity = allEntities[entityID];
+         if (!entity || !entity.tags) continue;
          if (entity.tags[key] === value) {
            if (!extent.intersects(entity.extent(graph))) continue;
 
@@ -219,7 +216,7 @@ export function uiFeatureList(context) {
             geometry: entity.geometry(graph),
             type: utilDisplayType(entity.id),
             name: utilDisplayName(entity) || key + '=' + value
-           } );}
+           });}
 
          if (tagResults.length > 100) break;
         }}


### PR DESCRIPTION
Fixes #11980

Adds support for searching features by tag in the feature list.

Users can now search using queries like:
- building=yes
- roof:shape=flat
- highway=residential

Pressing Enter selects all matching entities within the current viewport.

I tested this by searching tags such as `building=yes` and `roof:shape=flat`.
The results update based on the current viewport (zoom level), and pressing Enter selects all matching features.

Screenshots of the behavior are attached for reference.

1).Zoomed
<img width="1436" height="786" alt="Screenshot 2026-03-11 at 2 33 41 PM" src="https://github.com/user-attachments/assets/69d9e27b-c38d-4a48-8174-669db467e51b" />

2).Normal
<img width="1437" height="794" alt="Screenshot 2026-03-11 at 2 33 12 PM" src="https://github.com/user-attachments/assets/06fd73cf-5589-4698-a8c6-ccb9588b0b52" />
