### PR TITLE
fix console error about missing translation

### DIFF
--- a/modules/ui/sections/validation_issues.js
+++ b/modules/ui/sections/validation_issues.js
@@ -46,7 +46,7 @@ export function uiSectionValidationIssues(id, severity, context) {
         // finally: cut off at a maximum 1000 entries
         const center = context.map().center();
         const graph = context.graph();
-        const rules = sortBy(context.validator().getRuleKeys(), [
+        const rules = sortBy(context.validator().getRuleKeys().filter(key => key !== 'maprules'), [
             rule => t(`issues.${rule}.title`)
         ]);
         const withDistance = _issues.map(issue => {


### PR DESCRIPTION
Closes #12309

I had never heard of _MapRules_, but i just watched the [SotM-US talk](https://2018.stateofthemap.us/program/grossman-maprules.html). seems like a great idea, except there's no docs and it doesn't really work.

since other parts of the code [already exclude _MapRules_](https://github.com/openstreetmap/iD/blob/4efd41f6efd51f0d8131f4ac2d33629c034cdf19/modules/ui/sections/validation_rules.js#L20), this new code from 53156d54ba2ae50b2533dfcc8c462755571cb530 should also exclude it.