### PR TITLE
Fix: remove localized and prefix-based tags when switching presets (#12075)

### DIFF
--- a/modules/actions/change_preset.js
+++ b/modules/actions/change_preset.js
@@ -26,15 +26,56 @@ export function actionChangePreset(entityID, oldPreset, newPreset, skipFieldDefa
             }
 
             if (oldPreset && (oldPreset.id !== newPreset.id)) {
-                // 'field-keys' are keys used by fields (different to the keys used by preset itself)
-                const oldPresetFieldKeys = [
+                const oldFields = [
                     ...oldPreset.fields(loc),
                     ...oldPreset.moreFields(loc)
-                ].flatMap(f => f.allKeys());
+                ].filter(f => f.matchGeometry(geometry));
 
-                // field-keys used by the old preset but not the new preset
+                const oldPresetFieldKeys = oldFields.flatMap(f => f.allKeys());
+
                 const fieldKeysToRemove = utilArrayDifference(oldPresetFieldKeys, preserveKeys);
-                tags = utilObjectOmit(tags, fieldKeysToRemove);
+                const fieldKeysToRemoveSet = new Set(fieldKeysToRemove);
+
+                const expandedKeysToRemove = new Set();
+                const tagKeys = Object.keys(tags);  // Cache all existing tag keys once to avoid repeated Object iteration
+
+                // Only consider fields that are actually being removed
+                const fieldsToRemove = oldFields.filter(field => {
+                    const keys = field.allKeys();
+                    return keys.some(k => fieldKeysToRemoveSet.has(k));
+                });
+
+                // Expand removed fields into their full tag namespaces (localized and prefix-based)
+                for (const field of fieldsToRemove) {
+                    const keys = field.allKeys();
+
+                    const isLocalized = field.type === 'localized';
+                    const hasKeyPrefix = field.key && field.key.endsWith(':');
+
+                    for (const baseKey of keys) {
+                        // Always remove the base key itself (e.g. 'name', 'recycling')
+                        expandedKeysToRemove.add(baseKey);
+
+                        //For localized fields, remove all language variants (name:*)
+                        if (isLocalized) {
+                            for (const k of tagKeys) {
+                                if (k.startsWith(baseKey + ':')) {
+                                    expandedKeysToRemove.add(k);
+                                }
+                            }
+                        }
+                    }
+                    // For prefix-based fields, remove all tags that share the prefix (recycling:*)
+                    if (hasKeyPrefix) {
+                        for (const k of tagKeys) {
+                            if (k.startsWith(field.key)) {
+                                expandedKeysToRemove.add(k);
+                            }
+                        }
+                    }
+                }
+
+                tags = utilObjectOmit(tags, Array.from(expandedKeysToRemove));
             }
         }
         if (oldPreset) tags = oldPreset.unsetTags(tags, geometry, preserveKeys, false, loc);

--- a/test/spec/actions/change_preset.js
+++ b/test/spec/actions/change_preset.js
@@ -176,4 +176,76 @@ describe('iD.actionChangePreset', function() {
         var action = iD.actionChangePreset(entity.id, oldPreset, newPreset);
         expect(action(graph).entity(entity.id).tags).to.eql({highway: 'service'});
     });
+
+    // https://github.com/openstreetmap/iD/issues/12075
+    it('removes all localized name tags when switching presets', () => {
+        const graph = iD.coreGraph([
+            iD.osmNode({ id: 'n1', tags: {
+                craft: 'key_cutter',
+                name: 'foo',
+                'name:en': 'bar',
+                'name:hi': 'baz'
+            }})
+        ]);
+        const nameField = {
+            key: 'name',
+            type: 'localized',
+            allKeys: () => ['name'],
+            matchGeometry: () => true
+        };
+
+        const oldPreset = iD.presetPreset('craft/key_cutter', { tags: { craft: 'key_cutter' }, fields: ['name'] }, undefined, { name: nameField });
+        const newPreset = iD.presetPreset('amenity/recycling');
+
+        const result = iD.actionChangePreset('n1', oldPreset, newPreset)(graph);
+        const tags = result.entity('n1').tags;
+
+        expect(tags.name).to.be.undefined; // base localized key should be removed when the field is no longer present
+        expect(tags['name:en']).to.be.undefined; // all localized variants should also be removed
+        expect(tags['name:hi']).to.be.undefined;
+    });
+
+    it('removes all prefix-based recycling tags when switching presets', () => {
+        const graph = iD.coreGraph([
+            iD.osmNode({
+                id: 'n1',
+                tags: {
+                    amenity: 'recycling',
+                    'recycling:plastic': 'yes',
+                    'recycling:glass': 'yes',
+                    'recycling:paper': 'yes'
+                }
+            })
+        ]);
+
+        const recyclingField = {
+            key: 'recycling:',
+            type: 'combo',
+            allKeys: () => ['recycling'],
+            matchGeometry: () => true
+        };
+
+        const oldPreset = iD.presetPreset(
+            'amenity/recycling',
+            {
+                tags: { amenity: 'recycling' },
+                fields: ['recycling']
+            },
+            undefined,
+            { recycling: recyclingField }
+        );
+
+        const newPreset = iD.presetPreset(
+            'craft/key_cutter',
+            { tags: { craft: 'key_cutter' } }
+        );
+
+        const result = iD.actionChangePreset('n1', oldPreset, newPreset)(graph);
+        const tags = result.entity('n1').tags;
+
+        expect(tags['recycling:plastic']).to.be.undefined; //prefix-based tags should be removed when the field is no longer present
+        expect(tags['recycling:glass']).to.be.undefined;
+        expect(tags['recycling:paper']).to.be.undefined;
+        expect(tags.craft).to.equal('key_cutter');  // unrelated tags should be preserved during preset change
+    });
 });


### PR DESCRIPTION
Fix #12075


## Description

When switching presets, iD removes only the **base field keys**, but does not remove related tags belonging to the same namespace.

### Localized fields 

Only the base key (`name`) is removed, while language variants remain.

**Example:**

Before:
```
craft=key_cutter
name=foo
name:en=bar
name:hi=baz

```
After switching to recycling:
```
amenity=recycling
recycling_type=container
name:en=bar   ❌
name:hi=baz   ❌
```

### Prefix-based fields (multiCombo / key: 'prefix:')

Tags sharing a prefix are not removed.

**Example:**

Before:
```
amenity=recycling
recycling:plastic=yes
recycling:glass=yes
recycling:paper=yes
```
After switching to key cutter:
```
craft=key_cutter
recycling:plastic=yes   ❌
recycling:glass=yes     ❌
recycling:paper=yes     ❌
```

---

### Why this happens

The current implementation only removes **exact field keys**, but does not account for:

* localized namespaces (name:*)
* prefix-based namespaces (recycling:*)

As a result, related tags remain after the preset change.

## Solution

This PR expands the removal logic to handle full tag namespaces:

- Identify fields present in the old preset but not preserved in the new preset
- For each removed field:

  * **Localized fields (`type: localized`)**

    * remove: `name` and all `name:*`
  * **Prefix-based fields (`key` ends with `:`)**

    * remove: all tags matching the prefix (`recycling:*`)
- Collect all keys and remove them using `utilObjectOmit`

### Additional improvements:

* Use 'Set' for efficient lookups
* Cache `Object.keys(tags)` to avoid repeated iteration
* Filter fields using `matchGeometry(geometry)` for consistency with existing logic

## Demo Video(After)-

https://github.com/user-attachments/assets/930c4cb7-93fa-4b02-928b-c6f38a29ccb2


## Test

Added two tests to validate the behavior:

**Localized fields test**

  * Confirms `name` and all `name:*` tags are removed

**Prefix-based fields test**

  * Confirms all `recycling:*` tags are removed
  * Ensures unrelated tags are preserved

### Review appreciated, especially on:

- overall approach and correctness of the logic
- potential optimizations or edge cases
- test coverage and mocking strategy used in the test file

---