### PR TITLE
Do not render 'none' after selecting none layer

### DIFF
--- a/modules/ui/attribution.js
+++ b/modules/ui/attribution.js
@@ -16,9 +16,9 @@ export function uiAttribution(context) {
       .attr('class', klass)
       .merge(div);
 
-
+    const NO_IMAGERY = 'none';
     let attributions = div.selectAll('.attribution')
-      .data(data.filter(d => d.id !== 'none'), d => d.id);
+      .data(data.filter(d => d.id !== NO_IMAGERY), d => d.id);
 
     attributions.exit()
       .remove();

--- a/modules/ui/attribution.js
+++ b/modules/ui/attribution.js
@@ -18,7 +18,7 @@ export function uiAttribution(context) {
 
 
     let attributions = div.selectAll('.attribution')
-      .data(data, d => d.id);
+      .data(data.filter(d => d.id !== 'none'), d => d.id);
 
     attributions.exit()
       .remove();


### PR DESCRIPTION
Fixes #12154


This happens because the fallback logic uses the source id ("none") when no attribution is available. The change skips rendering attribution for the "none" imagery source, preventing placeholder text from appearing in the UI. This aligns with expected behavior, where no imagery results in no attribution being shown.


After (Light Mode):
<img width="526" height="273" alt="image" src="https://github.com/user-attachments/assets/4ed1289e-2e9e-4283-8e20-54337a30dcc9" />

After (Dark Mode):
<img width="512" height="277" alt="image" src="https://github.com/user-attachments/assets/d39d170d-4ded-42b6-be31-d1ace6611ad0" />
