### PR TITLE
dynamic number of nodes for circularized way, depending on size of circularized feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :sparkles: Usability & Accessibility
 #### :scissors: Operations
 * Correctly split a way on all selected vertices when three or more nodes are selected ([#12120])
+* Create fewer points when circularizing small features (and vice versa): the number of vertices in the resulting circle is now dynamic between a 12 and 32 depending on the radius of the circle (instead of always resulting in 19 nodes) ([#12139])
 #### :camera: Street-Level
 #### :white_check_mark: Validation
 * Treat most aerialways as part of the routable network when checking other ways' connectivity ([#9406])
@@ -73,6 +74,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#12078]: https://github.com/openstreetmap/iD/issues/12078
 [#12110]: https://github.com/openstreetmap/iD/issues/12110
 [#12120]: https://github.com/openstreetmap/iD/issues/12120
+[#12139]: https://github.com/openstreetmap/iD/pull/12139
 
 
 # 2.39.4

--- a/modules/actions/circularize.js
+++ b/modules/actions/circularize.js
@@ -1,5 +1,5 @@
 import { median as d3_median } from 'd3-array';
-
+import { geoLength } from 'd3-geo';
 import {
     polygonArea as d3_polygonArea,
     polygonHull as d3_polygonHull,
@@ -9,12 +9,11 @@ import {
 import { geoVecInterp, geoVecLength } from '../geo';
 import { osmNode } from '../osm/node';
 import { utilArrayUniq } from '../util';
-import { geoVecLengthSquare } from '../geo/vector';
+import { radiansToMeters } from '../ui/panels';
 
 
-export function actionCircularize(wayId, projection, maxAngle) {
-    maxAngle = (maxAngle || 20) * Math.PI / 180;
-
+export function actionCircularize(wayId, projection) {
+    const _maxSegmentLength = 4;
 
     var action = function(graph, t) {
         if (t === null || !isFinite(t)) t = 1;
@@ -58,6 +57,14 @@ export function actionCircularize(wayId, projection, maxAngle) {
             keyPoints.push(points[oppositeIndex]);
         }
 
+        const radiusM = radiansToMeters(geoLength({ type: 'LineString', coordinates: [
+            projection.invert(centroid),
+            projection.invert([centroid[0] + radius, centroid[1]])
+        ]}));
+        const numberOfPoints = Math.min(32, Math.max(12,
+            Math.round(radiusM * Math.PI / _maxSegmentLength) * 2
+        ));
+        const maxAngle = Math.PI * 2 / (numberOfPoints - 1);
         // key points and nodes are those connected to the ways,
         // they are projected onto the circle, in between nodes are moved
         // to constant intervals between key nodes, extra in between nodes are
@@ -244,21 +251,30 @@ export function actionCircularize(wayId, projection, maxAngle) {
         if (hull.length !== points.length || hull.length < 3){
             return false;
         }
-        var centroid = d3_polygonCentroid(points);
-        var radius = geoVecLengthSquare(centroid, points[0]);
+        const centroid = d3_polygonCentroid(points);
+        const radius = d3_median(points, p => geoVecLength(centroid, p));
 
         var i, actualPoint;
 
         // compare distances between centroid and points
         for (i = 0; i < hull.length; i++){
             actualPoint = hull[i];
-            var actualDist = geoVecLengthSquare(actualPoint, centroid);
+            var actualDist = geoVecLength(actualPoint, centroid);
             var diff = Math.abs(actualDist - radius);
             //compare distances with epsilon-error (5%)
-            if (diff > 0.05*radius) {
+            if (diff > 0.05 * radius) {
                 return false;
             }
         }
+
+        const radiusM = radiansToMeters(geoLength({ type: 'LineString', coordinates: [
+            projection.invert(centroid),
+            projection.invert([centroid[0] + radius, centroid[1]])
+        ]}));
+        const numberOfPoints = Math.min(32, Math.max(12,
+            Math.round(radiusM * Math.PI / _maxSegmentLength) * 2
+        ));
+        const maxAngle = Math.PI * 2 / (numberOfPoints - 1);
 
         //check if central angles are smaller than maxAngle
         for (i = 0; i < hull.length; i++){

--- a/modules/actions/circularize.js
+++ b/modules/actions/circularize.js
@@ -12,10 +12,11 @@ import { utilArrayUniq } from '../util';
 import { radiansToMeters } from '../ui/panels';
 
 
+const MAX_SEGMENT_LENGTH = 4;
+export const MIN_VERTICES = 12;
+export const MAX_VERTICES = 32;
+
 export function actionCircularize(wayId, projection) {
-    const MAX_SEGMENT_LENGTH = 4;
-    const MIN_VERTICES = 12;
-    const MAX_VERTICES = 32;
 
     var action = function(graph, t) {
         if (t === null || !isFinite(t)) t = 1;

--- a/modules/actions/circularize.js
+++ b/modules/actions/circularize.js
@@ -13,7 +13,9 @@ import { radiansToMeters } from '../ui/panels';
 
 
 export function actionCircularize(wayId, projection) {
-    const _maxSegmentLength = 4;
+    const MAX_SEGMENT_LENGTH = 4;
+    const MIN_VERTICES = 12;
+    const MAX_VERTICES = 32;
 
     var action = function(graph, t) {
         if (t === null || !isFinite(t)) t = 1;
@@ -40,6 +42,7 @@ export function actionCircularize(wayId, projection) {
             ? geoVecInterp(points[0], points[1], 0.5)
             : d3_polygonCentroid(points);
         const radius = d3_median(points, p => geoVecLength(centroid, p));
+        const maxAngle = getMaxAngle(centroid, radius);
         const sign = d3_polygonArea(points) > 0 ? 1 : -1;
         let ids, i, j, k;
 
@@ -57,14 +60,6 @@ export function actionCircularize(wayId, projection) {
             keyPoints.push(points[oppositeIndex]);
         }
 
-        const radiusM = radiansToMeters(geoLength({ type: 'LineString', coordinates: [
-            projection.invert(centroid),
-            projection.invert([centroid[0] + radius, centroid[1]])
-        ]}));
-        const numberOfPoints = Math.min(32, Math.max(12,
-            Math.round(radiusM * Math.PI / _maxSegmentLength) * 2
-        ));
-        const maxAngle = Math.PI * 2 / (numberOfPoints - 1);
         // key points and nodes are those connected to the ways,
         // they are projected onto the circle, in between nodes are moved
         // to constant intervals between key nodes, extra in between nodes are
@@ -203,6 +198,25 @@ export function actionCircularize(wayId, projection) {
     };
 
 
+    /**
+     * Returns the maximum internal angle of a regular polygon with
+     * the given centroid and radius such that the length of the segments
+     * are just shorter than approximately MAX_SEGMENT_LENGTH. But
+     * never returns fewer than MIN_VERTICES or more than MAX_VERTICES.
+     * #12139
+     */
+    function getMaxAngle(centroid, radius) {
+        const radiusM = radiansToMeters(geoLength({ type: 'LineString', coordinates: [
+            projection.invert(centroid),
+            projection.invert([centroid[0] + radius, centroid[1]])
+        ]}));
+        const numberOfPoints = Math.min(MAX_VERTICES, Math.max(MIN_VERTICES,
+            Math.round(radiusM * Math.PI / MAX_SEGMENT_LENGTH) * 2
+        ));
+        return Math.PI * 2 / (numberOfPoints - 1);
+    }
+
+
     action.makeConvex = function(graph) {
         var way = graph.entity(wayId);
         var nodes = utilArrayUniq(graph.childNodes(way));
@@ -253,6 +267,7 @@ export function actionCircularize(wayId, projection) {
         }
         const centroid = d3_polygonCentroid(points);
         const radius = d3_median(points, p => geoVecLength(centroid, p));
+        const maxAngle = getMaxAngle(centroid, radius);
 
         var i, actualPoint;
 
@@ -266,15 +281,6 @@ export function actionCircularize(wayId, projection) {
                 return false;
             }
         }
-
-        const radiusM = radiansToMeters(geoLength({ type: 'LineString', coordinates: [
-            projection.invert(centroid),
-            projection.invert([centroid[0] + radius, centroid[1]])
-        ]}));
-        const numberOfPoints = Math.min(32, Math.max(12,
-            Math.round(radiusM * Math.PI / _maxSegmentLength) * 2
-        ));
-        const maxAngle = Math.PI * 2 / (numberOfPoints - 1);
 
         //check if central angles are smaller than maxAngle
         for (i = 0; i < hull.length; i++){

--- a/modules/ui/panels/measurement.js
+++ b/modules/ui/panels/measurement.js
@@ -9,12 +9,13 @@ import { geoExtent, geoSphericalDistance } from '../../geo';
 import { services } from '../../services';
 import { utilGetAllNodes } from '../../util';
 
+export function radiansToMeters(r) {
+    // using WGS84 authalic radius (6371007.1809 m)
+    return r * 6371007.1809;
+}
+
 export function uiPanelMeasurement(context) {
 
-    function radiansToMeters(r) {
-        // using WGS84 authalic radius (6371007.1809 m)
-        return r * 6371007.1809;
-    }
 
     function steradiansToSqmeters(r) {
         // http://gis.stackexchange.com/a/124857/40446

--- a/test/spec/actions/circularize.js
+++ b/test/spec/actions/circularize.js
@@ -1,16 +1,20 @@
+import { MAX_VERTICES, MIN_VERTICES } from '../../../modules/actions/circularize';
+
 describe('iD.actionCircularize', function () {
-    var projection = d3.geoMercator().scale(150);
+    const projection = d3.geoMercator().scale(150);
 
-    function isCircular(id, graph) {
-        var points = graph.childNodes(graph.entity(id))
-                .map(function (n) { return projection(n.loc); }),
-            centroid = d3.polygonCentroid(points),
-            radius = iD.geoVecLength(centroid, points[0]),
-            estArea = Math.PI * radius * radius,
-            trueArea = Math.abs(d3.polygonArea(points)),
-            pctDiff = (estArea - trueArea) / estArea;
+    function isCircular(id, graph, _projection) {
+        if (!_projection) _projection = projection;
+        const points = graph.childNodes(graph.entity(id))
+            .map(function (n) { return _projection(n.loc); });
+        const centroid = d3.polygonCentroid(points);
+        const radius = iD.geoVecLength(centroid, points[0]);
+        const n = points.length - 1;
+        const estArea = Math.pow(radius, 2) * n / 2 * Math.sin(2 * Math.PI / n); // regular n-gon area
+        const trueArea = Math.abs(d3.polygonArea(points));
+        const pctDiff = Math.abs(estArea - trueArea) / estArea;
 
-        return (pctDiff < 0.025);   // within 2.5% of circular area..
+        return pctDiff < 1E-3; // area within 0.1% of expected area of regular polygon with n vertices
     }
 
     function intersection(a, b) {
@@ -24,20 +28,6 @@ describe('iD.actionCircularize', function () {
             delete seen[k];
             return exists;
         });
-    }
-
-    function angle(point1, point2, center) {
-        var vector1 = [point1[0] - center[0], point1[1] - center[1]],
-            vector2 = [point2[0] - center[0], point2[1] - center[1]],
-            distance;
-
-        distance = iD.geoVecLength(vector1, [0, 0]);
-        vector1 = [vector1[0] / distance, vector1[1] / distance];
-
-        distance = iD.geoVecLength(vector2, [0, 0]);
-        vector2 = [vector2[0] / distance, vector2[1] / distance];
-
-        return 180 / Math.PI * Math.acos(vector1[0] * vector2[0] + vector1[1] * vector2[1]);
     }
 
     function area(id, graph) {
@@ -61,7 +51,26 @@ describe('iD.actionCircularize', function () {
         graph = iD.actionCircularize('-', projection)(graph);
 
         expect(isCircular('-', graph)).to.be.ok;
-        expect(graph.entity('-').nodes).to.have.length(20);
+        expect(graph.entity('-').nodes).to.have.length(MAX_VERTICES + 1);
+    });
+
+    it('creates fewer nodes for small features', function () {
+        //    d - c
+        //    |   |
+        //    a - b
+        var graph = iD.coreGraph([
+                iD.osmNode({id: 'a', loc: [   0,    0]}),
+                iD.osmNode({id: 'b', loc: [2e-5,    0]}),
+                iD.osmNode({id: 'c', loc: [2e-5, 2e-5]}),
+                iD.osmNode({id: 'd', loc: [   0, 2e-5]}),
+                iD.osmWay({id: '-', nodes: ['a', 'b', 'c', 'd', 'a']})
+            ]);
+
+        const projection = d3.geoMercator().scale(150 * 1e5);
+        graph = iD.actionCircularize('-', projection)(graph);
+
+        expect(isCircular('-', graph, projection)).to.be.ok;
+        expect(graph.entity('-').nodes).to.have.length(MIN_VERTICES + 1);
     });
 
     it('reuses existing nodes', function () {
@@ -107,33 +116,6 @@ describe('iD.actionCircularize', function () {
 
         expect(isCircular('-', graph)).to.be.ok;
         expect(iD.geoVecLength(graph.entity('d').loc, [2, -2])).to.be.lt(0.5);
-    });
-
-    it('creates circle respecting min-angle limit', function() {
-        //    d ---- c
-        //    |      |
-        //    a ---- b
-        var graph = iD.coreGraph([
-                iD.osmNode({id: 'a', loc: [0, 0]}),
-                iD.osmNode({id: 'b', loc: [2, 0]}),
-                iD.osmNode({id: 'c', loc: [2, 2]}),
-                iD.osmNode({id: 'd', loc: [0, 2]}),
-                iD.osmWay({id: '-', nodes: ['a', 'b', 'c', 'd', 'a']})
-            ]),
-            centroid, points;
-
-        graph = iD.actionCircularize('-', projection, 20)(graph);
-
-        expect(isCircular('-', graph)).to.be.ok;
-        points = graph.childNodes(graph.entity('-'))
-            .map(function (n) { return projection(n.loc); });
-        centroid = d3.polygonCentroid(points);
-
-        for (var i = 0; i < points.length - 1; i++) {
-            expect(angle(points[i], points[i+1], centroid)).to.be.lte(20);
-        }
-
-        expect(angle(points[points.length - 1], points[0], centroid)).to.be.lte(20);
     });
 
     it('leaves clockwise ways clockwise', function () {
@@ -271,7 +253,7 @@ describe('iD.actionCircularize', function () {
 
         expect(isCircular('-', graph)).to.be.ok;
         expect(graph.entity('-').isConvex(graph)).to.be.true;
-        expect(graph.entity('-').nodes).to.have.length(20);
+        expect(graph.entity('-').nodes).to.have.length(MAX_VERTICES + 1);
     });
 
     it('circularizes a closed single line way', function () {
@@ -332,7 +314,7 @@ describe('iD.actionCircularize', function () {
                 ]);
             graph = iD.actionCircularize('-', projection)(graph, 0);
             expect(isCircular('-', graph)).to.be.not.ok;
-            expect(graph.entity('-').nodes).to.have.length(20);
+            expect(graph.entity('-').nodes).to.have.length(MAX_VERTICES + 1);
             expect(area('-', graph)).to.be.closeTo(-4, 1e-2);
         });
 
@@ -346,8 +328,8 @@ describe('iD.actionCircularize', function () {
                 ]);
             graph = iD.actionCircularize('-', projection)(graph, 0.5);
             expect(isCircular('-', graph)).to.be.not.ok;
-            expect(graph.entity('-').nodes).to.have.length(20);
-            expect(area('-', graph)).to.be.closeTo(-4.812, 1e-2);
+            expect(graph.entity('-').nodes).to.have.length(MAX_VERTICES + 1);
+            expect(area('-', graph)).to.be.closeTo(-4.74, 1e-2);
         });
 
         it('circularize at t = 1', function() {
@@ -360,8 +342,8 @@ describe('iD.actionCircularize', function () {
                 ]);
             graph = iD.actionCircularize('-', projection)(graph, 1);
             expect(isCircular('-', graph)).to.be.ok;
-            expect(graph.entity('-').nodes).to.have.length(20);
-            expect(area('-', graph)).to.be.closeTo(-6.168, 1e-2);
+            expect(graph.entity('-').nodes).to.have.length(MAX_VERTICES + 1);
+            expect(area('-', graph)).to.be.closeTo(-6.24, 1e-2);
         });
     });
 


### PR DESCRIPTION
calculate number of points from a target segment length, such that
* small circles are generated using fewer nodes (minimum: 12)
* large circles are generated using more nodes (maximum: 36)
* intermediate size circles end up with a similar number of nodes then previously (~20 nodes for a single lane roundabout)

addresses #12109 and fixes #8389

before / after:


<img width="300" src="https://github.com/user-attachments/assets/28ae5334-d4ae-43ed-8dc3-58699477c579" /> <img width="300" src="https://github.com/user-attachments/assets/467cbc46-d86a-40ad-a7df-a2afb56f795b" />

<img width="300" src="https://github.com/user-attachments/assets/d1eb56d5-e5d9-4fd7-999d-0e8268e6f0b6" /> <img width="300" src="https://github.com/user-attachments/assets/10e382e0-8111-4a12-92f2-6cb2b6c915b6" />

<img width="300" src="https://github.com/user-attachments/assets/b131f682-ffd4-4fca-85e0-84077477106f" /> <img width="300" src="https://github.com/user-attachments/assets/3bf4cd44-2067-4ec4-9c3f-305d055034ce" />

<img width="300" src="https://github.com/user-attachments/assets/57f58441-2ca5-4dc8-8bf7-5bc18afdaf94" /> <img width="300" src="https://github.com/user-attachments/assets/8a8b86bc-054f-4512-b338-f4ea2cd7d2f4" />

* [x] adjust/add tests
* [x] add to changelog