### PR TITLE
migrate coreGraph to TypeScript

### DIFF
--- a/modules/core/graph.ts
+++ b/modules/core/graph.ts
@@ -1,10 +1,18 @@
 import { debug } from '../index';
+import type { OsmNode as osmNode } from '../osm/node';
+import type { OsmRelation as osmRelation } from '../osm/relation';
+import type { OsmWay as osmWay } from '../osm/way';
 import { utilArrayDifference } from '../util';
 
+export class coreGraph {
+    entities: { [id: string]: iD.OsmEntity | undefined };
+    _parentWays: { [id: string]: Set<string> };
+    _parentRels: { [id: string]: Set<string> };
+    transients: { [id: string]: { [key: string]: unknown } };
+    _childNodes: { [id: string]: osmNode[] };
+    frozen: boolean;
 
-export function coreGraph(other, mutable) {
-    if (!(this instanceof coreGraph)) return new coreGraph(other, mutable);
-
+  constructor(other?: coreGraph, mutable?: boolean) {
     if (other instanceof coreGraph) {
         var base = other.base();
         this.entities = Object.assign(Object.create(base.entities), other.entities);
@@ -21,117 +29,110 @@ export function coreGraph(other, mutable) {
     this.transients = {};
     this._childNodes = {};
     this.frozen = !mutable;
-}
+  }
 
+    hasEntity<T extends iD.OsmEntity>(id: string) {
+        return this.entities[id] as T | undefined;
+    }
 
-coreGraph.prototype = {
-
-    hasEntity: function(id) {
-        return this.entities[id];
-    },
-
-
-    entity: function(id) {
+    entity<T extends iD.OsmEntity>(id: string) {
         var entity = this.entities[id];
 
         if (!entity) {
             throw new Error('entity ' + id + ' not found');
         }
-        return entity;
-    },
+        return entity as T;
+    }
 
-
-    geometry: function(id) {
+    geometry(id: string) {
         return this.entity(id).geometry(this);
-    },
+    }
 
-
-    transient: function(entity, key, fn) {
+    transient<T>(entity: iD.OsmEntity, key: string, fn: () => T): T {
         var id = entity.id;
         var transients = this.transients[id] || (this.transients[id] = {});
 
         if (transients[key] !== undefined) {
-            return transients[key];
+            return transients[key] as T;
         }
 
         transients[key] = fn.call(entity);
 
-        return transients[key];
-    },
+        return transients[key] as T;
+    }
 
-
-    parentWays: function(entity) {
+    parentWays(entity: iD.OsmEntity) {
         var parents = this._parentWays[entity.id];
-        var result = [];
+        var result: osmWay[] = [];
         if (parents) {
-            parents.forEach(function(id) {
-                result.push(this.entity(id));
+            parents.forEach((id) => {
+                result.push(this.entity<osmWay>(id));
             }, this);
         }
         return result;
-    },
+    }
 
-
-    isPoi: function(entity) {
+    isPoi(entity: iD.OsmEntity) {
         var parents = this._parentWays[entity.id];
         return !parents || parents.size === 0;
-    },
+    }
 
-
-    isShared: function(entity) {
+    isShared(entity: iD.OsmEntity) {
         var parents = this._parentWays[entity.id];
         return parents && parents.size > 1;
-    },
+    }
 
-
-    parentRelations: function(entity) {
+    parentRelations(entity: iD.OsmEntity) {
         var parents = this._parentRels[entity.id];
-        var result = [];
+        var result: osmRelation[] = [];
         if (parents) {
-            parents.forEach(function(id) {
-                result.push(this.entity(id));
+            parents.forEach((id) => {
+                result.push(this.entity<osmRelation>(id));
             }, this);
         }
         return result;
-    },
+    }
 
-    parentMultipolygons: function(entity) {
-        return this.parentRelations(entity).filter(function(relation) {
+    parentMultipolygons(entity: iD.OsmEntity) {
+        return this.parentRelations(entity).filter((relation) => {
             return relation.isMultipolygon();
         });
-    },
+    }
 
 
-    childNodes: function(entity) {
+    childNodes(entity: osmWay) {
         if (this._childNodes[entity.id]) return this._childNodes[entity.id];
         if (!entity.nodes) return [];
 
-        var nodes = [];
+        var nodes: osmNode[] = [];
         for (var i = 0; i < entity.nodes.length; i++) {
-            nodes[i] = this.entity(entity.nodes[i]);
+            nodes[i] = this.entity<osmNode>(entity.nodes[i]);
         }
 
         if (debug) Object.freeze(nodes);
 
+        // @ts-expect-error -- temporary issue which will be solved after upgrading osmEntity
         this._childNodes[entity.id] = nodes;
         return this._childNodes[entity.id];
-    },
+    }
 
-
-    base: function() {
+    base(): {
+        entities: coreGraph['entities'];
+        parentWays: coreGraph['_parentWays'];
+        parentRels: coreGraph['_parentRels'];
+    } {
         return {
             'entities': Object.getPrototypeOf(this.entities),
             'parentWays': Object.getPrototypeOf(this._parentWays),
             'parentRels': Object.getPrototypeOf(this._parentRels)
         };
-    },
-
+    }
 
     // Unlike other graph methods, rebase mutates in place. This is because it
     // is used only during the history operation that merges newly downloaded
     // data into each state. To external consumers, it should appear as if the
     // graph always contained the newly downloaded data.
-    rebase: function(entities, stack, force) {
+    rebase(entities: iD.OsmEntity[], stack: coreGraph[], force?: boolean) {
         var base = this.base();
         var i, j, k, id;
 
@@ -161,15 +162,14 @@ coreGraph.prototype = {
         for (i = 0; i < stack.length; i++) {
             stack[i]._updateRebased();
         }
-    },
+    }
 
-
-    _updateRebased: function() {
+    _updateRebased() {
         var base = this.base();
 
-        Object.keys(this._parentWays).forEach(function(child) {
+        Object.keys(this._parentWays).forEach((child) => {
             if (base.parentWays[child]) {
-                base.parentWays[child].forEach(function(id) {
+                base.parentWays[child].forEach((id) => {
                     if (!this.entities.hasOwnProperty(id)) {
                         this._parentWays[child].add(id);
                     }
@@ -177,9 +177,9 @@ coreGraph.prototype = {
             }
         }, this);
 
-        Object.keys(this._parentRels).forEach(function(child) {
+        Object.keys(this._parentRels).forEach((child) => {
             if (base.parentRels[child]) {
-                base.parentRels[child].forEach(function(id) {
+                base.parentRels[child].forEach((id) => {
                     if (!this.entities.hasOwnProperty(id)) {
                         this._parentRels[child].add(id);
                     }
@@ -191,18 +191,29 @@ coreGraph.prototype = {
 
         // this._childNodes is not updated, under the assumption that
         // ways are always downloaded with their child nodes.
-    },
-
+    }
 
     // Updates calculated properties (parentWays, parentRels) for the specified change
-    _updateCalculated: function(oldentity, entity, parentWays, parentRels) {
+    _updateCalculated(
+        oldentity: iD.OsmEntity | undefined,
+        entity: iD.OsmEntity | undefined,
+        parentWays?: coreGraph['_parentWays'],
+        parentRels?: coreGraph['_parentRels'],
+    ) {
         parentWays = parentWays || this._parentWays;
         parentRels = parentRels || this._parentRels;
 
         var type = entity && entity.type || oldentity && oldentity.type;
-        var removed, added, i;
+        let removed: string[] = [];
+        let added: string[] = [];
+        let i: number;
 
         if (type === 'way') {   // Update parentWays
+
+            // this is purely to help TypeScript understand
+            entity = <osmWay | undefined>entity;
+            oldentity = <osmWay | undefined>oldentity;
+
             if (oldentity && entity) {
                 removed = utilArrayDifference(oldentity.nodes, entity.nodes);
                 added = utilArrayDifference(entity.nodes, oldentity.nodes);
@@ -216,15 +227,19 @@ coreGraph.prototype = {
             for (i = 0; i < removed.length; i++) {
                 // make a copy of prototype property, store as own property, and update..
                 parentWays[removed[i]] = new Set(parentWays[removed[i]]);
-                parentWays[removed[i]].delete(oldentity.id);
+                parentWays[removed[i]].delete(oldentity!.id);
             }
             for (i = 0; i < added.length; i++) {
                 // make a copy of prototype property, store as own property, and update..
                 parentWays[added[i]] = new Set(parentWays[added[i]]);
-                parentWays[added[i]].add(entity.id);
+                parentWays[added[i]].add(entity!.id);
             }
 
         } else if (type === 'relation') {   // Update parentRels
+
+            // this is purely to help TypeScript understand
+            entity = <osmRelation | undefined>entity;
+            oldentity = <osmRelation | undefined>oldentity;
 
             // diff only on the IDs since the same entity can be a member multiple times with different roles
             var oldentityMemberIDs = oldentity ? oldentity.members.map(function(m) { return m.id; }) : [];
@@ -243,36 +258,33 @@ coreGraph.prototype = {
             for (i = 0; i < removed.length; i++) {
                 // make a copy of prototype property, store as own property, and update..
                 parentRels[removed[i]] = new Set(parentRels[removed[i]]);
-                parentRels[removed[i]].delete(oldentity.id);
+                parentRels[removed[i]].delete(oldentity!.id);
             }
             for (i = 0; i < added.length; i++) {
                 // make a copy of prototype property, store as own property, and update..
                 parentRels[added[i]] = new Set(parentRels[added[i]]);
-                parentRels[added[i]].add(entity.id);
+                parentRels[added[i]].add(entity!.id);
             }
         }
-    },
+    }
 
-
-    replace: function(entity) {
+    replace(entity: iD.OsmEntity) {
         if (this.entities[entity.id] === entity) return this;
 
         return this.update(function() {
             this._updateCalculated(this.entities[entity.id], entity);
             this.entities[entity.id] = entity;
         });
-    },
+    }
 
-
-    remove: function(entity) {
+    remove(entity: iD.OsmEntity) {
         return this.update(function() {
             this._updateCalculated(entity, undefined);
             this.entities[entity.id] = undefined;
         });
-    },
+    }
 
-
-    revert: function(id) {
+    revert(id: string) {
         var baseEntity = this.base().entities[id];
         var headEntity = this.entities[id];
         if (headEntity === baseEntity) return this;
@@ -281,23 +293,21 @@ coreGraph.prototype = {
             this._updateCalculated(headEntity, baseEntity);
             delete this.entities[id];
         });
-    },
+    }
 
-
-    update: function() {
+    update(...args: ((this: coreGraph, graph: coreGraph) => void)[]) {
         var graph = this.frozen ? new coreGraph(this, true) : this;
-        for (var i = 0; i < arguments.length; i++) {
-            arguments[i].call(graph, graph);
+        for (var i = 0; i < args.length; i++) {
+            args[i].call(graph, graph);
         }
 
         if (this.frozen) graph.frozen = true;
 
         return graph;
-    },
-
+    }
 
     // Obliterates any existing entities
-    load: function(entities) {
+    load(entities: { [key: string | number]: iD.OsmEntity }) {
         var base = this.base();
         this.entities = Object.create(base.entities);
 
@@ -308,4 +318,4 @@ coreGraph.prototype = {
 
         return this;
     }
-};
+}

--- a/modules/core/graph.ts
+++ b/modules/core/graph.ts
@@ -67,7 +67,7 @@ export class coreGraph {
         if (parents) {
             parents.forEach((id) => {
                 result.push(this.entity<osmWay>(id));
-            }, this);
+            });
         }
         return result;
     }
@@ -88,7 +88,7 @@ export class coreGraph {
         if (parents) {
             parents.forEach((id) => {
                 result.push(this.entity<osmRelation>(id));
-            }, this);
+            });
         }
         return result;
     }
@@ -173,9 +173,9 @@ export class coreGraph {
                     if (!this.entities.hasOwnProperty(id)) {
                         this._parentWays[child].add(id);
                     }
-                }, this);
+                });
             }
-        }, this);
+        });
 
         Object.keys(this._parentRels).forEach((child) => {
             if (base.parentRels[child]) {
@@ -183,9 +183,9 @@ export class coreGraph {
                     if (!this.entities.hasOwnProperty(id)) {
                         this._parentRels[child].add(id);
                     }
-                }, this);
+                });
             }
-        }, this);
+        });
 
         this.transients = {};
 

--- a/modules/globals.d.ts
+++ b/modules/globals.d.ts
@@ -23,13 +23,12 @@ declare global {
   declare namespace iD {
     export type Context = ReturnType<typeof iD.coreContext>;
 
-    export type Graph = InstanceType<typeof iD.coreGraph>;
-
+    export type Graph = import('./core/graph').coreGraph;
     export type OsmNode = import('./osm/node').OsmNode;
     export type OsmWay = import('./osm/way').OsmWay;
     export type OsmRelation = import('./osm/relation').OsmRelation;
 
-    export type AbstractEntity = InstanceType<typeof iD.osmEntity>;
+    export type AbstractEntity = typeof import('./osm/entity').osmEntity.prototype;
     export type OsmEntity = OsmNode | OsmWay | OsmRelation;
 
     export type Projection = import('./geo/raw_mercator').Projection;

--- a/modules/osm/entity.js
+++ b/modules/osm/entity.js
@@ -63,6 +63,12 @@ osmEntity.prototype = {
     /** @type {String} */
     id: undefined,
 
+    /** @type {number | undefined} */
+    v: undefined,
+
+    /** @type {boolean | undefined} */
+    visible: undefined,
+
     initialize: function(sources) {
         for (var i = 0; i < sources.length; ++i) {
             var source = sources[i];
@@ -127,7 +133,7 @@ osmEntity.prototype = {
      *
      * @param {Tags} tags tags to merge into this entity's tags
      * @param {Tags} setTags (optional) a set of tags to overwrite in this entity's tags
-     * @returns {iD.OsmEntity}
+     * @returns {typeof this}
      */
     mergeTags: function(tags, setTags = {}) {
         const merged = Object.assign({}, this.tags);   // shallow copy

--- a/modules/osm/node.js
+++ b/modules/osm/node.js
@@ -48,7 +48,7 @@ osmEntity.node = osmNode;
 osmNode.prototype = Object.create(osmEntity.prototype);
 
 const prototype = {
-    type: 'node',
+    type: /** @type {'node'} */ ('node'),
     loc: /** @type {Vec2} */ ([9999, 9999]),
 
     extent: function() {

--- a/modules/osm/relation.js
+++ b/modules/osm/relation.js
@@ -5,6 +5,11 @@ import { osmJoinWays } from './multipolygon';
 import { geoExtent, geoPolygonContainsPolygon, geoPolygonIntersectsPolygon } from '../geo';
 
 /**
+ * @typedef {'node' | 'way' | 'relation'} FeatureType
+ * @typedef {{ type: FeatureType; id: string; role: string }} RelationMember
+ */
+
+/**
  * @typedef {typeof prototype & iD.AbstractEntity} OsmRelation
  * @returns {OsmRelation}
  */
@@ -31,8 +36,8 @@ osmRelation.creationOrder = function(a, b) {
 
 
 const prototype = {
-    type: 'relation',
-    members: [],
+    type: /** @type {'relation'} */ ('relation'),
+    members: /** @type {RelationMember[]} */ ([]),
 
 
     copy: function(resolver, copies) {

--- a/modules/osm/way.js
+++ b/modules/osm/way.js
@@ -24,7 +24,7 @@ osmWay.prototype = Object.create(osmEntity.prototype);
 
 
 const prototype = {
-    type: 'way',
+    type: /** @type {'way'} */ ('way'),
     nodes: [],
 
 

--- a/modules/util/array.js
+++ b/modules/util/array.js
@@ -21,6 +21,7 @@ export function utilArrayIdentical(a, b) {
 //   [1]
 // utilArrayDifference(b, a)
 //   [4]
+/** @template T @param {T[]} a @param {T[]} b @returns {T[]} */
 export function utilArrayDifference(a, b) {
     var other = new Set(b);
     return Array.from(new Set(a))


### PR DESCRIPTION
this is the first PR to migrate a core class to TS. I've tried to minimize the diff as much as possible.

---

<details>
<summary>click to view the outdated comment about the `new` operator</summary>




It raises a tricky question: 

[ES classes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes) must be instantiated with the [`new`  operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new) (`new coreGraph()` instead of `coreGraph()`). That gives us two options:
1. do a mass update to replace `coreGraph(` with `new coreGraph(` , but I think we [try to avoid](https://github.com/openstreetmap/iD/pull/10823#issuecomment-2694433828) mass updates?
2. [wrap the class defintion](https://github.com/openstreetmap/iD/blob/7ed11ae842d2273ac0886cf4166c2189cf006c7e/modules/core/graph.ts#L323) in a helper function which allows us to use it without `new`. Then we don't have to update any other files. 

This PR includes option 2 as seperate commit. It's a bit odd, but i can't think of any other solution. 

RapiD [chose option 1](https://github.com/bhousel/Rapid/commit/8bbbb441). Thanks to [git-blame-ignore-revs](https://docs.gitlab.com/user/project/repository/files/git_blame/#ignore-specific-revisions), it's possible to hide the mass-update commit from the git history (locally and on GitHub). 

Not sure which approach is better. But it's a problem that we'll need to tackle somehow


</details>