### PR TITLE
Improve upload explanation message to clarify visibility and refresh behavior

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -604,7 +604,7 @@ en:
     retry: Retry
   commit:
     title: Upload to OpenStreetMap
-    upload_explanation: "The changes you upload will be visible on all maps that use OpenStreetMap data."
+    upload_explanation: "Your changes should appear on OpenStreetMap within a few minutes. If you don’t see them, try refreshing the page (you may need to clear cache). It may take longer for other maps to update."
     upload_explanation_with_user: "The changes you upload as {user} will be visible on all maps that use OpenStreetMap data."
     request_review: "I would like someone to review my edits."
     request_review_info: "Unsure about something? Invite an experienced mapper to check your work once it's live."

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -605,7 +605,7 @@ en:
   commit:
     title: Upload to OpenStreetMap
     upload_explanation: "Your changes should appear on OpenStreetMap within a few minutes. If you don’t see them, try refreshing the page (you may need to clear cache). It may take longer for other maps to update."
-    upload_explanation_with_user: "The changes you upload as {user} will be visible on all maps that use OpenStreetMap data."
+    upload_explanation_with_user: "Your changes, uploaded as {user}, should appear on OpenStreetMap within a few minutes. If you don’t see them, try refreshing the page (you may need to clear cache). It may take longer for other maps to update."
     request_review: "I would like someone to review my edits."
     request_review_info: "Unsure about something? Invite an experienced mapper to check your work once it's live."
     save: Upload

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -604,7 +604,7 @@ en:
     retry: Retry
   commit:
     title: Upload to OpenStreetMap
-    upload_explanation: "Your changes should appear on OpenStreetMap within a few minutes. If you don’t see them, try refreshing the page (you may need to clear cache). It may take longer for other maps to update."
+    upload_explanation: "Your changes should appear on OpenStreetMap within a few minutes. If you don’t see them, try refreshing the page (you may need to clear your browser cache). It may take longer for other maps to update."
     upload_explanation_with_user: "Your changes, uploaded as {user}, should appear on OpenStreetMap within a few minutes. If you don’t see them, try refreshing the page (you may need to clear cache). It may take longer for other maps to update."
     request_review: "I would like someone to review my edits."
     request_review_info: "Unsure about something? Invite an experienced mapper to check your work once it's live."


### PR DESCRIPTION
This updates the upload explanation message shown after saving changes to make it clearer for new contributors.
Previously, the message stated that changes would be visible on all maps, which could be misleading and did not provide guidance on what to do if changes were not immediately visible.
This change:
- Adds a clearer expectation about timing ("within a few minutes")
- Suggests refreshing the page (including cache)
- Clarifies that other maps may take longer to update
This aims to reduce confusion frequently observed among new users regarding when their edits appear.

fixes: #12113 