### PR TITLE
Fix background list tooltip showing 'undefined' (fixes #12013)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Add explanation how to fix "point should be vertex" validation warning ([#10958])
 * Suggest to "reposition features" before other fixes when the validator found overlapping buildings ([#11329])
 #### :bug: Bugfixes
+* Fix background list tooltip showing "undefined" for some imagery layers ([#12013])
 * Fix the sorting of tag values when multiple objects' tags are combined in `utilCombinedTags` ([#11932], thanks [@JaiswalShivang])
 * Don't change the value of `railway:turnout_side` when reversing a railway track ([#11645])
 * Fix a bug where the _squaring_ operation would remove a whole corner if it had duplicate vertices (same coordinates, but different node ids) at that point ([#9155])
@@ -92,6 +93,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#11952]: https://github.com/openstreetmap/iD/pull/11952
 [#11965]: https://github.com/openstreetmap/iD/pull/11965
 [#11976]: https://github.com/openstreetmap/iD/pull/11976
+[#12013]: https://github.com/openstreetmap/iD/issues/12013
 [@Shrinks99]: https://github.com/Shrinks99
 [@Vectorial1024]: https://github.com/Vectorial1024
 [@Oni-DOS]: https://github.com/Oni-DOS

--- a/modules/renderer/background_source.js
+++ b/modules/renderer/background_source.js
@@ -74,7 +74,13 @@ export function rendererBackgroundSource(data) {
     source.hasDescription = function() {
         var id_safe = source.id.replace(/\./g, '<TX_DOT>');
         var descriptionText = localizer.tInfo('imagery.' + id_safe + '.description', { default: _description }).text;
-        return descriptionText !== '';
+        return !!descriptionText;
+    };
+
+
+    source.descriptionText = function() {
+        var id_safe = source.id.replace(/\./g, '<TX_DOT>');
+        return t('imagery.' + id_safe + '.description', { default: _description });
     };
 
 

--- a/modules/ui/sections/background_list.js
+++ b/modules/ui/sections/background_list.js
@@ -138,10 +138,8 @@ export function uiSectionBackgroundList(context) {
     function setTooltips(selection) {
         selection.each(function(d, i, nodes) {
             var item = d3_select(this).select('label');
-            var span = item.select('span');
             var placement = (i < nodes.length / 2) ? 'bottom' : 'top';
             var hasDescription = d.hasDescription();
-            var isOverflowing = (span.property('clientWidth') !== span.property('scrollWidth'));
 
             item.call(uiTooltip().destroyAny);
 
@@ -151,10 +149,13 @@ export function uiSectionBackgroundList(context) {
                     .title(() => t.append('background.switch'))
                     .keys([uiCmd('⌘' + t('background.key'))])
                 );
-            } else if (hasDescription || isOverflowing) {
+            } else {
                 item.call(uiTooltip()
                     .placement(placement)
-                    .title(() => hasDescription ? d.description() : d.label())
+                    .title(() => {
+                        var text = (hasDescription ? d.descriptionText() : d.name());
+                        return (text !== null && text !== undefined && text !== '') ? text : d.id;
+                    })
                 );
             }
         });


### PR DESCRIPTION
Problem  
When hovering over certain background layers in the Background panel, the tooltip displayed the literal text "undefined."

Before the fix, hovering over the background URL tooltip would show "undefined."
After the fix, all layers now display a tooltip with either the name, description, or ID and no more "undefined."
Running `npm test`locally confirms all existing tests pass.

fixes #12013