### PR TITLE
Improve focus visibility for action buttons in note editor

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -408,6 +408,11 @@ button.action:focus,
 button.action:active {
     background: var(--link-focus-color);
 }
+.buttons .button:focus-visible {
+  outline: none !important;
+  border: 3px solid #ffffff !important;
+  box-shadow: 0 0 0 3px rgba(13, 110, 253, 0.8) !important;
+}
 button.secondary-action {
     background: var(--bg-color-3);
     font-weight: bold;


### PR DESCRIPTION
The current focus state for `button.action` only changes the background
color slightly, which results in very low contrast when navigating with
the keyboard.

This change adds a visible focus outline for `button.action:focus-visible`
so the focused button is clearly distinguishable during keyboard
navigation.

Fixes #11948