### PR TITLE
Fix tag search to also check addTags when searching by key=value

### DIFF
--- a/modules/presets/collection.js
+++ b/modules/presets/collection.js
@@ -170,11 +170,15 @@ export function presetCollection(collection) {
     // matches key=value to preset.tags
     let leadingTagKeyValues = [];
     if (value.includes('=')) {
-      leadingTagKeyValues = searchable.filter(a => a.tags &&
-          Object.keys(a.tags).some(key => key + '=' + a.tags[key] === value))
-        .concat(searchable.filter(a => a.tags &&
-          Object.keys(a.tags).some(key => leading(key + '=' + a.tags[key]))));
-    }
+    leadingTagKeyValues = searchable.filter(a => a.tags &&
+      Object.keys(a.tags).some(key => key + '=' + a.tags[key] === value))
+    .concat(searchable.filter(a => a.tags &&
+      Object.keys(a.tags).some(key => leading(key + '=' + a.tags[key]))))
+    .concat(searchable.filter(a => a.addTags &&
+      Object.keys(a.addTags).some(key => key + '=' + a.addTags[key] === value)))
+    .concat(searchable.filter(a => a.addTags &&
+      Object.keys(a.addTags).some(key => leading(key + '=' + a.addTags[key]))));
+}
 
     // also match cases where preset string is inside searched term
     const presetsInValues = searchable

--- a/test/spec/presets/collection.js
+++ b/test/spec/presets/collection.js
@@ -137,6 +137,18 @@ describe('iD.presetCollection', function() {
             expect(result.indexOf(p.grass1)).to.eql(0);  // 1. 'Grass' (by tag key=value)
         });
 
+        it('matches tag key=value in addTags', function() {
+            var school = iD.presetPreset('__TEST/education/school', {
+                name: 'School',
+                tags: { education: 'school' },
+                addTags: { amenity: 'school', education: 'school' },
+                geometry: ['point', 'area'],
+                terms: []
+            });
+            var collection = iD.presetCollection([school, p.point]);
+            var result = collection.search('amenity=school', 'point').collection;
+            expect(result.indexOf(school)).to.eql(0);
+        });
         it.each([
             'private grill',
             'very private and secret mysterious grill',


### PR DESCRIPTION
Fixes #12179
Tag search was not checking addTags when matching key=value queries. This meant searching amenity=school would not find School Grounds, even though amenity=school is defined in its addTags.
Fixed by also checking addTags in the leadingTagKeyValues search logic in collection.js.