### PR TITLE
Fix geoLineIntersection when intersection occurs at segment start (u = 0)

### DIFF
--- a/modules/geo/geom.ts
+++ b/modules/geo/geom.ts
@@ -189,7 +189,7 @@ export function geoLineIntersection(a: Vec2[], b: Vec2[]) {
     var uNumerator = geoVecCross(geoVecSubtract(q, p), r);
     var denominator = geoVecCross(r, s);
 
-    if (uNumerator && denominator) {
+    if (denominator) {
         var u = uNumerator / denominator;
         var t = geoVecCross(geoVecSubtract(q, p), s) / denominator;
 

--- a/test/spec/geo/geom.js
+++ b/test/spec/geo/geom.js
@@ -375,6 +375,12 @@ describe('iD.geo - geometry', function() {
             var b = [[5, 10], [5, -10]];
             expect(iD.geoLineIntersection(a, b)).to.eql([5, 0]);
         });
+        it('returns the intersection point when it lies on segment endpoints', function() {
+            // intersection at start of segment b (u = 0)
+            var a = [[0, 0], [10, 0]];
+            var b = [[5, 0], [5, 10]];
+            expect(iD.geoLineIntersection(a, b)).to.eql([5, 0]);
+        });
         it('returns null if lines are not parallel but not intersecting', function() {
             var a = [[0, 0], [10, 0]];
             var b = [[-5, 10], [-5, -10]];


### PR DESCRIPTION
## Problem

`geoLineIntersection` incorrectly returns `null` when the intersection lies at the start of the second segment (`uNumerator === 0`).

This happens because the function uses a truthy check:

```js
if (uNumerator && denominator)
```

Since `uNumerator` can legitimately be `0` for valid intersections, this condition incorrectly filters out those cases.

---

## Fix

Update the condition to check only `denominator`, which correctly handles parallel/colinear cases while allowing `u = 0` intersections:

```js
if (denominator)
```

---

## Impact

* Correctly detects intersections occurring at segment endpoints
* Fixes false negatives where valid intersections were previously missed
* Improves robustness of geometry utilities used across the editor

---

## Regression Test

Added a test case in `test/spec/geo/geom.js`:

* `a = [[0,0],[10,0]]`
* `b = [[5,0],[5,10]]`

Expected intersection: `[5,0]`

* Before fix: returned `null`
* After fix: returns `[5,0]`

---

## Verification

```bash
npm run -s test:once -- test/spec/geo/geom.js
npx -s eslint modules/geo/geom.ts test/spec/geo/geom.js
npm run -s test:typecheck
```

All checks pass.
