### PR TITLE
Fix unable to delete way after removing it from multipolygon relation

### DIFF
--- a/modules/core/graph.ts
+++ b/modules/core/graph.ts
@@ -204,8 +204,6 @@ export class coreGraph {
         parentRels = parentRels || this._parentRels;
 
         var type = entity && entity.type || oldentity && oldentity.type;
-        let removed: string[] = [];
-        let added: string[] = [];
         let i: number;
 
         if (type === 'way') {   // Update parentWays
@@ -214,6 +212,8 @@ export class coreGraph {
             entity = <osmWay | undefined>entity;
             oldentity = <osmWay | undefined>oldentity;
 
+            let removed: string[] = [];
+            let added: string[] = [];
             if (oldentity && entity) {
                 removed = utilArrayDifference(oldentity.nodes, entity.nodes);
                 added = utilArrayDifference(entity.nodes, oldentity.nodes);
@@ -241,29 +241,47 @@ export class coreGraph {
             entity = <osmRelation | undefined>entity;
             oldentity = <osmRelation | undefined>oldentity;
 
-            // diff only on the IDs since the same entity can be a member multiple times with different roles
-            var oldentityMemberIDs = oldentity ? oldentity.members.map(function(m) { return m.id; }) : [];
-            var entityMemberIDs = entity ? entity.members.map(function(m) { return m.id; }) : [];
+            function memberIDCounts(members: osmRelation['members'] | undefined) {
+                var counts = new Map<string, number>();
+                if (!members) return counts;
+                for (var j = 0; j < members.length; j++) {
+                    var mid = members[j].id;
+                    counts.set(mid, (counts.get(mid) || 0) + 1);
+                }
+                return counts;
+            }
 
+            // _parentRels stores each parent relation at most once per child id, but a relation
+            // may list the same member id multiple times (different roles). Membership changes
+            // must use multiset counts — utilArrayDifference(Set) breaks duplicate members.
             if (oldentity && entity) {
-                removed = utilArrayDifference(oldentityMemberIDs, entityMemberIDs);
-                added = utilArrayDifference(entityMemberIDs, oldentityMemberIDs);
+                var oldCounts = memberIDCounts(oldentity.members);
+                var newCounts = memberIDCounts(entity.members);
+                var relationId = oldentity.id;
+                var memberIds = new Set([...oldCounts.keys(), ...newCounts.keys()]);
+                memberIds.forEach(function(mid) {
+                    var oc = oldCounts.get(mid) || 0;
+                    var nc = newCounts.get(mid) || 0;
+                    if (oc > 0 && nc === 0) {
+                        parentRels[mid] = new Set(parentRels[mid]);
+                        parentRels[mid].delete(relationId);
+                    } else if (oc === 0 && nc > 0) {
+                        parentRels[mid] = new Set(parentRels[mid]);
+                        parentRels[mid].add(relationId);
+                    }
+                });
             } else if (oldentity) {
-                removed = oldentityMemberIDs;
-                added = [];
+                var removedRel = oldentity;
+                memberIDCounts(removedRel.members).forEach(function(_oc, mid) {
+                    parentRels[mid] = new Set(parentRels[mid]);
+                    parentRels[mid].delete(removedRel.id);
+                });
             } else if (entity) {
-                removed = [];
-                added = entityMemberIDs;
-            }
-            for (i = 0; i < removed.length; i++) {
-                // make a copy of prototype property, store as own property, and update..
-                parentRels[removed[i]] = new Set(parentRels[removed[i]]);
-                parentRels[removed[i]].delete(oldentity!.id);
-            }
-            for (i = 0; i < added.length; i++) {
-                // make a copy of prototype property, store as own property, and update..
-                parentRels[added[i]] = new Set(parentRels[added[i]]);
-                parentRels[added[i]].add(entity!.id);
+                var addedRel = entity;
+                memberIDCounts(addedRel.members).forEach(function(_nc, mid) {
+                    parentRels[mid] = new Set(parentRels[mid]);
+                    parentRels[mid].add(addedRel.id);
+                });
             }
         }
     }

--- a/modules/operations/delete.js
+++ b/modules/operations/delete.js
@@ -117,8 +117,11 @@ export function operationDelete(context, selectedIDs) {
             var parents = context.graph().parentRelations(entity);
             for (var i = 0; i < parents.length; i++) {
                 var parent = parents[i];
+                var membership = parent.memberById(id);
+                if (!membership) continue;
+
                 var type = parent.tags.type;
-                var role = parent.memberById(id).role || 'outer';
+                var role = membership.role || 'outer';
                 if (type === 'route' || type === 'boundary' || (type === 'multipolygon' && role === 'outer')) {
                     return true;
                 }

--- a/test/spec/core/graph.js
+++ b/test/spec/core/graph.js
@@ -544,7 +544,7 @@ describe('iD.coreGraph', function() {
             var relation = graph.parentRelations(graph.entity(wayRemoved))[0];
             var idx = relation.members.findIndex(function(m) { return m.id === wayRemoved; });
 
-            graph = iD.actionDeleteMembers(relation.id, [idx])(graph);
+            graph = iD.actionDeleteMember(relation.id, idx)(graph);
 
             expect(graph.parentRelations(graph.entity(wayRemoved))).to.eql([]);
         });

--- a/test/spec/core/graph.js
+++ b/test/spec/core/graph.js
@@ -529,6 +529,47 @@ describe('iD.coreGraph', function() {
             expect(graph.parentRelations(node)).to.eql([relation]);
             expect(graph.parentRelations(nonnode)).to.eql([]);
         });
+
+        it('updates after removing a way from a multipolygon (#split area → remove member)', function () {
+            var graph = new iD.coreGraph([
+                new iD.osmNode({id: 'a', loc: [0, 1]}),
+                new iD.osmNode({id: 'b', loc: [1, 1]}),
+                new iD.osmNode({id: 'c', loc: [1, 0]}),
+                new iD.osmNode({id: 'd', loc: [0, 0]}),
+                new iD.osmWay({id: '-', tags: { area: 'yes' }, nodes: ['a', 'b', 'c', 'd', 'a']}),
+            ]);
+            graph = iD.actionSplit('a', ['='])(graph);
+
+            var wayRemoved = '=';
+            var relation = graph.parentRelations(graph.entity(wayRemoved))[0];
+            var idx = relation.members.findIndex(function(m) { return m.id === wayRemoved; });
+
+            graph = iD.actionDeleteMembers(relation.id, [idx])(graph);
+
+            expect(graph.parentRelations(graph.entity(wayRemoved))).to.eql([]);
+        });
+
+        it('handles duplicate member ids when updating parentRels', function () {
+            var n = new iD.osmNode({ id: 'n1' }),
+                r = new iD.osmRelation({
+                    id: 'r',
+                    members: [
+                        { id: 'n1', type: 'node', role: 'outer' },
+                        { id: 'n1', type: 'node', role: 'inner' },
+                    ],
+                }),
+                graph = new iD.coreGraph([n, r]);
+
+            expect(graph.parentRelations(n).map(function(x) { return x.id; })).to.eql(['r']);
+
+            graph = graph.replace(graph.entity('r').removeMember(0));
+
+            expect(graph.parentRelations(n).map(function(x) { return x.id; })).to.eql(['r']);
+
+            graph = graph.replace(graph.entity('r').removeMember(0));
+
+            expect(graph.parentRelations(n)).to.eql([]);
+        });
     });
 
     describe('#childNodes', function () {


### PR DESCRIPTION
Summary:
This PR fixes a bug where a line/way could not be deleted after creating a multipolygon and then removing that way from the relation.

Fixes #12232

Problem:
After creating a multipolygon, removing a member way from the relation should allow that way to be deleted normally. Instead, the way remained in a blocked state and could not be deleted.

Solution:
Updated the relation/member cleanup logic so that once a way is removed from the multipolygon relation, it is treated as an independent feature again and can be deleted normally.