### PR TITLE
Enhance API error messages in status bar

### DIFF
--- a/modules/ui/status.js
+++ b/modules/ui/status.js
@@ -48,10 +48,21 @@ export function uiStatus(context) {
                         osm.reloadApiStatus();
                     }, 2000);
 
-                    // eslint-disable-next-line no-warning-comments
-                    // TODO: nice messages for different error types
+                    var suffix = ' ';
+                    if (err) {
+                        if (err.status && err.statusText) {
+                            suffix = ` (${err.status} ${err.statusText}) `;
+                        } else if (err.statusText) {
+                            suffix = ` (${err.statusText}) `;
+                        } else if (err.message) {
+                            suffix = ` (${err.message}) `;
+                        } else if (typeof err === 'string') {
+                            suffix = ` (${err}) `;
+                        }
+                    }
+
                     selection
-                        .call(t.append('osm_api_status.message.error', { suffix: ' ' }))
+                        .call(t.append('osm_api_status.message.error', { suffix: suffix }))
                         .append('a')
                         .attr('href', '#')
                         // let the user manually retry their connection directly


### PR DESCRIPTION
## Summary:

This PR enhances the error reporting in the editor's status bar by appending specific details (such as HTTP status codes and error messages) from the OpenStreetMap API to the generic error message. Previously, when the OSM API encountered an error (e.g., 502 Bad Gateway or a network timeout), iD would display a generic localized message without explaining the specific cause. This resolves a `TODO` found in [modules/ui/status.js](cci:7://file:///d:/open%20source/iD/modules/ui/status.js:0:0-0:0):`// TODO: nice messages for different error types`

## Changes:

- Updated [modules/ui/status.js](cci:7://file:///d:/open%20source/iD/modules/ui/status.js:0:0-0:0) to introspect the `err` object returned by the API services.
- If the error contains a [status](cci:1://file:///d:/open%20source/iD/modules/services/osm.js:781:4-806:5) and `statusText` (like `502 Bad Gateway`), it is now appended to the main error message.
- If the error is a string or contains a `message`, that detail is appended instead.

## Testing:

- Fixed local CRLF line-ending issues to ensure a clean test environment.
- Ran the full test suite (`npm test`).
- Verified that **2255** tests across **133** suites passed successfully.
- Manually verified the dynamic suffix injection logic in `ui/status.js`.
