### PR TITLE
Add a new validation for the charge tag

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1636,6 +1636,9 @@ en:
         message: '{feature} has an invalid URL'
         message_multi: '{feature} has multiple invalid URLs'
         reference: 'URLs must start with "http://" or "https://".'
+      charge:
+        message: '{feature} has a non-standard charge formatting'
+        reference: 'The key charge should have the following format: charge = <amount> <currency code>[/<unit>][/<time unit>]'
     line_as_area:
       message: '{feature} should be a line, not an area'
     line_as_point:

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1638,7 +1638,7 @@ en:
         reference: 'URLs must start with "http://" or "https://".'
       charge:
         message: '{feature} has a non-standard charge formatting'
-        reference: 'The key charge should have the following format: charge = <amount> <currency code>[/<unit>][/<time unit>]'
+        reference: 'The key charge should have the following format: <amount> <currency code>[/<unit>][/<time unit>]'
     line_as_area:
       message: '{feature} should be a line, not an area'
     line_as_point:

--- a/modules/validations/invalid_format.js
+++ b/modules/validations/invalid_format.js
@@ -60,7 +60,7 @@ export function validationFormatting() {
         }
 
         function isValidCharge(value) {
-            const charge_regex = /^\d+(\.\d{1,3})? [A-Z]{3}(\/.+)?$/;
+            const charge_regex = /^\d+(\.\d{1,3})? [A-Z]{3}(\/[^/]+)?$/;
             return (!value || charge_regex.test(value));
         }
 
@@ -189,19 +189,19 @@ export function validationFormatting() {
             }
         }
         if (entity.tags.charge) {
-            if(!isValidCharge(entity.tags.charge)) {
+            if (!isValidCharge(entity.tags.charge)) {
                 issues.push(new validationIssue({
                     type: type,
                     subtype: 'charge',
                     severity: 'suggestion',
-                    message: function(context) {
+                    message: function (context) {
                         var entity = context.hasEntity(this.entityIds[0]);
-                        return entity ? t.append('issues.invalid_format.charge.message' + this.data,
+                        return entity ? t.append('issues.invalid_format.charge.message',
                             { feature: utilDisplayLabel(entity, context.graph()) }) : '';
                     },
                     reference: showReferenceCharge,
                     entityIds: [entity.id],
-                    hash: entity.tags.charge.join(),
+                    hash: entity.tags.charge,
                 }));
             }
         }

--- a/modules/validations/invalid_format.js
+++ b/modules/validations/invalid_format.js
@@ -59,6 +59,20 @@ export function validationFormatting() {
                 .call(t.append('issues.invalid_format.website.reference'));
         }
 
+        function isValidCharge(value) {
+            const charge_regex = /^\d+(\.\d{1,3})? [A-Z]{3}(\/.+)?$/;
+            return (!value || charge_regex.test(value));
+        }
+
+        function showReferenceCharge(selection) {
+            selection.selectAll('.issue-reference')
+                .data([0])
+                .enter()
+                .append('div')
+                .attr('class', 'issue-reference')
+                .call(t.append('issues.invalid_format.charge.reference'));
+        }
+
         const websiteValidationIssueBase = {
             type: type,
             subtype: 'website',
@@ -171,6 +185,23 @@ export function validationFormatting() {
                     entityIds: [entity.id],
                     hash: emails.join(),
                     data: (emails.length > 1) ? '_multi' : ''
+                }));
+            }
+        }
+        if (entity.tags.charge) {
+            if(!isValidCharge(entity.tags.charge)) {
+                issues.push(new validationIssue({
+                    type: type,
+                    subtype: 'charge',
+                    severity: 'suggestion',
+                    message: function(context) {
+                        var entity = context.hasEntity(this.entityIds[0]);
+                        return entity ? t.append('issues.invalid_format.charge.message' + this.data,
+                            { feature: utilDisplayLabel(entity, context.graph()) }) : '';
+                    },
+                    reference: showReferenceCharge,
+                    entityIds: [entity.id],
+                    hash: entity.tags.charge.join(),
                 }));
             }
         }


### PR DESCRIPTION
This is a proposal for a validator that loosely checks if the tag `charge=*` is using the correct syntax.
Here you can find the osm-wiki article where the syntax is specified:
https://wiki.openstreetmap.org/wiki/Key:charge