### PR TITLE
Enhance OSM API error messages (Resolves TODO in uiStatus)

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -596,6 +596,9 @@ en:
   osm_api_status:
     message:
       error: Unable to reach the OpenStreetMap API. Your edits are safe locally. Check your network connection.
+      server_error: The OpenStreetMap server encountered an error (500). Your edits are safe locally.
+      service_unavailable: The OpenStreetMap service is temporarily unavailable (503). Your edits are safe locally.
+      timeout: The connection to OpenStreetMap timed out. Please check your internet connection.
       offline: The OpenStreetMap API is offline. Your edits are safe locally. Please come back later.
       readonly: The OpenStreetMap API is currently read-only. You can continue editing, but must wait to save your changes.
       rateLimit: The OpenStreetMap API is limiting anonymous connections. You can fix this by logging in.

--- a/modules/ui/status.js
+++ b/modules/ui/status.js
@@ -48,10 +48,17 @@ export function uiStatus(context) {
                         osm.reloadApiStatus();
                     }, 2000);
 
-                    // eslint-disable-next-line no-warning-comments
-                    // TODO: nice messages for different error types
+                    var messageKey = 'osm_api_status.message.error';
+                    if (err && err.status === 500) {
+                        messageKey = 'osm_api_status.message.server_error';
+                    } else if (err && err.status === 503) {
+                        messageKey = 'osm_api_status.message.service_unavailable';
+                    } else if (err && (err.status === -1 || err.timeout)) {
+                        messageKey = 'osm_api_status.message.timeout';
+                    }
+
                     selection
-                        .call(t.append('osm_api_status.message.error', { suffix: ' ' }))
+                        .call(t.append(messageKey, { suffix: ' ' }))
                         .append('a')
                         .attr('href', '#')
                         // let the user manually retry their connection directly


### PR DESCRIPTION
This PR resolves a TODO in modules/ui/status.js by providing more specific UI feedback when the OSM API fails, rather than falling back to the generic error message for all connection issues.

I added logic to check the error's HTTP status code and display a specific message for 500 errors, 503 errors, and network timeouts. If an unrecognized error occurs, it still safely falls back to the original generic error message.

Changes
modules/ui/status.js: Updated the update function to check err.status and select the appropriate translation key. Removed the old TODO comment.
data/core.yaml: Added server_error, service_unavailable, and timeout localization strings under osm_api_status.message.
Closes #12255