### PR TITLE
change how the flip operation detects non-numeric `direction` fields

### DIFF
--- a/modules/actions/reverse.js
+++ b/modules/actions/reverse.js
@@ -161,7 +161,7 @@ export function actionReverse(entityID, options) {
             const isDirectionField = field.key && (field.key === 'direction' || field.key.endsWith(':direction'));
             // some direction fields are for angles, so ensure that the
             // direction field on this preset is not a numeric field.
-            const isRelativeDirection = field.type === 'combo';
+            const isRelativeDirection = field.type !== 'number';
 
             // the field's geometry might be restricted to a subset of the preset's geometry
             const isGeometryValid = !field.geometry || field.geometry.includes(geometry);


### PR DESCRIPTION
see https://github.com/openstreetmap/id-tagging-schema/pull/2109#pullrequestreview-4049853428

now we hardcode `number` instead of `combo`/`radio`, so make it easier to switch between those two.