### PR TITLE
Fix: Prevent section toggle when clicking outside label in header

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -792,6 +792,12 @@ button.add-note svg.icon {
 ------------------------------------------------------- */
 summary.hide-toggle {
     display: block;
+
+    width: max-content;   /* Makes the element expand only as much as the text */
+
+    min-width: 0%;       /* we can adjust these two to the set the cap or remove completly*/
+    max-width: 100%;    
+
     list-style: none;
     cursor: pointer;
     color: var(--link-color);


### PR DESCRIPTION
## Fixes

Fixes #12076

## Problem

Currently, the entire section header row is clickable. This causes accidental toggling when users click in the empty space to the right of the label.

This becomes frustrating during tag editing, since users often click outside to confirm changes and unintentionally collapse the section.

## Solution

Limit the clickable area to only the label and the disclosure arrow, instead of the full header row.

## Result

* Prevents accidental open/close of sections
* Makes it safe to click outside while editing
* Works naturally with translated labels (click area follows text length)

## Before / After

**Before:** Clicking anywhere on the header row toggles the section


https://github.com/user-attachments/assets/9b83e76f-2961-4b85-b234-f1c21f0c976c


**After:** Only clicking the label or arrow toggles the section


https://github.com/user-attachments/assets/5d924453-1ce0-4aec-b51b-65148c5c2136

