### PR TITLE
Set 'Show Third Party Icons' unchecked by default to respect user pri…

### DIFF
--- a/modules/ui/sections/privacy.js
+++ b/modules/ui/sections/privacy.js
@@ -19,7 +19,7 @@ export function uiSectionPrivacy(context) {
 
       let thirdPartyIconsEnter = selection.select('.privacy-options-list')
         .selectAll('.privacy-third-party-icons-item')
-        .data([prefs('preferences.privacy.thirdpartyicons') || 'true'])
+        .data([prefs('preferences.privacy.thirdpartyicons') || 'false'])
         .enter()
         .append('li')
         .attr('class', 'privacy-third-party-icons-item')


### PR DESCRIPTION
Fixes #12019

Previously the "Show Third Party Icons" option defaulted to enabled due to:
prefs('preferences.privacy.thirdpartyicons') || 'true'

This change sets the default to false so that external icons are not loaded before the user explicitly enables the option.