### PR TITLE
Allow more dependabot PRs at the same time

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 20
     cooldown:
       semver-minor-days: 7
       semver-patch-days: 7


### PR DESCRIPTION
to prevent "no point in merging them, bot will open 4 new ones anyway" reaction - just let it open all