### PR TITLE
minor tweak to how osmEntity is instantiated

### DIFF
--- a/modules/osm/changeset.js
+++ b/modules/osm/changeset.js
@@ -4,10 +4,9 @@ import { geoExtent } from '../geo';
 
 export function osmChangeset() {
     if (!(this instanceof osmChangeset)) {
-        return (new osmChangeset()).initialize(arguments);
-    } else if (arguments.length) {
-        this.initialize(arguments);
+        return new osmChangeset(...arguments);
     }
+    this.initialize(arguments);
 }
 
 

--- a/modules/osm/entity.js
+++ b/modules/osm/entity.js
@@ -10,9 +10,9 @@ export function osmEntity(attrs) {
 
     // Create the appropriate subtype.
     if (attrs && attrs.type) {
-        return osmEntity[attrs.type].apply(this, arguments);
+        return new osmEntity[attrs.type](...arguments);
     } else if (attrs && attrs.id) {
-        return osmEntity[osmEntity.id.type(attrs.id)].apply(this, arguments);
+        return new osmEntity[osmEntity.id.type(attrs.id)](...arguments);
     }
 
     // Initialize a generic Entity (used only in tests).

--- a/modules/osm/node.js
+++ b/modules/osm/node.js
@@ -38,10 +38,9 @@ export const SIDE_ANGLE_OFFSET = { left: 180, right: 0 };
  */
 export function osmNode() {
     if (!(this instanceof osmNode)) {
-        return (new osmNode()).initialize(arguments);
-    } else if (arguments.length) {
-        this.initialize(arguments);
+        return new osmNode(...arguments);
     }
+    this.initialize(arguments);
 }
 
 osmEntity.node = osmNode;

--- a/modules/osm/relation.js
+++ b/modules/osm/relation.js
@@ -10,10 +10,9 @@ import { geoExtent, geoPolygonContainsPolygon, geoPolygonIntersectsPolygon } fro
  */
 export function osmRelation() {
     if (!(this instanceof osmRelation)) {
-        return (new osmRelation()).initialize(arguments);
-    } else if (arguments.length) {
-        this.initialize(arguments);
+        return new osmRelation(...arguments);
     }
+    this.initialize(arguments);
 }
 
 

--- a/modules/osm/way.js
+++ b/modules/osm/way.js
@@ -12,10 +12,9 @@ import { utilArrayUniq, utilCheckTagDictionary } from '../util';
  */
 export function osmWay() {
     if (!(this instanceof osmWay)) {
-        return (new osmWay()).initialize(arguments);
-    } else if (arguments.length) {
-        this.initialize(arguments);
+        return new osmWay(...arguments);
     }
+    this.initialize(arguments);
 }
 
 


### PR DESCRIPTION
unblocks https://github.com/openstreetmap/iD/pull/12093#issuecomment-4117706960 

we need to make a minor change first so that `new iD.osmNode()` has exactly the same effect as `iD.osmNode()`. unit tests confirm that everything still works, and brief manual testing to confirm everything still loads and basic operations work.

this quirk only affects `ōsmEntity` and its children, normal classes are not affected.

after this, we can do a bulk addition of the `new` operator


Partially closes #10909 (this is part 5)