### PR TITLE
Show partial relation memberships in multiselection

### DIFF
--- a/modules/ui/sections/raw_membership_editor.js
+++ b/modules/ui/sections/raw_membership_editor.js
@@ -16,7 +16,7 @@ import { svgIcon } from '../../svg/icon';
 import { uiCombobox } from '../combobox';
 import { uiSection } from '../section';
 import { uiTooltip } from '../tooltip';
-import { utilArrayGroupBy, utilArrayIntersection } from '../../util/array';
+import { utilArrayGroupBy} from '../../util/array';
 import { utilDisplayName, utilNoAuto, utilHighlightEntities, utilUniqueDomId } from '../../util';
 import { prefs } from '../../core';
 import { idMatch } from '../feature_list';
@@ -54,22 +54,22 @@ export function uiSectionRawMembershipEditor(context) {
     const recentlyAdded = new Set();
 
     function getAllParentRelations() {
-    var relationsMap = new Map();
+        var relationsMap = new Map();
 
-    for (var i = 0; i < _entityIDs.length; i++) {
-        var entity = context.graph().hasEntity(_entityIDs[i]);
-        if (!entity) continue;
+        for (var i = 0; i < _entityIDs.length; i++) {
+            var entity = context.graph().hasEntity(_entityIDs[i]);
+            if (!entity) continue;
 
-        var parents = context.graph().parentRelations(entity);
+            var parents = context.graph().parentRelations(entity);
 
-        for (var j = 0; j < parents.length; j++) {
-            var rel = parents[j];
-            relationsMap.set(rel.id, rel);   // ensures unique relations
+            for (var j = 0; j < parents.length; j++) {
+                var rel = parents[j];
+                relationsMap.set(rel.id, rel);   // ensures unique relations
+            }
         }
-    }
 
-    return Array.from(relationsMap.values());
-}
+        return Array.from(relationsMap.values());
+    }
 
     function getMemberships() {
 

--- a/modules/ui/sections/raw_membership_editor.js
+++ b/modules/ui/sections/raw_membership_editor.js
@@ -29,7 +29,7 @@ export function uiSectionRawMembershipEditor(context) {
             return _entityIDs && _entityIDs.length;
         })
         .label(function() {
-            var parents = getSharedParentRelations();
+            var parents = getAllParentRelations();
             var gt = parents.length > _maxMemberships ? '>' : '';
             var count = gt + parents.slice(0, _maxMemberships).length;
             return t.append('inspector.title_count', { title: t('inspector.relations'), count: count });
@@ -53,26 +53,28 @@ export function uiSectionRawMembershipEditor(context) {
     /** @type {Set<string>} relations that were added after this panel was opened */
     const recentlyAdded = new Set();
 
-    function getSharedParentRelations() {
-        var parents = [];
-        for (var i = 0; i < _entityIDs.length; i++) {
-            var entity = context.graph().hasEntity(_entityIDs[i]);
-            if (!entity) continue;
+    function getAllParentRelations() {
+    var relationsMap = new Map();
 
-            if (i === 0) {
-                parents = context.graph().parentRelations(entity);
-            } else {
-                parents = utilArrayIntersection(parents, context.graph().parentRelations(entity));
-            }
-            if (!parents.length) break;
+    for (var i = 0; i < _entityIDs.length; i++) {
+        var entity = context.graph().hasEntity(_entityIDs[i]);
+        if (!entity) continue;
+
+        var parents = context.graph().parentRelations(entity);
+
+        for (var j = 0; j < parents.length; j++) {
+            var rel = parents[j];
+            relationsMap.set(rel.id, rel);   // ensures unique relations
         }
-        return parents;
     }
+
+    return Array.from(relationsMap.values());
+}
 
     function getMemberships() {
 
         var memberships = [];
-        var relations = getSharedParentRelations().slice(0, _maxMemberships);
+        var relations = getAllParentRelations().slice(0, _maxMemberships);
 
         var isMultiselect = _entityIDs.length > 1;
 


### PR DESCRIPTION

https://github.com/user-attachments/assets/bc94cf24-2813-44fc-a501-3058140d8fb3

Currently, when multiple features are selected, the relation panel only shows relations shared by all selected entities. This hides relations that belong to only some of the selected features.
This PR changes the logic to collect the union of parent relations instead of the intersection, so all relation memberships are shown in the panel.
I also updated the relation count so it correctly reflects the number of displayed relations.
Example
Before:
Way A → R1
Way B → R2

Multiselect → Relations (0)

After:
Way A → R1
Way B → R2

Multiselect → Relations (no of relations) showing R1 and R2
Tested locally using real data with roads belonging to different bus route relations.
And at the bottom add:
Fixes #9198