### PR TITLE
Allow extending multi-selection with Shift while preventing duplicate…

### DIFF
--- a/modules/behavior/lasso.js
+++ b/modules/behavior/lasso.js
@@ -6,7 +6,6 @@ import { uiLasso } from '../ui/lasso';
 import { utilArrayIntersection } from '../util/array';
 import { utilGetAllNodes } from '../util/util';
 
-
 export function behaviorLasso(context) {
 
     // use pointer events on supported platforms; fallback to mouse events
@@ -102,7 +101,7 @@ export function behaviorLasso(context) {
         }
 
 
-        function pointerup() {
+        function pointerup(e) {
             d3_select(window)
                 .on(_pointerPrefix + 'move.lasso', null)
                 .on(_pointerPrefix + 'up.lasso', null);
@@ -111,9 +110,16 @@ export function behaviorLasso(context) {
 
             var ids = lassoed();
             lasso.close();
-
             if (ids.length) {
-                context.enter(modeSelect(context, ids));
+
+                let newIDs = ids;
+
+                if (e && e.shiftKey) {
+                    const current = context.selectedIDs();
+                    newIDs = Array.from(new Set([...current, ...ids]));
+                }
+
+                context.enter(modeSelect(context, newIDs));
             }
         }
 

--- a/modules/behavior/lasso.js
+++ b/modules/behavior/lasso.js
@@ -112,7 +112,7 @@ export function behaviorLasso(context) {
             lasso.close();
             if (ids.length) {
 
-                let newIDs = ids;
+                var newIDs = ids;
 
                 if (e && e.shiftKey) {
                     const current = context.selectedIDs();

--- a/modules/modes/select.js
+++ b/modules/modes/select.js
@@ -27,7 +27,6 @@ import {
     utilEntitySelector, utilKeybinding, utilTotalExtent, utilGetAllNodes
 } from '../util';
 
-
 export function modeSelect(context, selectedIDs) {
     var mode = {
         id: 'select',


### PR DESCRIPTION
This change improves multi-selection usability by allowing users to extend the
current selection using Shift + click and Shift + lasso.
Vedio of fixes: https://drive.google.com/file/d/13wMn-91atIUZN0aL4xTrUWcIgXCHHrDE/view?usp=sharing

Previously, new selections would replace the existing selection, making it
difficult to incrementally build a multi-selection.

The implementation merges the current selection (`context.selectedIDs()`)
with the newly selected IDs while ensuring uniqueness using `Set()` to avoid
duplicate entity IDs.

Behavior after this change:
- Click → replaces selection
- Shift + click → adds entity to selection
- Shift + lasso → adds entities to selection
- Selecting an already selected entity does not create duplicates.

This addresses usability issue #11134.