### PR TITLE
preset search - match when preset text is in term

### DIFF
--- a/modules/presets/collection.js
+++ b/modules/presets/collection.js
@@ -65,6 +65,14 @@ export function presetCollection(collection) {
       return index === 0;
     }
 
+    function presetInSearchTerm(presetText) {
+      if (presetText.length === 0) {
+        return false;
+      }
+      const index = value.indexOf(presetText.toLowerCase().trim());
+      return index === 0 || value[index - 1] === ' ';
+    }
+
     function sortPresets(nameProp, aliasesProp) {
       return function sortNames(a, b) {
         let aCompare = a[nameProp]();
@@ -168,6 +176,13 @@ export function presetCollection(collection) {
           Object.keys(a.tags).some(key => leading(key + '=' + a.tags[key]))));
     }
 
+    // also match cases where preset string is inside searched term
+    const presetsInValues = searchable
+      .filter(a => ([a.searchName()].concat(a.searchAliases(), a.terms(), a.searchNameStripped(), a.searchAliasesStripped())).some(presetInSearchTerm));
+
+    const presetsInValuesViaSuggested = suggestions
+      .filter(a => ([a.searchName()].concat(a.searchAliases(), a.terms(), a.searchNameStripped(), a.searchAliasesStripped())).some(presetInSearchTerm));
+
     let results = leadingNames.concat(
       leadingSuggestions,
       leadingNamesStripped,
@@ -178,7 +193,9 @@ export function presetCollection(collection) {
       similarName,
       similarSuggestions,
       similarTerms,
-      leadingTagKeyValues
+      leadingTagKeyValues,
+      presetsInValues,
+      presetsInValuesViaSuggested
     ).slice(0, MAXRESULTS - 1);
 
     if (geometry) {

--- a/test/spec/presets/collection.js
+++ b/test/spec/presets/collection.js
@@ -137,13 +137,12 @@ describe('iD.presetCollection', function() {
             expect(result.indexOf(p.grass1)).to.eql(0);  // 1. 'Grass' (by tag key=value)
         });
 
-        it('returns matches also when search term has a long unexpected prefix', function() {
-            var result = c.search('private grill', 'point').matchGeometry('point').collection;
-            expect(result.indexOf(p.grill), 'Grill').to.eql(0);
-        });
-
-        it('returns matches also when search term has a very long unexpected prefix', function() {
-            var result = c.search('very private and secret mysterious grill', 'point').matchGeometry('point').collection;
+        it.each([
+            'private grill',
+            'very private and secret mysterious grill',
+            'private grill in garden',
+        ])('returns matches also when search term includes the preset name as substring', function(search) {
+            var result = c.search(search, 'point').matchGeometry('point').collection;
             expect(result.indexOf(p.grill), 'Grill').to.eql(0);
         });
     });

--- a/test/spec/presets/collection.js
+++ b/test/spec/presets/collection.js
@@ -136,5 +136,15 @@ describe('iD.presetCollection', function() {
             var result = c.search('landuse=grass', 'area').collection;
             expect(result.indexOf(p.grass1)).to.eql(0);  // 1. 'Grass' (by tag key=value)
         });
+
+        it('returns matches also when search term has a long unexpected prefix', function() {
+            var result = c.search('private grill', 'point').matchGeometry('point').collection;
+            expect(result.indexOf(p.grill), 'Grill').to.eql(0);
+        });
+
+        it('returns matches also when search term has a very long unexpected prefix', function() {
+            var result = c.search('very private and secret mysterious grill', 'point').matchGeometry('point').collection;
+            expect(result.indexOf(p.grill), 'Grill').to.eql(0);
+        });
     });
 });


### PR DESCRIPTION
currently only when search terms are within preset text or text is close then matches are found

as result for example "private swimming pool" was not matching "swimming pool preset"

fixes #9105

Though it looks like sorting may be needed?

<img width="389" height="566" alt="screen-2026-04-01-21-13-58" src="https://github.com/user-attachments/assets/2e05ca46-a328-4d36-b18a-9e9d9a85804d" />
