### PR TITLE
fix: preserves all tags when re-selecting the same preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Fix title of preset search results not updating correctly ([#12050], thanks [@bhavyaKhatri2703])
 * Prevent duplicate nodes from being created while using spacebar key to draw a way ([#12051])
 * Fix user images and upload help text from showing up as duplicates in upload dialog ([#12063])
+* Fix some tags automatically deleted when re-selecting the same preset ([#12070], thanks [@k-yle])
 #### :earth_asia: Localization
 #### :hourglass: Performance
 #### :mortar_board: Walkthrough / Help
@@ -61,6 +62,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#12058]: https://github.com/openstreetmap/iD/pull/12058
 [#12063]: https://github.com/openstreetmap/iD/issues/12063
 [#12065]: https://github.com/openstreetmap/iD/issues/12065
+[#12070]: https://github.com/openstreetmap/iD/issues/12070
 
 
 # 2.39.2

--- a/modules/actions/change_preset.js
+++ b/modules/actions/change_preset.js
@@ -25,7 +25,7 @@ export function actionChangePreset(entityID, oldPreset, newPreset, skipFieldDefa
                     .forEach(key => preserveKeys.push(key));
             }
 
-            if (oldPreset) {
+            if (oldPreset && (oldPreset.id !== newPreset.id)) {
                 // 'field-keys' are keys used by fields (different to the keys used by preset itself)
                 const oldPresetFieldKeys = [
                     ...oldPreset.fields(loc),

--- a/test/spec/actions/change_preset.js
+++ b/test/spec/actions/change_preset.js
@@ -135,6 +135,36 @@ describe('iD.actionChangePreset', function() {
         });
     });
 
+    it('preserves all tags when re-selecting the same preset', () => {
+        const entity = iD.osmNode({
+            tags: {
+                building: 'yes', // the preset's own tags.
+                'building:colour': 'green', // a field which exists in the preset
+                'name': 'The Frog House', // a tag which does not exist in the preset
+            },
+            loc: [0, 0],
+        });
+        const graph = iD.coreGraph([entity]);
+
+        const fields = {
+            'building:colour': iD.presetField('building:colour', { key: 'building:colour', geometry: 'point' }),
+        };
+
+        const preset = iD.presetPreset(
+            'building/yes',
+            { tags: { building: 'yes' }, fields: ['building:colour'] },
+            undefined,
+            fields,
+        );
+        const action = iD.actionChangePreset(entity.id, preset, preset);
+        expect(action(graph).entity(entity.id).tags).toStrictEqual({
+            // all tags are preserved
+            building: 'yes',
+            'building:colour': 'green',
+            'name': 'The Frog House',
+        });
+    });
+
     // https://github.com/openstreetmap/iD/issues/9372
     it('does not preserve field tags when changing from a subpreset to its parent', function() {
         var entity = iD.osmNode({tags: {highway: 'service', service: 'driveway'}});


### PR DESCRIPTION
Closes #12068

