### PR TITLE
chore: make npm test exit properly and add test:watch script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -294,7 +294,9 @@ Test your code and make sure it passes.
 
 1. Go to the directory where you have checked out `iD`
 2. run `npm clean-install`
-3. run `npm test` to see whether your tests pass or fail. Note that this command will run constantly and automatically re-run tests if source or test files are modified – if you want to run tests only once, use `npm run test:once` instead
+3. run `npm test` to see whether your tests pass or fail.
+  - To re-run tests automatically in watch mode, use `npm run test:watch`.
+  - To run just the Vitest suite once, use `npm run test:spec` (or `npm run test:once`).
 
 ### Building / Installing
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "start:server": "node scripts/server.js",
     "test": "npm-run-all -s lint build test:typecheck test:spec",
     "test:typecheck": "tsc",
-    "test:spec": "vitest --no-isolate",
+    "test:spec": "vitest run --no-isolate",
+    "test:watch": "vitest --no-isolate",
     "test:once": "vitest run --no-isolate",
     "translations": "node scripts/update_locales.js"
   },


### PR DESCRIPTION
Fixes #12132 
## Description
Updates the test scripts so that `npm test` no longer runs in watch mode and exits properly. This improves compatibility with CI and scripting workflows.

## Changes
- Updated `test:spec` to use `vitest run` (single run, exits)
- Added `test:watch` script for watch mode during development
- Ensured `npm test` completes with exit code 0
- Updated documentation in `CONTRIBUTING.md` to reflect the new behavior

## Testing
- Verified that `npm test` runs once and exits cleanly
- Verified that `npm run test:spec` runs once
- Verified that `npm run test:watch` runs in watch mode

## Usage
- Run full test pipeline: `npm test`
- Run Vitest once: `npm run test:spec`
- Run in watch mode: `npm run test:watch`