### PR TITLE
preserve tags of the old preset when new preset has a field for the old preset's primary tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Use full width for the dropdown box for the values of the `access` field ([#12065])
 * Preserve the order of options when a combo field accepts both static options as well as autosuggestions from taginfo and display additional tag values from taginfo as raw-options only ([#12117])
 * When removing tags while changing presets: include all tags associated with `localized`, `multiCombo` and `directionalCombo` fields ([#12075], [#11696])
+* Preserve all feature tags when changing to a new preset that includes the old preset's primary tags as a field ([#12071])
 #### :hammer: Development
 * Replace `sinon` with `vitest`'s built in spy/mock library ([#12058])
 * Add type annotations to `context.js` module ([#11589], thanks [@k-yle])
@@ -102,6 +103,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#12063]: https://github.com/openstreetmap/iD/issues/12063
 [#12065]: https://github.com/openstreetmap/iD/issues/12065
 [#12070]: https://github.com/openstreetmap/iD/issues/12070
+[#12071]: https://github.com/openstreetmap/iD/issues/12071
 [#12075]: https://github.com/openstreetmap/iD/issues/12075
 [#12078]: https://github.com/openstreetmap/iD/issues/12078
 [#12110]: https://github.com/openstreetmap/iD/issues/12110

--- a/modules/actions/change_preset.js
+++ b/modules/actions/change_preset.js
@@ -2,13 +2,13 @@ import { utilArrayDifference, utilObjectOmit } from '../util';
 
 export function actionChangePreset(entityID, oldPreset, newPreset, skipFieldDefaults) {
     return function action(graph) {
-        var entity = graph.entity(entityID);
-        var geometry = entity.geometry(graph);
-        var tags = entity.tags;
+        const entity = graph.entity(entityID);
+        const geometry = entity.geometry(graph);
+        let tags = entity.tags;
         const loc = entity.extent(graph).center();
 
         // preserve tags that the new preset might care about, if any
-        var preserveKeys;
+        let preserveKeys;
         if (newPreset) {
             preserveKeys = [];
             if (newPreset.addTags) {
@@ -44,7 +44,20 @@ export function actionChangePreset(entityID, oldPreset, newPreset, skipFieldDefa
 
                     // field-keys used by the old preset but not the new preset
                     const fieldKeysToRemove = utilArrayDifference(oldPresetFieldKeys, preserveKeys);
-                    tags = utilObjectOmit(tags, fieldKeysToRemove);
+                    let reducedTags = utilObjectOmit(tags, fieldKeysToRemove);
+                    reducedTags = oldPreset.unsetTags(reducedTags, geometry, preserveKeys, false, loc);
+                    reducedTags = newPreset.setTags(reducedTags, geometry, skipFieldDefaults, loc);
+
+                    if (oldPreset.matchScore(reducedTags) === -1 /* -1 means, the preset does not match */) {
+                        // only actually remove tags if the old preset is fully orthogonal
+                        // with the new one: if the old preset also matches reduced set of tags of
+                        // the new preset, it is likely a case where the new preset is a "collective"
+                        // preset that is meant to include both presets
+                        // e.g. when changing from building to a school which has a field for the building
+                        // tag, building-specific subtags should remain on the feature
+                        // https://github.com/openstreetmap/iD/issues/12071
+                        tags = reducedTags;
+                    }
                 }
             }
         }

--- a/test/spec/actions/change_preset.js
+++ b/test/spec/actions/change_preset.js
@@ -280,6 +280,44 @@ describe('iD.actionChangePreset', function() {
         });
     });
 
+
+    // https://github.com/openstreetmap/iD/issues/12071
+    it('preserves tags of the old preset when selecting a new preset with a field for the old preset\'s primary tag', () => {
+        const entity = iD.osmNode({
+            tags: {
+                building: 'yes', // the preset's own tags.
+                'building:colour': 'green', // a field which exists in the preset
+            },
+            loc: [0, 0],
+        });
+        const graph = new iD.coreGraph([entity]);
+
+        const fields = {
+            'building:colour': iD.presetField('building:colour', { key: 'building:colour' }),
+            'building': iD.presetField('building', { key: 'building' }),
+        };
+
+        const oldPreset = iD.presetPreset(
+            'building/yes',
+            { tags: { building: 'yes' }, fields: ['building:colour'] },
+            undefined,
+            fields,
+        );
+        const newPreset = iD.presetPreset(
+            'amenity/school',
+            { tags: { amenity: 'school' }, fields: ['building'] },
+            undefined,
+            fields,
+        );
+        const action = iD.actionChangePreset(entity.id, oldPreset, newPreset);
+        expect(action(graph).entity(entity.id).tags).toStrictEqual({
+            // all tags are preserved
+            amenity: 'school',
+            building: 'yes',
+            'building:colour': 'green',
+        });
+    });
+
     // https://github.com/openstreetmap/iD/issues/9372
     it('does not preserve old preset\'s primary tags when changing from a subpreset to its parent', () => {
         const entity = new iD.osmNode({tags: {highway: 'service', service: 'driveway', name: 'foo bar'}});

--- a/test/spec/actions/change_preset.js
+++ b/test/spec/actions/change_preset.js
@@ -100,7 +100,7 @@ describe('iD.actionChangePreset', function() {
                 building: 'yes', // case 1: the preset's own tags.
                 'roof:colour': 'pink', // case 2: a field which exists in the old preset, but not the new one.
                 check_date: '2025-12-05', // case 3: a field which exists in the old AND new preset.
-                grades: '0-13', // case 4: a field which exists only in the new preset, not in the old one.
+                surface: 'grass', // case 4: a field which exists only in the new preset, not in the old one.
                 'ref:SG:address_id': '1234', // case 5: a tag which does not exist in either preset
             },
             loc: [0, 0],
@@ -110,7 +110,7 @@ describe('iD.actionChangePreset', function() {
         const fields = {
             'roof:colour': iD.presetField('roof:colour', { key: 'roof:colour', geometry: 'point' }),
             check_date: iD.presetField('check_date', { key: 'check_date', geometry: 'point' }),
-            grades: iD.presetField('roof:colour', { key: 'grades', geometry: 'point' }),
+            surface: iD.presetField('surface', { key: 'surface', geometry: 'point' }),
         };
 
         const oldPreset = iD.presetPreset(
@@ -120,17 +120,17 @@ describe('iD.actionChangePreset', function() {
             fields,
         );
         const newPreset = iD.presetPreset(
-            'amenity/school',
-            { tags: { amenity: 'school' }, fields: ['check_date', 'grades'] },
+            'leisure/pitch',
+            { tags: { leisure: 'pitch' }, fields: ['check_date', 'surface'] },
             undefined,
             fields,
         );
         const action = iD.actionChangePreset(entity.id, oldPreset, newPreset);
         expect(action(graph).entity(entity.id).tags).toStrictEqual({
-            amenity: 'school', // case 1: the preset's own tags were replaced.
+            leisure: 'pitch', // case 1: the preset's own tags were replaced.
             // case 2: the field which exists in the old preset was removed (roof:colour).
             check_date: '2025-12-05', // case 3: the field which exists in the old AND new preset was kept.
-            grades: '0-13', // case 4: a field which exists only in the new preset was also kept.
+            surface: 'grass', // case 4: a field which exists only in the new preset was also kept.
             'ref:SG:address_id': '1234', // case 5: tags which do not exist in either preset are kept
         });
     });
@@ -201,7 +201,7 @@ describe('iD.actionChangePreset', function() {
         const graph = new iD.coreGraph([entity]);
 
         const fields = {
-            [fieldId]: iD.presetField('recycling', { type: fieldType, key: fieldKey, keys: fieldKeys }),
+            [fieldId]: iD.presetField(fieldId, { type: fieldType, key: fieldKey, keys: fieldKeys }),
         };
 
         const oldPreset = iD.presetPreset(
@@ -219,9 +219,9 @@ describe('iD.actionChangePreset', function() {
         const action = iD.actionChangePreset(entity.id, oldPreset, newPreset);
         expect(action(graph).entity(entity.id).tags).toStrictEqual({
             // no field tags are preserved
-            amenity: 'bench',
             ...tagsToPreserve,
             unrelatedTagKey: 'unrelatedTagValue',
+            amenity: 'bench',
         });
     });
 
@@ -257,7 +257,7 @@ describe('iD.actionChangePreset', function() {
         const graph = new iD.coreGraph([entity]);
 
         const fields = {
-            [fieldId]: iD.presetField('recycling', { type: fieldType, key: fieldKey, keys: fieldKeys }),
+            [fieldId]: iD.presetField(fieldId, { type: fieldType, key: fieldKey, keys: fieldKeys }),
         };
 
         const oldPreset = iD.presetPreset(


### PR DESCRIPTION
fixes #12071
