### PR TITLE
Fix: deselect way when selecting first/last node

### DIFF
--- a/modules/modes/select.js
+++ b/modules/modes/select.js
@@ -491,48 +491,26 @@ export function modeSelect(context, selectedIDs) {
         }
 
 
-        function firstVertex(d3_event) {
-            d3_event.preventDefault();
-            var entity = singular();
-            var parentId = parentWayIdForVertexNavigation();
-            var way;
-
-            if (entity && entity.type === 'way') {
-                way = entity;
-            } else if (parentId) {
-                way = context.entity(parentId);
-            }
-            _focusedParentWayId = way && way.id;
-
-            if (way) {
-                context.enter(
-                    mode.selectedIDs([way.first()])
-                        .follow(true)
-                );
-            }
-        }
+        function firstVertex() {
+    var way = graph.hasEntity(_selectedData[0]);
+    if (way) {
+        context.enter(
+            modeSelect(context, [way.first()])
+                .follow(true)
+        );
+    }
+}
 
 
-        function lastVertex(d3_event) {
-            d3_event.preventDefault();
-            var entity = singular();
-            var parentId = parentWayIdForVertexNavigation();
-            var way;
-
-            if (entity && entity.type === 'way') {
-                way = entity;
-            } else if (parentId) {
-                way = context.entity(parentId);
-            }
-            _focusedParentWayId = way && way.id;
-
-            if (way) {
-                context.enter(
-                    mode.selectedIDs([way.last()])
-                        .follow(true)
-                );
-            }
-        }
+        function lastVertex() {
+    var way = graph.hasEntity(_selectedData[0]);
+    if (way) {
+        context.enter(
+            modeSelect(context, [way.last()])
+                .follow(true)
+        );
+    }
+}
 
 
         function previousVertex(d3_event) {


### PR DESCRIPTION
Fixes issue #10962

When selecting the first or last node of a way using keyboard shortcuts, the way remained visually selected, which caused confusion.

This change ensures that only the selected node remains active, and the parent way is properly deselected.

The fix replaces reuse of the existing mode with a fresh select mode, preventing stale selection state.

Tested locally:
- Selected a way
- Used first/last node shortcuts
- Confirmed that only the node is selected and the way is no longer highlighted