### PR TITLE
Fix npm run build:stats

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build": "run-s build:css build:data build:js",
     "build:css": "node scripts/build_css.js",
     "build:data": "shx mkdir -p dist/data && node scripts/build_data.js",
-    "build:stats": "node config/esbuild.config.js --stats && esbuild-visualizer --metadata dist/esbuild.json --exclude *.png --filename docs/statistics.html && shx rm dist/esbuild.json",
+    "build:stats": "node config/esbuild.config.js --stats && esbuild-visualizer --metadata dist/esbuild.json --filename docs/statistics.html && shx rm -f dist/esbuild.json",
     "build:js": "node config/esbuild.config.js",
     "build:js:watch": "node config/esbuild.config.js --watch",
     "clean": "shx rm -f dist/esbuild.json dist/*.js dist/*.map dist/*.css dist/img/*.svg",


### PR DESCRIPTION
The script we have currently fails:

```
% npm run build:stats

> @openstreetmap/id@2.39.0-dev build:stats
> node config/esbuild.config.js --stats && esbuild-visualizer --metadata dist/esbuild.json --exclude *.png --filename docs/statistics.html && shx rm dist/esbuild.json

Optionen:
  --version   Version anzeigen                                         [boolean]
  --filename  Output file name               [string] [Standard: "./stats.html"]
  --title     Output file title        [string] [Standard: "EsBuild Visualizer"]
  --template  Template type
  [string] [Möglichkeiten: "sunburst", "treemap", "network", "list", "raw-data"]
                                                           [Standard: "treemap"]
  --metadata  Input file name            [array] [Standard: ["./metadata.json"]]
  --open      Open file in browser                   [boolean] [Standard: false]
  --help      Hilfe anzeigen                                           [boolean]

Unbekanntes Argument: exclude
```

After this change, it works:

```
% npm run build:stats

> @openstreetmap/id@2.39.0-dev build:stats
> node config/esbuild.config.js --stats && esbuild-visualizer --metadata dist/esbuild.json --filename docs/statistics.html && shx rm -f dist/esbuild.json
```

* Removed `--exclude *.png` – esbuild-visualizer doesn’t support this option (it was causing “Unknown argument: exclude”), and *.png was being expanded by the shell.
* Added `-f` to `shx rm` – So removing `dist/esbuild.json` doesn’t fail if the file is already missing.