### PR TITLE
Side indicators on the map for `directionalCombo`s

### DIFF
--- a/css/20_map.css
+++ b/css/20_map.css
@@ -13,6 +13,8 @@
 .layer-osm path.sided-marker-coastline-path { fill: #77dede; }
 .layer-osm path.sided-marker-barrier-path   { fill: #ddd; }
 .layer-osm path.sided-marker-man_made-path  { fill: #fff; }
+.layer-osm path.directionalcombo-marker-left-path,
+.layer-osm path.directionalcombo-marker-right-path { fill: #7092ff; }
 
 /* IE/Edge rule for <use> marker style */
 .layer-osm path.viewfield-marker-path {
@@ -243,8 +245,13 @@ text {
 
 .onewaygroup path.oneway,
 .viewfieldgroup path.viewfield,
-.sidedgroup path.sided {
+.sidedgroup path.sided,
+.directional-combo-group path.directionalcombo {
     stroke-width: 6px;
+}
+
+.directional-combo-group path.directionalcombo {
+    opacity: 0.95;
 }
 
 text.arealabel-halo,

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -1664,6 +1664,23 @@ input.date-selector {
     display: table-cell;
     width: auto;
 }
+.form-field ul.rows.rows-table li.labeled-input > .preset-label-directionalcombo .directionalcombo-label-arrow {
+    width: 13.2px;
+    height: 13.2px;
+    margin-left: 0.35em;
+    vertical-align: middle;
+    transform: rotate(var(--indicator-rotation, 0deg));
+    transform-origin: center;
+    opacity: 1;
+}
+.form-field ul.rows.rows-table li.labeled-input > .preset-label-directionalcombo .directionalcombo-label-arrow path {
+    fill: var(--passive-text-color);
+    transition: fill 120ms ease-in-out;
+}
+.form-field ul.rows.rows-table li.labeled-input.is-active-indicator > .preset-label-directionalcombo .directionalcombo-label-arrow path { fill: #7092ff; }
+.form-field ul.rows.rows-table li.labeled-input > .preset-label-directionalcombo .directionalcombo-label-arrow.directionalcombo-label-arrow-hidden {
+    display: none;
+}
 
 
 /* Field - Structure

--- a/modules/core/context.js
+++ b/modules/core/context.js
@@ -336,6 +336,28 @@ export function coreContext() {
   context.selectedIDs = () => (_mode && _mode.selectedIDs && _mode.selectedIDs()) || [];
   context.activeID = () => _mode && _mode.activeID && _mode.activeID();
 
+  /**
+   * @typedef {{
+   *   side: 'left' | 'right',
+   *   entityIDs: string[]
+   * }} DirectionalComboIndicatorState
+   */
+
+  /** @type {DirectionalComboIndicatorState | null} */
+  let _directionalComboIndicator = null;
+  context.directionalComboIndicator = function() {
+    return _directionalComboIndicator;
+  };
+  /**
+   * @param {DirectionalComboIndicatorState | null} val
+   * @returns {typeof context}
+   */
+  context.setDirectionalComboIndicator = function(val) {
+    _directionalComboIndicator = val;
+    dispatch.call('change');
+    return context;
+  };
+
   let _selectedNoteID;
   context.selectedNoteID = function(noteID) {
     if (!arguments.length) return _selectedNoteID;

--- a/modules/geo/index.ts
+++ b/modules/geo/index.ts
@@ -35,6 +35,7 @@ export {
     WAY_STRAIGHTNESS_MIN_VISIBLE_LENGTH,
     geoPolylineStraightness,
     geoVisiblePolylineInExtent,
+    geoWayDominantHeadingInViewport,
     geoWayStraightnessInViewport
 } from './way_viewport_straightness.js';
 

--- a/modules/geo/index.ts
+++ b/modules/geo/index.ts
@@ -27,6 +27,17 @@ export { geoPolygonContainsPolygon } from './geom.js';
 export { geoPolygonIntersectsPolygon } from './geom.js';
 export { geoViewportEdge } from './geom.js';
 
+export {
+    WAY_STRAIGHTNESS_MAX_SPREAD_DEG,
+    WAY_STRAIGHTNESS_MAX_TORTUOSITY,
+    WAY_STRAIGHTNESS_MAX_TOTAL_TURN_DEG,
+    WAY_STRAIGHTNESS_MAX_TURN_DEG,
+    WAY_STRAIGHTNESS_MIN_VISIBLE_LENGTH,
+    geoPolylineStraightness,
+    geoVisiblePolylineInExtent,
+    geoWayStraightnessInViewport
+} from './way_viewport_straightness.js';
+
 export { geoRawMercator } from './raw_mercator.js';
 
 export { geoVecAdd } from './vector.js';

--- a/modules/geo/way_viewport_straightness.ts
+++ b/modules/geo/way_viewport_straightness.ts
@@ -33,8 +33,8 @@ export type WayStraightness = {
 
 
 function pointInExtent(p: Vec2, extent: geoExtent) {
-    return p[0] >= extent[0][0] && p[0] <= extent[1][0] &&
-        p[1] >= extent[0][1] && p[1] <= extent[1][1];
+    const { minX, minY, maxX, maxY } = extent.bbox();
+    return p[0] >= minX && p[0] <= maxX && p[1] >= minY && p[1] <= maxY;
 }
 
 
@@ -205,6 +205,104 @@ export function geoPolylineStraightness(points: Vec2[]): WayStraightness {
         spreadDeg,
         tortuosity,
         visiblePointCount: points.length
+    };
+}
+
+
+type VisibleSpan = {
+    length: number;
+    heading: number;
+};
+
+
+/**
+ * Longest portion of a segment that lies inside the viewport (or the full segment).
+ */
+function visibleSpanOnSegment(p0: Vec2, p1: Vec2, extent: geoExtent | null): VisibleSpan | null {
+    if (!extent) {
+        const length = geoVecLength(p0, p1);
+        if (length < 1) return null;
+        return { length, heading: geoVecAngle(p0, p1) };
+    }
+
+    const inside0 = pointInExtent(p0, extent);
+    const inside1 = pointInExtent(p1, extent);
+    const hits = segmentIntersectionsWithExtent(p0, p1, extent);
+
+    let start: Vec2;
+    let end: Vec2;
+
+    if (inside0 && inside1) {
+        start = p0;
+        end = p1;
+    } else if (inside0 && !inside1) {
+        start = p0;
+        const ordered = orderPointsAlongSegment(p0, p1, hits);
+        if (!ordered.length) return null;
+        end = ordered[ordered.length - 1];
+    } else if (!inside0 && inside1) {
+        end = p1;
+        const ordered = orderPointsAlongSegment(p0, p1, hits);
+        if (!ordered.length) return null;
+        start = ordered[0];
+    } else if (hits.length >= 2) {
+        const ordered = orderPointsAlongSegment(p0, p1, hits);
+        start = ordered[0];
+        end = ordered[ordered.length - 1];
+    } else {
+        return null;
+    }
+
+    const length = geoVecLength(start, end);
+    if (length < 1) return null;
+    return { length, heading: geoVecAngle(start, end) };
+}
+
+
+export type WayDominantHeading = {
+    headingDeg: number;
+    length: number;
+};
+
+
+/**
+ * Dominant travel heading (degrees) from the longest way segment currently visible
+ * in the viewport. Falls back to the longest full segment when clip extent is unset.
+ */
+export function geoWayDominantHeadingInViewport(
+    projection: Projection,
+    nodes: OsmNode[],
+    isClosed: boolean
+): WayDominantHeading | null {
+    const points = nodes
+        .map(n => projection(n.loc))
+        .filter((p): p is Vec2 => !!p);
+
+    if (points.length < 2) return null;
+
+    const clip = projection.clipExtent?.();
+    const extent = clip && geoExtent(clip);
+    const useExtent = extent && isFinite(extent.area()) && extent.area() > 0 ? extent : null;
+
+    let best: VisibleSpan | null = null;
+    const segmentCount = isClosed ? points.length : points.length - 1;
+
+    for (let i = 0; i < segmentCount; i++) {
+        const span = visibleSpanOnSegment(
+            points[i],
+            points[(i + 1) % points.length],
+            useExtent
+        );
+        if (span && (!best || span.length > best.length)) {
+            best = span;
+        }
+    }
+
+    if (!best) return null;
+
+    return {
+        headingDeg: best.heading * 180 / Math.PI,
+        length: best.length
     };
 }
 

--- a/modules/geo/way_viewport_straightness.ts
+++ b/modules/geo/way_viewport_straightness.ts
@@ -1,0 +1,232 @@
+import { geoExtent } from './extent.js';
+import { geoLineIntersection, geoPathLength } from './geom.js';
+import { geoVecAngle, geoVecLength, type Vec2 } from './vector.js';
+import type { Projection } from './raw_mercator.js';
+import type { OsmNode } from '../osm/node.js';
+
+
+/** Minimum visible path length (px) before left/right indicators are meaningful. */
+export const WAY_STRAIGHTNESS_MIN_VISIBLE_LENGTH = 40;
+
+/** Max turn between consecutive visible segments (degrees). */
+export const WAY_STRAIGHTNESS_MAX_TURN_DEG = 38;
+
+/** Max spread of segment headings across the visible path (degrees). */
+export const WAY_STRAIGHTNESS_MAX_SPREAD_DEG = 45;
+
+/** Visible path length divided by chord length; 1 = perfectly straight open span. */
+export const WAY_STRAIGHTNESS_MAX_TORTUOSITY = 1.15;
+
+/** Sum of all turns along the visible path (degrees). */
+export const WAY_STRAIGHTNESS_MAX_TOTAL_TURN_DEG = 55;
+
+
+export type WayStraightness = {
+    isStraightEnough: boolean;
+    visibleLength: number;
+    maxTurnDeg: number;
+    totalTurnDeg: number;
+    spreadDeg: number;
+    tortuosity: number;
+    visiblePointCount: number;
+};
+
+
+function pointInExtent(p: Vec2, extent: geoExtent) {
+    return p[0] >= extent[0][0] && p[0] <= extent[1][0] &&
+        p[1] >= extent[0][1] && p[1] <= extent[1][1];
+}
+
+
+function dedupePoints(points: Vec2[], epsilon = 0.01) {
+    const out: Vec2[] = [];
+    for (const p of points) {
+        const last = out[out.length - 1];
+        if (!last || geoVecLength(last, p) > epsilon) {
+            out.push(p);
+        }
+    }
+    return out;
+}
+
+
+function orderPointsAlongSegment(p0: Vec2, p1: Vec2, points: Vec2[]) {
+    const dx = p1[0] - p0[0];
+    const dy = p1[1] - p0[1];
+    return points.slice().sort((a, b) => {
+        const ta = (a[0] - p0[0]) * dx + (a[1] - p0[1]) * dy;
+        const tb = (b[0] - p0[0]) * dx + (b[1] - p0[1]) * dy;
+        return ta - tb;
+    });
+}
+
+
+function segmentIntersectionsWithExtent(p0: Vec2, p1: Vec2, extent: geoExtent) {
+    const polygon = extent.polygon();
+    const hits: Vec2[] = [];
+    for (let i = 0; i < 4; i++) {
+        const hit = geoLineIntersection([p0, p1], [polygon[i], polygon[i + 1]]);
+        if (hit) hits.push(hit);
+    }
+    return dedupePoints(hits);
+}
+
+
+/**
+ * Points along a segment that lie inside the viewport, in order from p0 toward p1.
+ * Includes boundary intersection points when the segment crosses the viewport edge.
+ */
+function visiblePointsOnSegment(p0: Vec2, p1: Vec2, extent: geoExtent) {
+    const inside0 = pointInExtent(p0, extent);
+    const inside1 = pointInExtent(p1, extent);
+    const hits = segmentIntersectionsWithExtent(p0, p1, extent);
+
+    if (inside0 && inside1) return [p1];
+    if (inside0 && !inside1) {
+        const ordered = orderPointsAlongSegment(p0, p1, hits);
+        return ordered.length ? [ordered[ordered.length - 1]] : [];
+    }
+    if (!inside0 && inside1) {
+        const ordered = orderPointsAlongSegment(p0, p1, hits);
+        return ordered.length ? [ordered[0], p1] : [p1];
+    }
+    if (hits.length >= 2) {
+        const ordered = orderPointsAlongSegment(p0, p1, hits);
+        return [ordered[0], ordered[ordered.length - 1]];
+    }
+    return [];
+}
+
+
+/**
+ * Builds a polyline of projected points that are currently visible in the viewport.
+ * For closed ways, includes the closing segment.
+ */
+export function geoVisiblePolylineInExtent(points: Vec2[], extent: geoExtent, isClosed: boolean) {
+    if (points.length < 2) return [];
+
+    const result: Vec2[] = [];
+    const segmentCount = isClosed ? points.length : points.length - 1;
+
+    function append(p: Vec2) {
+        const last = result[result.length - 1];
+        if (!last || last[0] !== p[0] || last[1] !== p[1]) {
+            result.push([p[0], p[1]]);
+        }
+    }
+
+    for (let i = 0; i < segmentCount; i++) {
+        const p0 = points[i];
+        const p1 = points[(i + 1) % points.length];
+        if (result.length === 0 && pointInExtent(p0, extent)) append(p0);
+        for (const p of visiblePointsOnSegment(p0, p1, extent)) append(p);
+    }
+
+    return result;
+}
+
+
+function angleDiffRadians(a: number, b: number) {
+    let d = a - b;
+    while (d > Math.PI) d -= 2 * Math.PI;
+    while (d < -Math.PI) d += 2 * Math.PI;
+    return d;
+}
+
+
+/**
+ * Smallest arc (radians) that contains all headings on a circle.
+ */
+function headingSpreadRadians(headings: number[]) {
+    if (headings.length < 2) return 0;
+    const sorted = headings.slice().sort((a, b) => a - b);
+    let maxGap = 0;
+    for (let i = 0; i < sorted.length; i++) {
+        const next = sorted[(i + 1) % sorted.length];
+        const gap = i === sorted.length - 1
+            ? sorted[0] + 2 * Math.PI - sorted[i]
+            : next - sorted[i];
+        maxGap = Math.max(maxGap, gap);
+    }
+    return 2 * Math.PI - maxGap;
+}
+
+
+/**
+ * Measures how straight a polyline is. Higher tortuosity / spread / turn ⇒ less straight.
+ */
+export function geoPolylineStraightness(points: Vec2[]): WayStraightness {
+    const empty: WayStraightness = {
+        isStraightEnough: false,
+        visibleLength: 0,
+        maxTurnDeg: 0,
+        totalTurnDeg: 0,
+        spreadDeg: 0,
+        tortuosity: Infinity,
+        visiblePointCount: points?.length || 0
+    };
+
+    if (!points || points.length < 2) return empty;
+
+    const visibleLength = geoPathLength(points);
+    if (visibleLength < WAY_STRAIGHTNESS_MIN_VISIBLE_LENGTH) {
+        return { ...empty, visibleLength, visiblePointCount: points.length };
+    }
+
+    const headings: number[] = [];
+    let maxTurnDeg = 0;
+    let totalTurnDeg = 0;
+
+    for (let i = 0; i < points.length - 1; i++) {
+        const heading = geoVecAngle(points[i], points[i + 1]);
+        if (headings.length) {
+            const turnDeg = Math.abs(angleDiffRadians(heading, headings[headings.length - 1])) * 180 / Math.PI;
+            maxTurnDeg = Math.max(maxTurnDeg, turnDeg);
+            totalTurnDeg += turnDeg;
+        }
+        headings.push(heading);
+    }
+
+    const spreadDeg = headingSpreadRadians(headings) * 180 / Math.PI;
+    const chord = geoVecLength(points[0], points[points.length - 1]);
+    const tortuosity = chord > 1 ? visibleLength / chord : Infinity;
+
+    const isStraightEnough =
+        maxTurnDeg <= WAY_STRAIGHTNESS_MAX_TURN_DEG &&
+        totalTurnDeg <= WAY_STRAIGHTNESS_MAX_TOTAL_TURN_DEG &&
+        spreadDeg <= WAY_STRAIGHTNESS_MAX_SPREAD_DEG &&
+        tortuosity <= WAY_STRAIGHTNESS_MAX_TORTUOSITY;
+
+    return {
+        isStraightEnough,
+        visibleLength,
+        maxTurnDeg,
+        totalTurnDeg,
+        spreadDeg,
+        tortuosity,
+        visiblePointCount: points.length
+    };
+}
+
+
+/**
+ * Whether left/right indicators are meaningful for the portion of a way currently in view.
+ */
+export function geoWayStraightnessInViewport(
+    projection: Projection,
+    nodes: OsmNode[],
+    isClosed: boolean
+): WayStraightness {
+    const points = nodes
+        .map(n => projection(n.loc))
+        .filter((p): p is Vec2 => !!p);
+
+    const clip = projection.clipExtent?.();
+    const extent = clip && geoExtent(clip);
+    if (!extent || !isFinite(extent.area()) || extent.area() <= 0) {
+        return geoPolylineStraightness(points);
+    }
+
+    const visible = geoVisiblePolylineInExtent(points, extent, isClosed);
+    return geoPolylineStraightness(visible);
+}

--- a/modules/svg/defs.js
+++ b/modules/svg/defs.js
@@ -84,6 +84,45 @@ export function svgDefs(context) {
         addSidedMarker('guard_rail', '#ddd', -1.5, 'circle');
         addSidedMarker('man_made', '#fff', 0);
 
+        /**
+         * Adds directional combo indicator marker on one side of a way.
+         * @param {'left' | 'right'} side
+         * @returns {void}
+         */
+        function addDirectionalComboMarker(side) {
+            // Two mirrored triangles (apex away from the stroke). With orient=auto, OSM :left / :right
+            // match the named marker only when mirrored geometry + refY use the opposite assignment
+            // from a naive “left = sided triangle” pairing (perpendicular offset was inverted).
+            const gap = 2.8;
+            const pathD = side === 'left'
+                ? 'M 0,2 L 1,1 L 2,2 z'
+                : 'M 0,0 L 1,1 L 2,0 z';
+            const refY = side === 'left' ? 2 + gap : -gap;
+            // Tight viewBox per side so uniform scale min(markerW/vbW, markerH/vbH) matches the old
+            // 2×2 viewBox + 3×3 marker (scale 1.5). A tall shared viewBox (e.g. 2×8) with marker 3×3
+            // used min(3/2, 3/8) and shrank the glyph ~4×.
+            const viewBox = side === 'left' ? '0 1 2 4' : '0 -3 2 4';
+            const markerW = 3;
+            const markerH = 6;
+            _defsSelection
+                .append('marker')
+                .attr('id', 'ideditor-directionalcombo-marker-' + side)
+                .attr('viewBox', viewBox)
+                .attr('refX', 1)
+                .attr('refY', refY)
+                .attr('markerWidth', markerW)
+                .attr('markerHeight', markerH)
+                .attr('markerUnits', 'strokeWidth')
+                .attr('orient', 'auto')
+                .append('path')
+                .attr('class', 'directionalcombo-marker-path directionalcombo-marker-' + side + '-path')
+                .attr('d', pathD)
+                .attr('stroke', 'none')
+                .attr('fill', '#7092ff');
+        }
+        addDirectionalComboMarker('left');
+        addDirectionalComboMarker('right');
+
         _defsSelection
             .append('marker')
             .attr('id', 'ideditor-viewfield-marker')

--- a/modules/svg/defs.js
+++ b/modules/svg/defs.js
@@ -2,6 +2,9 @@ import { svg as d3_svg } from 'd3-fetch';
 import { select as d3_select } from 'd3-selection';
 
 import { utilArrayUniq } from '../util';
+import {
+    DIRECTIONAL_COMBO_ARROW_DOWN_PATH, DIRECTIONAL_COMBO_ARROW_UP_PATH, DIRECTIONAL_COMBO_ARROW_VIEWBOX
+} from './directional_combo_arrow';
 
 
 /*
@@ -90,24 +93,15 @@ export function svgDefs(context) {
          * @returns {void}
          */
         function addDirectionalComboMarker(side) {
-            // Two mirrored triangles (apex away from the stroke). With orient=auto, OSM :left / :right
-            // match the named marker only when mirrored geometry + refY use the opposite assignment
-            // from a naive “left = sided triangle” pairing (perpendicular offset was inverted).
-            const gap = 2.8;
-            const pathD = side === 'left'
-                ? 'M 0,2 L 1,1 L 2,2 z'
-                : 'M 0,0 L 1,1 L 2,0 z';
+            const gap = 1.4;
+            const pathD = side === 'left' ? DIRECTIONAL_COMBO_ARROW_UP_PATH : DIRECTIONAL_COMBO_ARROW_DOWN_PATH;
             const refY = side === 'left' ? 2 + gap : -gap;
-            // Tight viewBox per side so uniform scale min(markerW/vbW, markerH/vbH) matches the old
-            // 2×2 viewBox + 3×3 marker (scale 1.5). A tall shared viewBox (e.g. 2×8) with marker 3×3
-            // used min(3/2, 3/8) and shrank the glyph ~4×.
-            const viewBox = side === 'left' ? '0 1 2 4' : '0 -3 2 4';
             const markerW = 3;
             const markerH = 6;
             _defsSelection
                 .append('marker')
                 .attr('id', 'ideditor-directionalcombo-marker-' + side)
-                .attr('viewBox', viewBox)
+                .attr('viewBox', DIRECTIONAL_COMBO_ARROW_VIEWBOX)
                 .attr('refX', 1)
                 .attr('refY', refY)
                 .attr('markerWidth', markerW)

--- a/modules/svg/directional_combo_arrow.js
+++ b/modules/svg/directional_combo_arrow.js
@@ -1,0 +1,10 @@
+/**
+ * Shared directional-combo arrow geometry.
+ * Keep map markers and sidebar label arrows visually aligned.
+ */
+export const DIRECTIONAL_COMBO_ARROW_VIEWBOX = '0 0 2 2.8';
+// Keep shaft width at 1/4 of total arrow width (0.5 on a width-2 viewBox),
+// and use a short stump so direction reads clearly.
+export const DIRECTIONAL_COMBO_ARROW_UP_PATH = 'M 0,1.1 L 1,0 L 2,1.1 L 1.25,1.1 L 1.25,1.6 L 0.75,1.6 L 0.75,1.1 Z';
+export const DIRECTIONAL_COMBO_ARROW_DOWN_PATH = 'M 0,1.7 L 1,2.8 L 2,1.7 L 1.25,1.7 L 1.25,1.2 L 0.75,1.2 L 0.75,1.7 Z';
+

--- a/modules/svg/lines.js
+++ b/modules/svg/lines.js
@@ -6,6 +6,7 @@ import {
 } from './helpers';
 import { svgTagClasses } from './tag_classes';
 
+import { geoWayStraightnessInViewport } from '../geo';
 import { osmEntity } from '../osm';
 import { utilArrayFlatten, utilArrayGroupBy } from '../util';
 import { utilDetect } from '../util/detect';
@@ -256,8 +257,18 @@ export function svgLines(projection, context) {
             const indicator = context.directionalComboIndicator && context.directionalComboIndicator();
             if (!indicator || !indicator.entityIDs || !indicator.entityIDs.length) return [];
 
+            const projection = context.projection;
+            const straightEntityIDs = indicator.entityIDs.filter(function(id) {
+                const entity = graph.hasEntity(id);
+                if (!entity || entity.geometry(graph) !== 'line') return false;
+                if (typeof projection !== 'function') return true;
+                const nodes = graph.childNodes(entity);
+                return geoWayStraightnessInViewport(projection, nodes, entity.isClosed()).isStraightEnough;
+            });
+            if (!straightEntityIDs.length) return [];
+
             const candidates = (pathdata[layer] || []).filter(function(entity) {
-                return indicator.entityIDs.indexOf(entity.id) !== -1;
+                return straightEntityIDs.indexOf(entity.id) !== -1;
             });
             if (!candidates.length) return [];
 

--- a/modules/svg/lines.js
+++ b/modules/svg/lines.js
@@ -244,7 +244,27 @@ export function svgLines(projection, context) {
         var ways = [];
         var onewaydata = {};
         var sideddata = {};
+        var directionalComboData = {};
         var oldMultiPolygonOuters = {};
+
+        /**
+         * Computes marker path segments for active directional combo indicator.
+         * @param {number} layer
+         * @returns {Array<{id: string, index: number, d: string}>}
+         */
+        function getDirectionalComboLayerData(layer) {
+            const indicator = context.directionalComboIndicator && context.directionalComboIndicator();
+            if (!indicator || !indicator.entityIDs || !indicator.entityIDs.length) return [];
+
+            const candidates = (pathdata[layer] || []).filter(function(entity) {
+                return indicator.entityIDs.indexOf(entity.id) !== -1;
+            });
+            if (!candidates.length) return [];
+
+            // Keep way direction so marker orientation matches left/right marker refY offsets.
+            const markerSegments = svgMarkerSegments(projection, graph, 30, function() { return false; });
+            return utilArrayFlatten(candidates.map(markerSegments));
+        }
 
         for (var i = 0; i < entities.length; i++) {
             var entity = entities[i];
@@ -275,6 +295,8 @@ export function svgLines(projection, context) {
                 projection, graph, 30
             );
             sideddata[k] = utilArrayFlatten(sidedArr.map(sidedSegments));
+
+            directionalComboData[k] = getDirectionalComboLayerData(k);
         });
 
 
@@ -323,6 +345,13 @@ export function svgLines(projection, context) {
                 function marker(d) {
                     var category = graph.entity(d.id).sidednessIdentifier();
                     return 'url(#ideditor-sided-marker-' + category + ')';
+                }
+            );
+            addMarkers(layergroup, 'directionalcombo', 'directional-combo-group', directionalComboData,
+                function marker() {
+                    const indicator = context.directionalComboIndicator && context.directionalComboIndicator();
+                    const side = indicator && indicator.side || 'right';
+                    return 'url(#ideditor-directionalcombo-marker-' + side + ')';
                 }
             );
         });

--- a/modules/svg/lines.js
+++ b/modules/svg/lines.js
@@ -257,7 +257,6 @@ export function svgLines(projection, context) {
             const indicator = context.directionalComboIndicator && context.directionalComboIndicator();
             if (!indicator || !indicator.entityIDs || !indicator.entityIDs.length) return [];
 
-            const projection = context.projection;
             const straightEntityIDs = indicator.entityIDs.filter(function(id) {
                 const entity = graph.hasEntity(id);
                 if (!entity || entity.geometry(graph) !== 'line') return false;

--- a/modules/ui/fields/directional_combo.js
+++ b/modules/ui/fields/directional_combo.js
@@ -1,7 +1,7 @@
 import { dispatch as d3_dispatch } from 'd3-dispatch';
 import { select as d3_select } from 'd3-selection';
 
-import { geoWayStraightnessInViewport } from '../../geo';
+import { geoWayDominantHeadingInViewport, geoWayStraightnessInViewport } from '../../geo';
 import { DIRECTIONAL_COMBO_ARROW_UP_PATH, DIRECTIONAL_COMBO_ARROW_VIEWBOX } from '../../svg/directional_combo_arrow';
 import { utilRebind } from '../../util';
 import { uiFieldCombo } from './combo';
@@ -81,8 +81,7 @@ export function uiFieldDirectionalCombo(field, context) {
         function refreshLabelArrowVisibility() {
             const entityIDs = selectedLinearEntityIDs();
             const straightEnough = selectedWaysStraightEnough(entityIDs);
-            if (straightEnough === _showLabelArrows) return;
-
+            const prevShow = _showLabelArrows;
             _showLabelArrows = straightEnough;
             items.selectAll('.directionalcombo-label-arrow')
                 .classed('directionalcombo-label-arrow-hidden', !_showLabelArrows);
@@ -90,32 +89,11 @@ export function uiFieldDirectionalCombo(field, context) {
             if (!_showLabelArrows && _activeIndicatorKey) {
                 clearIndicator();
             }
+            return prevShow !== straightEnough;
         }
 
         /**
-         * @returns {void}
-         */
-        function installMapListeners() {
-            if (_mapListenersInstalled || !context.map) return;
-            _mapListenersInstalled = true;
-            context.map()
-                .on('move.directionalcomboStraightness', refreshLabelArrowVisibility)
-                .on('drawn.directionalcomboStraightness', refreshLabelArrowVisibility);
-        }
-
-        /**
-         * @returns {void}
-         */
-        function uninstallMapListeners() {
-            if (!_mapListenersInstalled || !context.map) return;
-            _mapListenersInstalled = false;
-            context.map()
-                .on('move.directionalcomboStraightness', null)
-                .on('drawn.directionalcomboStraightness', null);
-        }
-
-        /**
-         * Compute base indicator rotation (degrees) from selected way direction.
+         * Compute base indicator rotation (degrees) from the longest visible way segment.
          * The shared label arrow glyph points "up" at 0deg.
          * Left uses base heading, right uses base + 180deg.
          * @param {string[]} entityIDs
@@ -128,43 +106,56 @@ export function uiFieldDirectionalCombo(field, context) {
 
             if (typeof projection !== 'function') return fallback;
 
-            let bestDX = null;
-            let bestDY = null;
+            let bestHeading = null;
             let bestLen = 0;
 
             for (let i = 0; i < entityIDs.length; i++) {
                 const entity = graph.hasEntity(entityIDs[i]);
                 if (!entity || entity.geometry(graph) !== 'line') continue;
 
-                const points = graph.childNodes(entity)
-                    .map(node => projection(node.loc))
-                    .filter(Boolean);
-
-                if (points.length < 2) continue;
-
-                for (let j = 0; j < points.length - 1; j++) {
-                    const dx = points[j + 1][0] - points[j][0];
-                    const dy = points[j + 1][1] - points[j][1];
-                    const len = Math.hypot(dx, dy);
-                    if (len > bestLen) {
-                        bestLen = len;
-                        bestDX = dx;
-                        bestDY = dy;
-                    }
+                const nodes = graph.childNodes(entity);
+                const dominant = geoWayDominantHeadingInViewport(projection, nodes, entity.isClosed());
+                if (dominant && dominant.length > bestLen) {
+                    bestLen = dominant.length;
+                    bestHeading = dominant.headingDeg;
                 }
             }
 
-            if (!bestLen || bestDX === null || bestDY === null) return fallback;
-
-            return Math.atan2(bestDY, bestDX) * 180 / Math.PI;
+            return bestHeading ?? fallback;
         }
 
         /**
          * Refreshes the base directional rotation from current selected linear entities.
-         * @returns {void}
+         * @returns {boolean} whether rotation changed
          */
         function refreshBaseIndicatorRotation() {
-            _baseIndicatorRotation = indicatorBaseRotation(selectedLinearEntityIDs());
+            const entityIDs = selectedLinearEntityIDs();
+            const next = indicatorBaseRotation(entityIDs);
+            const changed = next !== _baseIndicatorRotation;
+            _baseIndicatorRotation = next;
+            return changed;
+        }
+
+        /**
+         * Updates label arrows and rotation after pan/zoom or graph changes.
+         * @returns {void}
+         */
+        function refreshViewportDependentState() {
+            refreshLabelArrowVisibility();
+            if (refreshBaseIndicatorRotation()) {
+                updateIndicatorRowState();
+            }
+        }
+
+        /**
+         * @returns {void}
+         */
+        function installMapListeners() {
+            if (_mapListenersInstalled || !context.map) return;
+            _mapListenersInstalled = true;
+            context.map()
+                .on('move.directionalcomboStraightness', refreshViewportDependentState)
+                .on('drawn.directionalcomboStraightness', refreshViewportDependentState);
         }
 
         /**

--- a/modules/ui/fields/directional_combo.js
+++ b/modules/ui/fields/directional_combo.js
@@ -1,6 +1,8 @@
 import { dispatch as d3_dispatch } from 'd3-dispatch';
 import { select as d3_select } from 'd3-selection';
 
+import { geoWayStraightnessInViewport } from '../../geo';
+import { DIRECTIONAL_COMBO_ARROW_UP_PATH, DIRECTIONAL_COMBO_ARROW_VIEWBOX } from '../../svg/directional_combo_arrow';
 import { utilRebind } from '../../util';
 import { uiFieldCombo } from './combo';
 
@@ -9,6 +11,10 @@ export function uiFieldDirectionalCombo(field, context) {
     var dispatch = d3_dispatch('change');
     var items = d3_select(null);
     var wrap = d3_select(null);
+    var _activeIndicatorKey = null;
+    var _baseIndicatorRotation = null;
+    var _showLabelArrows = true;
+    var _mapListenersInstalled = false;
 
     /** @type {Record<string, ReturnType<typeof uiFieldCombo>>} */
     const _combos = {};
@@ -47,6 +53,139 @@ export function uiFieldDirectionalCombo(field, context) {
         }
 
         /**
+         * True when every selected linear entity is straight enough in the current viewport
+         * for left/right indicators to be meaningful.
+         * @param {string[]} entityIDs
+         * @returns {boolean}
+         */
+        function selectedWaysStraightEnough(entityIDs) {
+            const graph = context.graph();
+            const projection = context.projection;
+            if (typeof projection !== 'function') return false;
+
+            if (!entityIDs.length) return false;
+
+            return entityIDs.every(function(id) {
+                const entity = graph.hasEntity(id);
+                if (!entity || entity.geometry(graph) !== 'line') return false;
+                const nodes = graph.childNodes(entity);
+                if (nodes.length < 2) return false;
+                return geoWayStraightnessInViewport(projection, nodes, entity.isClosed()).isStraightEnough;
+            });
+        }
+
+        /**
+         * Refreshes label-arrow visibility from viewport straightness of selected ways.
+         * @returns {void}
+         */
+        function refreshLabelArrowVisibility() {
+            const entityIDs = selectedLinearEntityIDs();
+            const straightEnough = selectedWaysStraightEnough(entityIDs);
+            if (straightEnough === _showLabelArrows) return;
+
+            _showLabelArrows = straightEnough;
+            items.selectAll('.directionalcombo-label-arrow')
+                .classed('directionalcombo-label-arrow-hidden', !_showLabelArrows);
+
+            if (!_showLabelArrows && _activeIndicatorKey) {
+                clearIndicator();
+            }
+        }
+
+        /**
+         * @returns {void}
+         */
+        function installMapListeners() {
+            if (_mapListenersInstalled || !context.map) return;
+            _mapListenersInstalled = true;
+            context.map()
+                .on('move.directionalcomboStraightness', refreshLabelArrowVisibility)
+                .on('drawn.directionalcomboStraightness', refreshLabelArrowVisibility);
+        }
+
+        /**
+         * @returns {void}
+         */
+        function uninstallMapListeners() {
+            if (!_mapListenersInstalled || !context.map) return;
+            _mapListenersInstalled = false;
+            context.map()
+                .on('move.directionalcomboStraightness', null)
+                .on('drawn.directionalcomboStraightness', null);
+        }
+
+        /**
+         * Compute base indicator rotation (degrees) from selected way direction.
+         * The shared label arrow glyph points "up" at 0deg.
+         * Left uses base heading, right uses base + 180deg.
+         * @param {string[]} entityIDs
+         * @returns {number}
+         */
+        function indicatorBaseRotation(entityIDs) {
+            const graph = context.graph();
+            const projection = context.projection;
+            const fallback = 0;
+
+            if (typeof projection !== 'function') return fallback;
+
+            let bestDX = null;
+            let bestDY = null;
+            let bestLen = 0;
+
+            for (let i = 0; i < entityIDs.length; i++) {
+                const entity = graph.hasEntity(entityIDs[i]);
+                if (!entity || entity.geometry(graph) !== 'line') continue;
+
+                const points = graph.childNodes(entity)
+                    .map(node => projection(node.loc))
+                    .filter(Boolean);
+
+                if (points.length < 2) continue;
+
+                for (let j = 0; j < points.length - 1; j++) {
+                    const dx = points[j + 1][0] - points[j][0];
+                    const dy = points[j + 1][1] - points[j][1];
+                    const len = Math.hypot(dx, dy);
+                    if (len > bestLen) {
+                        bestLen = len;
+                        bestDX = dx;
+                        bestDY = dy;
+                    }
+                }
+            }
+
+            if (!bestLen || bestDX === null || bestDY === null) return fallback;
+
+            return Math.atan2(bestDY, bestDX) * 180 / Math.PI;
+        }
+
+        /**
+         * Refreshes the base directional rotation from current selected linear entities.
+         * @returns {void}
+         */
+        function refreshBaseIndicatorRotation() {
+            _baseIndicatorRotation = indicatorBaseRotation(selectedLinearEntityIDs());
+        }
+
+        /**
+         * Updates row hover class and directional side metadata.
+         * @returns {void}
+         */
+        function updateIndicatorRowState() {
+            items
+                .attr('data-indicator-side', key => keyToIndicatorSide(key) || null)
+                .style('--indicator-rotation', function(key) {
+                    const side = keyToIndicatorSide(key);
+                    if (!side || _baseIndicatorRotation === null) return null;
+                    const deg = side === 'left' ? _baseIndicatorRotation : (_baseIndicatorRotation + 180);
+                    return deg + 'deg';
+                })
+                .classed('is-active-indicator', function(key) {
+                    return key === _activeIndicatorKey;
+                });
+        }
+
+        /**
          * Activates map indicator for a directional combo row interaction.
          * @param {string} key
          * @returns {void}
@@ -54,11 +193,14 @@ export function uiFieldDirectionalCombo(field, context) {
         function activateIndicatorForKey(key) {
             const side = keyToIndicatorSide(key);
             const entityIDs = selectedLinearEntityIDs();
-            if (!side || !entityIDs.length) {
+            if (!side || !entityIDs.length || !selectedWaysStraightEnough(entityIDs)) {
                 clearIndicator();
                 return;
             }
 
+            _baseIndicatorRotation = indicatorBaseRotation(entityIDs);
+            _activeIndicatorKey = key;
+            updateIndicatorRowState();
             context.setDirectionalComboIndicator({
                 side: side,
                 entityIDs: entityIDs
@@ -70,6 +212,8 @@ export function uiFieldDirectionalCombo(field, context) {
          * @returns {void}
          */
         function clearIndicator() {
+            _activeIndicatorKey = null;
+            updateIndicatorRowState();
             context.setDirectionalComboIndicator(null);
         }
 
@@ -108,7 +252,15 @@ export function uiFieldDirectionalCombo(field, context) {
             .attr('class', 'label preset-label-directionalcombo')
             .attr('for', function(d) { return 'preset-input-directionalcombo-' + stripcolon(d); })
             .each(function(d) {
-                d3_select(this).call(field.t.append('types.' + d));
+                const label = d3_select(this);
+                label.call(field.t.append('types.' + d));
+                label
+                    .append('svg')
+                    .attr('class', 'directionalcombo-label-arrow')
+                    .attr('viewBox', DIRECTIONAL_COMBO_ARROW_VIEWBOX)
+                    .attr('aria-hidden', 'true')
+                    .append('path')
+                    .attr('d', DIRECTIONAL_COMBO_ARROW_UP_PATH);
             });
 
         enter
@@ -127,12 +279,32 @@ export function uiFieldDirectionalCombo(field, context) {
             });
 
         items = items.merge(enter);
+        installMapListeners();
+        refreshBaseIndicatorRotation();
+        refreshLabelArrowVisibility();
+        updateIndicatorRowState();
+
+        /**
+         * True if pointer moved from row into the open combobox for that row.
+         * @param {HTMLElement} row
+         * @param {EventTarget | null} related
+         * @returns {boolean}
+         */
+        function isRelatedTargetInsideOpenCombobox(row, related) {
+            const input = row.querySelector('input');
+            if (!input || !related || !(related instanceof Node)) return false;
+            const comboEl = context.container().select('.combobox');
+            return !comboEl.empty() &&
+                comboEl.datum() === input &&
+                comboEl.node().contains(/** @type {Node} */ (related));
+        }
 
         items
             .on('mouseenter.indicator', function(d3_event, key) {
                 activateIndicatorForKey(key);
             })
-            .on('mouseleave.indicator', function() {
+            .on('mouseleave.indicator', function(d3_event) {
+                if (isRelatedTargetInsideOpenCombobox(this, d3_event.relatedTarget)) return;
                 clearIndicator();
             });
 
@@ -253,6 +425,12 @@ export function uiFieldDirectionalCombo(field, context) {
     };
 
     directionalCombo.off = function() {
+        if (_mapListenersInstalled && context.map) {
+            context.map()
+                .on('move.directionalcomboStraightness', null)
+                .on('drawn.directionalcomboStraightness', null);
+            _mapListenersInstalled = false;
+        }
         context.setDirectionalComboIndicator(null);
     };
 

--- a/modules/ui/fields/directional_combo.js
+++ b/modules/ui/fields/directional_combo.js
@@ -23,6 +23,56 @@ export function uiFieldDirectionalCombo(field, context) {
     }
 
     function directionalCombo(selection) {
+        /**
+         * Maps a directional combo key to renderer-facing indicator side.
+         * @param {string} key
+         * @returns {'left' | 'right' | null}
+         */
+        function keyToIndicatorSide(key) {
+            if (/:left(:|$)/.test(key)) return 'left';
+            if (/:right(:|$)/.test(key)) return 'right';
+            return null;
+        }
+
+        /**
+         * Returns selected editable linear entity IDs for indicator rendering.
+         * @returns {string[]}
+         */
+        function selectedLinearEntityIDs() {
+            const graph = context.graph();
+            return context.selectedIDs().filter(function(id) {
+                const entity = graph.hasEntity(id);
+                return entity && entity.geometry(graph) === 'line';
+            });
+        }
+
+        /**
+         * Activates map indicator for a directional combo row interaction.
+         * @param {string} key
+         * @returns {void}
+         */
+        function activateIndicatorForKey(key) {
+            const side = keyToIndicatorSide(key);
+            const entityIDs = selectedLinearEntityIDs();
+            if (!side || !entityIDs.length) {
+                clearIndicator();
+                return;
+            }
+
+            context.setDirectionalComboIndicator({
+                side: side,
+                entityIDs: entityIDs
+            });
+        }
+
+        /**
+         * Deactivates the directional combo indicator and row highlight.
+         * @returns {void}
+         */
+        function clearIndicator() {
+            context.setDirectionalComboIndicator(null);
+        }
+
 
         function stripcolon(s) {
             return s.replaceAll(':', '');
@@ -77,6 +127,14 @@ export function uiFieldDirectionalCombo(field, context) {
             });
 
         items = items.merge(enter);
+
+        items
+            .on('mouseenter.indicator', function(d3_event, key) {
+                activateIndicatorForKey(key);
+            })
+            .on('mouseleave.indicator', function() {
+                clearIndicator();
+            });
 
         // Update
         wrap.selectAll('.preset-input-directionalcombo')
@@ -192,6 +250,10 @@ export function uiFieldDirectionalCombo(field, context) {
     directionalCombo.focus = function() {
         var node = wrap.selectAll('input').node();
         if (node) node.focus();
+    };
+
+    directionalCombo.off = function() {
+        context.setDirectionalComboIndicator(null);
     };
 
 

--- a/test/spec/geo/way_viewport_straightness.js
+++ b/test/spec/geo/way_viewport_straightness.js
@@ -52,6 +52,23 @@ describe('geoWayStraightnessInViewport', () => {
         expect(result.totalTurnDeg).to.be.above(90);
     });
 
+    it('uses the longest visible segment for dominant heading', () => {
+        const nodes = [
+            node('h0', [0, 0]),
+            node('h1', [0.00002, 0]),
+            node('h2', [0.00004, 0])
+        ];
+        const center = projection([0, 0]);
+        projection.clipExtent([
+            [center[0] - 60, center[1] - 30],
+            [center[0] + 60, center[1] + 30]
+        ]);
+        const result = iD.geoWayDominantHeadingInViewport(projection, nodes, false);
+        expect(result).to.not.be.null;
+        expect(result.length).to.be.above(40);
+        expect(result.headingDeg).to.be.closeTo(0, 2);
+    });
+
     it('only measures the portion inside the viewport', () => {
         const points = [[50, 200], [200, 200], [350, 200]];
         const visible = iD.geoVisiblePolylineInExtent(

--- a/test/spec/geo/way_viewport_straightness.js
+++ b/test/spec/geo/way_viewport_straightness.js
@@ -1,0 +1,80 @@
+describe('geoPolylineStraightness', () => {
+    it('treats an L-shaped path as not straight enough', () => {
+        const result = iD.geoPolylineStraightness([[0, 0], [200, 0], [200, 200]]);
+        expect(result.isStraightEnough).to.be.false;
+        expect(result.totalTurnDeg).to.be.closeTo(90, 1);
+    });
+});
+
+describe('geoWayStraightnessInViewport', () => {
+    /** @type {import('../../modules/geo/raw_mercator').Projection} */
+    let projection;
+
+    beforeEach(() => {
+        projection = iD.geoRawMercator();
+        projection.scale(256 * Math.pow(2, 19))
+            .translate([100, 100])
+            .clipExtent([[0, 0], [400, 400]]);
+    });
+
+    function node(id, loc) {
+        return new iD.osmNode({ id, loc });
+    }
+
+    it('treats a straight visible segment as straight enough', () => {
+        const a = node('a', [0, 0]);
+        const b = node('b', [0.05, 0]);
+        const result = iD.geoWayStraightnessInViewport(projection, [a, b], false);
+        expect(result.isStraightEnough).to.be.true;
+        expect(result.tortuosity).to.be.closeTo(1, 0.05);
+    });
+
+    it('treats a sharp visible bend as not straight enough', () => {
+        const visible = [[100, 100], [300, 100], [300, 300]];
+        const result = iD.geoPolylineStraightness(visible);
+        expect(result.isStraightEnough).to.be.false;
+        expect(result.maxTurnDeg).to.be.above(40);
+    });
+
+    it('treats a visible circular arc as not straight enough', () => {
+        const visible = [];
+        const steps = 16;
+        const radius = 80;
+        for (let i = 0; i <= steps; i++) {
+            const t = (i / steps) * Math.PI;
+            visible.push([
+                200 + radius * Math.cos(t),
+                200 + radius * Math.sin(t)
+            ]);
+        }
+        const result = iD.geoPolylineStraightness(visible);
+        expect(result.isStraightEnough).to.be.false;
+        expect(result.totalTurnDeg).to.be.above(90);
+    });
+
+    it('only measures the portion inside the viewport', () => {
+        const points = [[50, 200], [200, 200], [350, 200]];
+        const visible = iD.geoVisiblePolylineInExtent(
+            points,
+            iD.geoExtent([[150, 0], [250, 400]]),
+            false
+        );
+        expect(visible).to.eql([[150, 200], [200, 200], [250, 200]]);
+        expect(iD.geoPolylineStraightness(visible).isStraightEnough).to.be.true;
+    });
+
+    it('ignores geometry outside the viewport when judging curves', () => {
+        const nodes = [
+            node('a', [-0.05, -0.05]),
+            node('b', [0, 0]),
+            node('c', [0.05, 0.05])
+        ];
+        const center = projection([0, 0]);
+        projection.clipExtent([
+            [center[0] - 20, center[1] - 20],
+            [center[0] + 20, center[1] + 20]
+        ]);
+        const result = iD.geoWayStraightnessInViewport(projection, nodes, false);
+        expect(result.isStraightEnough).to.be.true;
+    });
+});

--- a/test/spec/svg/lines.js
+++ b/test/spec/svg/lines.js
@@ -222,7 +222,7 @@ describe('iD.svgLines', function () {
     describe('directional-combo-indicator-markers', function() {
         it('has directional combo indicator markers for active side', function() {
             var a = iD.osmNode({id: 'a', loc: [0, 0]});
-            var b = iD.osmNode({id: 'b', loc: [1e-2, 0]});
+            var b = iD.osmNode({id: 'b', loc: [50, 0]});
             var way = iD.osmWay({id: 'directional-way', tags: {highway: 'residential'}, nodes: [a.id, b.id]});
             var graph = new iD.coreGraph([a, b, way]);
 
@@ -233,14 +233,16 @@ describe('iD.svgLines', function () {
 
             surface.call(iD.svgLines(projection, context), graph, [way], all);
             var selection = surface.selectAll('g.directional-combo-group > path');
-            expect(selection.size()).to.eql(1);
-            expect(selection.nodes()[0].attributes['marker-mid'].nodeValue)
-                .to.eql('url(#ideditor-directionalcombo-marker-right)');
+            expect(selection.size()).to.be.above(0);
+            selection.nodes().forEach(function(node) {
+                expect(node.attributes['marker-mid'].nodeValue)
+                    .to.eql('url(#ideditor-directionalcombo-marker-right)');
+            });
         });
 
         it('has no directional combo indicator markers when inactive', function() {
             var a = iD.osmNode({id: 'a', loc: [0, 0]});
-            var b = iD.osmNode({id: 'b', loc: [1e-2, 0]});
+            var b = iD.osmNode({id: 'b', loc: [50, 0]});
             var way = iD.osmWay({id: 'directional-way', tags: {highway: 'residential'}, nodes: [a.id, b.id]});
             var graph = new iD.coreGraph([a, b, way]);
 

--- a/test/spec/svg/lines.js
+++ b/test/spec/svg/lines.js
@@ -218,4 +218,37 @@ describe('iD.svgLines', function () {
             expect(selection.empty()).to.be.true;
         });
     });
+
+    describe('directional-combo-indicator-markers', function() {
+        it('has directional combo indicator markers for active side', function() {
+            var a = iD.osmNode({id: 'a', loc: [0, 0]});
+            var b = iD.osmNode({id: 'b', loc: [1e-2, 0]});
+            var way = iD.osmWay({id: 'directional-way', tags: {highway: 'residential'}, nodes: [a.id, b.id]});
+            var graph = new iD.coreGraph([a, b, way]);
+
+            context.setDirectionalComboIndicator({
+                side: 'right',
+                entityIDs: [way.id]
+            });
+
+            surface.call(iD.svgLines(projection, context), graph, [way], all);
+            var selection = surface.selectAll('g.directional-combo-group > path');
+            expect(selection.size()).to.eql(1);
+            expect(selection.nodes()[0].attributes['marker-mid'].nodeValue)
+                .to.eql('url(#ideditor-directionalcombo-marker-right)');
+        });
+
+        it('has no directional combo indicator markers when inactive', function() {
+            var a = iD.osmNode({id: 'a', loc: [0, 0]});
+            var b = iD.osmNode({id: 'b', loc: [1e-2, 0]});
+            var way = iD.osmWay({id: 'directional-way', tags: {highway: 'residential'}, nodes: [a.id, b.id]});
+            var graph = new iD.coreGraph([a, b, way]);
+
+            context.setDirectionalComboIndicator(null);
+
+            surface.call(iD.svgLines(projection, context), graph, [way], all);
+            var selection = surface.selectAll('g.directional-combo-group > path');
+            expect(selection.empty()).to.be.true;
+        });
+    });
 });

--- a/test/spec/ui/fields/directional_combo.js
+++ b/test/spec/ui/fields/directional_combo.js
@@ -208,4 +208,59 @@ describe('iD.uiFieldDirectionalCombo', () => {
             });
         });
     });
+
+    describe('directional combo indicator interaction', function() {
+        const field = iD.presetField('name', {
+            key: 'cycleway',
+            keys: ['cycleway:left', 'cycleway:right'],
+        });
+
+        it('translates left/right row interaction to indicator sides', () => {
+            const instance = iD.uiFieldDirectionalCombo(field, context);
+            const onIndicator = vi.spyOn(context, 'setDirectionalComboIndicator');
+            const a = iD.osmNode({ id: 'nA', loc: [0, 0] });
+            const b = iD.osmNode({ id: 'nB', loc: [1, 1] });
+            const way = iD.osmWay({ id: 'w1', nodes: [a.id, b.id] });
+            vi.spyOn(context, 'selectedIDs').mockReturnValue([way.id]);
+            vi.spyOn(context, 'graph').mockReturnValue(new iD.coreGraph([a, b, way]));
+            selection.call(instance);
+
+            const rows = selection.selectAll('li.labeled-input').nodes();
+            expect(rows).toHaveLength(2);
+
+            d3.select(rows[0]).dispatch('mouseenter');
+            expect(onIndicator).toHaveBeenLastCalledWith(
+                expect.objectContaining({ side: 'left' })
+            );
+
+            d3.select(rows[1]).dispatch('mouseenter');
+            expect(onIndicator).toHaveBeenLastCalledWith(
+                expect.objectContaining({ side: 'right' })
+            );
+
+            d3.select(rows[1]).dispatch('mouseleave');
+            expect(onIndicator).toHaveBeenLastCalledWith(null);
+        });
+
+        it('ignores non-left/right directional keys', () => {
+            const forwardBackwardField = iD.presetField('name', {
+                key: 'cycleway',
+                keys: ['cycleway:forward', 'cycleway:backward'],
+            });
+            const instance = iD.uiFieldDirectionalCombo(forwardBackwardField, context);
+            const onIndicator = vi.spyOn(context, 'setDirectionalComboIndicator');
+            const a = iD.osmNode({ id: 'nA2', loc: [0, 0] });
+            const b = iD.osmNode({ id: 'nB2', loc: [1, 1] });
+            const way = iD.osmWay({ id: 'w2', nodes: [a.id, b.id] });
+            vi.spyOn(context, 'selectedIDs').mockReturnValue([way.id]);
+            vi.spyOn(context, 'graph').mockReturnValue(new iD.coreGraph([a, b, way]));
+            selection.call(instance);
+
+            const rows = selection.selectAll('li.labeled-input').nodes();
+            expect(rows).toHaveLength(2);
+
+            d3.select(rows[0]).dispatch('mouseenter');
+            expect(onIndicator).toHaveBeenLastCalledWith(null);
+        });
+    });
 });

--- a/test/spec/ui/fields/directional_combo.js
+++ b/test/spec/ui/fields/directional_combo.js
@@ -215,11 +215,35 @@ describe('iD.uiFieldDirectionalCombo', () => {
             keys: ['cycleway:left', 'cycleway:right'],
         });
 
+        beforeEach(() => {
+            context.projection
+                .scale(256 * Math.pow(2, 19))
+                .translate([100, 100])
+                .clipExtent([[0, 0], [2000, 2000]]);
+        });
+
+        it('sets directional rotation metadata before hover', () => {
+            const instance = iD.uiFieldDirectionalCombo(field, context);
+            const a = iD.osmNode({ id: 'nA0', loc: [0, 0] });
+            const b = iD.osmNode({ id: 'nB0', loc: [0.01, 0] });
+            const way = iD.osmWay({ id: 'w0', nodes: [a.id, b.id] });
+            vi.spyOn(context, 'selectedIDs').mockReturnValue([way.id]);
+            vi.spyOn(context, 'graph').mockReturnValue(new iD.coreGraph([a, b, way]));
+            selection.call(instance);
+
+            const rows = selection.selectAll('li.labeled-input').nodes();
+            expect(rows).toHaveLength(2);
+            expect(rows[0].dataset.indicatorSide).toBe('left');
+            expect(rows[1].dataset.indicatorSide).toBe('right');
+            expect(rows[0].style.getPropertyValue('--indicator-rotation')).not.toBe('');
+            expect(rows[1].style.getPropertyValue('--indicator-rotation')).not.toBe('');
+        });
+
         it('translates left/right row interaction to indicator sides', () => {
             const instance = iD.uiFieldDirectionalCombo(field, context);
             const onIndicator = vi.spyOn(context, 'setDirectionalComboIndicator');
             const a = iD.osmNode({ id: 'nA', loc: [0, 0] });
-            const b = iD.osmNode({ id: 'nB', loc: [1, 1] });
+            const b = iD.osmNode({ id: 'nB', loc: [0.01, 0] });
             const way = iD.osmWay({ id: 'w1', nodes: [a.id, b.id] });
             vi.spyOn(context, 'selectedIDs').mockReturnValue([way.id]);
             vi.spyOn(context, 'graph').mockReturnValue(new iD.coreGraph([a, b, way]));
@@ -232,14 +256,22 @@ describe('iD.uiFieldDirectionalCombo', () => {
             expect(onIndicator).toHaveBeenLastCalledWith(
                 expect.objectContaining({ side: 'left' })
             );
+            expect(rows[0].classList.contains('is-active-indicator')).toBe(true);
+            expect(rows[0].dataset.indicatorSide).toBe('left');
+            expect(rows[0].style.getPropertyValue('--indicator-rotation')).not.toBe('');
 
             d3.select(rows[1]).dispatch('mouseenter');
             expect(onIndicator).toHaveBeenLastCalledWith(
                 expect.objectContaining({ side: 'right' })
             );
+            expect(rows[1].classList.contains('is-active-indicator')).toBe(true);
+            expect(rows[1].dataset.indicatorSide).toBe('right');
+            expect(rows[1].style.getPropertyValue('--indicator-rotation')).not.toBe('');
 
             d3.select(rows[1]).dispatch('mouseleave');
             expect(onIndicator).toHaveBeenLastCalledWith(null);
+            expect(rows[1].classList.contains('is-active-indicator')).toBe(false);
+            expect(rows[1].style.getPropertyValue('--indicator-rotation')).not.toBe('');
         });
 
         it('ignores non-left/right directional keys', () => {
@@ -261,6 +293,63 @@ describe('iD.uiFieldDirectionalCombo', () => {
 
             d3.select(rows[0]).dispatch('mouseenter');
             expect(onIndicator).toHaveBeenLastCalledWith(null);
+            expect(rows[0].classList.contains('is-active-indicator')).toBe(false);
+            expect(rows[0].dataset.indicatorSide).toBe(undefined);
+        });
+
+        it('hides label arrows and suppresses map indicator on curved ways', () => {
+            const instance = iD.uiFieldDirectionalCombo(field, context);
+            const onIndicator = vi.spyOn(context, 'setDirectionalComboIndicator');
+            const curveNodes = [];
+            for (let i = 0; i <= 12; i++) {
+                const t = (i / 12) * Math.PI;
+                curveNodes.push(iD.osmNode({
+                    id: 'nC4_' + i,
+                    loc: [0.001 * Math.cos(t), 0.001 * Math.sin(t)]
+                }));
+            }
+            const way = iD.osmWay({
+                id: 'w4',
+                nodes: curveNodes.map(n => n.id)
+            });
+            vi.spyOn(context, 'selectedIDs').mockReturnValue([way.id]);
+            vi.spyOn(context, 'graph').mockReturnValue(new iD.coreGraph([...curveNodes, way]));
+            selection.call(instance);
+
+            const rows = selection.selectAll('li.labeled-input').nodes();
+            expect(selection.selectAll('.directionalcombo-label-arrow-hidden').size()).toBe(2);
+
+            d3.select(rows[0]).dispatch('mouseenter');
+            expect(onIndicator).toHaveBeenLastCalledWith(null);
+            expect(rows[0].classList.contains('is-active-indicator')).toBe(false);
+        });
+
+        it('keeps indicator active when moving pointer into open combobox', () => {
+            const instance = iD.uiFieldDirectionalCombo(field, context);
+            const onIndicator = vi.spyOn(context, 'setDirectionalComboIndicator');
+            const a = iD.osmNode({ id: 'nA3', loc: [0, 0] });
+            const b = iD.osmNode({ id: 'nB3', loc: [0.01, 0] });
+            const way = iD.osmWay({ id: 'w3', nodes: [a.id, b.id] });
+            vi.spyOn(context, 'selectedIDs').mockReturnValue([way.id]);
+            vi.spyOn(context, 'graph').mockReturnValue(new iD.coreGraph([a, b, way]));
+
+            const container = d3.select(document.createElement('div'));
+            context.container(container);
+            selection = container.append('div');
+            selection.call(instance);
+
+            const row = selection.selectAll('li.labeled-input').nodes()[0];
+            d3.select(row).dispatch('mouseenter');
+            const input = row.querySelector('input');
+
+            const combobox = container.append('div')
+                .attr('class', 'combobox')
+                .datum(input);
+            const option = combobox.append('div').node();
+
+            row.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true, relatedTarget: option }));
+            expect(onIndicator).not.toHaveBeenLastCalledWith(null);
+            expect(row.classList.contains('is-active-indicator')).toBe(true);
         });
     });
 });


### PR DESCRIPTION
A take to resolve https://github.com/openstreetmap/iD/issues/11950

> [!NOTE]
> **This is a draft PR meant to discuss styling and interaction.** 
> The code is generated and checked only a litte; not reviewed yet and not meant to be reviewed.

---

Right now, it is quite hard to add and review direction input fields on the map. One has to find the small <img width="30" height="27" alt="image" src="https://github.com/user-attachments/assets/7c13277a-ac94-4461-a547-ccfe79694a3b" /> arrow – that is sometimes hidden below the label name – and then extrapolate the left|right side based on that.

The idea of this change is, to give a visual indicator on the map when using the specific side.

There are a few cases out there that use a similar style…
* https://github.com/zlant/parking-lanes
* https://a-b-street.github.io/speedwalk

<details><summary>Example Screenshot from Speedwalk</summary>
<p>

<img width="1550" height="792" alt="Bildschirmfoto 2026-02-02 um 16 39 40" src="https://github.com/user-attachments/assets/2a12daa7-1698-46b0-82e4-00426bed5cb9" />


</p>
</details> 

But this solution suggests to only show the side that we are selecting ATM and only when we are working on this specific field/row.

---

### Blue arrows

The idea is to reuse the color we use for the newly added helper lines from https://github.com/openstreetmap/iD/pull/11774

<img width="676" height="312" alt="Bildschirmfoto 2026-03-25 um 06 38 08" src="https://github.com/user-attachments/assets/983288f1-fe63-4d57-aa8e-7e76e3216ae7" />
<img width="699" height="292" alt="Bildschirmfoto 2026-03-25 um 06 38 13" src="https://github.com/user-attachments/assets/5c726561-d984-4ae9-a7d8-e931b41688a2" />

### Red arrow

The idea here is to re-use the red color that we use for the "high is highlighted" and just add a "we look at this direction for this field" icon.

<img width="734" height="232" alt="Bildschirmfoto 2026-03-25 um 06 40 48" src="https://github.com/user-attachments/assets/0fe75b00-0fab-49e3-8c7a-5f31a2cdce69" />
<img width="762" height="233" alt="Bildschirmfoto 2026-03-25 um 06 40 51" src="https://github.com/user-attachments/assets/3a6add7b-eb11-4d46-ae35-98ed753bbc97" />

### Red select indicator (and label)

The idea here is to reuse the selection indicator below the line and move it to be bigger on the side that we indicate. (Ideally this would still show on the "other" side and just make the indicator side larger; here it moves.)

This also shows how we might show the key+value as an additional label. (This is not fleshed out, yet…)

<img width="731" height="153" alt="Bildschirmfoto 2026-03-25 um 06 50 59" src="https://github.com/user-attachments/assets/36bc7769-2999-4a51-97ae-af27a0b7ec3c" />
<img width="745" height="174" alt="Bildschirmfoto 2026-03-25 um 06 51 03" src="https://github.com/user-attachments/assets/5d1b63fe-3ff7-4aae-83db-201dfb568850" />


### Other options?

https://github.com/openstreetmap/iD/pull/10303 does something with side, but there is no style we can reuse here, IMO. Other than using the gray color, maybe. But I don't think this will help here. We use the gray indicators for things that are visible on the map all the time; the blue and red is for things that happen on indicator.

--- 

The Code will handle `forward|backward` as well by translating it to `rigth|left`. Does this sound right and what field could we test this on? https://github.com/openstreetmap/iD/pull/12099/changes#diff-4fa4b7fd7b8bbe73f21424cef0b08d14b77f072153d2f744c5728e47f1585569R33-R36