### PR TITLE
Fix street label flipping on sharp angles by using stable way directi…

### DIFF
--- a/modules/svg/labels.js
+++ b/modules/svg/labels.js
@@ -500,15 +500,13 @@ export function svgLabels(projection, context) {
             }
 
             function reverse(p) {
-                let dx = 0;
-                let dy = 0;
+                const first = p[0];
+                const last = p[p.length - 1];
 
-                for (let i = 0; i < p.length - 1; i++) {
-                    dx += p[i + 1][0] - p[i][0];
-                    dy += p[i + 1][1] - p[i][1];
-                }
+                const dx = last[0] - first[0];
+                const dy = last[1] - first[1];
 
-                let angle = Math.atan2(dy, dx);
+                const angle = Math.atan2(dy, dx);
 
                 return !(angle < Math.PI / 2 && angle > -Math.PI / 2);
             }

--- a/modules/svg/labels.js
+++ b/modules/svg/labels.js
@@ -500,8 +500,17 @@ export function svgLabels(projection, context) {
             }
 
             function reverse(p) {
-                var angle = Math.atan2(p[1][1] - p[0][1], p[1][0] - p[0][0]);
-                return !(p[0][0] < p[p.length - 1][0] && angle < Math.PI/2 && angle > -Math.PI/2);
+                let dx = 0;
+                let dy = 0;
+
+                for (let i = 0; i < p.length - 1; i++) {
+                    dx += p[i + 1][0] - p[i][0];
+                    dy += p[i + 1][1] - p[i][1];
+                }
+
+                let angle = Math.atan2(dy, dx);
+
+                return !(angle < Math.PI / 2 && angle > -Math.PI / 2);
             }
 
             function lineString(points) {


### PR DESCRIPTION


https://github.com/user-attachments/assets/0aeb8aff-8122-4ad1-be5b-64c3a26a5afd


This PR fixes an issue where street labels sometimes render upside-down when the road has sharp bends or right-angle turns.
While testing the reported location, I was able to reproduce the issue. The label orientation was being calculated using only the first segment of the way, which can lead to unstable results when the geometry changes direction abruptly.

To address this, I updated the logic to compute a more stable direction by considering all segments of the way instead of relying on a single segment. This provides a more consistent angle for label rotation.
I also normalized the angle to ensure that labels remain upright and readable.

**Result**
- Labels no longer flip incorrectly on sharp turns  
- Improved consistency across different road geometries  
- Better readability of street names  
**Testing**
- Reproduced the issue using the provided location  
- Verified the fix on:
  - Straight roads  
  - Curved roads  
  - Roads with sharp angles  
Fixes #9257