### PR TITLE
Start refactoring UI modules to typescript

### DIFF
--- a/modules/globals.d.ts
+++ b/modules/globals.d.ts
@@ -9,7 +9,14 @@ declare global {
   declare var after: typeof afterEach;
   declare var VITEST: true;
 
-  declare type Tags = { [key: string]: string | undefined };
+  declare type EntityID = string;
+
+  declare type TagKey = string;
+  declare type TagValue = string;
+  declare type TagValueUpdate = string | undefined;
+  declare type Tags = { [key: TagKey]: TagValue };
+  declare type TagsMulti = { [key: TagKey]: TagValue | TagValue[] };
+  declare type TagsUpdate = { [key: TagKey]: TagValueUpdate };
 
   /**
    * A class method that acts as both a getter and a

--- a/modules/globals.d.ts
+++ b/modules/globals.d.ts
@@ -38,7 +38,7 @@ declare global {
   declare namespace d3 {
     export type Selection<T = any> = import('d3').Selection<
       T,
-      unknown,
+      any,
       unknown,
       unknown
     >;

--- a/modules/globals.d.ts
+++ b/modules/globals.d.ts
@@ -9,7 +9,7 @@ declare global {
   declare var after: typeof afterEach;
   declare var VITEST: true;
 
-  declare type Tags = { [key: string]: string };
+  declare type Tags = { [key: string]: string | undefined };
 
   /**
    * A class method that acts as both a getter and a

--- a/modules/renderer/map.js
+++ b/modules/renderer/map.js
@@ -1080,6 +1080,7 @@ export function rendererMap(context) {
     };
 
 
+    /** @type import('../ui/sections/map_style_options').MapStyle[] */
     map.areaFillOptions = ['wireframe', 'partial', 'full'];
 
     map.activeAreaFill = function(val) {

--- a/modules/ui/fields/check.ts
+++ b/modules/ui/fields/check.ts
@@ -18,10 +18,10 @@ export { uiFieldCheck as uiFieldOnewayCheck };
 export function uiFieldCheck(field: any, context: iD.Context) {
     const dispatch = d3_dispatch('change');
     let options = field.options;
-    let values: (string | undefined)[] = [];
+    let values: TagValueUpdate[] = [];
     let texts: ReturnType<typeof t.append>[] = [];
 
-    let _tags: Tags;
+    let _tags: TagsMulti;
 
     let input:    d3.Selection<HTMLInputElement>  | d3.Selection<null> = d3_select(null);
     let text:     d3.Selection<HTMLSpanElement>   | d3.Selection<null> = d3_select(null);
@@ -29,8 +29,8 @@ export function uiFieldCheck(field: any, context: iD.Context) {
     let reverser: d3.Selection<HTMLButtonElement> | d3.Selection<null> = d3_select(null);
 
     let _impliedYes: boolean;
-    let _entityIDs: string[]  = [];
-    let _value: string | undefined;
+    let _entityIDs: EntityID[]  = [];
+    let _value: TagValueUpdate;
 
 
     var stringsField = field.resolveReference('stringsCrossReference');
@@ -130,7 +130,7 @@ export function uiFieldCheck(field: any, context: iD.Context) {
         input
             .on('click', function(d3_event) {
                 d3_event.stopPropagation();
-                var t: Tags = {};
+                var t: TagsUpdate = {};
 
                 if (Array.isArray(_tags[field.key])) {
                     if (values.includes('yes')) {
@@ -186,7 +186,7 @@ export function uiFieldCheck(field: any, context: iD.Context) {
     };
 
 
-    check.tags = function(tags: Tags) {
+    check.tags = function(tags: TagsMulti) {
 
         _tags = tags;
 
@@ -202,9 +202,9 @@ export function uiFieldCheck(field: any, context: iD.Context) {
 
         checkImpliedYes();
 
-        var isMixed = Array.isArray(tags[field.key]);
-
-        _value = !isMixed && tags[field.key] ? tags[field.key]?.toLowerCase() : undefined;
+        const tag = tags[field.key];
+        const isMixed = Array.isArray(tag);
+        _value = !isMixed && tag ? tag.toLowerCase() : undefined;
 
         if (field.type === 'onewayCheck' && (_value === '1' || _value === '-1')) {
             _value = 'yes';

--- a/modules/ui/fields/check.ts
+++ b/modules/ui/fields/check.ts
@@ -15,22 +15,22 @@ export { uiFieldCheck as uiFieldDefaultCheck };
 export { uiFieldCheck as uiFieldOnewayCheck };
 
 
-export function uiFieldCheck(field, context) {
-    var dispatch = d3_dispatch('change');
-    var options = field.options;
-    var values = [];
-    var texts = [];
+export function uiFieldCheck(field: any, context: iD.Context) {
+    const dispatch = d3_dispatch('change');
+    let options = field.options;
+    let values: (string | undefined)[] = [];
+    let texts: ReturnType<typeof t.append>[] = [];
 
-    var _tags;
+    let _tags: Tags;
 
-    var input = d3_select(null);
-    var text = d3_select(null);
-    var label = d3_select(null);
-    var reverser = d3_select(null);
+    let input:    d3.Selection<HTMLInputElement>  | d3.Selection<null> = d3_select(null);
+    let text:     d3.Selection<HTMLSpanElement>   | d3.Selection<null> = d3_select(null);
+    let label:    d3.Selection<HTMLLabelElement>  | d3.Selection<null> = d3_select(null);
+    let reverser: d3.Selection<HTMLButtonElement> | d3.Selection<null> = d3_select(null);
 
-    var _impliedYes;
-    var _entityIDs = [];
-    var _value;
+    let _impliedYes: boolean;
+    let _entityIDs: string[]  = [];
+    let _value: string | undefined;
 
 
     var stringsField = field.resolveReference('stringsCrossReference');
@@ -76,7 +76,7 @@ export function uiFieldCheck(field, context) {
     }
 
 
-    function reverserSetText(selection) {
+    function reverserSetText(selection: d3.Selection) {
         var entity = _entityIDs.length && context.hasEntity(_entityIDs[0]);
         if (reverserHidden() || !entity) return selection;
 
@@ -94,10 +94,10 @@ export function uiFieldCheck(field, context) {
     }
 
 
-    var check = function(selection) {
+    const check = function(selection: d3.Selection) {
         checkImpliedYes();
 
-        label = selection.selectAll('.form-field-input-wrap')
+        label = selection.selectAll<HTMLLabelElement, any>('.form-field-input-wrap')
             .data([0]);
 
         var enter = label.enter()
@@ -124,16 +124,16 @@ export function uiFieldCheck(field, context) {
         }
 
         label = label.merge(enter);
-        input = label.selectAll('input');
-        text = label.selectAll('span.value');
+        input = label.selectAll<HTMLInputElement, any>('input');
+        text = label.selectAll<HTMLSpanElement, any>('span.value');
 
         input
             .on('click', function(d3_event) {
                 d3_event.stopPropagation();
-                var t = {};
+                var t: Tags = {};
 
                 if (Array.isArray(_tags[field.key])) {
-                    if (values.indexOf('yes') !== -1) {
+                    if (values.includes('yes')) {
                         t[field.key] = 'yes';
                     } else {
                         t[field.key] = values[0];
@@ -152,7 +152,7 @@ export function uiFieldCheck(field, context) {
             });
 
         if (field.type === 'onewayCheck') {
-            reverser = label.selectAll('.reverser');
+            reverser = label.selectAll<HTMLButtonElement, any>('.reverser');
 
             reverser
                 .call(reverserSetText)
@@ -160,7 +160,7 @@ export function uiFieldCheck(field, context) {
                     d3_event.preventDefault();
                     d3_event.stopPropagation();
                     context.perform(
-                        function(graph) {
+                        function(graph: iD.Graph) {
                             for (var i in _entityIDs) {
                                 graph = actionReverse(_entityIDs[i])(graph);
                             }
@@ -179,22 +179,22 @@ export function uiFieldCheck(field, context) {
     };
 
 
-    check.entityIDs = function(val) {
+    check.entityIDs = function(val?: string[]) {
         if (!arguments.length) return _entityIDs;
-        _entityIDs = val;
+        _entityIDs = val!;
         return check;
     };
 
 
-    check.tags = function(tags) {
+    check.tags = function(tags: Tags) {
 
         _tags = tags;
 
-        function isChecked(val) {
+        function isChecked(val: string | undefined) {
             return val !== 'no' && val !== '' && val !== undefined && val !== null;
         }
 
-        function textFor(val) {
+        function textFor(val: string | undefined) {
             if (val === '') val = undefined;
             var index = values.indexOf(val);
             return (index !== -1 ? texts[index] : ('"' + val + '"'));
@@ -204,7 +204,7 @@ export function uiFieldCheck(field, context) {
 
         var isMixed = Array.isArray(tags[field.key]);
 
-        _value = !isMixed && tags[field.key] && tags[field.key].toLowerCase();
+        _value = !isMixed && tags[field.key] ? tags[field.key]?.toLowerCase() : undefined;
 
         if (field.type === 'onewayCheck' && (_value === '1' || _value === '-1')) {
             _value = 'yes';
@@ -215,11 +215,12 @@ export function uiFieldCheck(field, context) {
             .property('checked', isChecked(_value));
 
         const textForValue = textFor(_value);
-        text
-            .text('')
-            .call(isMixed
+        text.text('');
+        text.call(isMixed
                 ? t.append('inspector.multiple_values')
-                : typeof textForValue === 'string' ? selection => selection.text(textForValue) : textForValue)
+                : typeof textForValue === 'string'
+                    ? (selection: d3.Selection) => selection.text(textForValue)
+                    : textForValue)
             .classed('mixed', isMixed);
 
         label
@@ -234,7 +235,7 @@ export function uiFieldCheck(field, context) {
 
 
     check.focus = function() {
-        input.node().focus();
+        input.node()?.focus();
     };
 
     return utilRebind(check, dispatch, 'on');

--- a/modules/ui/sections/map_style_options.ts
+++ b/modules/ui/sections/map_style_options.ts
@@ -4,15 +4,17 @@ import { t } from '../../core/localizer';
 import { uiTooltip } from '../tooltip';
 import { uiSection } from '../section';
 
-export function uiSectionMapStyleOptions(context) {
+export type MapStyle = 'wireframe' | 'area_fill' | 'highlight_edits';
 
-    var section = uiSection('fill-area', context)
+export function uiSectionMapStyleOptions(context: iD.Context) {
+
+    const section = (uiSection('fill-area', context) as any)
         .label(() => t.append('map_data.style_options'))
         .disclosureContent(renderDisclosureContent)
         .expandedByDefault(false);
 
-    function renderDisclosureContent(selection) {
-        var container = selection.selectAll('.layer-fill-list')
+    function renderDisclosureContent(selection: d3.Selection) {
+        const container = selection.selectAll<HTMLUListElement, any>('ul.layer-fill-list')
             .data([0]);
 
         container.enter()
@@ -21,20 +23,27 @@ export function uiSectionMapStyleOptions(context) {
             .merge(container)
             .call(drawListItems, context.map().areaFillOptions, 'radio', 'area_fill', setFill, isActiveFill);
 
-        var container2 = selection.selectAll('.layer-visual-diff-list')
+        const container2 = selection.selectAll<HTMLUListElement, any>('ul.layer-visual-diff-list')
             .data([0]);
 
         container2.enter()
             .append('ul')
             .attr('class', 'layer-list layer-visual-diff-list')
             .merge(container2)
-            .call(drawListItems, ['highlight_edits'], 'checkbox', 'visual_diff', toggleHighlightEdited, function() {
-                return context.surface().classed('highlight-edited');
-            });
+            .call(drawListItems, ['highlight_edits'], 'checkbox', 'visual_diff', toggleHighlightEdited, () =>
+                context.surface().classed('highlight-edited')
+            );
     }
 
-    function drawListItems(selection, data, type, name, change, active) {
-        var items = selection.selectAll('li')
+    function drawListItems(
+        selection: d3.Selection<HTMLUListElement>,
+        data: MapStyle[],
+        type: 'radio' | 'checkbox',
+        name: string,
+        change: any,
+        active: (d: string) => boolean
+    ) {
+        let items = selection.selectAll<HTMLLIElement, any>('li')
             .data(data);
 
         // Exit
@@ -42,21 +51,19 @@ export function uiSectionMapStyleOptions(context) {
             .remove();
 
         // Enter
-        var enter = items.enter()
+        const enter = items.enter()
             .append('li')
-            .call(uiTooltip()
-                .title(function(d) {
-                    return t.append(name + '.' + d + '.tooltip');
-                })
-                .keys(function(d) {
-                    var key = (d === 'wireframe' ? t('area_fill.wireframe.key') : null);
+            .call((uiTooltip() as any)
+                .title((d: MapStyle) => t.append(`${name}.${d}.tooltip`))
+                .keys((d: MapStyle) => {
+                    let key = (d === 'wireframe' ? t('area_fill.wireframe.key') : null);
                     if (d === 'highlight_edits') key = t('map_data.highlight_edits.key');
                     return key ? [key] : null;
                 })
                 .placement('top')
             );
 
-        var label = enter
+        const label = enter
             .append('label');
 
         label
@@ -67,8 +74,8 @@ export function uiSectionMapStyleOptions(context) {
 
         label
             .append('span')
-            .each(function(d) {
-                d3_select(this).call(t.append(name + '.' + d + '.description'));
+            .each(function(d: string) {
+                d3_select(this).call(t.append(`${name}.${d}.description`));
             });
 
         // Update
@@ -82,16 +89,16 @@ export function uiSectionMapStyleOptions(context) {
             .property('indeterminate', false);
     }
 
-    function isActiveFill(d) {
+    function isActiveFill(d: string) {
         return context.map().activeAreaFill() === d;
     }
 
-    function toggleHighlightEdited(d3_event) {
+    function toggleHighlightEdited(d3_event: Event) {
         d3_event.preventDefault();
         context.map().toggleHighlightEdited();
     }
 
-    function setFill(d3_event, d) {
+    function setFill(ignored: Event, d: string) {
         context.map().activeAreaFill(d);
     }
 


### PR DESCRIPTION
In order to avoid oversights such as 0241c7653d4a93692f59b7aa1021242e63a3de72 from slipping through (incomplete) unit tests as well as manual testing, it is probably necessary to port the frontend modules over to typescript.

As a proof of concept here is how this might look like for one of the UI code:
* [x] `modules/ui/sections/map_style_options.js`
* [x] `modules/ui/fields/check.ts`
* [x] `modules/ui/cmd_sequence.ts` in #11998

Notably, for `d3.select` one needs to include the respective type hints, e.g. `selection.selectAll<HTMLUListElement, any>(ul.…)`, and interfacing to existing not-type annotated modules sometimes require an explicit case to `any` (e.g. in `uiSectionMapStyleOptions(context: any)`, or `(uiTooltip() as any).…`), at least as long as we don't port them over as well.

Feedback welcome!