### PR TITLE
make `contact:*` fields clickable if they contain usernames or full URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 # Unreleased (2.41.0-dev)
 
 #### :sparkles: Usability & Accessibility
+* Make tags like `contact:instagram` clickable if they contain a plain username, or a full URL ([#12306], thanks [@k-yle])
 #### :scissors: Operations
 #### :camera: Street-Level
 #### :white_check_mark: Validation
@@ -52,6 +53,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :hammer: Development
 
 [#12297]: https://github.com/openstreetmap/iD/issues/12297
+[#12306]: https://github.com/openstreetmap/iD/pull/12306
 
 
 # 2.40.0

--- a/modules/ui/fields/input.js
+++ b/modules/ui/fields/input.js
@@ -13,6 +13,7 @@ import { cardinal } from '../../osm/node';
 import { isColorValid } from '../../osm/tags';
 import { uiLengthIndicator } from '..';
 import { uiTooltip } from '../tooltip';
+import { utilIsValidURL } from '../../util/util';
 
 export {
     uiFieldText as uiFieldColour,
@@ -193,13 +194,10 @@ export function uiFieldText(field, context) {
             outlinkButton
                 .on('click', function(d3_event) {
                     d3_event.preventDefault();
-                    var value = validIdentifierValueForLink();
-                    if (value) {
-                        var url = field.urlFormat.replace(/{value}/, encodeURIComponent(value));
-                        window.open(url, '_blank');
-                    }
+                    const url = getExternalLink();
+                    if (url) window.open(url, '_blank');
                 })
-                .classed('disabled', () => !validIdentifierValueForLink())
+                .classed('disabled', () => !getExternalLink())
                 .merge(outlinkButton);
         } else if (field.type === 'schedule') {
 
@@ -216,9 +214,8 @@ export function uiFieldText(field, context) {
                 .on('click', function(d3_event) {
                     d3_event.preventDefault();
 
-                    var value = validIdentifierValueForLink();
-                    var url = yoHoursURLFormat.replace(/{value}/, encodeURIComponent(value || ''));
-                    window.open(url, '_blank');
+                    const url = getExternalLink();
+                    if (url) window.open(url, '_blank');
                 })
                 .merge(outlinkButton);
         } else if (field.type === 'url') {
@@ -235,7 +232,7 @@ export function uiFieldText(field, context) {
                 .on('click', function(d3_event) {
                     d3_event.preventDefault();
 
-                    const value = validIdentifierValueForLink();
+                    const value = getExternalLink();
                     if (value) window.open(value, '_blank');
                 })
                 .merge(outlinkButton);
@@ -394,21 +391,23 @@ export function uiFieldText(field, context) {
     }
 
 
-    function validIdentifierValueForLink() {
+    /** @returns {string | null} */
+    function getExternalLink() {
         const value = utilGetSetValue(input).trim();
+        if (!value) return null;
 
-        if (field.type === 'url' && value) {
-            try {
-                return (new URL(value)).href;
-            } catch {
-                return null;
-            }
+        if (field.type === 'url' && utilIsValidURL(value, true)) {
+            return value;
         }
         if (field.type === 'identifier' && field.pattern) {
-            return value && value.match(new RegExp(field.pattern))?.[0];
+            if (utilIsValidURL(value, true)) return value;
+            const id = value.match(new RegExp(field.pattern))?.[0];
+            if (id) {
+                return field.urlFormat.replace(/{value}/, encodeURIComponent(id));
+            }
         }
         if (field.type === 'schedule') {
-            return value;
+            return yoHoursURLFormat.replace(/{value}/, encodeURIComponent(value || ''));
         }
         return null;
     }
@@ -581,7 +580,7 @@ export function uiFieldText(field, context) {
         if (field.type === 'date') updateDateField();
 
         if (outlinkButton && !outlinkButton.empty()) {
-            var disabled = !validIdentifierValueForLink() && field.type !== 'schedule';
+            var disabled = !getExternalLink() && field.type !== 'schedule';
             outlinkButton.classed('disabled', disabled);
         }
 

--- a/modules/util/util.js
+++ b/modules/util/util.js
@@ -720,3 +720,16 @@ export function utilGzip(input) {
         return undefined;
     }
 }
+
+/** @param {string} url */
+export function utilIsValidURL(url, strict = false) {
+    try {
+        // First try strict WHATWG parsing
+        const link = new URL(url);
+        return link.protocol.startsWith('http');
+    } catch {
+        if (strict) return false;
+        // Fallback: accept if it looks like a valid scheme://something, even if semicolons are present
+        return /^https?:\/\/\S+$/i.test(url);
+    }
+}

--- a/modules/validations/invalid_format.js
+++ b/modules/validations/invalid_format.js
@@ -3,6 +3,7 @@ import { utilDisplayLabel } from '../util/utilDisplayLabel';
 import { validationIssue, validationIssueFix } from '../core/validation';
 import { actionChangeTags } from '../actions/change_tags';
 import { osmUrlKeys } from '../osm/tags';
+import { utilIsValidURL as isValidURL } from '../util/util';
 
 export function validationFormatting() {
     var type = 'invalid_format';
@@ -26,18 +27,6 @@ export function validationFormatting() {
                 .append('div')
                 .attr('class', 'issue-reference')
                 .call(t.append('issues.invalid_format.email.reference'));
-        }
-
-        function isValidURL(url, strict = false) {
-            try {
-                // First try strict WHATWG parsing
-                const link = new URL(url);
-                return link.protocol.startsWith('http');
-            } catch {
-                if (strict) return false;
-                // Fallback: accept if it looks like a valid scheme://something, even if semicolons are present
-                return /^https?:\/\/\S+$/i.test(url);
-            }
         }
 
         function cleanWikimediaCommonsReference(value) {


### PR DESCRIPTION
Closes https://github.com/openstreetmap/id-tagging-schema/pull/1019#issuecomment-4324879974
Closes https://github.com/openstreetmap/iD/issues/11120 via an alternative approach
Replaces https://github.com/openstreetmap/iD/pull/11124

Goal: to make both of these cases support clickable links (since both tagging styles are valid):
- `contact:instagram`=[`tinyssandwichbar`](https://instagr.am/tinyssandwichbar)
- `contact:instagram`=[`https://instagr.am/tinyssandwichbar`](https://instagr.am/tinyssandwichbar)

<img width="291" height="81" alt="image" src="https://github.com/user-attachments/assets/cfe1c55f-c390-492d-afad-cccb5065a008" />

The solutions is to change social media fields like `contact:instagram` from `type=url` to `type=identifier`. 

Fields with `type=identifier` are already clickable if the `pattern` matches. But they are not clickable if the value is a full URL. This PR fixes that limitation.

The OSM-website has already implemented this approach, for every key supported by [tag2link](https://github.com/JOSM/tag2link)
