### PR TITLE
include all tags from special fields when removing tags during preset change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Standardize tooltips in combo boxes: always show (full) raw tag, don't duplicate the already rendered titles, and show descriptions from wiki/taginfo where available ([#12010], thanks [@tordans])
 * Use full width for the dropdown box for the values of the `access` field ([#12065])
 * Preserve the order of options when a combo field accepts both static options as well as autosuggestions from taginfo and display additional tag values from taginfo as raw-options only ([#12117])
+* When removing tags while changing presets: include all tags associated with `localized`, `multiCombo` and `directionalCombo` fields ([#12075], [#11696])
 #### :hammer: Development
 * Replace `sinon` with `vitest`'s built in spy/mock library ([#12058])
 * Add type annotations to `context.js` module ([#11589], thanks [@k-yle])
@@ -90,6 +91,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#12063]: https://github.com/openstreetmap/iD/issues/12063
 [#12065]: https://github.com/openstreetmap/iD/issues/12065
 [#12070]: https://github.com/openstreetmap/iD/issues/12070
+[#12075]: https://github.com/openstreetmap/iD/issues/12075
 [#12078]: https://github.com/openstreetmap/iD/issues/12078
 [#12110]: https://github.com/openstreetmap/iD/issues/12110
 [#12117]: https://github.com/openstreetmap/iD/issues/12117

--- a/modules/actions/change_preset.js
+++ b/modules/actions/change_preset.js
@@ -30,7 +30,7 @@ export function actionChangePreset(entityID, oldPreset, newPreset, skipFieldDefa
                 const oldPresetFieldKeys = [
                     ...oldPreset.fields(loc),
                     ...oldPreset.moreFields(loc)
-                ].flatMap(f => f.allKeys());
+                ].flatMap(f => f.allKeys(tags));
 
                 // field-keys used by the old preset but not the new preset
                 const fieldKeysToRemove = utilArrayDifference(oldPresetFieldKeys, preserveKeys);

--- a/modules/actions/change_preset.js
+++ b/modules/actions/change_preset.js
@@ -14,27 +14,38 @@ export function actionChangePreset(entityID, oldPreset, newPreset, skipFieldDefa
             if (newPreset.addTags) {
                 preserveKeys = preserveKeys.concat(Object.keys(newPreset.addTags));
             }
-            if (oldPreset && !oldPreset.id.startsWith(newPreset.id)) {
-                // only if old preset is not a sub-preset of the new one:
-                // preserve tags for which the new preset has a field
-                // https://github.com/openstreetmap/iD/issues/9372
+            if (oldPreset) {
+                const wasSubPreset = oldPreset.id.startsWith(newPreset.id);
                 newPreset.fields(loc).concat(newPreset.moreFields(loc))
                     .filter(f => f.matchGeometry(geometry))
                     .flatMap(f => f.allKeys(tags))
+                    .filter(key => {
+                        if (wasSubPreset) {
+                            // if old preset was a sub-preset of the new one:
+                            // don't preserve tags which defined the old sub-preset,
+                            // even if the new preset has a field for it
+                            // for example:
+                            //   amenity=restaurant + cuisine=pizza + name, etc.
+                            //   should result in: amenity=restaurant + name, etc.
+                            // https://github.com/openstreetmap/iD/issues/9372
+                            return oldPreset.tags[key] === undefined;
+                        }
+                        return true;
+                    })
                     .filter(Boolean)
                     .forEach(key => preserveKeys.push(key));
-            }
 
-            if (oldPreset && (oldPreset.id !== newPreset.id)) {
-                // 'field-keys' are keys used by fields (different to the keys used by preset itself)
-                const oldPresetFieldKeys = [
-                    ...oldPreset.fields(loc),
-                    ...oldPreset.moreFields(loc)
-                ].flatMap(f => f.allKeys(tags));
+                if (oldPreset.id !== newPreset.id) {
+                    // 'field-keys' are keys used by fields (different to the keys used by preset itself)
+                    const oldPresetFieldKeys = [
+                        ...oldPreset.fields(loc),
+                        ...oldPreset.moreFields(loc)
+                    ].flatMap(f => f.allKeys(tags));
 
-                // field-keys used by the old preset but not the new preset
-                const fieldKeysToRemove = utilArrayDifference(oldPresetFieldKeys, preserveKeys);
-                tags = utilObjectOmit(tags, fieldKeysToRemove);
+                    // field-keys used by the old preset but not the new preset
+                    const fieldKeysToRemove = utilArrayDifference(oldPresetFieldKeys, preserveKeys);
+                    tags = utilObjectOmit(tags, fieldKeysToRemove);
+                }
             }
         }
         if (oldPreset) tags = oldPreset.unsetTags(tags, geometry, preserveKeys, false, loc);

--- a/modules/actions/change_preset.js
+++ b/modules/actions/change_preset.js
@@ -20,7 +20,7 @@ export function actionChangePreset(entityID, oldPreset, newPreset, skipFieldDefa
                 // https://github.com/openstreetmap/iD/issues/9372
                 newPreset.fields(loc).concat(newPreset.moreFields(loc))
                     .filter(f => f.matchGeometry(geometry))
-                    .flatMap(f => f.allKeys())
+                    .flatMap(f => f.allKeys(tags))
                     .filter(Boolean)
                     .forEach(key => preserveKeys.push(key));
             }

--- a/modules/presets/field.js
+++ b/modules/presets/field.js
@@ -74,7 +74,7 @@ export function presetField(fieldID, field, allFields) {
             .forEach(key => allKeys.add(key));
     }
     if (field.type === 'multiCombo' && field.key && tags) {
-        const prefix = field.key + field.key.endsWith(':') ? '' : ':';
+        const prefix = field.key + (field.key.endsWith(':') ? '' : ':');
         Object.keys(tags)
             .filter(k => k.startsWith(prefix))
             .forEach(key => allKeys.add(key));

--- a/modules/presets/field.js
+++ b/modules/presets/field.js
@@ -1,4 +1,5 @@
 import { localizer, t } from '../core/localizer';
+import { LANGUAGE_SUFFIX_REGEX } from '../ui/fields';
 import { utilSafeClassName } from '../util/util';
 
 
@@ -53,11 +54,32 @@ export function presetField(fieldID, field, allFields) {
   _this.increment = (_this.type === 'number' || _this.type === 'integer') ? (_this.increment || 1) : undefined;
 
   /** all keys controlled by this field */
-  _this.allKeys = () => {
-    const allKeys = [];
-    if (_this.key) allKeys.push(_this.key);
-    if (_this.keys) allKeys.push(..._this.keys);
-    return allKeys;
+  _this.allKeys = (tags) => {
+    const allKeys = new Set();
+    if (_this.key) allKeys.add(_this.key);
+    if (_this.keys) _this.keys.forEach(key => allKeys.add(key));
+    if (field.type === 'directionalCombo' && _this.key) {
+        // directionalCombo fields can have an additional key describing the for
+        // cases where both directions share a "common" value.
+        // The field also support *:both. The preset decides which field to write to.
+        const baseKey = field.key.replace(/:both$/, '');
+        allKeys.add(baseKey);
+        allKeys.add(`${baseKey}:both`);
+    }
+    if (field.type === 'localized' && field.key && tags) {
+        const prefix = `${field.key}:`;
+        Object.keys(tags)
+            .filter(k => k.startsWith(prefix))
+            .filter(k => LANGUAGE_SUFFIX_REGEX.test(k))
+            .forEach(key => allKeys.add(key));
+    }
+    if (field.type === 'multiCombo' && field.key && tags) {
+        const prefix = field.key + field.key.endsWith(':') ? '' : ':';
+        Object.keys(tags)
+            .filter(k => k.startsWith(prefix))
+            .forEach(key => allKeys.add(key));
+    }
+    return [...allKeys];
   };
 
   return _this;

--- a/modules/ui/field.js
+++ b/modules/ui/field.js
@@ -66,15 +66,7 @@ export function uiField(context, presetField, entityIDs, options) {
 
 
     function allKeys() {
-        let keys = field.keys || [field.key];
-        if (field.type === 'directionalCombo' && field.key) {
-            // directionalCombo fields can have an additional key describing the for
-            // cases where both directions share a "common" value.
-            // The field also support *:both. The preset decides which field to write to.
-            const baseKey = field.key.replace(/:both$/, '');
-            keys = keys.concat(baseKey, `${baseKey}:both`);
-        }
-        return keys;
+        return field.allKeys();
     }
 
 

--- a/test/spec/actions/change_preset.js
+++ b/test/spec/actions/change_preset.js
@@ -281,14 +281,16 @@ describe('iD.actionChangePreset', function() {
     });
 
     // https://github.com/openstreetmap/iD/issues/9372
-    it('does not preserve field tags when changing from a subpreset to its parent', function() {
-        var entity = new iD.osmNode({tags: {highway: 'service', service: 'driveway'}});
-        var graph = new iD.coreGraph([entity]);
-        var oldPreset = iD.presetPreset('highway/service/driveway', {tags: {highway: 'service', service: 'driveway'}});
-        var newPreset = iD.presetPreset('highway/service', {tags: {highway: 'service'}, fields: ['field']}, undefined, {
-            field: iD.presetField('field', {key: 'service'})
-        });
-        var action = iD.actionChangePreset(entity.id, oldPreset, newPreset);
-        expect(action(graph).entity(entity.id).tags).to.eql({highway: 'service'});
+    it('does not preserve old preset\'s primary tags when changing from a subpreset to its parent', () => {
+        const entity = new iD.osmNode({tags: {highway: 'service', service: 'driveway', name: 'foo bar'}});
+        const graph = new iD.coreGraph([entity]);
+        const fields = {
+            field: iD.presetField('field', {key: 'service'}),
+            name: iD.presetField('name', {key: 'name'})
+        };
+        const oldPreset = iD.presetPreset('highway/service/driveway', {tags: {highway: 'service', service: 'driveway'}, fields: ['name']}, undefined, fields);
+        const newPreset = iD.presetPreset('highway/service', {tags: {highway: 'service'}, fields: ['field', 'name']}, undefined, fields);
+        const action = iD.actionChangePreset(entity.id, oldPreset, newPreset);
+        expect(action(graph).entity(entity.id).tags).to.eql({highway: 'service', name: 'foo bar'});
     });
 });

--- a/test/spec/actions/change_preset.js
+++ b/test/spec/actions/change_preset.js
@@ -165,6 +165,64 @@ describe('iD.actionChangePreset', function() {
         });
     });
 
+    // https://github.com/openstreetmap/iD/issues/12075
+    it.each([{
+        fieldType: 'multiCombo',
+        fieldId: 'recycling',
+        fieldKey: 'recycling:',
+        fieldKeys: [],
+        oldTags: { 'recycling:paper': 'yes', 'recycling:others': 'no' },
+        tagsToPreserve: {}
+    }, {
+        fieldType: 'localized',
+        fieldId: 'name',
+        fieldKey: 'name',
+        fieldKeys: [],
+        oldTags: { 'name': 'foo', 'name:en': 'bar', 'name:etymology:wikidata': 'Q860' },
+        tagsToPreserve: { 'name:etymology:wikidata': 'Q860' }
+    }, {
+        fieldType: 'directionalCombo',
+        fieldId: 'cycleway',
+        fieldKey: 'cycleway',
+        fieldKeys: [ 'cycleway:left', 'cycleway:right' ],
+        oldTags: { 'cycleway:left': 'no', 'cycleway:both': 'separate', 'cycleway:foo': 'bar' },
+        tagsToPreserve: { 'cycleway:foo': 'bar' }
+    }])('does not preserve $fieldType field tags that are only present in the old preset', ({
+        fieldType, fieldId, fieldKey, fieldKeys, oldTags: fieldTags, tagsToPreserve
+    }) => {
+        const entity = iD.osmNode({
+            tags: {
+                amenity: 'recycling',
+                ...fieldTags
+            },
+            loc: [0, 0],
+        });
+        const graph = new iD.coreGraph([entity]);
+
+        const fields = {
+            [fieldId]: iD.presetField('recycling', { type: fieldType, key: fieldKey, keys: fieldKeys }),
+        };
+
+        const oldPreset = iD.presetPreset(
+            'amenity/recycling',
+            { tags: { amenity: 'recycling' }, fields: [fieldId] },
+            undefined,
+            fields,
+        );
+        const newPreset = iD.presetPreset(
+            'amenity/bench',
+            { tags: { amenity: 'bench' }, fields: [] },
+            undefined,
+            fields,
+        );
+        const action = iD.actionChangePreset(entity.id, oldPreset, newPreset);
+        expect(action(graph).entity(entity.id).tags).toStrictEqual({
+            // no field tags are preserved
+            amenity: 'bench',
+            ...tagsToPreserve
+        });
+    });
+
     // https://github.com/openstreetmap/iD/issues/9372
     it('does not preserve field tags when changing from a subpreset to its parent', function() {
         var entity = new iD.osmNode({tags: {highway: 'service', service: 'driveway'}});

--- a/test/spec/actions/change_preset.js
+++ b/test/spec/actions/change_preset.js
@@ -188,12 +188,12 @@ describe('iD.actionChangePreset', function() {
         oldTags: { 'cycleway:left': 'no', 'cycleway:both': 'separate', 'cycleway:foo': 'bar' },
         tagsToPreserve: { 'cycleway:foo': 'bar' }
     }])('does not preserve $fieldType field tags that are only present in the old preset', ({
-        fieldType, fieldId, fieldKey, fieldKeys, oldTags: fieldTags, tagsToPreserve
+        fieldType, fieldId, fieldKey, fieldKeys, oldTags, tagsToPreserve
     }) => {
         const entity = iD.osmNode({
             tags: {
                 amenity: 'recycling',
-                ...fieldTags,
+                ...oldTags,
                 unrelatedTagKey: 'unrelatedTagValue',
             },
             loc: [0, 0],
@@ -222,6 +222,61 @@ describe('iD.actionChangePreset', function() {
             amenity: 'bench',
             ...tagsToPreserve,
             unrelatedTagKey: 'unrelatedTagValue',
+        });
+    });
+
+    // https://github.com/openstreetmap/iD/pull/12218#issuecomment-4314204446
+    it.each([{
+        fieldType: 'multiCombo',
+        fieldId: 'recycling',
+        fieldKey: 'recycling:',
+        fieldKeys: [],
+        oldTags: { 'recycling:paper': 'yes', 'recycling:others': 'no' }
+    }, {
+        fieldType: 'localized',
+        fieldId: 'name',
+        fieldKey: 'name',
+        fieldKeys: [],
+        oldTags: { 'name': 'foo', 'name:en': 'bar', 'name:etymology:wikidata': 'Q860' }
+    }, {
+        fieldType: 'directionalCombo',
+        fieldId: 'cycleway',
+        fieldKey: 'cycleway',
+        fieldKeys: [ 'cycleway:left', 'cycleway:right' ],
+        oldTags: { 'cycleway:left': 'no', 'cycleway:both': 'separate', 'cycleway:foo': 'bar' }
+    }])('preserve $fieldType field tags when they are present in the old and the new preset', ({
+        fieldType, fieldId, fieldKey, fieldKeys, oldTags
+    }) => {
+        const entity = iD.osmNode({
+            tags: {
+                amenity: 'recycling',
+                ...oldTags,
+            },
+            loc: [0, 0],
+        });
+        const graph = new iD.coreGraph([entity]);
+
+        const fields = {
+            [fieldId]: iD.presetField('recycling', { type: fieldType, key: fieldKey, keys: fieldKeys }),
+        };
+
+        const oldPreset = iD.presetPreset(
+            'amenity/recycling',
+            { tags: { amenity: 'recycling' }, fields: [fieldId] },
+            undefined,
+            fields,
+        );
+        const newPreset = iD.presetPreset(
+            'amenity/bench',
+            { tags: { amenity: 'bench' }, fields: [fieldId] },
+            undefined,
+            fields,
+        );
+        const action = iD.actionChangePreset(entity.id, oldPreset, newPreset);
+        expect(action(graph).entity(entity.id).tags).toStrictEqual({
+            // all field tags are preserved
+            ...oldTags,
+            amenity: 'bench', // override primary preset tag
         });
     });
 

--- a/test/spec/actions/change_preset.js
+++ b/test/spec/actions/change_preset.js
@@ -193,7 +193,8 @@ describe('iD.actionChangePreset', function() {
         const entity = iD.osmNode({
             tags: {
                 amenity: 'recycling',
-                ...fieldTags
+                ...fieldTags,
+                unrelatedTagKey: 'unrelatedTagValue',
             },
             loc: [0, 0],
         });
@@ -219,7 +220,8 @@ describe('iD.actionChangePreset', function() {
         expect(action(graph).entity(entity.id).tags).toStrictEqual({
             // no field tags are preserved
             amenity: 'bench',
-            ...tagsToPreserve
+            ...tagsToPreserve,
+            unrelatedTagKey: 'unrelatedTagValue',
         });
     });
 


### PR DESCRIPTION
fixes #12075, replaces and closes #12107, see also #11696

includes special handling for the following fields:
* `localized`
* `multiCombo`
* `directionalCombo` fields

also refactors two similar function `allTags` function that do the same thing essentially.