### PR TITLE
Update outdated D3 behavior note in ARCHITECTURE.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -244,8 +244,8 @@ remove a `hover` class from map elements.
 
 Because certain behaviors are appropriate to some but not all modes, we need
 the ability to remove a behavior when entering a mode where it is not
-appropriate. (This is functionality [not yet
-provided](https://github.com/mbostock/d3/issues/894) by d3's own behaviors.)
+appropriate. While older versions of D3 did not provide this functionality,
+it is now possible to remove namespaced event listeners (e.g. `selection.on(".zoom", null)`).
 Each behavior implements an `off` function that "uninstalls" the behavior.
 This is very similar to the `exit` method of a mode, and in fact many modes do
 little else but uninstall behaviors in their `exit` methods.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -244,11 +244,11 @@ remove a `hover` class from map elements.
 
 Because certain behaviors are appropriate to some but not all modes, we need
 the ability to remove a behavior when entering a mode where it is not
-appropriate. While older versions of D3 did not provide this functionality,
-it is now possible to remove namespaced event listeners (e.g. `selection.on(".zoom", null)`).
-Each behavior implements an `off` function that "uninstalls" the behavior.
-This is very similar to the `exit` method of a mode, and in fact many modes do
-little else but uninstall behaviors in their `exit` methods.
+appropriate. Although it is possible to remove event listeners by namespace
+(e.g. `selection.on(".zoom", null)`), each behavior implements an `off` function
+that "uninstalls" the behavior. This is very similar to the `exit` method of
+a mode, and in fact many modes do little else but uninstall behaviors in
+their `exit` methods.
 
 ### Operations Module
 


### PR DESCRIPTION
Addresses #12239

Updates outdated D3 behavior note in ARCHITECTURE.md.

D3 now supports namespaced event listener removal (e.g. `selection.on(".zoom", null)`).

