### PR TITLE
fix: don't deselect non-note objects when toggling notes layer

### DIFF
--- a/modules/ui/sections/data_layers.js
+++ b/modules/ui/sections/data_layers.js
@@ -58,7 +58,14 @@ export function uiSectionDataLayers(context) {
             layer.enabled(enabled);
 
             if (!enabled && (which === 'osm' || which === 'notes')) {
-                context.enter(modeBrowse(context));
+                var modeId = mode && mode.id;
+                var isNoteMode = modeId === 'add-note' || modeId === 'select-note' || modeId === 'drag-note';
+
+                if (which === 'osm' && !isNoteMode) {
+                    context.enter(modeBrowse(context));
+                } else if (which === 'notes' && isNoteMode) {
+                    context.enter(modeBrowse(context));
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #12304

When disabling the notes layer...the editor was unconditionally entering 
browse mode....which deselected any currently selected object even if it 
wasn't a note...This fix only enters browse mode when disabling the notes 
layer if a note is actually selected..