### PR TITLE
restrict url/website validation to specific tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :camera: Street-Level
 #### :white_check_mark: Validation
 * Treat most aerialways as part of the routable network when checking other ways' connectivity ([#9406])
+* Only consider well known tags containing URLs during website validation ([#12178], thanks [@bhavyaKhatri2703])
 #### :bug: Bugfixes
 * Fix title of preset search results not updating correctly ([#12050], thanks [@bhavyaKhatri2703])
 * Prevent duplicate nodes from being created while using spacebar key to draw a way ([#12051])
@@ -83,6 +84,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#12110]: https://github.com/openstreetmap/iD/issues/12110
 [#12120]: https://github.com/openstreetmap/iD/issues/12120
 [#12139]: https://github.com/openstreetmap/iD/pull/12139
+[#12178]: https://github.com/openstreetmap/iD/pull/12178
 
 
 # 2.39.6

--- a/modules/osm/tags.js
+++ b/modules/osm/tags.js
@@ -423,7 +423,6 @@ export const osmUrlKeys = new Set([
     'source:website',
     'source:url',
     'image',
-    'wikimedia_commons',
     'brand:website',
     'operator:website',
     'network:website',

--- a/modules/osm/tags.js
+++ b/modules/osm/tags.js
@@ -414,3 +414,21 @@ export const osmIsoCountryKeys = new Set([
   'country',
   'target'
 ]);
+
+export const osmUrlKeys = new Set([
+    'website',
+    'url',
+    'contact:website',
+    'contact:url',
+    'source:website',
+    'source:url',
+    'image',
+    'wikimedia_commons',
+    'brand:website',
+    'operator:website',
+    'network:website',
+    'website:en',
+    'website:fr',
+    'website:menu',
+    'post_office:website',
+]);

--- a/modules/validations/invalid_format.js
+++ b/modules/validations/invalid_format.js
@@ -2,6 +2,7 @@ import { t } from '../core/localizer';
 import { utilDisplayLabel } from '../util/utilDisplayLabel';
 import { validationIssue, validationIssueFix } from '../core/validation';
 import { actionChangeTags } from '../actions/change_tags';
+import { osmUrlKeys } from '../osm/tags';
 
 export function validationFormatting() {
     var type = 'invalid_format';
@@ -118,26 +119,8 @@ export function validationFormatting() {
             entityIds: [entity.id]
         };
 
-        const urlValidationKeys = new Set([
-            'website',
-            'url',
-            'contact:website',
-            'contact:url',
-            'source:website',
-            'source:url',
-            'image',
-            'wikimedia_commons',
-            'brand:website',
-            'operator:website',
-            'network:website',
-            'website:en',
-            'website:fr',
-            'website:menu',
-            'post_office:website',
-        ]);
-
         Object.entries(entity.tags).map(function([key, tag]) {
-            if (!urlValidationKeys.has(key)) return null;
+            if (!osmUrlKeys.has(key)) return null;
             if (!tag) return null;
             const value = tag.trim();
             if (!value) return null;

--- a/modules/validations/invalid_format.js
+++ b/modules/validations/invalid_format.js
@@ -118,8 +118,26 @@ export function validationFormatting() {
             entityIds: [entity.id]
         };
 
+        const urlValidationKeys = new Set([
+            'website',
+            'url',
+            'contact:website',
+            'contact:url',
+            'source:website',
+            'source:url',
+            'image',
+            'wikimedia_commons',
+            'brand:website',
+            'operator:website',
+            'network:website',
+            'website:en',
+            'website:fr',
+            'website:menu',
+            'post_office:website',
+        ]);
+
         Object.entries(entity.tags).map(function([key, tag]) {
-            if (!/\b(website|url)\b|^image$/i.test(key)) return null;
+            if (!urlValidationKeys.has(key)) return null;
             if (!tag) return null;
             const value = tag.trim();
             if (!value) return null;

--- a/test/spec/validations/invalid_format.js
+++ b/test/spec/validations/invalid_format.js
@@ -122,7 +122,8 @@ describe('iD.validations.invalid_format', function () {
 
         it('should only flag well known tags containing URLs', function() {
             var entity = createPointWithTags({
-                'website:source': 'survey'
+                'website:source': 'survey',
+                'wikimedia_commons': 'File:photo.jpg'
             });
             var issues = validate(entity);
             expect(issues).to.have.lengthOf(0);

--- a/test/spec/validations/invalid_format.js
+++ b/test/spec/validations/invalid_format.js
@@ -120,6 +120,14 @@ describe('iD.validations.invalid_format', function () {
             expect(issues).to.have.lengthOf(0);
         });
 
+        it('should only flag well known tags containing URLs', function() {
+            var entity = createPointWithTags({
+                'website:source': 'survey'
+            });
+            var issues = validate(entity);
+            expect(issues).to.have.lengthOf(0);
+        });
+
         it('should suggest moving image URLs to Wikimedia Commons', function() {
             const entity = createPointWithTags({
                 image: 'File:OpenStreetMap-Editor iD Logo.svg'


### PR DESCRIPTION
fixes #12137 

This pr restricts the url validator to specific tags like:
` 'website',
            'url',
            'contact:website',
            'contact:url',
            'source:website',
            'source:url',
            'image',
            'wikimedia_commons',
            'brand:website',
            'operator:website',
            'network:website',
            'website:en',
            'website:fr',
            'website:menu',
            'post_office:website',`