### PR TITLE
Fix spacebar creating duplicate nodes during way/area drawing

### DIFF
--- a/modules/behavior/draw.js
+++ b/modules/behavior/draw.js
@@ -12,6 +12,7 @@ import { utilFastMouse, utilKeybinding, utilRebind } from '../util';
 
 var _disableSpace = false;
 var _lastSpace = null;
+var _spaceHeld = false;
 
 
 export function behaviorDraw(context) {
@@ -191,6 +192,10 @@ export function behaviorDraw(context) {
         d3_event.preventDefault();
         d3_event.stopPropagation();
 
+        // ignore key-repeat events while space is held down
+        if (_spaceHeld) return;
+        _spaceHeld = true;
+
         var currSpace = context.map().mouse();
         if (_disableSpace && _lastSpace) {
             var dist = geoVecLength(_lastSpace, currSpace);
@@ -209,6 +214,7 @@ export function behaviorDraw(context) {
             d3_event.preventDefault();
             d3_event.stopPropagation();
             _disableSpace = false;
+            _spaceHeld = false;
             d3_select(window).on('keyup.space-block', null);
         });
 


### PR DESCRIPTION
Fixes #12051

### Description
When drawing a way or area, pressing Space multiple times (or holding it down) could create multiple stacked nodes at the same or nearly identical coordinates. This happened because the browser fires repeated `keydown` events during key-repeat, and the existing `_disableSpace` guard would re-enable itself once the mouse moved more than 12 pixels.

### Root Cause
The [space()] function in [behavior/draw.js] relied solely on a `_disableSpace` flag that could be reset by mouse movement, allowing key-repeat `keydown` events to slip through and create extra nodes.

### Fix
Added a `_spaceHeld` flag that tracks whether the spacebar is physically held down:
- Set to `true` on the first `keydown` event — blocks all subsequent key-repeat events
- Reset to `false` only on `keyup` — ensures exactly one node per press-release cycle

This preserves the ability to rapidly tap Space to place multiple intentional nodes, while preventing accidental duplicates from key-repeat or holding the key.

### Testing
- `npm run test:once` passes
- ESLint passes with zero warnings
