### PR TITLE
Fix/simplify how features are sorted into "other" category

### DIFF
--- a/modules/renderer/features.js
+++ b/modules/renderer/features.js
@@ -2,7 +2,7 @@ import { dispatch as d3_dispatch } from 'd3-dispatch';
 
 import { prefs } from '../core/preferences';
 import { osmEntity } from '../osm';
-import { osmLanduseTags, osmLifecyclePrefixes } from '../osm/tags.js';
+import { osmIsInterestingTag, osmLanduseTags, osmLifecyclePrefixes } from '../osm/tags.js';
 import { utilRebind } from '../util/rebind';
 import { utilArrayGroupBy, utilArrayUnion, utilQsString, utilStringQs } from '../util';
 import { isAddressPoint } from '../svg/labels';
@@ -161,12 +161,12 @@ export function rendererFeatures(context) {
             !_rules.pistes.filter(tags);
     });
 
-    defineRule('boundaries', function isBoundary(tags, geometry) {
+    defineRule('boundaries', function isBoundary(tags, geometry, parents) {
         // This rule applies if the object has no interesting tags, and if either:
         //   (a) is a way having a `boundary=*` tag, or
         //   (b) is a relation of `type=boundary`.
         return (
-            (geometry === 'line' && !!tags.boundary) ||
+            (geometry === 'line' && (!!tags.boundary || parents.some(p => p.tags.type === 'boundary'))) ||
             (geometry === 'relation' && tags.type === 'boundary')
         ) && !(
             traffic_roads[tags.highway] ||
@@ -242,8 +242,9 @@ export function rendererFeatures(context) {
     // Lines or areas that don't match another feature filter.
     // IMPORTANT: The 'others' feature must be the last one defined,
     //   so that code in getMatches can skip this test if `hasMatch = true`
-    defineRule('others', function isOther(tags, geometry) {
-        return (geometry === 'line' || geometry === 'area');
+    defineRule('others', function isOther(tags, geometry, parents) {
+        return geometry === 'area' ||
+            geometry === 'line' && (parents.length === 0 || Object.keys(tags).find(k => osmIsInterestingTag(k)));
     });
 
 
@@ -437,35 +438,29 @@ export function rendererFeatures(context) {
             var hasMatch = false;
 
             for (var i = 0; i < _keys.length; i++) {
+                const parents = features.getParents(entity, resolver, geometry);
+
                 if (_keys[i] === 'others') {
                     if (hasMatch) continue;
 
-                    // If an entity...
-                    //   1. is a way that hasn't matched other 'interesting' feature rules,
+                    // If an entity is a way that hasn't matched other 'interesting' feature rules,
+                    // ...then match whatever feature rules the parent relation(s) have matched.
+                    // see #2548, #2887
+                    //
+                    // IMPORTANT:
+                    // For this to work, getMatches must be called on relations before ways.
+                    //
                     if (entity.type === 'way') {
-                        var parents = features.getParents(entity, resolver, geometry);
-
-                        //   2a. belongs only to a single multipolygon relation
-                        if ((parents.length === 1 && parents[0].isMultipolygon()) ||
-                            // 2b. or belongs only to boundary relations
-                            (parents.length > 0 && parents.every(function(parent) { return parent.tags.type === 'boundary'; }))) {
-
-                            // ...then match whatever feature rules the parent relation has matched.
-                            // see #2548, #2887
-                            //
-                            // IMPORTANT:
-                            // For this to work, getMatches must be called on relations before ways.
-                            //
-                            var pkey = osmEntity.key(parents[0]);
+                        for (const parent of parents) {
+                            const pkey = osmEntity.key(parent);
                             if (_cache[pkey] && _cache[pkey].matches) {
-                                matches = Object.assign({}, _cache[pkey].matches);  // shallow copy
-                                continue;
+                                matches = Object.assign(matches, _cache[pkey].matches);
                             }
                         }
                     }
                 }
 
-                if (_rules[_keys[i]].filter(entity.tags, geometry)) {
+                if (_rules[_keys[i]].filter(entity.tags, geometry, parents)) {
                     matches[_keys[i]] = true;
                     hasMatch = true;
                 }

--- a/test/spec/renderer/features.js
+++ b/test/spec/renderer/features.js
@@ -524,13 +524,13 @@ describe('iD.rendererFeatures', function() {
             features.gatherStats(all, graph, dimensions);
 
             doMatch('others', [
-                'fence', 'pipeline'
+                'fence', 'pipeline', 'inner2'
             ]);
 
             dontMatch('others', [
                 'point_bar', 'motorway', 'service', 'path', 'building_yes',
                 'forest', 'boundary', 'boundary_member', 'water', 'railway', 'power_line',
-                'motorway_construction', 'retail', 'outer', 'inner1', 'inner2', 'inner3'
+                'motorway_construction', 'retail', 'outer', 'inner1', 'inner3'
             ]);
         });
     });
@@ -577,7 +577,7 @@ describe('iD.rendererFeatures', function() {
             features.gatherStats(all, graph, dimensions);
 
             expect(features.isHidden(outer, graph, outer.geometry(graph))).to.be.true;     // #2548
-            expect(features.isHidden(inner1, graph, inner1.geometry(graph))).to.be.true;   // #2548
+            expect(features.isHidden(inner1, graph, inner1.geometry(graph))).to.be.false;  // #9065
             expect(features.isHidden(inner2, graph, inner2.geometry(graph))).to.be.true;   // #2548
             expect(features.isHidden(inner3, graph, inner3.geometry(graph))).to.be.false;  // #2887
         });


### PR DESCRIPTION
addresses #9065:
* _boundaries_ also includes all ways that are a member of a boundary relation
* ways that don't match any non-"other" category inherit the categories of all their parent relations
* _other_ includes only the remaining tagged ways that don't match any other category

todos:
* [ ] handle case where feature is member of one relation (e.g. type=route) which does not match any category by itself
* [ ] test extensively
* [ ] add unit test for boundary ways
* [ ] add unit test for other category