### PR TITLE
add PR 12151 to git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# Commits listed in this file will not be shown in the git blame.
+# Useful for commits that make mass-reformatting changes.
+
+# use the `new` operator to instantiate coreGraph & osmEntity classes (#12151)
+547b60149c1383f93185c1e28173bb48b6f82334


### PR DESCRIPTION
now that #12151 is merged, we can hide it from the inline git blame using this file. Even the github UI [supports it now.](https://github.com/orgs/community/discussions/5033)