### PR TITLE
fix: tooltip undefined description 

### DIFF
--- a/modules/renderer/background_source.js
+++ b/modules/renderer/background_source.js
@@ -74,7 +74,7 @@ export function rendererBackgroundSource(data) {
     source.hasDescription = function() {
         var id_safe = source.id.replace(/\./g, '<TX_DOT>');
         var descriptionText = localizer.tInfo('imagery.' + id_safe + '.description', { default: _description }).text;
-        return descriptionText !== '';
+        return !!descriptionText;
     };
 
 


### PR DESCRIPTION
fixes: #12013 

I tried logging hasDescription and the descriptionText for the backgorunds and saw that even if descriptonText is undefined hasDescription is returned as true.

the issue lies in this line
`return descriptionText !== '';` in background_source.js;
`undefined !== ''` still
evaluates to true
fixed by replacing it with ` return !!descriptionText;`