### PR TITLE
refactor dark mode switcher, to simplify the css compilation process 

### DIFF
--- a/css/10_colors.css
+++ b/css/10_colors.css
@@ -65,8 +65,7 @@
     --error-icon-color: #f00;
 }
 
-@media (prefers-color-scheme: dark) {
-    .ideditor {
+.ideditor.theme-dark {
         color-scheme: dark;
         --bg-color: #212529;
         --bg-color-2: #2b3035;
@@ -126,5 +125,4 @@
         --error-border-color: #800;
         --error-text-color: #e33;
         --error-highlight-text-color: #e66;
-    }
 }

--- a/modules/core/context.js
+++ b/modules/core/context.js
@@ -419,7 +419,11 @@ export function coreContext() {
 
   /* Container */
   let _container = d3_select(null);
-  let _theme;
+
+  const themeQuery = window.matchMedia?.('(prefers-color-scheme: dark)');
+  themeQuery?.addEventListener?.('change', () => context.theme(themeQuery.matches ? 'dark' : 'light'));
+  let _theme = themeQuery?.matches ? 'dark' : 'light';
+
   context.container = function(val) {
     if (!arguments.length) return _container;
     _container = val;

--- a/scripts/build_css.js
+++ b/scripts/build_css.js
@@ -32,7 +32,6 @@ export function buildCSS() {
         const css = fs.readFileSync('dist/iD.css', 'utf8');
         return postcss([
             autoprefixer,
-            duplicateDarkMode,
             prepend({ prefix: '.ideditor', exclude: [ /^\.ideditor(\[.*?\])*/ ] })
           ])
           .process(css, { from: 'dist/iD.css', to: 'dist/iD.css' });
@@ -60,22 +59,3 @@ function doConcat(files, output) {
     });
   });
 }
-
-
-function duplicateDarkMode() {
-  return {
-    postcssPlugin: 'duplicate-from-media',
-    Once(root) {
-      root.walkAtRules('media', atRule => {
-        if (atRule.params !== '(prefers-color-scheme: dark)') return;
-        atRule.walkRules(rule => {
-          const cloned = rule.clone();
-          rule.selector += ':not(.theme-light)';
-          cloned.selector += '.theme-dark';
-          atRule.parent.insertBefore(atRule, cloned);
-        });
-      });
-    }
-  };
-}
-duplicateDarkMode.postcss = true;


### PR DESCRIPTION
this PR removes a compile-time script for duplicating CSS, and replaces it with a few lines of JS.

This simplifies the build process, which would make it easier to switch to a faster bundler in the future, as discussed on slack recently.

tested with:
 - `?theme=light`
 - `?theme=dark`
 - no `theme` parameter, and using the devtools to override the theme:

<img width="623" height="164" alt="image" src="https://github.com/user-attachments/assets/dc5813b8-6b25-4d93-bf00-446c1e8e616f" />

&nbsp;

cc @hlfan