### PR TITLE
fix: ensure comparator returns 0 for equal values in address field so…

### DIFF
--- a/modules/ui/fields/address.js
+++ b/modules/ui/fields/address.js
@@ -187,7 +187,7 @@ export function uiFieldAddress(field, context) {
         return utilArrayUniqBy([
             ...enclosingAddresses,
             ...nearPointAddresses
-        ], 'value').sort((a, b) => a.value > b.value ? 1 : -1);
+        ], 'value').sort((a, b) => a.value === b.value ? 0 : (a.value > b.value ? 1 : -1));
     }
 
 


### PR DESCRIPTION
Fixes #12130 

## Description
This PR fixes an issue in the address field sorting comparator where equal values were not handled correctly. The comparator always returned -1, even when values were equal.

## Changes
- Updated comparator to return 0 when values are equal

## Testing
- Verified sorting behavior manually
- Ensured no regressions in address field UI