### PR TITLE
Add foot=yes assumption on highway=living_street

### DIFF
--- a/modules/ui/fields/access.js
+++ b/modules/ui/fields/access.js
@@ -132,6 +132,9 @@ export function uiFieldAccess(field, context) {
                 foot: 'yes',
                 motor_vehicle: 'no'
             },
+            living_street: {
+                foot: 'yes'
+            },
             cycleway: {
                 motor_vehicle: 'no',
                 bicycle: 'designated'


### PR DESCRIPTION
fixes #12035

may be argued that `designated` is better, at least in some areas but `yes` is definitely better than "Not specified" that strongly encourages overtagging

other modes are sadly less obvious