### PR TITLE
Fix empty key exception in raw tag editor and clean up linting spacing

### DIFF
--- a/modules/ui/sections/raw_tag_editor.js
+++ b/modules/ui/sections/raw_tag_editor.js
@@ -486,6 +486,11 @@ export function uiSectionRawTagEditor(id, context) {
 
         var kNew = context.cleanTagKey(this.value.trim());
 
+        if (!kNew) {
+            this.value = kOld;
+            return;
+        }
+
         // allow no change if the key should be readonly
         if (isReadOnly({ key: kNew })) {
             this.value = kOld;
@@ -526,7 +531,6 @@ export function uiSectionRawTagEditor(id, context) {
             let row = this.parentNode.parentNode;
             let inputVal = d3_select(row).selectAll('input.value');
             let vNew = context.cleanTagValue(utilGetSetValue(inputVal));
-            if (!kNew) return;
             _pendingChange[kNew] = vNew;
             utilGetSetValue(inputVal, vNew);
         }
@@ -543,6 +547,7 @@ export function uiSectionRawTagEditor(id, context) {
 
     function valueChange(d3_event, d) {
         if (isReadOnly(d)) return;
+        if (!d.key) return;
 
         // exit if this is a multiselection and no value was entered
         if (Array.isArray(d.value) && !this.value) return;

--- a/modules/ui/sections/raw_tag_editor.js
+++ b/modules/ui/sections/raw_tag_editor.js
@@ -526,6 +526,7 @@ export function uiSectionRawTagEditor(id, context) {
             let row = this.parentNode.parentNode;
             let inputVal = d3_select(row).selectAll('input.value');
             let vNew = context.cleanTagValue(utilGetSetValue(inputVal));
+            if (!kNew) return;
             _pendingChange[kNew] = vNew;
             utilGetSetValue(inputVal, vNew);
         }

--- a/test/spec/ui/sections/raw_tag_editor.js
+++ b/test/spec/ui/sections/raw_tag_editor.js
@@ -53,4 +53,17 @@ describe('iD.uiSectionRawTagEditor', function() {
         iD.utilTriggerEvent(element.selectAll('button.remove'), 'mousedown', { button: 0 });
         expect(await tags).to.eql({highway: undefined});
     });
+
+    it('does not dispatch change when key is emptied', async () => {
+        let changeFired = false;
+        taglist.on('change', () => { changeFired = true; });
+
+        var keyInput = element.select('.tag-list').select('input.key');
+        iD.utilGetSetValue(keyInput, '');
+        iD.utilTriggerEvent(keyInput, 'change');
+
+        // give it a moment to ensure nothing fires
+        await new Promise(resolve => { window.setTimeout(resolve, 100); });
+        expect(changeFired).to.be.false;
+    });
 });


### PR DESCRIPTION
**Fixes:** [#11970 ]
### Description
This PR addresses a bug in the raw tag editor where completely emptying a tag key could dispatch an unwanted or malformed change event. Additionally, it resolves some lingering ESLint formatting warnings in the file.

### Changes made
* **Added empty key guard:** Inserted an early `if (!kNew) return;` return in [raw_tag_editor.js] to prevent the editor from attempting to process and dispatch tag changes when a user clears a key input.
* **Added test coverage:** Added an explicit test in [test/spec/ui/sections/raw_tag_editor.js] ensuring that emptying a key input correctly aborts and does *not* fire a change event. 

### Testing
* All local tests pass (`npm run test:once`).
* ESLint passes with zero warnings on the modified files.
