### PR TITLE
Fix: Preset search bar linebreaking issue 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,12 +43,14 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :camera: Street-Level
 #### :white_check_mark: Validation
 #### :bug: Bugfixes
+* Fix title of preset search results not updating correctly ([#12050], thanks [@bhavyaKhatri2703])
 #### :earth_asia: Localization
 #### :hourglass: Performance
 #### :mortar_board: Walkthrough / Help
 #### :hammer: Development
 * Replace `sinon` with `vitest`'s built in spy/mock library ([#12058])
 
+[#12050]: https://github.com/openstreetmap/iD/issues/12050
 [#12058]: https://github.com/openstreetmap/iD/pull/12058
 
 

--- a/modules/ui/preset_list.js
+++ b/modules/ui/preset_list.js
@@ -35,7 +35,7 @@ export function uiPresetList(context) {
 
         var message = messagewrap
             .append('h2')
-            .call(t.append('inspector.choose'));
+            .call(t.addOrUpdate('inspector.choose'));
 
         messagewrap
             .append('button')


### PR DESCRIPTION
fixes: #12050 

The problem is Initial render uses t.append() causing text to accumulate in the h2 instead of being replaced.
fixed it by using t.addOrUpdate instead.