### PR TITLE
refactor `uiCmdSequence` into a separate function

### DIFF
--- a/modules/ui/cmd.ts
+++ b/modules/ui/cmd.ts
@@ -4,7 +4,7 @@ import { utilDetect } from '../util/detect';
 
 // Translate a MacOS key command into the appropriate Windows/Linux equivalent.
 // For example, ⌘Z -> Ctrl+Z
-export var uiCmd = function (code) {
+export function uiCmd(code: string) {
     var detected = utilDetect();
 
     if (detected.os === 'mac') {
@@ -16,7 +16,7 @@ export var uiCmd = function (code) {
     }
 
     var result = '',
-        replacements = {
+        replacements: Record<string, string> = {
             '⌘': 'Ctrl',
             '⇧': 'Shift',
             '⌥': 'Alt',
@@ -37,12 +37,12 @@ export var uiCmd = function (code) {
 
 
 // return a display-focused string for a given keyboard code
-uiCmd.display = function(code) {
+uiCmd.display = function(code: string) {
     if (code.length !== 1) return code;
 
     var detected = utilDetect();
     var mac = (detected.os === 'mac');
-    var replacements = {
+    var replacements: Record<string, string> = {
         '⌘': mac ? '⌘ ' + t('shortcuts.key.cmd')    : t('shortcuts.key.ctrl'),
         '⇧': mac ? '⇧ ' + t('shortcuts.key.shift')  : t('shortcuts.key.shift'),
         '⌥': mac ? '⌥ ' + t('shortcuts.key.option') : t('shortcuts.key.alt'),

--- a/modules/ui/cmd_sequence.ts
+++ b/modules/ui/cmd_sequence.ts
@@ -1,0 +1,158 @@
+import { select as d3_select, type EnterElement } from 'd3-selection';
+import { t } from '../core/localizer';
+import { svgIcon } from '../svg/icon';
+import { uiCmd } from './cmd';
+import { utilArrayUniq } from '../util';
+import { utilDetect } from '../util/detect';
+
+const detected = utilDetect();
+
+export interface CmdSequence {
+    modifiers?: string[];
+    shortcuts: string[];
+    separator?: string;
+    suffix?: string;
+    text?: string;
+    gesture?: string;
+}
+
+interface Flattened {
+    shortcut: string;
+    separator: string | undefined;
+    suffix: string | undefined;
+}
+
+/**
+ * Renders a sequence of keyboard shortcuts, which might
+ * consist of multiple `<kbd>` separated by `+` or `-or-`.
+ * Also handles mouse-click operations.
+ */
+export function uiCmdSequence(shortcut: CmdSequence) {
+    return (selection: d3.Selection) => {
+        const shortcutKeys = selection
+            .selectAll('div')
+            .data([shortcut])
+            .enter()
+            .append('div');
+
+        const modifierKeys = shortcutKeys.filter((d) => !!d.modifiers);
+
+        modifierKeys
+            .selectAll('kbd.modifier')
+            .data((d) => {
+                if (
+                    detected.os === 'win' &&
+                    d.text === 'shortcuts.editing.commands.redo'
+                ) {
+                    return ['⌘'];
+                } else if (
+                    detected.os !== 'mac' &&
+                    d.text === 'shortcuts.browsing.display_options.fullscreen'
+                ) {
+                    return [];
+                } else {
+                    return d.modifiers!;
+                }
+            })
+            .enter()
+            .each(function () {
+                const selection = d3_select<EnterElement, string>(this);
+
+                selection
+                    .append('kbd')
+                    .attr('class', 'modifier')
+                    .text(uiCmd.display);
+                selection.append('span').text('+');
+            });
+
+        shortcutKeys
+            .selectAll('kbd.shortcut')
+            .data((d) => {
+                let arr = d.shortcuts;
+                if (
+                    detected.os === 'win' &&
+                    d.text === 'shortcuts.editing.commands.redo'
+                ) {
+                    arr = ['Y'];
+                } else if (
+                    detected.os !== 'mac' &&
+                    d.text === 'shortcuts.browsing.display_options.fullscreen'
+                ) {
+                    arr = ['F11'];
+                }
+
+                // replace translations
+                arr = arr.map((s) => {
+                    return uiCmd.display(s.includes('.') ? t(s) : s);
+                });
+
+                return utilArrayUniq(arr).map(
+                    (s): Flattened => ({
+                        shortcut: s,
+                        separator: d.separator,
+                        suffix: d.suffix,
+                    }),
+                );
+            })
+            .enter()
+            .each(function (d, i, nodes) {
+                const selection = d3_select<EnterElement, Flattened>(this);
+                const click = d.shortcut.toLowerCase().match(/(.*).click/);
+
+                if (click && click[1]) {
+                    // replace "left_click", "right_click" with mouse icon
+                    selection.call(
+                        svgIcon(
+                            '#iD-walkthrough-mouse-' + click[1],
+                            'operation',
+                        ),
+                    );
+                } else if (d.shortcut.toLowerCase() === 'long-press') {
+                    selection.call(
+                        svgIcon(
+                            '#iD-walkthrough-longpress',
+                            'longpress operation',
+                        ),
+                    );
+                } else if (d.shortcut.toLowerCase() === 'tap') {
+                    selection.call(
+                        svgIcon('#iD-walkthrough-tap', 'tap operation'),
+                    );
+                } else {
+                    selection
+                        .append('kbd')
+                        .attr('class', 'shortcut')
+                        .text((d) => d.shortcut);
+                }
+
+                if (i < nodes.length - 1) {
+                    if (d.separator) {
+                        selection
+                            .append('span')
+                            .text(d.separator);
+                    } else {
+                        selection.append('span').text('\u00a0');
+                        selection.append('span').call(t.append('shortcuts.or'));
+                        selection.append('span').text('\u00a0');
+                    }
+                } else if (i === nodes.length - 1 && d.suffix) {
+                    selection.append('span').text(d.suffix);
+                }
+            });
+
+        shortcutKeys
+            .filter((d) => !!d.gesture)
+            .each(function () {
+                const selection = d3_select<HTMLElement, CmdSequence>(this);
+
+                selection.append('span').text('+');
+
+                selection
+                    .append('span')
+                    .attr('class', 'gesture')
+                    .each(function (d) {
+                        d3_select(this).call(t.addOrUpdate(d.gesture));
+                    });
+            });
+    };
+}

--- a/modules/ui/shortcuts.js
+++ b/modules/ui/shortcuts.js
@@ -1,16 +1,11 @@
 import { select as d3_select } from 'd3-selection';
-
 import { fileFetcher } from '../core/file_fetcher';
 import { t } from '../core/localizer';
-import { svgIcon } from '../svg/icon';
-import { uiCmd } from './cmd';
 import { uiModal } from './modal';
-import { utilArrayUniq } from '../util';
-import { utilDetect } from '../util/detect';
+import { uiCmdSequence } from './cmd_sequence';
 
 
 export function uiShortcuts(context) {
-    var detected = utilDetect();
     var _activeTab = 0;
     var _modalSelection;
     var _selection = d3_select(null);
@@ -131,118 +126,12 @@ export function uiShortcuts(context) {
         var shortcutRows = rowsEnter
             .filter(function (d) { return d.shortcuts; });
 
-        var shortcutKeys = shortcutRows
+        shortcutRows
             .append('td')
-            .attr('class', 'shortcut-keys');
-
-        var modifierKeys = shortcutKeys
-            .filter(function (d) { return d.modifiers; });
-
-        modifierKeys
-            .selectAll('kbd.modifier')
-            .data(function (d) {
-                if (detected.os === 'win' && d.text === 'shortcuts.editing.commands.redo') {
-                    return ['⌘'];
-                } else if (detected.os !== 'mac' && d.text === 'shortcuts.browsing.display_options.fullscreen') {
-                    return [];
-                } else {
-                    return d.modifiers;
-                }
-            })
-            .enter()
-            .each(function () {
-                var selection = d3_select(this);
-
-                selection
-                    .append('kbd')
-                    .attr('class', 'modifier')
-                    .text(function (d) { return uiCmd.display(d); });
-
-                selection
-                    .append('span')
-                    .text('+');
+            .attr('class', 'shortcut-keys')
+            .each(function (d) {
+                uiCmdSequence(d)(d3_select(this));
             });
-
-
-        shortcutKeys
-            .selectAll('kbd.shortcut')
-            .data(function (d) {
-                var arr = d.shortcuts;
-                if (detected.os === 'win' && d.text === 'shortcuts.editing.commands.redo') {
-                    arr = ['Y'];
-                } else if (detected.os !== 'mac' && d.text === 'shortcuts.browsing.display_options.fullscreen') {
-                    arr = ['F11'];
-                }
-
-                // replace translations
-                arr = arr.map(function(s) {
-                    return uiCmd.display(s.indexOf('.') !== -1 ? t(s) : s);
-                });
-
-                return utilArrayUniq(arr).map(function(s) {
-                    return {
-                        shortcut: s,
-                        separator: d.separator,
-                        suffix: d.suffix
-                    };
-                });
-            })
-            .enter()
-            .each(function (d, i, nodes) {
-                var selection = d3_select(this);
-                var click = d.shortcut.toLowerCase().match(/(.*).click/);
-
-                if (click && click[1]) {   // replace "left_click", "right_click" with mouse icon
-                    selection
-                        .call(svgIcon('#iD-walkthrough-mouse-' + click[1], 'operation'));
-                } else if (d.shortcut.toLowerCase() === 'long-press') {
-                    selection
-                        .call(svgIcon('#iD-walkthrough-longpress', 'longpress operation'));
-                } else if (d.shortcut.toLowerCase() === 'tap') {
-                    selection
-                        .call(svgIcon('#iD-walkthrough-tap', 'tap operation'));
-                } else {
-                    selection
-                        .append('kbd')
-                        .attr('class', 'shortcut')
-                        .text(function (d) { return d.shortcut; });
-                }
-
-                if (i < nodes.length - 1) {
-                    if (d.separator) {
-                        selection
-                            .append('span')
-                            .text(d.separator);
-                    } else {
-                        selection.append('span').text('\u00a0');
-                        selection.append('span').call(t.append('shortcuts.or'));
-                        selection.append('span').text('\u00a0');
-                    }
-                } else if (i === nodes.length - 1 && d.suffix) {
-                    selection
-                        .append('span')
-                        .text(d.suffix);
-                }
-            });
-
-
-        shortcutKeys
-            .filter(function(d) { return d.gesture; })
-            .each(function () {
-                var selection = d3_select(this);
-
-                selection
-                    .append('span')
-                    .text('+');
-
-                selection
-                    .append('span')
-                    .attr('class', 'gesture')
-                    .each(function (d) {
-                        d3_select(this).call(t.addOrUpdate(d.gesture));
-                    });
-            });
-
 
         shortcutRows
             .append('td')


### PR DESCRIPTION
prerequisite for #11999 

In that PR I want to reuse the logic that converts:
```js
{  modifiers: ["⌥"], shortcuts: ["+", "-"], separator: "," }
```
into:

> <kbd>⌥  Option</kbd> <kbd>+</kbd>, <kbd> -</kbd>

To test: check that the [keyboard shortcuts popup](https://github.com/user-attachments/assets/8879a530-79dd-4edf-833b-b55c3e6d81a4) still renders correctly. 

