### PR TITLE
fixed bug in `canSumTags` logic: correctly determine numeric tag values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Fix user images and upload help text from showing up as duplicates in upload dialog ([#12063])
 * Fix some tags automatically deleted when re-selecting the same preset ([#12070], thanks [@k-yle])
 * Fix crash when a checkbox-field is rendered using a custom (non-`yes/no`) value ([#12078])
+* Fix a bug that caused `step_count` to be set to `NaN` when merging features with non-numeric step count values ([#12110], thanks [@JaiswalShivang])
 #### :earth_asia: Localization
 #### :hourglass: Performance
 #### :mortar_board: Walkthrough / Help
@@ -69,6 +70,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#12065]: https://github.com/openstreetmap/iD/issues/12065
 [#12070]: https://github.com/openstreetmap/iD/issues/12070
 [#12078]: https://github.com/openstreetmap/iD/issues/12078
+[#12110]: https://github.com/openstreetmap/iD/issues/12110
 
 
 # 2.39.4

--- a/modules/actions/join.js
+++ b/modules/actions/join.js
@@ -210,8 +210,8 @@ export function actionJoin(ids) {
 
     function canSumTags(key, tagsA, tagsB) {
         return osmSummableTags.has(key) &&
-            isFinite(tagsA[key] &&
-            isFinite(tagsB[key]));
+            isFinite(tagsA[key]) &&
+            isFinite(tagsB[key]);
     }
 
 

--- a/test/spec/actions/join.js
+++ b/test/spec/actions/join.js
@@ -611,40 +611,37 @@ describe('iD.actionJoin', function () {
         expect(graph.entity('-').tags.step_count).to.equal('42');
     });
 
-    it('does not produce NaN when the first way has a non-numeric summable tag', function () {
-        let graph = iD.coreGraph([
+    it('returns conflicting_tags when the first way has a non-numeric summable tag', function () {
+        var graph = iD.coreGraph([
             iD.osmNode({ id: 'a', loc: [0, 0] }),
             iD.osmNode({ id: 'b', loc: [1, 0] }),
             iD.osmNode({ id: 'c', loc: [4, 0] }),
             iD.osmWay({ id: '-', nodes: ['a', 'b'], tags: { highway: 'steps', step_count: 'many' } }),
             iD.osmWay({ id: '=', nodes: ['b', 'c'], tags: { highway: 'steps', step_count: '10' } })
         ]);
-        graph = iD.actionJoin(['-', '='])(graph);
-        expect(graph.entity('-').tags.step_count).not.to.equal('NaN');
+        expect(iD.actionJoin(['-', '=']).disabled(graph)).to.equal('conflicting_tags');
     });
 
-    it('does not produce NaN when the second way has a non-numeric summable tag', function () {
-        let graph = iD.coreGraph([
+    it('returns conflicting_tags when the second way has a non-numeric summable tag', function () {
+        var graph = iD.coreGraph([
             iD.osmNode({ id: 'a', loc: [0, 0] }),
             iD.osmNode({ id: 'b', loc: [1, 0] }),
             iD.osmNode({ id: 'c', loc: [4, 0] }),
             iD.osmWay({ id: '-', nodes: ['a', 'b'], tags: { highway: 'steps', step_count: '10' } }),
             iD.osmWay({ id: '=', nodes: ['b', 'c'], tags: { highway: 'steps', step_count: 'bbb' } })
         ]);
-        graph = iD.actionJoin(['-', '='])(graph);
-        expect(graph.entity('-').tags.step_count).not.to.equal('NaN');
+        expect(iD.actionJoin(['-', '=']).disabled(graph)).to.equal('conflicting_tags');
     });
 
-    it('does not produce NaN when both ways have non-numeric summable tags', function () {
-        let graph = iD.coreGraph([
+    it('returns conflicting_tags when both ways have non-numeric summable tags', function () {
+        var graph = iD.coreGraph([
             iD.osmNode({ id: 'a', loc: [0, 0] }),
             iD.osmNode({ id: 'b', loc: [1, 0] }),
             iD.osmNode({ id: 'c', loc: [4, 0] }),
             iD.osmWay({ id: '-', nodes: ['a', 'b'], tags: { highway: 'steps', step_count: 'many' } }),
             iD.osmWay({ id: '=', nodes: ['b', 'c'], tags: { highway: 'steps', step_count: 'lots' } })
         ]);
-        graph = iD.actionJoin(['-', '='])(graph);
-        expect(graph.entity('-').tags.step_count).not.to.equal('NaN');
+        expect(iD.actionJoin(['-', '=']).disabled(graph)).to.equal('conflicting_tags');
     });
 
 

--- a/test/spec/actions/join.js
+++ b/test/spec/actions/join.js
@@ -611,6 +611,42 @@ describe('iD.actionJoin', function () {
         expect(graph.entity('-').tags.step_count).to.equal('42');
     });
 
+    it('does not produce NaN when the first way has a non-numeric summable tag', function () {
+        let graph = iD.coreGraph([
+            iD.osmNode({ id: 'a', loc: [0, 0] }),
+            iD.osmNode({ id: 'b', loc: [1, 0] }),
+            iD.osmNode({ id: 'c', loc: [4, 0] }),
+            iD.osmWay({ id: '-', nodes: ['a', 'b'], tags: { highway: 'steps', step_count: 'many' } }),
+            iD.osmWay({ id: '=', nodes: ['b', 'c'], tags: { highway: 'steps', step_count: '10' } })
+        ]);
+        graph = iD.actionJoin(['-', '='])(graph);
+        expect(graph.entity('-').tags.step_count).not.to.equal('NaN');
+    });
+
+    it('does not produce NaN when the second way has a non-numeric summable tag', function () {
+        let graph = iD.coreGraph([
+            iD.osmNode({ id: 'a', loc: [0, 0] }),
+            iD.osmNode({ id: 'b', loc: [1, 0] }),
+            iD.osmNode({ id: 'c', loc: [4, 0] }),
+            iD.osmWay({ id: '-', nodes: ['a', 'b'], tags: { highway: 'steps', step_count: '10' } }),
+            iD.osmWay({ id: '=', nodes: ['b', 'c'], tags: { highway: 'steps', step_count: 'bbb' } })
+        ]);
+        graph = iD.actionJoin(['-', '='])(graph);
+        expect(graph.entity('-').tags.step_count).not.to.equal('NaN');
+    });
+
+    it('does not produce NaN when both ways have non-numeric summable tags', function () {
+        let graph = iD.coreGraph([
+            iD.osmNode({ id: 'a', loc: [0, 0] }),
+            iD.osmNode({ id: 'b', loc: [1, 0] }),
+            iD.osmNode({ id: 'c', loc: [4, 0] }),
+            iD.osmWay({ id: '-', nodes: ['a', 'b'], tags: { highway: 'steps', step_count: 'many' } }),
+            iD.osmWay({ id: '=', nodes: ['b', 'c'], tags: { highway: 'steps', step_count: 'lots' } })
+        ]);
+        graph = iD.actionJoin(['-', '='])(graph);
+        expect(graph.entity('-').tags.step_count).not.to.equal('NaN');
+    });
+
 
     it('merges relations', function () {
         var graph = iD.coreGraph([


### PR DESCRIPTION
Fixes #12110 

### Description

In `modules/actions/join.js`, the `canSumTags()` helper function has a misplaced parenthesis that causes the `isFinite()` check on `tagsA[key]` to be completely bypassed.

`tagsA[key] && isFinite(tagsB[key])` is evaluated first — producing a boolean

### Current Code (Line 211-215)

```js
function canSumTags(key, tagsA, tagsB) {
    return osmSummableTags.has(key) &&
        isFinite(tagsA[key] &&
        isFinite(tagsB[key]));
}
