### PR TITLE
rename `osmEntity.key` to `osmIdManager.key`

### DIFF
--- a/modules/core/history.js
+++ b/modules/core/history.js
@@ -457,7 +457,7 @@ export function coreHistory(context) {
                 Object.keys(i.graph.entities).forEach(function(id) {
                     var entity = i.graph.entities[id];
                     if (entity) {
-                        var key = osmEntity.key(entity);
+                        var key = osmIdManager.key(entity);
                         allEntities[key] = entity;
                         modified.push(key);
                     } else {
@@ -524,7 +524,7 @@ export function coreHistory(context) {
                 var allEntities = {};
 
                 h.entities.forEach(function(entity) {
-                    allEntities[osmEntity.key(entity)] = osmEntity(entity);
+                    allEntities[osmIdManager.key(entity)] = osmEntity(entity);
                 });
 
                 if (h.version === 3) {

--- a/modules/core/history.js
+++ b/modules/core/history.js
@@ -457,7 +457,7 @@ export function coreHistory(context) {
                 Object.keys(i.graph.entities).forEach(function(id) {
                     var entity = i.graph.entities[id];
                     if (entity) {
-                        var key = osmEntity.key(entity);
+                        var key = entity.key();
                         allEntities[key] = entity;
                         modified.push(key);
                     } else {
@@ -523,8 +523,9 @@ export function coreHistory(context) {
             if (h.version === 2 || h.version === 3) {
                 var allEntities = {};
 
-                h.entities.forEach(function(entity) {
-                    allEntities[osmEntity.key(entity)] = osmEntity(entity);
+                h.entities.forEach(function(rawEntity) {
+                    const entity = osmEntity(rawEntity);
+                    allEntities[entity.key()] = entity;
                 });
 
                 if (h.version === 3) {

--- a/modules/geo/vector.ts
+++ b/modules/geo/vector.ts
@@ -39,7 +39,7 @@ export function geoVecInterp(a: Vec2, b: Vec2, t: number): Vec2 {
 }
 
 // http://jsperf.com/id-dist-optimization
-export function geoVecLength(a: Vec2, b: Vec2) {
+export function geoVecLength(a: Vec2, b?: Vec2) {
     return Math.sqrt(geoVecLengthSquare(a,b));
 }
 

--- a/modules/osm/entity.js
+++ b/modules/osm/entity.js
@@ -20,12 +20,6 @@ export function osmEntity(attrs) {
 }
 
 
-// A function suitable for use as the second argument to d3.selection#data().
-osmEntity.key = function(entity) {
-    return entity.id + 'v' + (entity.v || 0);
-};
-
-
 osmEntity.prototype = {
 
     /** @type {Tags} */

--- a/modules/osm/entity.js
+++ b/modules/osm/entity.js
@@ -20,12 +20,6 @@ export function osmEntity(attrs) {
 }
 
 
-// A function suitable for use as the second argument to d3.selection#data().
-osmEntity.key = function(entity) {
-    return entity.id + 'v' + (entity.v || 0);
-};
-
-
 osmEntity.prototype = {
 
     /** @type {Tags} */
@@ -86,6 +80,12 @@ osmEntity.prototype = {
 
     osmId: function() {
         return osmIdManager.toOSM(this.id);
+    },
+
+
+    /** A function suitable for use as the second argument to d3.selection#data() */
+    key() {
+        return this.id + 'v' + (this.v || 0);
     },
 
 

--- a/modules/osm/id_manager.ts
+++ b/modules/osm/id_manager.ts
@@ -31,6 +31,7 @@ class OsmIdManager {
         );
     }
 
+    /** A function suitable for use as the second argument to d3.selection#data(). */
     key(entity: iD.OsmEntity) {
         return entity.id + 'v' + (entity.v || 0);
     }

--- a/modules/renderer/features.js
+++ b/modules/renderer/features.js
@@ -1,7 +1,7 @@
 import { dispatch as d3_dispatch } from 'd3-dispatch';
 
 import { prefs } from '../core/preferences';
-import { osmEntity } from '../osm';
+import { osmIdManager } from '../osm';
 import { osmLanduseTags, osmLifecyclePrefixes } from '../osm/tags.js';
 import { utilRebind } from '../util/rebind';
 import { utilArrayGroupBy, utilArrayUnion, utilStringQs } from '../util';
@@ -389,7 +389,7 @@ export function rendererFeatures(context) {
 
 
     features.clearEntity = function(entity) {
-        delete _cache[osmEntity.key(entity)];
+        delete _cache[osmIdManager.key(entity)];
         for (const key in _cache) {
             if (_cache[key].parents) {
                 for (const parent of _cache[key].parents) {
@@ -422,7 +422,7 @@ export function rendererFeatures(context) {
         if (geometry === 'vertex' ||
             (geometry === 'relation' && !relationShouldBeChecked(entity))) return {};
 
-        var ent = osmEntity.key(entity);
+        var ent = osmIdManager.key(entity);
         if (!_cache[ent]) {
             _cache[ent] = {};
         }
@@ -451,7 +451,7 @@ export function rendererFeatures(context) {
                             // IMPORTANT:
                             // For this to work, getMatches must be called on relations before ways.
                             //
-                            var pkey = osmEntity.key(parents[0]);
+                            var pkey = osmIdManager.key(parents[0]);
                             if (_cache[pkey] && _cache[pkey].matches) {
                                 matches = Object.assign({}, _cache[pkey].matches);  // shallow copy
                                 continue;
@@ -475,7 +475,7 @@ export function rendererFeatures(context) {
     features.getParents = function(entity, resolver, geometry) {
         if (geometry === 'point') return [];
 
-        const ent = osmEntity.key(entity);
+        const ent = osmIdManager.key(entity);
         if (!_cache[ent]) {
             _cache[ent] = {};
         }

--- a/modules/renderer/features.js
+++ b/modules/renderer/features.js
@@ -1,7 +1,6 @@
 import { dispatch as d3_dispatch } from 'd3-dispatch';
 
 import { prefs } from '../core/preferences';
-import { osmEntity } from '../osm';
 import { osmLanduseTags, osmLifecyclePrefixes } from '../osm/tags.js';
 import { utilRebind } from '../util/rebind';
 import { utilArrayGroupBy, utilArrayUnion, utilQsString, utilStringQs } from '../util';
@@ -394,7 +393,7 @@ export function rendererFeatures(context) {
 
 
     features.clearEntity = function(entity) {
-        delete _cache[osmEntity.key(entity)];
+        delete _cache[entity.key()];
         for (const key in _cache) {
             if (_cache[key].parents) {
                 for (const parent of _cache[key].parents) {
@@ -427,7 +426,7 @@ export function rendererFeatures(context) {
         if (geometry === 'vertex' ||
             (geometry === 'relation' && !relationShouldBeChecked(entity))) return {};
 
-        var ent = osmEntity.key(entity);
+        var ent = entity.key();
         if (!_cache[ent]) {
             _cache[ent] = {};
         }
@@ -456,7 +455,7 @@ export function rendererFeatures(context) {
                             // IMPORTANT:
                             // For this to work, getMatches must be called on relations before ways.
                             //
-                            var pkey = osmEntity.key(parents[0]);
+                            var pkey = parents[0].key();
                             if (_cache[pkey] && _cache[pkey].matches) {
                                 matches = Object.assign({}, _cache[pkey].matches);  // shallow copy
                                 continue;
@@ -480,7 +479,7 @@ export function rendererFeatures(context) {
     features.getParents = function(entity, resolver, geometry) {
         if (geometry === 'point') return [];
 
-        const ent = osmEntity.key(entity);
+        const ent = entity.key();
         if (!_cache[ent]) {
             _cache[ent] = {};
         }

--- a/modules/svg/areas.js
+++ b/modules/svg/areas.js
@@ -1,7 +1,7 @@
 import { deepEqual } from 'fast-equals';
 import { bisector as d3_bisector } from 'd3-array';
 
-import { osmEntity } from '../osm';
+import { osmIdManager } from '../osm';
 import { svgPath, svgSegmentWay } from './helpers';
 import { svgTagClasses } from './tag_classes';
 import { svgTagPattern } from './tag_pattern';
@@ -118,7 +118,7 @@ export function svgAreas(projection, context) {
 
         var clipPaths = context.surface().selectAll('defs').selectAll('.clipPath-osm')
            .filter(filter)
-           .data(data.clip, osmEntity.key);
+           .data(data.clip, osmIdManager.key);
 
         clipPaths.exit()
            .remove();
@@ -152,7 +152,7 @@ export function svgAreas(projection, context) {
         var paths = areagroup
             .selectAll('path')
             .filter(filter)
-            .data(function(layer) { return data[layer]; }, osmEntity.key);
+            .data(function(layer) { return data[layer]; }, osmIdManager.key);
 
         paths.exit()
             .remove();

--- a/modules/svg/areas.js
+++ b/modules/svg/areas.js
@@ -118,7 +118,7 @@ export function svgAreas(projection, context) {
 
         var clipPaths = context.surface().selectAll('defs').selectAll('.clipPath-osm')
            .filter(filter)
-           .data(data.clip, osmEntity.key);
+           .data(data.clip, d => d.key());
 
         clipPaths.exit()
            .remove();
@@ -152,7 +152,10 @@ export function svgAreas(projection, context) {
         var paths = areagroup
             .selectAll('path')
             .filter(filter)
-            .data(function(layer) { return data[layer]; }, osmEntity.key);
+            .data(
+                layer => data[layer],
+                d => d instanceof osmEntity ? d.key() : d,
+            );
 
         paths.exit()
             .remove();

--- a/modules/svg/labels.js
+++ b/modules/svg/labels.js
@@ -9,7 +9,7 @@ import {
     geoScaleToZoom, geoVecInterp, geoVecLength
 } from '../geo';
 import { presetManager } from '../presets';
-import { osmEntity, osmIsInterestingTag } from '../osm';
+import { osmIdManager, osmIsInterestingTag } from '../osm';
 import { utilDetect } from '../util/detect';
 import { utilArrayDifference, utilArrayUniq, utilDisplayName, utilDisplayNameForPath, utilEntitySelector } from '../util';
 
@@ -90,7 +90,7 @@ export function svgLabels(projection, context) {
     function drawLinePaths(selection, labels, filter, classes) {
         var paths = selection.selectAll('path:not(.debug)')
             .filter(d => filter(d.entity))
-            .data(labels, d => osmEntity.key(d.entity));
+            .data(labels, d => osmIdManager.key(d.entity));
 
         // exit
         paths.exit()
@@ -110,7 +110,7 @@ export function svgLabels(projection, context) {
     function drawLineLabels(selection, labels, filter, classes) {
         var texts = selection.selectAll('text.' + classes)
             .filter(d => filter(d.entity))
-            .data(labels, d => osmEntity.key(d.entity));
+            .data(labels, d => osmIdManager.key(d.entity));
 
         // exit
         texts.exit()
@@ -127,7 +127,7 @@ export function svgLabels(projection, context) {
         // update
         selection.selectAll('text.' + classes).selectAll('.textpath')
             .filter(d => filter(d.entity))
-            .data(labels, d => osmEntity.key(d.entity))
+            .data(labels, d => osmIdManager.key(d.entity))
             .attr('startOffset', '50%')
             .attr('xlink:href', function(d) { return '#ideditor-labelpath-' + d.entity.id; })
             .text(d => d.name);
@@ -140,7 +140,7 @@ export function svgLabels(projection, context) {
         }
         var texts = selection.selectAll('text.' + classes)
             .filter(d => filter(d.entity))
-            .data(labels, d => osmEntity.key(d.entity));
+            .data(labels, d => osmIdManager.key(d.entity));
 
         // exit
         texts.exit()
@@ -171,7 +171,7 @@ export function svgLabels(projection, context) {
     function drawAreaIcons(selection, labels, filter, classes) {
         var icons = selection.selectAll('use.' + classes)
             .filter(d => filter(d.entity))
-            .data(labels, d => osmEntity.key(d.entity));
+            .data(labels, d => osmIdManager.key(d.entity));
 
         // exit
         icons.exit()

--- a/modules/svg/labels.js
+++ b/modules/svg/labels.js
@@ -9,7 +9,7 @@ import {
     geoScaleToZoom, geoVecInterp, geoVecLength
 } from '../geo';
 import { presetManager } from '../presets';
-import { osmEntity, osmIsInterestingTag } from '../osm';
+import { osmIsInterestingTag } from '../osm';
 import { utilDetect } from '../util/detect';
 import { utilArrayDifference, utilArrayUniq, utilDisplayName, utilDisplayNameForPath, utilEntitySelector } from '../util';
 
@@ -90,7 +90,7 @@ export function svgLabels(projection, context) {
     function drawLinePaths(selection, labels, filter, classes) {
         var paths = selection.selectAll('path:not(.debug)')
             .filter(d => filter(d.entity))
-            .data(labels, d => osmEntity.key(d.entity));
+            .data(labels, d => d.entity.key());
 
         // exit
         paths.exit()
@@ -110,7 +110,7 @@ export function svgLabels(projection, context) {
     function drawLineLabels(selection, labels, filter, classes) {
         var texts = selection.selectAll('text.' + classes)
             .filter(d => filter(d.entity))
-            .data(labels, d => osmEntity.key(d.entity));
+            .data(labels, d => d.entity.key());
 
         // exit
         texts.exit()
@@ -127,7 +127,7 @@ export function svgLabels(projection, context) {
         // update
         selection.selectAll('text.' + classes).selectAll('.textpath')
             .filter(d => filter(d.entity))
-            .data(labels, d => osmEntity.key(d.entity))
+            .data(labels, d => d.entity.key())
             .attr('startOffset', '50%')
             .attr('xlink:href', function(d) { return '#ideditor-labelpath-' + d.entity.id; })
             .text(d => d.name);
@@ -140,7 +140,7 @@ export function svgLabels(projection, context) {
         }
         var texts = selection.selectAll('text.' + classes)
             .filter(d => filter(d.entity))
-            .data(labels, d => osmEntity.key(d.entity));
+            .data(labels, d => d.entity.key());
 
         // exit
         texts.exit()
@@ -171,7 +171,7 @@ export function svgLabels(projection, context) {
     function drawAreaIcons(selection, labels, filter, classes) {
         var icons = selection.selectAll('use.' + classes)
             .filter(d => filter(d.entity))
-            .data(labels, d => osmEntity.key(d.entity));
+            .data(labels, d => d.entity.key());
 
         // exit
         icons.exit()

--- a/modules/svg/lines.js
+++ b/modules/svg/lines.js
@@ -6,7 +6,7 @@ import {
 } from './helpers';
 import { svgTagClasses } from './tag_classes';
 
-import { osmEntity } from '../osm';
+import { osmIdManager } from '../osm';
 import { utilArrayFlatten, utilArrayGroupBy } from '../util';
 import { utilDetect } from '../util/detect';
 
@@ -136,13 +136,13 @@ export function svgLines(projection, context) {
             var lines = selection
                 .selectAll('path')
                 .filter(filter)
-                .data(getPathData(isSelected), osmEntity.key);
+                .data(getPathData(isSelected), osmIdManager.key);
 
             lines.exit()
                 .remove();
 
             // Optimization: Call expensive TagClasses only on enter selection. This
-            // works because osmEntity.key is defined to include the entity v attribute.
+            // works because osmIdManager.key is defined to include the entity v attribute.
             lines.enter()
                 .append('path')
                 .attr('class', function(d) {

--- a/modules/svg/lines.js
+++ b/modules/svg/lines.js
@@ -136,7 +136,7 @@ export function svgLines(projection, context) {
             var lines = selection
                 .selectAll('path')
                 .filter(filter)
-                .data(getPathData(isSelected), osmEntity.key);
+                .data(getPathData(isSelected), d => d instanceof osmEntity ? d.key() : d);
 
             lines.exit()
                 .remove();

--- a/modules/svg/points.js
+++ b/modules/svg/points.js
@@ -3,7 +3,7 @@ import { clamp } from 'es-toolkit/compat';
 import { select as d3_select } from 'd3';
 
 import { geoScaleToZoom } from '../geo';
-import { osmEntity } from '../osm';
+import { osmIdManager } from '../osm';
 import { svgPointTransform } from './helpers';
 import { svgTagClasses } from './tag_classes';
 import { presetManager } from '../presets';
@@ -40,7 +40,7 @@ export function svgPoints(projection, context) {
     function fastEntityKey(d) {
         const mode = context.mode();
         const isMoving = mode && /^(add|draw|drag|move|rotate)/.test(mode.id);
-        return isMoving ? d.id : osmEntity.key(d);
+        return isMoving ? d.id : osmIdManager.key(d);
     }
 
 

--- a/modules/svg/points.js
+++ b/modules/svg/points.js
@@ -3,7 +3,6 @@ import { clamp } from 'es-toolkit/compat';
 import { select as d3_select } from 'd3';
 
 import { geoScaleToZoom } from '../geo';
-import { osmEntity } from '../osm';
 import { svgPointTransform } from './helpers';
 import { svgTagClasses } from './tag_classes';
 import { presetManager } from '../presets';
@@ -38,9 +37,10 @@ export function svgPoints(projection, context) {
     // Avoid exit/enter if we're just moving stuff around.
     // The node will get a new version but we only need to run the update selection.
     function fastEntityKey(d) {
+        if (typeof d === 'number') return d;
         const mode = context.mode();
         const isMoving = mode && /^(add|draw|drag|move|rotate)/.test(mode.id);
-        return isMoving ? d.id : osmEntity.key(d);
+        return isMoving ? d.id : d.key();
     }
 
 

--- a/modules/svg/vertices.js
+++ b/modules/svg/vertices.js
@@ -3,7 +3,7 @@ import { select as d3_select } from 'd3-selection';
 
 import { presetManager } from '../presets';
 import { geoScaleToZoom } from '../geo';
-import { osmEntity } from '../osm';
+import { osmIdManager } from '../osm';
 import { svgPassiveVertex, svgPointTransform } from './helpers';
 import { svgTagClasses } from './tag_classes';
 
@@ -33,7 +33,7 @@ export function svgVertices(projection, context) {
     function fastEntityKey(d) {
         var mode = context.mode();
         var isMoving = mode && /^(add|draw|drag|move|rotate)/.test(mode.id);
-        return isMoving ? d.id : osmEntity.key(d);
+        return isMoving ? d.id : osmIdManager.key(d);
     }
 
 
@@ -182,7 +182,7 @@ export function svgVertices(projection, context) {
             .merge(dgroups);
 
         var viewfields = dgroups.selectAll('.viewfield')
-            .data(getDirections, function key(d) { return osmEntity.key(d); });
+            .data(getDirections, function key(d) { return osmIdManager.key(d); });
 
         // exit
         viewfields.exit()

--- a/modules/svg/vertices.js
+++ b/modules/svg/vertices.js
@@ -31,9 +31,10 @@ export function svgVertices(projection, context) {
     // Avoid exit/enter if we're just moving stuff around.
     // The node will get a new version but we only need to run the update selection.
     function fastEntityKey(d) {
+        if (typeof d === 'number') return d;
         var mode = context.mode();
         var isMoving = mode && /^(add|draw|drag|move|rotate)/.test(mode.id);
-        return isMoving ? d.id : osmEntity.key(d);
+        return isMoving ? d.id : d.key();
     }
 
 
@@ -182,7 +183,7 @@ export function svgVertices(projection, context) {
             .merge(dgroups);
 
         var viewfields = dgroups.selectAll('.viewfield')
-            .data(getDirections, function key(d) { return osmEntity.key(d); });
+            .data(getDirections, d => d instanceof osmEntity ? d.key(d) : d);
 
         // exit
         viewfields.exit()

--- a/modules/ui/sections/raw_member_editor.js
+++ b/modules/ui/sections/raw_member_editor.js
@@ -10,7 +10,7 @@ import { actionDeleteMember } from '../../actions/delete_member';
 import { actionMoveMember } from '../../actions/move_member';
 import { modeBrowse } from '../../modes/browse';
 import { modeSelect } from '../../modes/select';
-import { osmEntity } from '../../osm';
+import { osmIdManager } from '../../osm';
 import { getRelationColor } from '../../osm/tags';
 import { svgIcon } from '../../svg/icon';
 import { services } from '../../services';
@@ -150,8 +150,8 @@ export function uiSectionRawMemberEditor(context) {
 
         var items = list.selectAll('li')
             .data(memberships, function(d) {
-                return osmEntity.key(d.relation) + ',' + d.index + ',' +
-                    (d.member ? osmEntity.key(d.member) : 'incomplete');
+                return osmIdManager.key(d.relation) + ',' + d.index + ',' +
+                    (d.member ? osmIdManager.key(d.member) : 'incomplete');
             });
 
         items.exit()

--- a/modules/ui/sections/raw_member_editor.js
+++ b/modules/ui/sections/raw_member_editor.js
@@ -10,7 +10,6 @@ import { actionDeleteMember } from '../../actions/delete_member';
 import { actionMoveMember } from '../../actions/move_member';
 import { modeBrowse } from '../../modes/browse';
 import { modeSelect } from '../../modes/select';
-import { osmEntity } from '../../osm';
 import { getRelationColor } from '../../osm/tags';
 import { svgIcon } from '../../svg/icon';
 import { services } from '../../services';
@@ -150,8 +149,8 @@ export function uiSectionRawMemberEditor(context) {
 
         var items = list.selectAll('li')
             .data(memberships, function(d) {
-                return osmEntity.key(d.relation) + ',' + d.index + ',' +
-                    (d.member ? osmEntity.key(d.member) : 'incomplete');
+                return d.relation.key() + ',' + d.index + ',' +
+                    (d.member ? d.member.key() : 'incomplete');
             });
 
         items.exit()

--- a/modules/ui/sections/raw_membership_editor.js
+++ b/modules/ui/sections/raw_membership_editor.js
@@ -9,7 +9,7 @@ import { actionChangeMember } from '../../actions/change_member';
 import { actionDeleteMembers } from '../../actions/delete_members';
 
 import { modeSelect } from '../../modes/select';
-import { osmEntity, osmRelation } from '../../osm';
+import { osmIdManager, osmRelation } from '../../osm';
 import { getRelationColor, isColorValid } from '../../osm/tags';
 import { services } from '../../services';
 import { svgIcon } from '../../svg/icon';
@@ -81,7 +81,7 @@ export function uiSectionRawMembershipEditor(context) {
             membership = {
                 relation: relation,
                 members: [],
-                hash: osmEntity.key(relation)
+                hash: osmIdManager.key(relation)
             };
             for (index = 0; index < relation.members.length; index++) {
                 member = relation.members[index];
@@ -98,7 +98,7 @@ export function uiSectionRawMembershipEditor(context) {
                         membership = {
                             relation: relation,
                             members: [],
-                            hash: osmEntity.key(relation)
+                            hash: osmIdManager.key(relation)
                         };
                     }
                 }

--- a/modules/ui/sections/raw_membership_editor.js
+++ b/modules/ui/sections/raw_membership_editor.js
@@ -9,7 +9,7 @@ import { actionChangeMember } from '../../actions/change_member';
 import { actionDeleteMembers } from '../../actions/delete_members';
 
 import { modeSelect } from '../../modes/select';
-import { osmEntity, osmRelation } from '../../osm';
+import { osmRelation } from '../../osm';
 import { getRelationColor, isColorValid } from '../../osm/tags';
 import { services } from '../../services';
 import { svgIcon } from '../../svg/icon';
@@ -82,7 +82,7 @@ export function uiSectionRawMembershipEditor(context) {
             membership = {
                 relation: relation,
                 members: [],
-                hash: osmEntity.key(relation)
+                hash: relation.key()
             };
             for (index = 0; index < relation.members.length; index++) {
                 member = relation.members[index];
@@ -99,7 +99,7 @@ export function uiSectionRawMembershipEditor(context) {
                         membership = {
                             relation: relation,
                             members: [],
-                            hash: osmEntity.key(relation)
+                            hash: relation.key()
                         };
                     }
                 }

--- a/modules/ui/sections/selection_list.js
+++ b/modules/ui/sections/selection_list.js
@@ -2,7 +2,7 @@ import { select as d3_select } from 'd3-selection';
 
 import { presetManager } from '../../presets';
 import { modeSelect } from '../../modes/select';
-import { osmEntity } from '../../osm';
+import { osmIdManager } from '../../osm';
 import { svgIcon } from '../../svg/icon';
 import { uiSection } from '../section';
 import { t } from '../../core/localizer';
@@ -62,7 +62,7 @@ export function uiSectionSelectionList(context) {
             .filter(Boolean);
 
         var items = list.selectAll('.feature-list-item')
-            .data(entities, osmEntity.key);
+            .data(entities, osmIdManager.key);
 
         items.exit()
             .remove();

--- a/modules/ui/sections/selection_list.js
+++ b/modules/ui/sections/selection_list.js
@@ -2,7 +2,6 @@ import { select as d3_select } from 'd3-selection';
 
 import { presetManager } from '../../presets';
 import { modeSelect } from '../../modes/select';
-import { osmEntity } from '../../osm';
 import { svgIcon } from '../../svg/icon';
 import { uiSection } from '../section';
 import { t } from '../../core/localizer';
@@ -62,7 +61,7 @@ export function uiSectionSelectionList(context) {
             .filter(Boolean);
 
         var items = list.selectAll('.feature-list-item')
-            .data(entities, osmEntity.key);
+            .data(entities, d => d.key());
 
         items.exit()
             .remove();

--- a/modules/util/utilDisplayLabel.js
+++ b/modules/util/utilDisplayLabel.js
@@ -9,7 +9,7 @@ import { utilDisplayName, utilDisplayType } from './util';
  *
  * If `verbose=true`, include both preset name and feature name.
  *    "Tertiary Road Main Street"
- * @param {osmEntity} entity
+ * @param {iD.OsmEntity} entity
  * @param {string | unknown} graphOrGeometry
  * @param {boolean} [verbose]
  * @returns {string}

--- a/modules/validations/crossing_ways.js
+++ b/modules/validations/crossing_ways.js
@@ -774,7 +774,7 @@ export function validationCrossingWays(context) {
         return fix;
     }
 
-    /** @returns {osmEntity | undefined} */
+    /** @returns {iD.OsmEntity | undefined} */
     function getSelectedFeature() {
         const mode = context.mode();
         if (!mode || mode.id !== 'select') return undefined;


### PR DESCRIPTION
part 7 of #10909.

this is the last PR for the preëmptive work ! after that is should be easy to convert `osmEntity` it to an ES6 Class. i might try this tonight.

---

in this PR: we replace a static function `osmEntity.key(...)` with a class method, so that:
- it matches every other class method
- we don't need to import `osmEntity` is as many files
- it removes another random thing which was attached to this abstract class, to make it easier to refactor this file in the next PR