### PR TITLE
Fix Node selection at stacked vertices

### DIFF
--- a/modules/svg/vertices.js
+++ b/modules/svg/vertices.js
@@ -199,11 +199,40 @@ export function svgVertices(projection, context) {
     }
 
 
+    // Node ids of every selected way, so we can keep their vertices on top when stacked.
+    function selectedWayNodeIDs(graph) {
+        var ids = {};
+        context.selectedIDs().forEach(function(id) {
+            var entity = graph.hasEntity(id);
+            if (entity && entity.type === 'way') {
+                entity.nodes.forEach(function(nodeID) { ids[nodeID] = true; });
+            }
+        });
+        return ids;
+    }
+
+    // Sort so the selected way's vertex is last (drawn on top), so it receives the pointer
+    // when targets stack at the same location. Z-order only matters where circles overlap.
+    // A vertex of a selected way ranks above a merely co-selected node, which ranks above the
+    // rest - this keeps the right endpoint grabbable after e.g. disconnecting it. #11314
+    function sortTouchByLocSelected(items, wayNodeIDs) {
+        function rank(item) {
+            var id = item.properties.entity.id;
+            if (id in wayNodeIDs) return 2;
+            if (id in _currSelected) return 1;
+            return 0;
+        }
+        items.sort(function(a, b) {
+            return rank(a) - rank(b);
+        });
+    }
+
     function drawTargets(selection, graph, entities, filter) {
         var targetClass = context.getDebug('target') ? 'pink ' : 'nocolor ';
         var nopeClass = context.getDebug('target') ? 'red ' : 'nocolor ';
         var getTransform = svgPointTransform(projection).geojson;
         var activeID = context.activeID();
+        var wayNodeIDs = selectedWayNodeIDs(graph);
         var data = { targets: [], nopes: [] };
 
         entities.forEach(function(node) {
@@ -234,6 +263,10 @@ export function svgVertices(projection, context) {
             }
         });
 
+        // At stacked locations, put the selected way's vertex last so it ends up on top. #11314
+        sortTouchByLocSelected(data.targets, wayNodeIDs);
+        sortTouchByLocSelected(data.nopes, wayNodeIDs);
+
         // Targets allow hover and vertex snapping
         var targets = selection.selectAll('.vertex.target-allowed')
             .filter(function(d) { return filter(d.properties.entity); })
@@ -251,6 +284,7 @@ export function svgVertices(projection, context) {
                   || radiuses.shadow[3];
             })
             .merge(targets)
+            .order()  // keep DOM order in sync with the sorted data (selected vertex on top) #11314
             .attr('class', function(d) {
                 return 'node vertex target target-allowed '
                 + targetClass + d.id;
@@ -272,6 +306,7 @@ export function svgVertices(projection, context) {
             .append('circle')
             .attr('r', function(d) { return (_radii[d.properties.entity.id] || radiuses.shadow[3]); })
             .merge(nopes)
+            .order()  // keep DOM order in sync with the sorted data (selected vertex on top) #11314
             .attr('class', function(d) { return 'node vertex target target-nope ' + nopeClass + d.id; })
             .attr('transform', getTransform);
     }

--- a/test/spec/svg/vertices.js
+++ b/test/spec/svg/vertices.js
@@ -27,4 +27,76 @@ describe('iD.svgVertices', function () {
         surface.call(iD.svgVertices(projection, context), graph, [node], filter, extent);
         expect(surface.select('.vertex').classed('shared')).to.be.true;
     });
+
+
+    // Regression for #11314: disconnected ways with coincident endpoints. The bug was
+    // touch-layer DOM order not matching sorted data after selection changed, so the
+    // wrong node received pointer events. We assert z-order (last circle = on top) rather
+    // than simulating click-drag through behaviorDrag (heavy, flaky in jsdom).
+    describe('stacked endpoint hit-target order (#11314)', function () {
+        var drawVertices;
+        var stackLoc = [0, 0];
+        var nodeA, nodeB, nodeOffA, nodeOffB, wayA, wayB;
+        var entities, filter, extent;
+
+        function redrawVertices(fullRedraw) {
+            surface
+                .call(drawVertices.drawSelected, context.graph(), extent)
+                .call(drawVertices, context.graph(), entities, filter, extent, fullRedraw);
+        }
+
+        function topStackedTouchEntityId() {
+            var circles = surface.selectAll('.layer-touch.points circle.vertex.target').nodes()
+                .filter(function(node) {
+                    var loc = node.__data__.properties.entity.loc;
+                    return loc[0] === stackLoc[0] && loc[1] === stackLoc[1];
+                });
+
+            expect(circles).to.have.length(2);
+            return circles[circles.length - 1].__data__.properties.entity.id;
+        }
+
+        beforeEach(function () {
+            nodeA = iD.osmNode({ loc: stackLoc });
+            nodeB = iD.osmNode({ loc: stackLoc });
+            nodeOffA = iD.osmNode({ loc: [1, 0] });
+            nodeOffB = iD.osmNode({ loc: [0, 1] });
+            wayA = iD.osmWay({ nodes: [nodeA.id, nodeOffA.id], tags: { highway: 'residential' } });
+            wayB = iD.osmWay({ nodes: [nodeB.id, nodeOffB.id], tags: { highway: 'service' } });
+            entities = [nodeA, nodeB, nodeOffA, nodeOffB, wayA, wayB];
+
+            context.perform(
+                iD.actionAddEntity(nodeA),
+                iD.actionAddEntity(nodeB),
+                iD.actionAddEntity(nodeOffA),
+                iD.actionAddEntity(nodeOffB),
+                iD.actionAddEntity(wayA),
+                iD.actionAddEntity(wayB)
+            );
+
+            drawVertices = iD.svgVertices(projection, context);
+            filter = function() { return true; };
+            extent = iD.geoExtent([-1, -1], [2, 2]);
+        });
+
+        it('puts the selected way\'s endpoint on top in the touch layer', function () {
+            context.enter(iD.modeSelect(context, [wayA.id]));
+            redrawVertices(true);
+            expect(topStackedTouchEntityId()).to.equal(nodeA.id);
+
+            context.enter(iD.modeSelect(context, [wayB.id]));
+            redrawVertices(true);
+            expect(topStackedTouchEntityId()).to.equal(nodeB.id);
+        });
+
+        it('reorders touch targets after selection changes via drawSelected', function () {
+            context.enter(iD.modeSelect(context, [wayA.id]));
+            redrawVertices(true);
+            expect(topStackedTouchEntityId()).to.equal(nodeA.id);
+
+            context.enter(iD.modeSelect(context, [wayB.id]));
+            surface.call(drawVertices.drawSelected, context.graph(), extent);
+            expect(topStackedTouchEntityId()).to.equal(nodeB.id);
+        });
+    });
 });


### PR DESCRIPTION
> [!NOTE]
> _Update 2026-04-30:_ After Kyles Code Review I did a full cleanup and another round of fixes with Opus 4.8 High an tested the results manually.

This is a take at fixing https://github.com/openstreetmap/iD/issues/11314.
There are a couple of more tickets that sound similar: https://github.com/openstreetmap/iD/issues/8174, https://github.com/openstreetmap/iD/issues/2206 and other already closed issues.

I find this issue annoying again and again and using the changes here feel like a good improvement.

---

## Fix: wrong node grabbed at stacked vertices after disconnect

### Problem

When two vertices stack at the exact same location and **both** are part of the current selection, the touch layer put the wrong one on top, so dragging grabbed the wrong feature.

Repro: select line 1 (which shares a middle node with line 2), shift-click that node to disconnect line 1, then immediately drag the node. Line 1 stays highlighted, but line 2 moves instead.

### Root cause

Disconnecting gives the selected way a brand-new vertex stacked on top of the original shared node. Both ended up in `_currSelected` (the way's child vertices *and* the co-selected junction node), so `sortTouchByLocSelected`'s `selected vs. not-selected` comparator returned a tie and left the wrong node's hit-target on top.

### Fix

`sortTouchByLocSelected` now ranks stacked touch targets in three tiers instead of two:

1. vertex of a **selected way** (highest)
2. a merely co-selected node
3. everything else

This guarantees the selected way's endpoint stays on top and grabbable. The fix is deterministic and requires no redraw/timing changes.
