### PR TITLE
treat landuse=basin as water areas on map

### DIFF
--- a/css/25_areas.css
+++ b/css/25_areas.css
@@ -76,6 +76,7 @@ path.fill.tag-golf-green {
 
 /* Blue things */
 path.stroke.tag-amenity-fountain,
+path.fill.tag-landuse-basin,
 path.stroke.tag-leisure-swimming_pool,
 path.stroke.tag-natural-bay,
 path.stroke.tag-natural-strait,
@@ -83,6 +84,7 @@ path.stroke.tag-natural-water {
     stroke: rgb(119, 211, 222);
 }
 path.fill.tag-amenity-fountain,
+path.fill.tag-landuse-basin,
 path.fill.tag-leisure-swimming_pool,
 path.fill.tag-natural-bay,
 path.fill.tag-natural-strait,


### PR DESCRIPTION
followup to https://github.com/openstreetmap/id-tagging-schema/pull/1955

now that these areas are not deprecated, it is useful to indicate that these are not actually landuse areas (used on entire basin infrastructure area) but water areas (used only where basin holds water)