### PR TITLE
create a command bar UI

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -6125,3 +6125,87 @@ textarea:focus:dir(rtl)::-webkit-resizer {
     width: 100px;
     color: var(--link-color);
 }
+
+.command-bar {
+    margin: 10% auto;
+    border: solid 1px var(--border-color);
+    border-radius: 4px;
+    width: 600px;
+    padding: 0;
+    font-size: 14px;
+    background: var(--bg-color);
+}
+
+.command-bar::backdrop {
+    background-color: #000a;
+}
+
+.command-bar footer {
+    display: flex;
+    justify-content: center;
+    padding: 8px 0 6px 0;
+    gap: 20px;
+    border-top: solid 1px var(--border-color);
+}
+
+.command-bar input {
+    width: 100%;
+    border: 0;
+    background: var(--bg-color-3);
+    padding: 8px 12px;
+    box-shadow: inset 0 0px 2px 0px var(--shadow-color);
+}
+.command-bar:focus-visible,
+.command-bar input:focus-visible {
+    outline: none;
+}
+
+.command-bar ul {
+    max-height: 450px;
+    overflow-y: auto;
+    padding: 4px;
+    margin: 0;
+    max-height: 50vh;
+}
+
+.command-bar li {
+    content-visibility: auto; /* major perf boost if supported */
+    list-style-type: none;
+    display: flex;
+    justify-content: space-between;
+    gap: 4px;
+    user-select: none;
+    cursor: pointer;
+    padding: 4px 8px;
+    border-radius: 4px;
+    align-items: center;
+    line-height: 1.2;
+    height: 30px;
+    position: relative;
+}
+.command-bar li:hover {
+    background-color: #0231;
+}
+.command-bar li.command-bar-selected {
+    background-color: var(--suggestion-highlight-color);
+    color: var(--dark-tooltip-text-color);
+}
+.command-bar li.command-bar-selected kbd {
+    color: initial;
+}
+li.command-bar-recently-used:not(:has(+ li.command-bar-recently-used))::after {
+    /* line after the last recently-used item */
+    content: "";
+    position: absolute;
+    left: 4px;
+    right: 4px;
+    bottom: 0;
+    height: 1px;
+    background: var(--border-color);
+}
+.command-bar-no-results {
+    text-align: center;
+    padding-bottom: 4px;
+    padding-bottom: 8px;
+    color: var(--passive-text-color);
+}

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1477,6 +1477,13 @@ en:
       label: "Browse files"
     no_geolocation:
       tooltip: Image without geolocation cannot be located on the map
+  command-bar:
+    key: K
+    placeholder: Run a command…
+    help:
+      navigate_list: to navigate
+      execute: to use
+      exit: to exit
   note:
     note: Note
     title: Edit note
@@ -2496,6 +2503,7 @@ en:
         save: "Save changes"
     tools:
       title: "Tools"
+      command-bar: Open the Command Bar
       info:
         title: "Information"
         all: "Toggle all information panels"

--- a/data/shortcuts.json
+++ b/data/shortcuts.json
@@ -362,6 +362,11 @@
           },
           {
             "modifiers": ["⌘"],
+            "shortcuts": ["command-bar.key"],
+            "text": "shortcuts.tools.command-bar"
+          },
+          {
+            "modifiers": ["⌘"],
             "shortcuts": ["info_panels.key"],
             "text": "shortcuts.tools.info.all"
           },

--- a/modules/behavior/paste.js
+++ b/modules/behavior/paste.js
@@ -6,6 +6,7 @@ import { operationPaste } from '../operations';
 import { t } from '../core/localizer';
 import { uiCmd } from '../ui/cmd';
 
+/** @param {iD.Context} context */
 // see also `operationPaste`
 export function behaviorPaste(context) {
 
@@ -76,12 +77,20 @@ export function behaviorPaste(context) {
 
     function behavior() {
         context.keybinding().on(uiCmd('⌘V'), doPaste);
+        context.commands.register({
+            categoryId: 'behavior',
+            id: 'paste',
+            label: t('shortcuts.editing.commands.paste'),
+            action: doPaste,
+            keyboardShortcut: { modifiers: ['⌘'], shortcuts: ['V'] },
+        });
         return behavior;
     }
 
 
     behavior.off = function() {
         context.keybinding().off(uiCmd('⌘V'));
+        delete context.commands.registry.paste;
     };
 
 

--- a/modules/core/command_registry.ts
+++ b/modules/core/command_registry.ts
@@ -1,0 +1,33 @@
+import type { CmdSequence } from '../ui/cmd_sequence';
+import { t } from './localizer';
+
+export const COMMAND_CATEGORIES = {
+  background: () => t('background.title'),
+  panels: () => 'UI Panels', // TODO: i18n
+  behavior: () => 'Behaviour', // TODO: i18n
+} satisfies Record<string, () => string>;
+
+export type CommandCategory = keyof typeof COMMAND_CATEGORIES;
+
+export interface Command {
+  id: string;
+  categoryId: CommandCategory;
+  label: string;
+  action(event: KeyboardEvent | MouseEvent): void;
+  terms?: string[];
+  keyboardShortcut?: CmdSequence;
+}
+
+export class CommandRegistry {
+  readonly registry: { [id: string]: Command } = {};
+
+  register(...items: Command[]) {
+    for (const item of items) {
+      this.registry[item.id] = item;
+    }
+  }
+
+  getAll() {
+    return Object.values(this.registry);
+  }
+}

--- a/modules/core/context.js
+++ b/modules/core/context.js
@@ -21,7 +21,7 @@ import { rendererBackground, rendererFeatures, rendererMap, rendererPhotos } fro
 import { services } from '../services';
 import { uiInit } from '../ui/init';
 import { utilKeybinding, utilRebind, utilStringQs, utilCleanOsmString } from '../util';
-
+import { CommandRegistry } from './command_registry';
 
 export function coreContext() {
   const dispatch = d3_dispatch('enter', 'exit', 'change');
@@ -417,10 +417,12 @@ export function coreContext() {
     return context;
   };
 
+  context.commands = new CommandRegistry();
 
   /* Container */
   let _container = d3_select(null);
   let _theme;
+  /** @type {GetSet<typeof context, d3.Selection>} */
   context.container = function(val) {
     if (!arguments.length) return _container;
     _container = val;

--- a/modules/core/index.js
+++ b/modules/core/index.js
@@ -1,3 +1,4 @@
+export * from './command_registry';
 export { coreContext } from './context';
 export { coreFileFetcher, fileFetcher } from './file_fetcher';
 export { coreDifference } from './difference';

--- a/modules/globals.d.ts
+++ b/modules/globals.d.ts
@@ -39,7 +39,7 @@ declare global {
     export type Selection<T = any> = import('d3').Selection<
       T,
       unknown,
-      unknown,
+      any,
       unknown
     >;
   }

--- a/modules/ui/cmd.ts
+++ b/modules/ui/cmd.ts
@@ -4,7 +4,7 @@ import { utilDetect } from '../util/detect';
 
 // Translate a MacOS key command into the appropriate Windows/Linux equivalent.
 // For example, ⌘Z -> Ctrl+Z
-export var uiCmd = function (code) {
+export function uiCmd(code: string) {
     var detected = utilDetect();
 
     if (detected.os === 'mac') {
@@ -16,7 +16,7 @@ export var uiCmd = function (code) {
     }
 
     var result = '',
-        replacements = {
+        replacements: Record<string, string> = {
             '⌘': 'Ctrl',
             '⇧': 'Shift',
             '⌥': 'Alt',
@@ -37,12 +37,12 @@ export var uiCmd = function (code) {
 
 
 // return a display-focused string for a given keyboard code
-uiCmd.display = function(code) {
+uiCmd.display = function(code: string) {
     if (code.length !== 1) return code;
 
     var detected = utilDetect();
     var mac = (detected.os === 'mac');
-    var replacements = {
+    var replacements: Record<string, string> = {
         '⌘': mac ? '⌘ ' + t('shortcuts.key.cmd')    : t('shortcuts.key.ctrl'),
         '⇧': mac ? '⇧ ' + t('shortcuts.key.shift')  : t('shortcuts.key.shift'),
         '⌥': mac ? '⌥ ' + t('shortcuts.key.option') : t('shortcuts.key.alt'),

--- a/modules/ui/cmd_sequence.ts
+++ b/modules/ui/cmd_sequence.ts
@@ -1,0 +1,139 @@
+import { select as d3_select, type EnterElement } from 'd3-selection';
+import { t } from '../core/localizer';
+import { svgIcon } from '../svg/icon';
+import { uiCmd } from './cmd';
+import { utilArrayUniq } from '../util';
+import { utilDetect } from '../util/detect';
+
+const detected = utilDetect();
+
+export interface CmdSequence {
+  modifiers?: string[];
+  shortcuts: string[];
+  separator?: string;
+  suffix?: string;
+  text?: string;
+  gesture?: string;
+}
+
+interface Flattened {
+  shortcut: string;
+  separator: string | undefined;
+  suffix: string | undefined;
+}
+
+/**
+ * Renders a sequence of keyboard shortcuts, which might
+ * consist of multiple `<kbd>` separated by `+` or `-or-`.
+ * Also handles mouse-click operations.
+ */
+export function uiCmdSequence(shortcut: CmdSequence) {
+  return (selection: d3.Selection) => {
+    const shortcutKeys = selection
+      .selectAll('div')
+      .data([shortcut])
+      .enter()
+      .append('div');
+
+    const modifierKeys = shortcutKeys.filter((d) => !!d.modifiers);
+
+    modifierKeys
+      .selectAll('kbd.modifier')
+      .data((d) => {
+        if (
+          detected.os === 'win' &&
+          d.text === 'shortcuts.editing.commands.redo'
+        ) {
+          return ['⌘'];
+        } else if (
+          detected.os !== 'mac' &&
+          d.text === 'shortcuts.browsing.display_options.fullscreen'
+        ) {
+          return [];
+        } else {
+          return d.modifiers!;
+        }
+      })
+      .enter()
+      .each(function () {
+        const selection = d3_select<EnterElement, string>(this);
+
+        selection.append('kbd').attr('class', 'modifier').text(uiCmd.display);
+        selection.append('span').text('+');
+      });
+
+    shortcutKeys
+      .selectAll('kbd.shortcut')
+      .data((d) => {
+        let arr = d.shortcuts;
+        if (
+          detected.os === 'win' &&
+          d.text === 'shortcuts.editing.commands.redo'
+        ) {
+          arr = ['Y'];
+        } else if (
+          detected.os !== 'mac' &&
+          d.text === 'shortcuts.browsing.display_options.fullscreen'
+        ) {
+          arr = ['F11'];
+        }
+
+        // replace translations
+        arr = arr.map((s) => {
+          return uiCmd.display(s.includes('.') ? t(s) : s);
+        });
+
+        return utilArrayUniq(arr).map(
+          (s): Flattened => ({
+            shortcut: s,
+            separator: d.separator,
+            suffix: d.suffix,
+          }),
+        );
+      })
+      .enter()
+      .each(function (d, i, nodes) {
+        const selection = d3_select<EnterElement, Flattened>(this);
+        const click = d.shortcut.toLowerCase().match(/(.*).click/);
+
+        if (click && click[1]) {
+          // replace "left_click", "right_click" with mouse icon
+          selection.call(
+            svgIcon('#iD-walkthrough-mouse-' + click[1], 'operation'),
+          );
+        } else if (d.shortcut.toLowerCase() === 'long-press') {
+          selection.call(
+            svgIcon('#iD-walkthrough-longpress', 'longpress operation'),
+          );
+        } else if (d.shortcut.toLowerCase() === 'tap') {
+          selection.call(svgIcon('#iD-walkthrough-tap', 'tap operation'));
+        } else {
+          selection
+            .append('kbd')
+            .attr('class', 'shortcut')
+            .text((d) => d.shortcut);
+        }
+
+        if (i < nodes.length - 1) {
+          selection
+            .append('span')
+            .html(d.separator || '\u00a0' + t.html('shortcuts.or') + '\u00a0');
+        } else if (i === nodes.length - 1 && d.suffix) {
+          selection.append('span').text(d.suffix);
+        }
+      });
+
+    shortcutKeys
+      .filter((d) => !!d.gesture)
+      .each(function () {
+        const selection = d3_select<HTMLElement, CmdSequence>(this);
+
+        selection.append('span').text('+');
+
+        selection
+          .append('span')
+          .attr('class', 'gesture')
+          .html((d) => t.html(d.gesture));
+      });
+  };
+}

--- a/modules/ui/command_bar.ts
+++ b/modules/ui/command_bar.ts
@@ -1,0 +1,159 @@
+import { select as d3_select } from 'd3-selection';
+import { COMMAND_CATEGORIES, t, type Command } from '../core';
+import { uiCmd } from './cmd';
+import { uiCmdSequence } from './cmd_sequence';
+import { isElementScrolledIntoView } from '../util/layout';
+
+const MAX_RECENTS = 8;
+
+export function uiCommandBar(context: iD.Context) {
+  let _selection = d3_select<HTMLDialogElement, never>(null!);
+  let _selectedId: string | undefined;
+  let _searchValue = '';
+  let _filteredEntries: Command[] = [];
+  let _recentlyUsed: string[] = [];
+
+  function execute(event: MouseEvent | KeyboardEvent, entry: Command) {
+    // remember the N most recently used commands
+    _recentlyUsed = _recentlyUsed
+      .filter((id) => id !== entry.id)
+      .slice(0, MAX_RECENTS - 1);
+    _recentlyUsed.unshift(entry.id);
+
+    // reset state
+    _selectedId = undefined;
+    _searchValue = '';
+    const input = _selection.select<HTMLInputElement>('input').node();
+    if (input) input.value = '';
+
+    _selection.node()?.close();
+    entry.action(event);
+  }
+
+  function onKeyDown(event: KeyboardEvent) {
+    // trigger the currently-selected item
+    if (event.key === 'Enter' && _selectedId) {
+      const selected = context.commands.registry[_selectedId];
+      if (selected) execute(event, selected);
+    }
+
+    // navigate up & down the list
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      const index = _filteredEntries.findIndex((x) => x.id === _selectedId);
+
+      const newIndex =
+        event.key === 'ArrowDown'
+          ? Math.min(index + 1, _filteredEntries.length - 1)
+          : Math.max(index - 1, 0);
+
+      const newId = _filteredEntries[newIndex]?.id;
+      _selectedId = newId;
+      event.preventDefault();
+      reRenderList();
+      return;
+    }
+  }
+
+  /** called as the user types or navigates the list */
+  function reRenderList() {
+    const allCommands = context.commands.getAll();
+
+    // TODO: use utilEditDistance like the preset searchbar?
+
+    _filteredEntries = _searchValue
+      ? // if there is a search query, only show matching results
+        allCommands.filter((t) =>
+          t.label.toLowerCase().includes(_searchValue.toLowerCase()),
+        )
+      : // else, show recently used first, then all others
+        [
+          ..._recentlyUsed.map((id) => context.commands.registry[id]),
+          ...allCommands.filter((x) => !_recentlyUsed.includes(x.id)),
+        ];
+
+    _selection
+      .select('.command-bar-no-results')
+      .classed('hide', !!_filteredEntries.length);
+
+    const ul = _selection.select('div').select('ul');
+
+    const li = ul
+      .selectAll<HTMLLIElement, Command>('li')
+      .data(_filteredEntries, (d) => d?.id)
+      .order();
+
+    const liEnter = li.enter().append('li').on('click', execute);
+
+    liEnter
+      .append('span')
+      .text((d) => `${COMMAND_CATEGORIES[d.categoryId]()}: ${d.label}`);
+
+    liEnter.each(function (d) {
+      if (!d.keyboardShortcut) return;
+      uiCmdSequence(d.keyboardShortcut)(d3_select(this));
+    });
+
+    liEnter
+      .merge(li)
+      .classed('command-bar-selected', (d) => d.id === _selectedId)
+      .classed('command-bar-recently-used', (d) => _recentlyUsed.includes(d.id))
+      .each(function (d) {
+        if (d.id === _selectedId) {
+          // this list item is selected, so ensure that it's in view
+          if (!isElementScrolledIntoView(this, this.parentElement!)) {
+            this.scrollIntoView({ behavior: 'smooth' });
+          }
+        }
+      });
+    li.exit().remove();
+  }
+
+  /** called once */
+  function render(selection: typeof _selection) {
+    _selection = selection.append('dialog').classed('command-bar', true);
+
+    const wrapper = _selection.append('div');
+
+    wrapper
+      .append('input')
+      .attr('placeholder', t('command-bar.placeholder'))
+      .on('input', (event) => {
+        _searchValue = event.target.value;
+        reRenderList();
+      })
+      .on('keydown', onKeyDown);
+
+    wrapper.append('ul').data([]);
+    reRenderList();
+
+    wrapper
+      .append('div')
+      .classed('command-bar-no-results', true)
+      .classed('hide', true)
+      .text('No Results!');
+
+    const footer = wrapper.append('footer');
+
+    const section1 = footer.append('section');
+    section1.append('kbd').attr('class', 'shortcut').text(uiCmd.display('↑'));
+    section1.append('kbd').attr('class', 'shortcut').text(uiCmd.display('↓'));
+    section1.append('span').text(' ' + t('command-bar.help.navigate_list'));
+
+    const section2 = footer.append('section');
+    section2.append('kbd').attr('class', 'shortcut').text(uiCmd.display('↩'));
+    section2.append('span').text(' ' + t('command-bar.help.execute'));
+
+    const section3 = footer.append('section');
+    section3.append('kbd').attr('class', 'shortcut').text(uiCmd.display('⎋'));
+    section3.append('span').text(' ' + t('command-bar.help.exit'));
+  }
+
+  function activate() {
+    reRenderList();
+    _selection.node()?.showModal();
+  }
+
+  context.keybinding().on('⌘' + t('command-bar.key'), activate);
+
+  return render;
+}

--- a/modules/ui/info.js
+++ b/modules/ui/info.js
@@ -138,6 +138,13 @@ export function uiInfo(context) {
                     d3_event.preventDefault();
                     info.toggle(k);
                 });
+            context.commands.register({
+                categoryId: 'panels',
+                id: 'toggle_panel_measurement',
+                label: t('shortcuts.tools.info.' + k),
+                action: () => info.toggle(k),
+                keyboardShortcut: { shortcuts: [key], modifiers: ['⌘', '⇧'] },
+            });
         });
     }
 

--- a/modules/ui/init.js
+++ b/modules/ui/init.js
@@ -41,6 +41,7 @@ import { uiVersion } from './version';
 import { uiZoom } from './zoom';
 import { uiZoomToSelection } from './zoom_to_selection';
 import { uiCmd } from './cmd';
+import { uiCommandBar } from './command_bar';
 
 import { uiPaneBackground } from './panes/background';
 import { uiPaneHelp } from './panes/help';
@@ -122,6 +123,9 @@ export function uiInit(context) {
         // setup fullscreen keybindings (no button shown at this time)
         container
             .call(uiFullScreen(context));
+
+        container
+            .call(uiCommandBar(context));
 
         var map = context.map();
         map.redrawEnable(false);  // don't draw until we've set zoom/lat/long

--- a/modules/ui/pane.js
+++ b/modules/ui/pane.js
@@ -26,6 +26,13 @@ export function uiPane(id, context) {
     pane.label = function(val) {
         if (!arguments.length) return _label;
         _label = val;
+        context.commands.register({
+            categoryId: 'panels',
+            id: `panel-${id}`,
+            label: t(val.stringId),
+            keyboardShortcut: { shortcuts: [_key] },
+            action: () => pane.togglePane(),
+        });
         return pane;
     };
 

--- a/modules/ui/sections/data_layers.js
+++ b/modules/ui/sections/data_layers.js
@@ -13,6 +13,7 @@ import { uiCmd } from '../cmd';
 import { uiSection } from '../section';
 import { uiSettingsCustomData } from '../settings/custom_data';
 
+/** @param {iD.Context} context */
 export function uiSectionDataLayers(context) {
 
     var settingsCustomData = uiSettingsCustomData(context)
@@ -100,12 +101,28 @@ export function uiSectionDataLayers(context) {
                             .keys([uiCmd('⌥' + t('area_fill.wireframe.key'))])
                             .placement('bottom')
                         );
+                    context.commands.register({
+                        categoryId: 'background',
+                        id: `toggle_layer-${d.id}`,
+                        label: `Toggle ‘${t(`map_data.layers.${d.id}.title`)}’`, // TODO: i18n
+                        action: () => toggleLayer(d.id),
+                        terms: [t(`map_data.layers.${d.id}.tooltip`)],
+                        keyboardShortcuts: ['⌥' + t('area_fill.wireframe.key')],
+                    });
                 } else {
                     d3_select(this)
                         .call(uiTooltip()
                             .title(() => t.append('map_data.layers.' + d.id + '.tooltip'))
                             .placement('bottom')
                         );
+                    context.commands.register({
+                        categoryId: 'background',
+                        id: `toggle_layer-${d.id}`,
+                        label: `Toggle ‘${t(`map_data.layers.${d.id}.title`)}’`, // TODO: i18n
+                        action: () => toggleLayer(d.id),
+                        terms: [t(`map_data.layers.${d.id}.tooltip`)],
+                        keyboardShortcuts: [],
+                    });
                 }
             });
 
@@ -158,6 +175,13 @@ export function uiSectionDataLayers(context) {
                         .title(() => t.append('map_data.layers.' + d.id + '.tooltip'))
                         .placement('bottom')
                     );
+                context.commands.register({
+                    categoryId: 'background',
+                    id: `toggle_layer-${d.id}`,
+                    label: `Toggle ‘${t(`map_data.layers.${d.id}.title`)}’`, // TODO: i18n
+                    action: () => toggleLayer(d.id),
+                    terms: [t(`map_data.layers.${d.id}.tooltip`)],
+                });
             });
 
         labelEnter

--- a/modules/ui/shortcuts.js
+++ b/modules/ui/shortcuts.js
@@ -1,16 +1,11 @@
 import { select as d3_select } from 'd3-selection';
-
 import { fileFetcher } from '../core/file_fetcher';
 import { t } from '../core/localizer';
-import { svgIcon } from '../svg/icon';
-import { uiCmd } from './cmd';
 import { uiModal } from './modal';
-import { utilArrayUniq } from '../util';
-import { utilDetect } from '../util/detect';
+import { uiCmdSequence } from './cmd_sequence';
 
 
 export function uiShortcuts(context) {
-    var detected = utilDetect();
     var _activeTab = 0;
     var _modalSelection;
     var _selection = d3_select(null);
@@ -127,109 +122,13 @@ export function uiShortcuts(context) {
         var shortcutRows = rowsEnter
             .filter(function (d) { return d.shortcuts; });
 
-        var shortcutKeys = shortcutRows
+        shortcutRows
             .append('td')
-            .attr('class', 'shortcut-keys');
-
-        var modifierKeys = shortcutKeys
-            .filter(function (d) { return d.modifiers; });
-
-        modifierKeys
-            .selectAll('kbd.modifier')
-            .data(function (d) {
-                if (detected.os === 'win' && d.text === 'shortcuts.editing.commands.redo') {
-                    return ['⌘'];
-                } else if (detected.os !== 'mac' && d.text === 'shortcuts.browsing.display_options.fullscreen') {
-                    return [];
-                } else {
-                    return d.modifiers;
-                }
-            })
-            .enter()
-            .each(function () {
-                var selection = d3_select(this);
-
-                selection
-                    .append('kbd')
-                    .attr('class', 'modifier')
-                    .text(function (d) { return uiCmd.display(d); });
-
-                selection
-                    .append('span')
-                    .text('+');
+            .attr('class', 'shortcut-keys')
+            .each(function (d) {
+                uiCmdSequence(d)(d3_select(this));
             });
 
-
-        shortcutKeys
-            .selectAll('kbd.shortcut')
-            .data(function (d) {
-                var arr = d.shortcuts;
-                if (detected.os === 'win' && d.text === 'shortcuts.editing.commands.redo') {
-                    arr = ['Y'];
-                } else if (detected.os !== 'mac' && d.text === 'shortcuts.browsing.display_options.fullscreen') {
-                    arr = ['F11'];
-                }
-
-                // replace translations
-                arr = arr.map(function(s) {
-                    return uiCmd.display(s.indexOf('.') !== -1 ? t(s) : s);
-                });
-
-                return utilArrayUniq(arr).map(function(s) {
-                    return {
-                        shortcut: s,
-                        separator: d.separator,
-                        suffix: d.suffix
-                    };
-                });
-            })
-            .enter()
-            .each(function (d, i, nodes) {
-                var selection = d3_select(this);
-                var click = d.shortcut.toLowerCase().match(/(.*).click/);
-
-                if (click && click[1]) {   // replace "left_click", "right_click" with mouse icon
-                    selection
-                        .call(svgIcon('#iD-walkthrough-mouse-' + click[1], 'operation'));
-                } else if (d.shortcut.toLowerCase() === 'long-press') {
-                    selection
-                        .call(svgIcon('#iD-walkthrough-longpress', 'longpress operation'));
-                } else if (d.shortcut.toLowerCase() === 'tap') {
-                    selection
-                        .call(svgIcon('#iD-walkthrough-tap', 'tap operation'));
-                } else {
-                    selection
-                        .append('kbd')
-                        .attr('class', 'shortcut')
-                        .text(function (d) { return d.shortcut; });
-                }
-
-                if (i < nodes.length - 1) {
-                    selection
-                        .append('span')
-                        .html(d.separator || '\u00a0' + t.html('shortcuts.or') + '\u00a0');
-                } else if (i === nodes.length - 1 && d.suffix) {
-                    selection
-                        .append('span')
-                        .text(d.suffix);
-                }
-            });
-
-
-        shortcutKeys
-            .filter(function(d) { return d.gesture; })
-            .each(function () {
-                var selection = d3_select(this);
-
-                selection
-                    .append('span')
-                    .text('+');
-
-                selection
-                    .append('span')
-                    .attr('class', 'gesture')
-                    .html(function (d) { return t.html(d.gesture); });
-            });
 
 
         shortcutRows

--- a/modules/ui/zoom.js
+++ b/modules/ui/zoom.js
@@ -102,11 +102,39 @@ export function uiZoom(context) {
         utilKeybinding.plusKeys.forEach(function(key) {
             context.keybinding().on([key], zoomIn);
             context.keybinding().on([uiCmd('⌥' + key)], zoomInFurther);
+            context.commands.register({
+                categoryId: 'behavior',
+                id: 'zoom_in',
+                label: t('shortcuts.browsing.navigation.zoom'), // TODO: bad label
+                action: zoomIn,
+                keyboardShortcut: { shortcuts: [key] },
+            });
+            context.commands.register({
+                categoryId: 'behavior',
+                id: 'zoom_in_more',
+                label: t('shortcuts.browsing.navigation.zoom_more'), // TODO: bad label
+                action: zoomInFurther,
+                keyboardShortcut: { modifiers: ['⌥'], shortcuts: [key] },
+            });
         });
 
         utilKeybinding.minusKeys.forEach(function(key) {
             context.keybinding().on([key], zoomOut);
             context.keybinding().on([uiCmd('⌥' + key)], zoomOutFurther);
+            context.commands.register({
+                categoryId: 'behavior',
+                id: 'zoom_out',
+                label: t('shortcuts.browsing.navigation.zoom'), // TODO: bad label
+                action: zoomOut,
+                keyboardShortcut: { shortcuts: [key] },
+            });
+            context.commands.register({
+                categoryId: 'behavior',
+                id: 'zoom_out_more',
+                label: t('shortcuts.browsing.navigation.zoom_more'), // TODO: bad label
+                action: zoomOutFurther,
+                keyboardShortcut: { modifiers: ['⌥'], shortcuts: [key] },
+            });
         });
 
         function updateButtonStates() {

--- a/modules/util/layout.ts
+++ b/modules/util/layout.ts
@@ -1,0 +1,18 @@
+/**
+ * returns true if `child` is visible relative to its
+ * scrolling-`parent`.
+ */
+export function isElementScrolledIntoView(
+  child: HTMLElement,
+  parent: HTMLElement,
+) {
+  const parentRect = parent.getBoundingClientRect();
+  const childRect = child.getBoundingClientRect();
+
+  return (
+    childRect.top >= parentRect.top &&
+    childRect.bottom <= parentRect.bottom &&
+    childRect.left >= parentRect.left &&
+    childRect.right <= parentRect.right
+  );
+}


### PR DESCRIPTION
Closes #8801 

When you press <kbd>Ctrl</kbd> <kbd>K</kbd>[^1], you get a 'command bar' where you can search for any iD setting, instead of clicking through the menus. This is most valuable for commands that have no keyboard shortcut.

<table>
<tr>
<td><img height="589" alt="image" src="https://github.com/user-attachments/assets/79770e86-eb14-4195-bc3f-82b7e9714b9c" /></td>
<td><img height="589" alt="image" src="https://github.com/user-attachments/assets/17bcde47-44dc-41bd-be9a-c09005ab0999" /></td>
</tr>
</table>

The design is based on the command bar in VSCode and the Chrome Dev Tools, which I use on a daily basis.

This is an early prototype to get feedback; it only has a few commands available. Adding more commands should probably be done in a follow-up PR, so that this one doesn't become too big.

[^1]: the exact shortcut needs discussion, see https://github.com/openstreetmap/iD/issues/10479#issuecomment-3316119174
