### PR TITLE
split `osmEntity.id` into a new class `osmIdManager`

### DIFF
--- a/modules/core/history.js
+++ b/modules/core/history.js
@@ -12,6 +12,7 @@ import {
     utilArrayDifference, utilArrayGroupBy, utilArrayUnion,
     utilObjectOmit, utilRebind, utilSessionMutex
 } from '../util';
+import { osmIdManager } from '../osm';
 
 
 export function coreHistory(context) {
@@ -505,7 +506,7 @@ export function coreHistory(context) {
                 entities: Object.values(allEntities),
                 baseEntities: Object.values(baseEntities),
                 stack: s,
-                nextIDs: osmEntity.id.next,
+                nextIDs: osmIdManager.next,
                 index: _index,
                 // note the time the changes were saved
                 timestamp: (new Date()).getTime()
@@ -516,7 +517,7 @@ export function coreHistory(context) {
         fromJSON: function(h, loadChildNodes) {
             var loadComplete = true;
 
-            osmEntity.id.next = h.nextIDs;
+            osmIdManager.next = h.nextIDs;
             _index = h.index;
 
             if (h.version === 2 || h.version === 3) {

--- a/modules/osm/entity.js
+++ b/modules/osm/entity.js
@@ -1,4 +1,4 @@
-import { debug } from '../index';
+import { debug, osmIdManager } from '../index';
 import { osmIsInterestingTag } from './tags';
 import { utilArrayUnion } from '../util/array';
 import { utilUnicodeCharsTruncated } from '../util/util';
@@ -12,41 +12,12 @@ export function osmEntity(attrs) {
     if (attrs && attrs.type) {
         return new osmEntity[attrs.type](...arguments);
     } else if (attrs && attrs.id) {
-        return new osmEntity[osmEntity.id.type(attrs.id)](...arguments);
+        return new osmEntity[osmIdManager.type(attrs.id)](...arguments);
     }
 
     // Initialize a generic Entity (used only in tests).
     return (new osmEntity()).initialize(arguments);
 }
-
-
-osmEntity.id = function(type) {
-    return osmEntity.id.fromOSM(type, osmEntity.id.next[type]--);
-};
-
-
-osmEntity.id.next = {
-    changeset: -1, node: -1, way: -1, relation: -1
-};
-
-
-osmEntity.id.fromOSM = function(type, id) {
-    return type[0] + id;
-};
-
-
-osmEntity.id.toOSM = function(id) {
-    var match = id.match(/^[cnwr](-?\d+)$/);
-    if (match) {
-        return match[1];
-    }
-    return '';
-};
-
-
-osmEntity.id.type = function(id) {
-    return { 'c': 'changeset', 'n': 'node', 'w': 'way', 'r': 'relation' }[id[0]];
-};
 
 
 // A function suitable for use as the second argument to d3.selection#data().
@@ -84,7 +55,7 @@ osmEntity.prototype = {
         }
 
         if (!this.id && this.type) {
-            this.id = osmEntity.id(this.type);
+            this.id = osmIdManager.newId(this.type);
         }
         if (!this.hasOwnProperty('visible')) {
             this.visible = true;
@@ -114,12 +85,12 @@ osmEntity.prototype = {
 
 
     osmId: function() {
-        return osmEntity.id.toOSM(this.id);
+        return osmIdManager.toOSM(this.id);
     },
 
 
     isNew: function() {
-        var osmId = osmEntity.id.toOSM(this.id);
+        var osmId = osmIdManager.toOSM(this.id);
         return osmId.length === 0 || osmId[0] === '-';
     },
 

--- a/modules/osm/id_manager.ts
+++ b/modules/osm/id_manager.ts
@@ -1,0 +1,43 @@
+export type FeatureType = 'node' | 'way' | 'relation';
+
+/**
+ * All newly created features need an ID, so this singleton
+ * class allocates the next available ID, starting from -1
+ * and decrementing.
+ */
+class OsmIdManager {
+    next = {
+        changeset: -1,
+        node: -1,
+        way: -1,
+        relation: -1,
+    };
+
+    fromOSM(type: FeatureType, id: number) {
+        return type[0] + id;
+    }
+
+    toOSM(id: string) {
+        var match = id.match(/^[cnwr](-?\d+)$/);
+        if (match) {
+            return match[1];
+        }
+        return '';
+    }
+
+    type(id: string) {
+        return <FeatureType>(
+            { c: 'changeset', n: 'node', w: 'way', r: 'relation' }[id[0]]
+        );
+    }
+
+    key(entity: iD.OsmEntity) {
+        return entity.id + 'v' + (entity.v || 0);
+    }
+
+    newId(type: FeatureType) {
+        return this.fromOSM(type, this.next[type]--);
+    }
+}
+
+export const osmIdManager = new OsmIdManager();

--- a/modules/osm/index.js
+++ b/modules/osm/index.js
@@ -1,5 +1,6 @@
 export { osmChangeset } from './changeset';
 export { osmEntity } from './entity';
+export * from './id_manager';
 export { osmNode } from './node';
 export { osmNote } from './note';
 export { osmRelation } from './relation';

--- a/modules/osm/intersection.js
+++ b/modules/osm/intersection.js
@@ -3,7 +3,7 @@ import { actionReverse } from '../actions/reverse';
 import { actionSplit } from '../actions/split';
 import { coreGraph } from '../core/graph';
 import { geoAngle, geoSphericalDistance } from '../geo';
-import { osmEntity } from './entity';
+import { osmIdManager } from './id_manager';
 import { utilArrayDifference, utilArrayUniq } from '../util';
 
 
@@ -155,7 +155,7 @@ export function osmIntersection(graph, startVertexId, maxDistance) {
 
 
     // STEP 4:  Split ways on key vertices
-    var origCount = osmEntity.id.next.way;
+    var origCount = osmIdManager.next.way;
     vertices.forEach(function(v) {
         // This is an odd way to do it, but we need to find all the ways that
         // will be split here, then split them one at a time to ensure that these
@@ -182,7 +182,7 @@ export function osmIntersection(graph, startVertexId, maxDistance) {
     //     these actions later if the user decides to create a turn restriction
     //  2. Avoids churning way ids just by hovering over a vertex
     //     and displaying the turn restriction editor
-    osmEntity.id.next.way = origCount;
+    osmIdManager.next.way = origCount;
 
 
     // STEP 5:  Update arrays to point to vgraph entities

--- a/modules/osm/relation.js
+++ b/modules/osm/relation.js
@@ -3,10 +3,10 @@ import { geoArea as d3_geoArea } from 'd3-geo';
 import { osmEntity } from './entity';
 import { osmJoinWays } from './multipolygon';
 import { geoExtent, geoPolygonContainsPolygon, geoPolygonIntersectsPolygon } from '../geo';
+import { osmIdManager } from './id_manager';
 
 /**
- * @typedef {'node' | 'way' | 'relation'} FeatureType
- * @typedef {{ type: FeatureType; id: string; role: string }} RelationMember
+ * @typedef {{ type: import('./id_manager').FeatureType; id: string; role: string }} RelationMember
  */
 
 /**
@@ -27,8 +27,8 @@ osmRelation.prototype = Object.create(osmEntity.prototype);
 
 
 osmRelation.creationOrder = function(a, b) {
-    var aId = parseInt(osmEntity.id.toOSM(a.id), 10);
-    var bId = parseInt(osmEntity.id.toOSM(b.id), 10);
+    var aId = parseInt(osmIdManager.toOSM(a.id), 10);
+    var bId = parseInt(osmIdManager.toOSM(b.id), 10);
 
     if (aId < 0 || bId < 0) return aId - bId;
     return bId - aId;
@@ -205,7 +205,7 @@ const prototype = {
                         keyAttributes: {
                             type: member.type,
                             role: member.role,
-                            ref: osmEntity.id.toOSM(member.id)
+                            ref: osmIdManager.toOSM(member.id)
                         }
                     };
                 }, this),

--- a/modules/osm/way.js
+++ b/modules/osm/way.js
@@ -5,6 +5,7 @@ import { osmEntity } from './entity';
 import { osmLanes } from './lanes';
 import { osmTagSuggestingArea, osmRightSideIsInsideTags, osmRemoveLifecyclePrefix, osmOneWayBiDirectionalTags, osmOneWayBackwardTags, osmOneWayForwardTags, osmOneWayTags } from './tags';
 import { utilArrayUniq, utilCheckTagDictionary } from '../util';
+import { osmIdManager } from './id_manager';
 
 /**
  * @typedef {typeof prototype & iD.AbstractEntity} OsmWay
@@ -478,7 +479,7 @@ const prototype = {
                 '@id': this.osmId(),
                 '@version': this.version || 0,
                 nd: this.nodes.map(function(id) {
-                    return { keyAttributes: { ref: osmEntity.id.toOSM(id) } };
+                    return { keyAttributes: { ref: osmIdManager.toOSM(id) } };
                 }, this),
                 tag: Object.keys(this.tags).map(function(k) {
                     return { keyAttributes: { k: k, v: this.tags[k] } };

--- a/modules/services/osm.js
+++ b/modules/services/osm.js
@@ -7,7 +7,7 @@ import RBush from 'rbush';
 
 import { JXON } from '../util/jxon';
 import { geoExtent, geoRawMercator, geoVecAdd, geoZoomToScale } from '../geo';
-import { osmEntity, osmNode, osmNote, osmRelation, osmWay } from '../osm';
+import { osmIdManager, osmNode, osmNote, osmRelation, osmWay } from '../osm';
 import { utilArrayChunk, utilArrayGroupBy, utilArrayUniq, utilObjectOmit, utilRebind, utilTiler, utilQsString } from '../util';
 import { localizer } from '../core/localizer.js';
 import { utilGzip } from '../util/util';
@@ -206,7 +206,7 @@ function parseJSON(payload, callback, options) {
 
         var uid;
 
-        uid = osmEntity.id.fromOSM(child.type, child.id);
+        uid = osmIdManager.fromOSM(child.type, child.id);
         if (options.skipSeen) {
             if (_tileCache.seen[uid]) return null;  // avoid reparsing a "seen" entity
             _tileCache.seen[uid] = true;
@@ -484,8 +484,8 @@ export default {
     // GET /api/0.6/node/#id
     // GET /api/0.6/[way|relation]/#id/full
     loadEntity: function(id, callback) {
-        var type = osmEntity.id.type(id);
-        var osmID = osmEntity.id.toOSM(id);
+        var type = osmIdManager.type(id);
+        var osmID = osmIdManager.toOSM(id);
         var options = { skipSeen: false };
 
         this.loadFromAPI(
@@ -514,8 +514,8 @@ export default {
     // Load a single entity with a specific version
     // GET /api/0.6/[node|way|relation]/#id/#version
     loadEntityVersion: function(id, version, callback) {
-        var type = osmEntity.id.type(id);
-        var osmID = osmEntity.id.toOSM(id);
+        var type = osmIdManager.type(id);
+        var osmID = osmIdManager.toOSM(id);
         var options = { skipSeen: false };
 
         this.loadFromAPI(
@@ -531,8 +531,8 @@ export default {
     // Load the relations of a single entity with the given.
     // GET /api/0.6/[node|way|relation]/#id/relations
     loadEntityRelations: function(id, callback) {
-        var type = osmEntity.id.type(id);
-        var osmID = osmEntity.id.toOSM(id);
+        var type = osmIdManager.type(id);
+        var osmID = osmIdManager.toOSM(id);
         var options = { skipSeen: false };
 
         this.loadFromAPI(
@@ -551,11 +551,11 @@ export default {
     // GET /api/0.6/[nodes|ways|relations]?#parameters
     loadMultiple: function(ids, callback) {
         var that = this;
-        var groups = utilArrayGroupBy(utilArrayUniq(ids), osmEntity.id.type);
+        var groups = utilArrayGroupBy(utilArrayUniq(ids), osmIdManager.type);
 
         Object.keys(groups).forEach(function(k) {
             var type = k + 's';   // nodes, ways, relations
-            var osmIDs = groups[k].map(function(id) { return osmEntity.id.toOSM(id); });
+            var osmIDs = groups[k].map(function(id) { return osmIdManager.toOSM(id); });
             var options = { skipSeen: false };
 
             utilArrayChunk(osmIDs, 150).forEach(function(arr) {

--- a/modules/ui/feature_list.js
+++ b/modules/ui/feature_list.js
@@ -22,6 +22,7 @@ import {
     utilHighlightEntities,
     utilNoAuto
 } from '../util';
+import { osmIdManager } from '../osm';
 
 
 export const idMatch = q => {
@@ -214,7 +215,7 @@ export function uiFeatureList(context) {
 
                     // Make a temporary osmEntity so we can preset match
                     // and better localize the search result - #4725
-                    var id = osmEntity.id.fromOSM(d.osm_type, d.osm_id);
+                    var id = osmIdManager.fromOSM(d.osm_type, d.osm_id);
                     var tags = {};
                     tags[d.class] = d.type;
 

--- a/test/spec/core/history.js
+++ b/test/spec/core/history.js
@@ -403,7 +403,7 @@ describe('iD.coreHistory', function () {
             expect(history.graph().entity('n-1')).to.eql(new iD.osmNode({id: 'n-1', loc: [1, 2]}));
             expect(history.undoAnnotation()).to.eql('Added a point.');
             expect(history.imageryUsed()).to.eql(['Bing']);
-            expect(iD.osmEntity.id.next).to.eql({node: -2, way: -1, relation: -1});
+            expect(iD.osmIdManager.next).to.eql({node: -2, way: -1, relation: -1});
         });
 
         it('restores from v1 JSON (modification)', function() {
@@ -420,7 +420,7 @@ describe('iD.coreHistory', function () {
             expect(history.graph().entity('n-1')).to.eql(new iD.osmNode({id: 'n-1', loc: [2, 3], v: 1}));
             expect(history.undoAnnotation()).to.eql('Moved a point.');
             expect(history.imageryUsed()).to.eql(['Bing']);
-            expect(iD.osmEntity.id.next).to.eql({node: -2, way: -1, relation: -1});
+            expect(iD.osmIdManager.next).to.eql({node: -2, way: -1, relation: -1});
         });
 
         it('restores from v1 JSON (deletion)', function() {
@@ -437,7 +437,7 @@ describe('iD.coreHistory', function () {
             expect(history.graph().hasEntity('n1')).to.be.undefined;
             expect(history.undoAnnotation()).to.eql('Deleted a point.');
             expect(history.imageryUsed()).to.eql(['Bing']);
-            expect(iD.osmEntity.id.next).to.eql({node: -1, way: -2, relation: -3});
+            expect(iD.osmIdManager.next).to.eql({node: -1, way: -2, relation: -3});
         });
 
         it('restores from v2 JSON (creation)', function() {
@@ -457,7 +457,7 @@ describe('iD.coreHistory', function () {
             expect(history.graph().entity('n-1')).to.eql(new iD.osmNode({id: 'n-1', loc: [1, 2]}));
             expect(history.undoAnnotation()).to.eql('Added a point.');
             expect(history.imageryUsed()).to.eql(['Bing']);
-            expect(iD.osmEntity.id.next).to.eql({node: -2, way: -1, relation: -1});
+            expect(iD.osmIdManager.next).to.eql({node: -2, way: -1, relation: -1});
             expect(history.difference().created().length).to.eql(1);
         });
 
@@ -479,7 +479,7 @@ describe('iD.coreHistory', function () {
             expect(history.graph().entity('n1')).to.eql(new iD.osmNode({id: 'n1', loc: [2, 3], v: 1}));
             expect(history.undoAnnotation()).to.eql('Moved a point.');
             expect(history.imageryUsed()).to.eql(['Bing']);
-            expect(iD.osmEntity.id.next).to.eql({node: -2, way: -1, relation: -1});
+            expect(iD.osmIdManager.next).to.eql({node: -2, way: -1, relation: -1});
             expect(history.difference().modified().length).to.eql(1);
         });
 
@@ -499,7 +499,7 @@ describe('iD.coreHistory', function () {
             expect(history.graph().hasEntity('n1')).to.be.undefined;
             expect(history.undoAnnotation()).to.eql('Deleted a point.');
             expect(history.imageryUsed()).to.eql(['Bing']);
-            expect(iD.osmEntity.id.next).to.eql({node: -1, way: -2, relation: -3});
+            expect(iD.osmIdManager.next).to.eql({node: -1, way: -2, relation: -3});
             expect(history.difference().deleted().length).to.eql(1);
         });
 
@@ -521,7 +521,7 @@ describe('iD.coreHistory', function () {
             expect(history.graph().entity('n-1')).to.eql(new iD.osmNode({id: 'n-1', loc: [1, 2]}));
             expect(history.undoAnnotation()).to.eql('Added a point.');
             expect(history.imageryUsed()).to.eql(['Bing']);
-            expect(iD.osmEntity.id.next).to.eql({node: -2, way: -1, relation: -1});
+            expect(iD.osmIdManager.next).to.eql({node: -2, way: -1, relation: -1});
             expect(history.difference().created().length).to.eql(1);
         });
 
@@ -543,7 +543,7 @@ describe('iD.coreHistory', function () {
             expect(history.graph().entity('n1')).to.eql(new iD.osmNode({id: 'n1', loc: [2, 3], v: 1}));
             expect(history.undoAnnotation()).to.eql('Moved a point.');
             expect(history.imageryUsed()).to.eql(['Bing']);
-            expect(iD.osmEntity.id.next).to.eql({node: -2, way: -1, relation: -1});
+            expect(iD.osmIdManager.next).to.eql({node: -2, way: -1, relation: -1});
             expect(history.difference().modified().length).to.eql(1);
         });
 
@@ -563,7 +563,7 @@ describe('iD.coreHistory', function () {
             expect(history.graph().hasEntity('n1')).to.be.undefined;
             expect(history.undoAnnotation()).to.eql('Deleted a point.');
             expect(history.imageryUsed()).to.eql(['Bing']);
-            expect(iD.osmEntity.id.next).to.eql({node: -1, way: -2, relation: -3});
+            expect(iD.osmIdManager.next).to.eql({node: -1, way: -2, relation: -3});
             expect(history.difference().deleted().length).to.eql(1);
         });
     });

--- a/test/spec/osm/entity.js
+++ b/test/spec/osm/entity.js
@@ -20,23 +20,23 @@ describe('iD.osmEntity', function () {
 
     describe('.id', function () {
         it('generates unique IDs', function () {
-            expect(iD.osmEntity.id('node')).not.to.equal(iD.osmEntity.id('node'));
+            expect(iD.osmIdManager.newId('node')).not.to.equal(iD.osmIdManager.newId('node'));
         });
 
         describe('.fromOSM', function () {
             it('returns a ID string unique across entity types', function () {
-                expect(iD.osmEntity.id.fromOSM('node', '1')).to.equal('n1');
+                expect(iD.osmIdManager.fromOSM('node', '1')).to.equal('n1');
             });
         });
 
         describe('.toOSM', function () {
             it('reverses fromOSM', function () {
-                expect(iD.osmEntity.id.toOSM(iD.osmEntity.id.fromOSM('node', '1'))).to.equal('1');
-                expect(iD.osmEntity.id.toOSM(iD.osmEntity.id.fromOSM('node', '-1'))).to.equal('-1');
+                expect(iD.osmIdManager.toOSM(iD.osmIdManager.fromOSM('node', '1'))).to.equal('1');
+                expect(iD.osmIdManager.toOSM(iD.osmIdManager.fromOSM('node', '-1'))).to.equal('-1');
             });
 
             it('returns the empty string for other strings', function () {
-                expect(iD.osmEntity.id.toOSM('a')).to.equal('');
+                expect(iD.osmIdManager.toOSM('a')).to.equal('');
             });
         });
     });


### PR DESCRIPTION
Another prerequisite to #10909

Currently `osmEntity.id` is a static property with various odd methods. We can decouple this by moving those methods into a seperate class. 

Simplifying `osmEntity` will make it much easier to refactor this weird class in the future 

Closes #10909