### PR TITLE
Fix shortcuts modal scrolling: constrain scroll to content area and preserve header scroll behavior

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -5352,6 +5352,21 @@ img.tile-debug {
     max-width: 1050px;
 }
 
+.modal-shortcuts .content {
+   display: flex;
+   flex-direction: column;
+   max-height: 90vh;
+   overflow-y: hidden;
+}
+
+
+.modal-shortcuts .wrapper {
+   flex: 1 1 auto;
+   min-height: 0;
+   overflow-y: auto;
+}
+
+
 .modal-shortcuts .modal-section:last-child {
     padding: 10px 15px 20px 15px;
     min-height: 275px;

--- a/modules/ui/shortcuts.js
+++ b/modules/ui/shortcuts.js
@@ -13,24 +13,39 @@ export function uiShortcuts(context) {
 
 
     function shortcutsModal(_modalSelection) {
-        _modalSelection.select('.modal')
-            .classed('modal-shortcuts', true);
+       _modalSelection.select('.modal')
+           .classed('modal-shortcuts', true);
 
-        var content = _modalSelection.select('.content');
 
-        content
-            .append('div')
-            .attr('class', 'modal-section header')
-            .append('h2')
-            .call(t.append('shortcuts.title'));
+       var content = _modalSelection.select('.content');
 
-        fileFetcher.get('shortcuts')
-            .then(function(data) {
-                _dataShortcuts = data;
-                content.call(render);
-            })
-            .catch(function() { /* ignore */ });
-    }
+
+       var header = content
+           .append('div')
+           .attr('class', 'modal-section header')
+           .on('wheel', function (d3_event) {
+               var wrapper = content.select('.wrapper').node();
+               if (!wrapper) return;
+
+
+               wrapper.scrollTop += d3_event.deltaY;
+               d3_event.preventDefault();
+           });
+
+
+       header
+           .append('h2')
+           .call(t.append('shortcuts.title'));
+
+
+       fileFetcher.get('shortcuts')
+           .then(function (data) {
+               _dataShortcuts = data;
+               content.call(render);
+           })
+           .catch(function () { /* ignore */ });
+   }
+
 
 
     function render(selection) {


### PR DESCRIPTION
**Closes #10591**

This change fixes the scrollbar behavior in the Keyboard Shortcuts modal. Previously, the scrollbar extended into the header area because scrolling was applied to the entire modal content container. This caused the header to appear visually inconsistent and not remain fixed during scrolling.

**This fix:**
- Restricts scrolling to the content wrapper instead of the full modal container
- Keeps the header fixed at the top of the modal
- Prevents the scrollbar from overlapping the header

Additionally, this change preserves expected scrolling behavior by forwarding wheel events from the header to the scrollable content area. This ensures users can still scroll the modal even when hovering over the header.

**Testing**
- Resized the browser window to force overflow
- Verified scrollbar is limited to the content area
- Verified header remains fixed during scroll
- Verified scrolling works when hovering over both content and header

No regressions observed in the test suite (`npm test` passed).