### PR TITLE
Fix incorrect sort comparator in crossing_ways

### DIFF
--- a/modules/validations/crossing_ways.js
+++ b/modules/validations/crossing_ways.js
@@ -376,22 +376,6 @@ export function validationCrossingWays(context) {
 
 
     function createIssue(crossing, graph) {
-
-        // use the entities with the tags that define the feature type
-        crossing.wayInfos.sort(function(way1Info, way2Info) {
-            var type1 = way1Info.featureType;
-            var type2 = way2Info.featureType;
-            if (type1 === type2) {
-                var label1 = utilDisplayLabel(way1Info.way, graph);
-                var label2 = utilDisplayLabel(way2Info.way, graph);
-                return label1 > label2 ? 1 : label1 < label2 ? -1 : 0;
-            } else if (type1 === 'waterway') {
-                return 1;
-            } else if (type2 === 'waterway') {
-                return -1;
-            }
-            return type1 > type2 ? 1 : type1 < type2 ? -1 : 0;
-        });
         var entities = crossing.wayInfos.map(function(wayInfo) {
             return getFeatureWithFeatureTypeTagsForWay(wayInfo.way, graph);
         });

--- a/modules/validations/crossing_ways.js
+++ b/modules/validations/crossing_ways.js
@@ -382,13 +382,15 @@ export function validationCrossingWays(context) {
             var type1 = way1Info.featureType;
             var type2 = way2Info.featureType;
             if (type1 === type2) {
-                return utilDisplayLabel(way1Info.way, graph) > utilDisplayLabel(way2Info.way, graph);
+                var label1 = utilDisplayLabel(way1Info.way, graph);
+                var label2 = utilDisplayLabel(way2Info.way, graph);
+                return label1 > label2 ? 1 : label1 < label2 ? -1 : 0;
             } else if (type1 === 'waterway') {
-                return true;
+                return 1;
             } else if (type2 === 'waterway') {
-                return false;
+                return -1;
             }
-            return type1 < type2;
+            return type1 > type2 ? 1 : type1 < type2 ? -1 : 0;
         });
         var entities = crossing.wayInfos.map(function(wayInfo) {
             return getFeatureWithFeatureTypeTagsForWay(wayInfo.way, graph);

--- a/test/spec/validations/crossing_ways.js
+++ b/test/spec/validations/crossing_ways.js
@@ -368,7 +368,9 @@ describe('iD.validations.crossing_ways', function () {
 
     it('flags minor road crossing waterway', function() {
         createWaysWithOneCrossingPoint({ highway: 'residential' }, { waterway: 'river' });
-        verifySingleCrossingIssue(validate(), { ford: 'yes' });
+        const issues = validate();
+        verifySingleCrossingIssue(issues, { ford: 'yes' });
+        expect(issues[0].data.featureTypes).to.eql(['highway', 'waterway']);
     });
 
     it('flags major road crossing waterway', function() {


### PR DESCRIPTION
Fixes: #12119 
The current Array.prototype.sort() comparator in crossing_ways.js returns boolean values (true/false), which are coerced to 1/0.

This can lead to incorrect and unstable sorting behavior because the comparator never returns negative values, which are required to correctly order elements in JavaScript's sort algorithm.

### Before
Comparator returned boolean values:
- true → 1
- false → 0

### After
Comparator now returns proper numeric values:
- negative (a < b)
- positive (a > b)
- zero (equal)

This PR updates the comparator to return proper numeric values (-1, 0, 1), ensuring consistent and correct ordering.

✅ Fixes unstable sorting  
✅ Aligns with JavaScript sort specification