### PR TITLE
Render `access=unknown` as raw tag; but only the label

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -2486,8 +2486,11 @@ div.combobox:has(.has-description) {
     white-space: normal;
     padding-top: 2px;
 }
-.combobox .combobox-option.raw-option {
+.combobox .combobox-option.raw-option .combobox-option-label {
     font-family: monospace;
+    color: var(--text-color);
+}
+.combobox .combobox-option.raw-option .combobox-option-description {
     color: var(--text-color);
 }
 

--- a/modules/ui/fields/access.js
+++ b/modules/ui/fields/access.js
@@ -98,13 +98,17 @@ export function uiFieldAccess(field, context) {
             options.splice(options.length - 4, 0, 'dismount');
         }
 
-        var stringsField = field.resolveReference('stringsCrossReference');
+        const stringsField = field.resolveReference('stringsCrossReference');
         return options.map(function(option) {
+            const isRawKey = option === 'unknown';
+            const description = stringsField.hasTextForStringId('options.' + option + '.description')
+                ? stringsField.t('options.' + option + '.description') : undefined;
+            const title = isRawKey ? option : stringsField.t('options.' + option + '.description');
             return {
-                title: stringsField.t('options.' + option + '.description'),
-                description: stringsField.hasTextForStringId('options.' + option + '.description')
-                    ? stringsField.t('options.' + option + '.description') : undefined,
-                value: option
+                title: title,
+                description: description,
+                value: option,
+                klass: isRawKey ? 'raw-option' : ''
             };
         });
     };


### PR DESCRIPTION
Follow up to https://github.com/openstreetmap/iD/pull/12010 which introduced the description line below the label.
This PR changes the style, so that only the label is affected by the raw tag class and the description gets the regular font style.

Related to https://github.com/openstreetmap/iD/pull/12011.

A bit related to https://github.com/openstreetmap/iD/pull/12010 but should be mergable independently.

**Why…**

A while back we introduced a style difference between fields values from the preset that we promote as translated values and the raw values. IMO the `unknown` value in the access field is more like the raw tags than a promoted, translated value.

As such, we should render it differently; which this PR does.

We could also argue that we should not promote the value at all given that it is not used too often https://taginfo.openstreetmap.org/search?q=unknown#values and the field will render values other than the recommendations just fine… just not promote them.

https://wiki.openstreetmap.org/wiki/Tag:access%3Dunknown

---

Should we decide not to change rendering of the `access=unknown` I would extract the style changes here because they are a better fit IMO than what we have now. Even if https://github.com/openstreetmap/iD/pull/12010 clarifies that this combination is not used ATM, the combination is still valid from a code point of view.

---

The code in this PR is created using Cursor with LLM support. I reviewed it and tested it.