### PR TITLE
Explore and fix `maprules` URL param and explore adding `presets` URL param

### DIFF
--- a/API.md
+++ b/API.md
@@ -36,7 +36,7 @@ of iD (e.g. `https://ideditor-release.netlify.app`), the following parameters ar
   _Available values:_ Any of the [supported locales](https://github.com/openstreetmap/iD/tree/develop/dist/locales).
 * __`map`__ - A slash-separated `zoom/latitude/longitude`.<br/>
   _Example:_ `map=20.00/38.90085/-77.02271`
-* __`maprules`__ - A path to a [MapRules](https://github.com/radiant-maxar/maprules) service endpoint for enhanced tag validation.<br/>
+* __`maprules`__ - A URL to a static JSON file of custom tag-validation rules, loaded once at startup. See [CUSTOM_PRESETS.md](CUSTOM_PRESETS.md) for the JSON format, an example, and notes on what this parameter can and cannot do (in particular: it only adds validation rules, not presets).<br/>
   _Example:_ `maprules=https://path/to/file.json`
 * __`notes`__ - Enables the notes layer by default.<br/>
   _Example:_ `notes=true`
@@ -54,6 +54,8 @@ of iD (e.g. `https://ideditor-release.netlify.app`), the following parameters ar
   _Available prefixes:_ `streetside/`, `mapillary/`, `kartaview`
 * __`presets`__ - A comma-separated list of preset IDs. These will be the only presets the user may select.<br/>
   _Example:_ `presets=building,highway/residential,highway/unclassified`
+* __`presets_url`__ - A URL to a static JSON file describing custom presets (and optionally fields, categories, defaults) to merge into iD's preset library at startup. The JSON shape matches what [`@openstreetmap/id-tagging-schema`](https://github.com/openstreetmap/id-tagging-schema) ships, i.e. an object with one or more of the keys `presets`, `fields`, `categories`, `defaults`, `featureCollection`. See [CUSTOM_PRESETS.md](CUSTOM_PRESETS.md) for the full shape, an example file, and caveats.<br/>
+  _Example:_ `presets_url=https://path/to/presets.json`
 * __`rtl=true`__ - Force iD into right-to-left mode (useful for testing).
 * __`source`__ - Prefills the changeset source.<br/>
   _Example:_ `source=Bing%3BMapillary`
@@ -92,6 +94,7 @@ _Example:_ `https://www.openstreetmap.org/edit?editor=id#gpx=https://gist.github
 * __`photo_overlay`__
 * __`photo_username`__
 * __`presets`__
+* __`presets_url`__
 * __`source`__
 * __`validationDisable`__
 * __`validationWarning`__

--- a/API.md
+++ b/API.md
@@ -36,7 +36,7 @@ of iD (e.g. `https://ideditor-release.netlify.app`), the following parameters ar
   _Available values:_ Any of the [supported locales](https://github.com/openstreetmap/iD/tree/develop/dist/locales).
 * __`map`__ - A slash-separated `zoom/latitude/longitude`.<br/>
   _Example:_ `map=20.00/38.90085/-77.02271`
-* __`maprules`__ - A URL to a static JSON file of custom tag-validation rules, loaded once at startup (same "parameter value is a URL" pattern as `gpx` and `presets_merge`). See [CUSTOM_PRESETS.md](CUSTOM_PRESETS.md) for the JSON format, an example, and notes on what this parameter can and cannot do (in particular: it only adds validation rules, not presets).<br/>
+* __`maprules`__ - A URL to a static JSON file of custom tag-validation rules, loaded once at startup (same "parameter value is a URL" pattern as `gpx` and `presets` when used as a merge URL). See [CUSTOM_PRESETS.md](CUSTOM_PRESETS.md) for the JSON format, an example, and notes on what this parameter can and cannot do (in particular: it only adds validation rules, not presets).<br/>
   _Example:_ `maprules=https://path/to/file.json`
 * __`notes`__ - Enables the notes layer by default.<br/>
   _Example:_ `notes=true`
@@ -52,10 +52,11 @@ of iD (e.g. `https://ideditor-release.netlify.app`), the following parameters ar
 * __`photo`__ - The service and ID of the street-level photo to show.<br/>
   _Example:_ `photo=streetside/718514589`<br/>
   _Available prefixes:_ `streetside/`, `mapillary/`, `kartaview`
-* __`presets`__ - A comma-separated list of preset IDs. These will be the only presets the user may select.<br/>
-  _Example:_ `presets=building,highway/residential,highway/unclassified`
-* __`presets_merge`__ - A URL to a static JSON file describing custom presets (and optionally fields, categories, defaults) to merge into iD's preset library at startup. Same URL-as-value pattern as `gpx` and `maprules`; the name is `presets_merge` (not `presets`) because `presets=` is already the built-in-preset allowlist. The JSON shape matches what [`@openstreetmap/id-tagging-schema`](https://github.com/openstreetmap/id-tagging-schema) ships, i.e. an object with one or more of the keys `presets`, `fields`, `categories`, `defaults`, `featureCollection`. See [CUSTOM_PRESETS.md](CUSTOM_PRESETS.md) for the full shape, an example file, and caveats.<br/>
-  _Example:_ `presets_merge=https://path/to/presets.json`
+* __`presets`__ - Two modes, distinguished by the value (you cannot combine both in one parameter):<br/>
+  - **Allowlist** — a comma-separated list of preset IDs. These will be the only built-in presets the user may select. The value must **not** start with `http://` or `https://`.<br/>
+    _Example:_ `presets=building,highway/residential,highway/unclassified`<br/>
+  - **Custom merge** — an `http` or `https` URL to a static JSON file describing extra presets (and optionally fields, categories, defaults) to merge into iD's preset library at startup, after bundled presets load. Same URL-as-value pattern as `gpx` and `maprules`. The JSON shape matches what [`@openstreetmap/id-tagging-schema`](https://github.com/openstreetmap/id-tagging-schema) ships, i.e. an object with one or more of the keys `presets`, `fields`, `categories`, `defaults`, `featureCollection`. See [CUSTOM_PRESETS.md](CUSTOM_PRESETS.md) for the full shape, an example file, and caveats.<br/>
+    _Example:_ `presets=https://path/to/presets.json`
 * __`rtl=true`__ - Force iD into right-to-left mode (useful for testing).
 * __`source`__ - Prefills the changeset source.<br/>
   _Example:_ `source=Bing%3BMapillary`
@@ -94,7 +95,6 @@ _Example:_ `https://www.openstreetmap.org/edit?editor=id#gpx=https://gist.github
 * __`photo_overlay`__
 * __`photo_username`__
 * __`presets`__
-* __`presets_merge`__
 * __`source`__
 * __`validationDisable`__
 * __`validationWarning`__

--- a/API.md
+++ b/API.md
@@ -36,7 +36,7 @@ of iD (e.g. `https://ideditor-release.netlify.app`), the following parameters ar
   _Available values:_ Any of the [supported locales](https://github.com/openstreetmap/iD/tree/develop/dist/locales).
 * __`map`__ - A slash-separated `zoom/latitude/longitude`.<br/>
   _Example:_ `map=20.00/38.90085/-77.02271`
-* __`maprules`__ - A URL to a static JSON file of custom tag-validation rules, loaded once at startup. See [CUSTOM_PRESETS.md](CUSTOM_PRESETS.md) for the JSON format, an example, and notes on what this parameter can and cannot do (in particular: it only adds validation rules, not presets).<br/>
+* __`maprules`__ - A URL to a static JSON file of custom tag-validation rules, loaded once at startup (same "parameter value is a URL" pattern as `gpx` and `presets_merge`). See [CUSTOM_PRESETS.md](CUSTOM_PRESETS.md) for the JSON format, an example, and notes on what this parameter can and cannot do (in particular: it only adds validation rules, not presets).<br/>
   _Example:_ `maprules=https://path/to/file.json`
 * __`notes`__ - Enables the notes layer by default.<br/>
   _Example:_ `notes=true`
@@ -54,8 +54,8 @@ of iD (e.g. `https://ideditor-release.netlify.app`), the following parameters ar
   _Available prefixes:_ `streetside/`, `mapillary/`, `kartaview`
 * __`presets`__ - A comma-separated list of preset IDs. These will be the only presets the user may select.<br/>
   _Example:_ `presets=building,highway/residential,highway/unclassified`
-* __`presets_url`__ - A URL to a static JSON file describing custom presets (and optionally fields, categories, defaults) to merge into iD's preset library at startup. The JSON shape matches what [`@openstreetmap/id-tagging-schema`](https://github.com/openstreetmap/id-tagging-schema) ships, i.e. an object with one or more of the keys `presets`, `fields`, `categories`, `defaults`, `featureCollection`. See [CUSTOM_PRESETS.md](CUSTOM_PRESETS.md) for the full shape, an example file, and caveats.<br/>
-  _Example:_ `presets_url=https://path/to/presets.json`
+* __`presets_merge`__ - A URL to a static JSON file describing custom presets (and optionally fields, categories, defaults) to merge into iD's preset library at startup. Same URL-as-value pattern as `gpx` and `maprules`; the name is `presets_merge` (not `presets`) because `presets=` is already the built-in-preset allowlist. The JSON shape matches what [`@openstreetmap/id-tagging-schema`](https://github.com/openstreetmap/id-tagging-schema) ships, i.e. an object with one or more of the keys `presets`, `fields`, `categories`, `defaults`, `featureCollection`. See [CUSTOM_PRESETS.md](CUSTOM_PRESETS.md) for the full shape, an example file, and caveats.<br/>
+  _Example:_ `presets_merge=https://path/to/presets.json`
 * __`rtl=true`__ - Force iD into right-to-left mode (useful for testing).
 * __`source`__ - Prefills the changeset source.<br/>
   _Example:_ `source=Bing%3BMapillary`
@@ -94,7 +94,7 @@ _Example:_ `https://www.openstreetmap.org/edit?editor=id#gpx=https://gist.github
 * __`photo_overlay`__
 * __`photo_username`__
 * __`presets`__
-* __`presets_url`__
+* __`presets_merge`__
 * __`source`__
 * __`validationDisable`__
 * __`validationWarning`__

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -450,7 +450,7 @@ A tag of a feature has an unexpected syntax.
 
 ##### `maprules`
 
-An issue raised by a custom validation rule loaded via the `maprules=` URL hash parameter. Each rule is defined by a JSON selector object describing a tag-based condition and a `warning` or `error` message. See [CUSTOM_PRESETS.md](CUSTOM_PRESETS.md) for the JSON format and usage notes.
+An issue raised by a custom validation rule loaded via the `maprules=` URL hash parameter. Each rule is defined by a JSON selector object describing a tag-based condition and an `error`, `warning`, or `suggestion` message; selectors may also declare optional `fixes` (tag merge quick actions). See [CUSTOM_PRESETS.md](CUSTOM_PRESETS.md) for the JSON format and usage notes.
 
 ##### `mismatched_geometry`
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -450,7 +450,7 @@ A tag of a feature has an unexpected syntax.
 
 ##### `maprules`
 
-An issue with the active [MapRules](https://github.com/radiant-maxar/maprules) validation rules.
+An issue raised by a custom validation rule loaded via the `maprules=` URL hash parameter. Each rule is defined by a JSON selector object describing a tag-based condition and a `warning` or `error` message. See [CUSTOM_PRESETS.md](CUSTOM_PRESETS.md) for the JSON format and usage notes.
 
 ##### `mismatched_geometry`
 

--- a/CUSTOM_PRESETS.md
+++ b/CUSTOM_PRESETS.md
@@ -134,4 +134,4 @@ Worked example you can open, fork, or copy from — a **Bench with Backrest** pr
 
 https://gist.github.com/tordans/549a328ccff34963192899113c73d35a
 
-Point `presets=` at the raw URL of the preset object file and `maprules=` at the raw URL of the rules array file in one editor link to try both together.
+Full hash example (same gist raw files, `presets=` merge URL + `maprules=`; adjust host/port if your dev server differs): [open local iD with both loaded](http://localhost:8080/#presets=https://gist.githubusercontent.com/tordans/549a328ccff34963192899113c73d35a/raw/bench-presets.json&maprules=https://gist.githubusercontent.com/tordans/549a328ccff34963192899113c73d35a/raw/bench-rules.json&map=20.00/52.47414/13.44576&disable_features=boundaries&id=n6399964554&locale=en)

--- a/CUSTOM_PRESETS.md
+++ b/CUSTOM_PRESETS.md
@@ -64,7 +64,7 @@ Use the same `presets=` URL hash parameter with a **comma-separated list of pres
 
 ## 3. Adding custom validation rules at runtime
 
-iD supports loading a JSON file of custom warnings and errors via the `maprules=` URL hash parameter. The file is fetched once at iD startup and each entry is registered as an extra rule that runs alongside the built-in validators.
+iD supports loading a JSON file of custom validation rules (errors, warnings, and optional soft suggestions) via the `maprules=` URL hash parameter. The file is fetched once at iD startup and each entry is registered as an extra rule that runs alongside the built-in validators.
 
 This mechanism originated as the client side of the [MapRules](https://github.com/radiant-maxar/maprules) service, which is no longer maintained. **You do not need that service.** The URL just points at a static JSON file on any host that allows CORS — for example a GitHub Pages site, an S3 bucket, a [GitHub Gist](https://gist.github.com/) raw file (see [section 4](#4-hosting-on-github-gist)), or your campaign's own server.
 
@@ -77,7 +77,7 @@ https://ideditor-release.netlify.app/#maprules=https://example.org/my-rules.json
 - The URL is fetched once at iD startup. Changing the file requires a page reload.
 - The URL must be reachable via CORS from the iD origin. If the request fails or the JSON is malformed, the failure is silently ignored — there is no error toast.
 - Issues raised by these rules show up in the sidebar like any other issue, but the `maprules` rule type is intentionally hidden from the issue-rule toggle UI under _Map Data → Issues_, so users cannot disable individual custom rules from the UI.
-- Rules can produce either errors (which block changeset upload) or warnings (which do not). See `error` / `warning` below.
+- Rules can produce errors (which block changeset upload), warnings (which do not), or suggestions (the softer blue notice; they do not block upload). See the message keys below.
 
 ### JSON file format
 
@@ -97,9 +97,17 @@ Each selector object has:
   - `greaterThan` / `greaterThanEqual` / `lessThan` / `lessThanEqual`: `{ key: number }` — compared against the raw OSM tag value (string-coerced; intended for numeric tags).
   - `positiveRegex` / `negativeRegex`: `{ key: ["regex1", "regex2"] }` — the entries are joined with `|` and used as a single `RegExp`. Anchor with `^` / `$` if you want exact matches.
 
-- Exactly one of:
+- Exactly one **message** (use only one key per selector; if more than one is present, iD uses **error** first, then **warning**, then **suggestion**, and logs a console warning):
   - `error: "message"` — surfaced as an error, blocks changeset upload.
   - `warning: "message"` — surfaced as a warning, does not block upload.
+  - `suggestion: "message"` — surfaced as a suggestion (blue notice), does not block upload.
+
+- Optional **`fixes`** — array of quick actions shown on the issue in the inspector. Each item:
+  - `title` (**required**) — short label on the button, plain text (not translated through iD’s locale files).
+  - `tags` (**required**) — object of tag keys and values to **merge** onto the feature when the user chooses that fix (existing tags are kept unless overwritten by a key in `tags`).
+  - `icon` (optional) — icon id (same style as other issue fixes, e.g. `iD-icon-wrench`).
+
+Selectors without a `fixes` array behave as before (only **Ignore** is offered for warnings and suggestions, besides built-in behavior).
 
 ### Example file
 
@@ -122,6 +130,17 @@ Each selector object has:
     "equals": { "man_made": "tower", "tower:type": "communication" },
     "presence": "height",
     "warning": "Communication towers should record height when known"
+  },
+  {
+    "geometry": "node",
+    "equals": { "amenity": "bench" },
+    "presence": "backrest",
+    "negativeRegex": { "backrest": ["^yes$", "^no$"] },
+    "suggestion": "Bench backrest should be yes or no",
+    "fixes": [
+      { "title": "Set backrest=yes", "tags": { "backrest": "yes" } },
+      { "title": "Set backrest=no", "tags": { "backrest": "no" } }
+    ]
   }
 ]
 ```

--- a/CUSTOM_PRESETS.md
+++ b/CUSTOM_PRESETS.md
@@ -109,6 +109,8 @@ Each selector object has:
 
 Selectors without a `fixes` array behave as before (only **Ignore** is offered for warnings and suggestions, besides built-in behavior).
 
+Each rule is independent: **all** of its conditions must match for that rule (and its `fixes`) to apply. For example, a rule with `absence: "backrest"` never runs at the same time as one with `presence: "backrest"` — so if you want quick fixes both when the tag is missing and when it is present but invalid, add the same `fixes` to **both** selector objects (or split concerns across two rules as in the gist example).
+
 ### Example file
 
 ```json
@@ -130,6 +132,16 @@ Selectors without a `fixes` array behave as before (only **Ignore** is offered f
     "equals": { "man_made": "tower", "tower:type": "communication" },
     "presence": "height",
     "warning": "Communication towers should record height when known"
+  },
+  {
+    "geometry": "node",
+    "equals": { "amenity": "bench" },
+    "absence": "backrest",
+    "warning": "Bench is missing backrest=yes or backrest=no",
+    "fixes": [
+      { "title": "Set backrest=yes", "tags": { "backrest": "yes" } },
+      { "title": "Set backrest=no", "tags": { "backrest": "no" } }
+    ]
   },
   {
     "geometry": "node",

--- a/CUSTOM_PRESETS.md
+++ b/CUSTOM_PRESETS.md
@@ -6,7 +6,7 @@ This document answers a recurring question:
 
 Short answer: yes, both. iD supports loading custom **presets** at runtime via the `presets=` URL hash parameter when its value is an `http`/`https` URL to a JSON file, and custom **validation rules** at runtime via the `maprules=` URL hash parameter. Both are static-JSON files you host yourself — no server, no fork, no rebuild.
 
-The sections below explain the available extension points (`presets=` in two modes, plus `maprules=`) and which one to use when.
+The sections below explain the available extension points (`presets=` in two modes, plus `maprules=`).
 
 ---
 
@@ -66,7 +66,7 @@ Use the same `presets=` URL hash parameter with a **comma-separated list of pres
 
 iD supports loading a JSON file of custom warnings and errors via the `maprules=` URL hash parameter. The file is fetched once at iD startup and each entry is registered as an extra rule that runs alongside the built-in validators.
 
-This mechanism originated as the client side of the [MapRules](https://github.com/radiant-maxar/maprules) service, which is no longer maintained. **You do not need that service.** The URL just points at a static JSON file on any host that allows CORS — for example a GitHub Pages site, an S3 bucket, or your campaign's own server.
+This mechanism originated as the client side of the [MapRules](https://github.com/radiant-maxar/maprules) service, which is no longer maintained. **You do not need that service.** The URL just points at a static JSON file on any host that allows CORS — for example a GitHub Pages site, an S3 bucket, a [GitHub Gist](https://gist.github.com/) raw file (see [section 4](#4-hosting-on-github-gist)), or your campaign's own server.
 
 ```
 https://ideditor-release.netlify.app/#maprules=https://example.org/my-rules.json&map=18/52.5/13.4
@@ -126,8 +126,12 @@ Each selector object has:
 ]
 ```
 
-### When to use `maprules=` vs. `presets=` (URL merge)
+## 4. Hosting on GitHub Gist
 
-- Use `presets=https://…` when you want a new entry in the preset picker, with its own icon, default tags, fields, and search terms (the _Bench with Backrest_ example in Section 1).
-- Use `maprules=` when you want to validate or constrain tag combinations on existing presets without adding a new picker entry ("warn when an `amenity=bench` is missing `backrest`").
-- The two compose: ship a `presets=` URL merge file with your custom preset _and_ a `maprules=` file with the validation rules that go with it.
+[GitHub Gists](https://gist.github.com/) are a practical place to host the static JSON for `presets=` (URL merge) and `maprules=`: create a gist, add one file per payload (preset bundle as a single object, rules as a single array), then open each file and use its **Raw** URL from the browser address bar in your iD hash parameters. Raw gist URLs typically work with iD's fetch + CORS expectations for small campaign files.
+
+Worked example you can open, fork, or copy from — a **Bench with Backrest** preset JSON and a companion **bench** `maprules` array in the same gist:
+
+https://gist.github.com/tordans/549a328ccff34963192899113c73d35a
+
+Point `presets=` at the raw URL of the preset object file and `maprules=` at the raw URL of the rules array file in one editor link to try both together.

--- a/CUSTOM_PRESETS.md
+++ b/CUSTOM_PRESETS.md
@@ -4,25 +4,25 @@ This document answers a recurring question:
 
 > _"Can I add my own presets or validation rules to iD — for a mapping campaign, an organization, or a custom tagging schema?"_
 
-Short answer: yes, both. iD supports loading custom **presets** at runtime via the `presets_merge=` URL hash parameter, and custom **validation rules** at runtime via the `maprules=` URL hash parameter. Both are static-JSON files you host yourself — no server, no fork, no rebuild.
+Short answer: yes, both. iD supports loading custom **presets** at runtime via the `presets=` URL hash parameter when its value is an `http`/`https` URL to a JSON file, and custom **validation rules** at runtime via the `maprules=` URL hash parameter. Both are static-JSON files you host yourself — no server, no fork, no rebuild.
 
-The sections below explain the three available extension points and which one to use when.
+The sections below explain the available extension points (`presets=` in two modes, plus `maprules=`) and which one to use when.
 
 ---
 
 ## 1. Adding custom presets at runtime
 
-iD supports merging extra presets, fields, categories, and defaults into the running preset library via the `presets_merge=` URL hash parameter. The file is fetched once at iD startup, after iD's bundled presets finish loading, and merged in via the same `presetManager.merge` API used internally by the Name-Suggestion-Index.
+iD supports merging extra presets, fields, categories, and defaults into the running preset library when `presets=` is set to an **`http` or `https` URL** pointing at a JSON file. The file is fetched once at iD startup, after iD's bundled presets finish loading, and merged in via the same `presetManager.merge` API used internally by the Name-Suggestion-Index.
 
 ```
-https://ideditor-release.netlify.app/#presets_merge=https://example.org/my-presets.json&map=18/52.5/13.4
+https://ideditor-release.netlify.app/#presets=https://example.org/my-presets.json&map=18/52.5/13.4
 ```
 
 ### Operational notes
 
 - The URL is fetched once at startup. Changes to the file require a page reload.
 - The URL must be reachable via CORS from the iD origin.
-- On success / failure / wrong shape, `[presets_merge] …` lines are written to the browser console.
+- On success / failure / wrong shape, `[presets] …` lines are written to the browser console.
 - Field IDs referenced under each preset's `fields` array must already exist (either as iD built-ins or because you also defined them under a `fields` key in the same file).
 - Mappers without your URL will not see the preset. Use this for campaigns, organization-internal deployments, and previewing schema changes — not as a substitute for contributing to [`@openstreetmap/id-tagging-schema`](https://github.com/openstreetmap/id-tagging-schema) when the preset belongs in the global library.
 
@@ -60,7 +60,7 @@ After loading, the preset shows up in the search list and the _Change feature ty
 
 ## 2. Restricting which built-in presets a user may select
 
-Use the `presets=` URL hash parameter to allowlist which built-in presets may be selected (for example, campaigns limited to certain feature types). It only **filters** the built-in library; it does not add new presets. See the __`presets`__ entry under [URL parameters → iD Standalone in API.md](API.md#id-standalone).
+Use the same `presets=` URL hash parameter with a **comma-separated list of preset IDs** (when the value does **not** start with `http://` or `https://`). That allowlists which built-in presets may be selected (for example, campaigns limited to certain feature types). It only **filters** the built-in library; it does not add new presets. You cannot combine a merge URL and an allowlist in a single `presets=` value — pick one mode per link. See the __`presets`__ entry under [URL parameters → iD Standalone in API.md](API.md#id-standalone).
 
 ## 3. Adding custom validation rules at runtime
 
@@ -126,8 +126,8 @@ Each selector object has:
 ]
 ```
 
-### When to use `maprules=` vs. `presets_merge=`
+### When to use `maprules=` vs. `presets=` (URL merge)
 
-- Use `presets_merge=` when you want a new entry in the preset picker, with its own icon, default tags, fields, and search terms (the _Bench with Backrest_ example in Section 1).
+- Use `presets=https://…` when you want a new entry in the preset picker, with its own icon, default tags, fields, and search terms (the _Bench with Backrest_ example in Section 1).
 - Use `maprules=` when you want to validate or constrain tag combinations on existing presets without adding a new picker entry ("warn when an `amenity=bench` is missing `backrest`").
-- The two compose: ship a `presets_merge=` file with your custom preset _and_ a `maprules=` file with the validation rules that go with it.
+- The two compose: ship a `presets=` URL merge file with your custom preset _and_ a `maprules=` file with the validation rules that go with it.

--- a/CUSTOM_PRESETS.md
+++ b/CUSTOM_PRESETS.md
@@ -4,7 +4,7 @@ This document answers a recurring question:
 
 > _"Can I add my own presets or validation rules to iD — for a mapping campaign, an organization, or a custom tagging schema?"_
 
-Short answer: yes, both. iD supports loading custom **presets** at runtime via the `presets_url=` URL hash parameter, and custom **validation rules** at runtime via the `maprules=` URL hash parameter. Both are static-JSON files you host yourself — no server, no fork, no rebuild.
+Short answer: yes, both. iD supports loading custom **presets** at runtime via the `presets_merge=` URL hash parameter, and custom **validation rules** at runtime via the `maprules=` URL hash parameter. Both are static-JSON files you host yourself — no server, no fork, no rebuild.
 
 The sections below explain the three available extension points and which one to use when.
 
@@ -12,17 +12,17 @@ The sections below explain the three available extension points and which one to
 
 ## 1. Adding custom presets at runtime
 
-iD supports merging extra presets, fields, categories, and defaults into the running preset library via the `presets_url=` URL hash parameter. The file is fetched once at iD startup, after iD's bundled presets finish loading, and merged in via the same `presetManager.merge` API used internally by the Name-Suggestion-Index.
+iD supports merging extra presets, fields, categories, and defaults into the running preset library via the `presets_merge=` URL hash parameter. The file is fetched once at iD startup, after iD's bundled presets finish loading, and merged in via the same `presetManager.merge` API used internally by the Name-Suggestion-Index.
 
 ```
-https://ideditor-release.netlify.app/#presets_url=https://example.org/my-presets.json&map=18/52.5/13.4
+https://ideditor-release.netlify.app/#presets_merge=https://example.org/my-presets.json&map=18/52.5/13.4
 ```
 
 ### Operational notes
 
 - The URL is fetched once at startup. Changes to the file require a page reload.
 - The URL must be reachable via CORS from the iD origin.
-- On success / failure / wrong shape, `[presets_url] …` lines are written to the browser console.
+- On success / failure / wrong shape, `[presets_merge] …` lines are written to the browser console.
 - Field IDs referenced under each preset's `fields` array must already exist (either as iD built-ins or because you also defined them under a `fields` key in the same file).
 - Mappers without your URL will not see the preset. Use this for campaigns, organization-internal deployments, and previewing schema changes — not as a substitute for contributing to [`@openstreetmap/id-tagging-schema`](https://github.com/openstreetmap/id-tagging-schema) when the preset belongs in the global library.
 
@@ -126,8 +126,8 @@ Each selector object has:
 ]
 ```
 
-### When to use `maprules=` vs. `presets_url=`
+### When to use `maprules=` vs. `presets_merge=`
 
-- Use `presets_url=` when you want a new entry in the preset picker, with its own icon, default tags, fields, and search terms (the _Bench with Backrest_ example in Section 1).
+- Use `presets_merge=` when you want a new entry in the preset picker, with its own icon, default tags, fields, and search terms (the _Bench with Backrest_ example in Section 1).
 - Use `maprules=` when you want to validate or constrain tag combinations on existing presets without adding a new picker entry ("warn when an `amenity=bench` is missing `backrest`").
-- The two compose: ship a `presets_url=` file with your custom preset _and_ a `maprules=` file with the validation rules that go with it.
+- The two compose: ship a `presets_merge=` file with your custom preset _and_ a `maprules=` file with the validation rules that go with it.

--- a/CUSTOM_PRESETS.md
+++ b/CUSTOM_PRESETS.md
@@ -1,0 +1,133 @@
+# Custom presets and validation rules
+
+This document answers a recurring question:
+
+> _"Can I add my own presets or validation rules to iD — for a mapping campaign, an organization, or a custom tagging schema?"_
+
+Short answer: yes, both. iD supports loading custom **presets** at runtime via the `presets_url=` URL hash parameter, and custom **validation rules** at runtime via the `maprules=` URL hash parameter. Both are static-JSON files you host yourself — no server, no fork, no rebuild.
+
+The sections below explain the three available extension points and which one to use when.
+
+---
+
+## 1. Adding custom presets at runtime
+
+iD supports merging extra presets, fields, categories, and defaults into the running preset library via the `presets_url=` URL hash parameter. The file is fetched once at iD startup, after iD's bundled presets finish loading, and merged in via the same `presetManager.merge` API used internally by the Name-Suggestion-Index.
+
+```
+https://ideditor-release.netlify.app/#presets_url=https://example.org/my-presets.json&map=18/52.5/13.4
+```
+
+### Operational notes
+
+- The URL is fetched once at startup. Changes to the file require a page reload.
+- The URL must be reachable via CORS from the iD origin.
+- On success / failure / wrong shape, `[presets_url] …` lines are written to the browser console.
+- Field IDs referenced under each preset's `fields` array must already exist (either as iD built-ins or because you also defined them under a `fields` key in the same file).
+- Mappers without your URL will not see the preset. Use this for campaigns, organization-internal deployments, and previewing schema changes — not as a substitute for contributing to [`@openstreetmap/id-tagging-schema`](https://github.com/openstreetmap/id-tagging-schema) when the preset belongs in the global library.
+
+### JSON file format
+
+The file must be a JSON **object** (not an array). It can carry any subset of the keys below; each one is merged into the corresponding part of the preset index:
+
+- `presets` — object keyed by preset ID (e.g. `"amenity/bench_with_backrest"`). Each entry uses the [id-tagging-schema preset shape](https://github.com/ideditor/schema-builder#presets) (`name`, `icon`, `geometry`, `tags`, `addTags`, `fields`, `terms`, `searchable`, …).
+- `fields` — object keyed by field ID. Same shape as built-in fields.
+- `categories` — object keyed by category ID. Used to group presets in the picker.
+- `defaults` — object keyed by geometry (`area`, `line`, `point`, `vertex`, `relation`); each value is an array of preset/category IDs to show as the default suggestions for that geometry.
+- `featureCollection` — GeoJSON FeatureCollection of location-set polygons referenced by `locationSet` keys in your presets/fields.
+
+### Example file
+
+A "Bench with Backrest" preset that adds both `amenity=bench` and `backrest=yes` when selected:
+
+```json
+{
+  "presets": {
+    "amenity/bench_with_backrest": {
+      "icon": "maki-bench",
+      "geometry": ["point"],
+      "tags": { "amenity": "bench", "backrest": "yes" },
+      "addTags": { "amenity": "bench", "backrest": "yes" },
+      "fields": ["inscription", "material", "seats", "colour"],
+      "name": "Bench with Backrest",
+      "terms": ["bench", "seat", "backrest"]
+    }
+  }
+}
+```
+
+After loading, the preset shows up in the search list and the _Change feature type_ dialog. Pair it with the `maprules=` example below to also flag any benches that are missing `backrest` or have a non-`yes`/`no` value.
+
+## 2. Restricting which built-in presets a user may select
+
+Use the `presets=` URL hash parameter to allowlist which built-in presets may be selected (for example, campaigns limited to certain feature types). It only **filters** the built-in library; it does not add new presets. See the __`presets`__ entry under [URL parameters → iD Standalone in API.md](API.md#id-standalone).
+
+## 3. Adding custom validation rules at runtime
+
+iD supports loading a JSON file of custom warnings and errors via the `maprules=` URL hash parameter. The file is fetched once at iD startup and each entry is registered as an extra rule that runs alongside the built-in validators.
+
+This mechanism originated as the client side of the [MapRules](https://github.com/radiant-maxar/maprules) service, which is no longer maintained. **You do not need that service.** The URL just points at a static JSON file on any host that allows CORS — for example a GitHub Pages site, an S3 bucket, or your campaign's own server.
+
+```
+https://ideditor-release.netlify.app/#maprules=https://example.org/my-rules.json&map=18/52.5/13.4
+```
+
+### Operational notes
+
+- The URL is fetched once at iD startup. Changing the file requires a page reload.
+- The URL must be reachable via CORS from the iD origin. If the request fails or the JSON is malformed, the failure is silently ignored — there is no error toast.
+- Issues raised by these rules show up in the sidebar like any other issue, but the `maprules` rule type is intentionally hidden from the issue-rule toggle UI under _Map Data → Issues_, so users cannot disable individual custom rules from the UI.
+- Rules can produce either errors (which block changeset upload) or warnings (which do not). See `error` / `warning` below.
+
+### JSON file format
+
+The file must contain a JSON **array** of selector objects. Each selector describes one rule — a tag-based condition plus the message to display when it matches.
+
+Each selector object has:
+
+- `geometry` (**required**) — one of `"node"`, `"way"`, `"closedway"`, `"relation"`.
+  - For `"node"` and `"relation"` the entity type must match exactly.
+  - For `"way"` and `"closedway"` the geometry is **inferred from the selector's tags**, using the same area-key vs. line-key logic as iD itself. (This means a selector with `geometry: "closedway"` will fire on any closed way whose tags imply an area; an explicit `area=yes` / `area=no` tag in the selector flips this.)
+
+- One or more **conditions** (all must match for the rule to fire on a given entity):
+  - `equals: { key: value }`
+  - `notEquals: { key: value }`
+  - `presence: "key"`
+  - `absence: "key"`
+  - `greaterThan` / `greaterThanEqual` / `lessThan` / `lessThanEqual`: `{ key: number }` — compared against the raw OSM tag value (string-coerced; intended for numeric tags).
+  - `positiveRegex` / `negativeRegex`: `{ key: ["regex1", "regex2"] }` — the entries are joined with `|` and used as a single `RegExp`. Anchor with `^` / `$` if you want exact matches.
+
+- Exactly one of:
+  - `error: "message"` — surfaced as an error, blocks changeset upload.
+  - `warning: "message"` — surfaced as a warning, does not block upload.
+
+### Example file
+
+```json
+[
+  {
+    "geometry": "node",
+    "equals": { "amenity": "marketplace" },
+    "absence": "name",
+    "error": "Marketplace must have a name"
+  },
+  {
+    "geometry": "way",
+    "equals": { "highway": "residential" },
+    "positiveRegex": { "structure": ["bridge", "tunnel"] },
+    "warning": "Residential road should not be a bridge or tunnel"
+  },
+  {
+    "geometry": "node",
+    "equals": { "man_made": "tower", "tower:type": "communication" },
+    "presence": "height",
+    "warning": "Communication towers should record height when known"
+  }
+]
+```
+
+### When to use `maprules=` vs. `presets_url=`
+
+- Use `presets_url=` when you want a new entry in the preset picker, with its own icon, default tags, fields, and search terms (the _Bench with Backrest_ example in Section 1).
+- Use `maprules=` when you want to validate or constrain tag combinations on existing presets without adding a new picker entry ("warn when an `amenity=bench` is missing `backrest`").
+- The two compose: ship a `presets_url=` file with your custom preset _and_ a `maprules=` file with the validation rules that go with it.

--- a/CUSTOM_PRESETS.md
+++ b/CUSTOM_PRESETS.md
@@ -69,7 +69,7 @@ iD supports loading a JSON file of custom validation rules (errors, warnings, an
 This mechanism originated as the client side of the [MapRules](https://github.com/radiant-maxar/maprules) service, which is no longer maintained. **You do not need that service.** The URL just points at a static JSON file on any host that allows CORS — for example a GitHub Pages site, an S3 bucket, a [GitHub Gist](https://gist.github.com/) raw file (see [section 4](#4-hosting-on-github-gist)), or your campaign's own server.
 
 ```
-https://ideditor-release.netlify.app/#maprules=https://example.org/my-rules.json&map=18/52.5/13.4
+https://ideditor.netlify.app/#maprules=https://example.org/my-rules.json&map=18/52.5/13.4
 ```
 
 ### Operational notes
@@ -153,4 +153,4 @@ Worked example you can open, fork, or copy from — a **Bench with Backrest** pr
 
 https://gist.github.com/tordans/549a328ccff34963192899113c73d35a
 
-Full hash example (same gist raw files, `presets=` merge URL + `maprules=`; adjust host/port if your dev server differs): [open local iD with both loaded](http://localhost:8080/#presets=https://gist.githubusercontent.com/tordans/549a328ccff34963192899113c73d35a/raw/bench-presets.json&maprules=https://gist.githubusercontent.com/tordans/549a328ccff34963192899113c73d35a/raw/bench-rules.json&map=20.00/52.47414/13.44576&disable_features=boundaries&id=n6399964554&locale=en)
+Full hash example (same gist raw files, `presets=` merge URL + `maprules=`; adjust host/port if your dev server differs): [open local iD with both loaded](https://ideditor.netlify.app/#presets=https://gist.githubusercontent.com/tordans/549a328ccff34963192899113c73d35a/raw/bench-presets.json&maprules=https://gist.githubusercontent.com/tordans/549a328ccff34963192899113c73d35a/raw/bench-rules.json&map=20.00/52.47414/13.44576&disable_features=boundaries&id=n6399964554&locale=en)

--- a/FAQ.md
+++ b/FAQ.md
@@ -75,7 +75,7 @@ and/or a tile rendering stack, but neither of these are required for editing wit
 
 Yes. There are three URL hash parameters that cover the common cases:
 
-- `presets_url=` loads a static JSON file of additional presets (and optionally fields, categories, defaults) and merges them into the running preset library at startup. Use this to add a new entry to the preset picker.
+- `presets_merge=` loads a static JSON file of additional presets (and optionally fields, categories, defaults) and merges them into the running preset library at startup. Use this to add a new entry to the preset picker.
 - `presets=` restricts the built-in preset list to an allowlist (e.g. roads only). It does not add new presets.
 - `maprules=` loads a static JSON file of custom validation warnings and errors, useful for enforcing tag conventions without adding a new preset.
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -69,3 +69,16 @@ is bundled with it. Your changes will be saved to your own database. To use a st
 
 Depending on your requirements, you may also want to set up [cgimap](https://github.com/openstreetmap/cgimap)
 and/or a tile rendering stack, but neither of these are required for editing with iD.
+
+
+## Can I add custom presets to iD?
+
+Yes. There are three URL hash parameters that cover the common cases:
+
+- `presets_url=` loads a static JSON file of additional presets (and optionally fields, categories, defaults) and merges them into the running preset library at startup. Use this to add a new entry to the preset picker.
+- `presets=` restricts the built-in preset list to an allowlist (e.g. roads only). It does not add new presets.
+- `maprules=` loads a static JSON file of custom validation warnings and errors, useful for enforcing tag conventions without adding a new preset.
+
+The presets shipped to all iD users are still maintained centrally in [`@openstreetmap/id-tagging-schema`](https://github.com/openstreetmap/id-tagging-schema); contribute there if your preset belongs in the global library rather than only in a campaign or organization-internal deployment.
+
+See [CUSTOM_PRESETS.md](CUSTOM_PRESETS.md) for the JSON formats, worked examples, and guidance on when each option is appropriate.

--- a/FAQ.md
+++ b/FAQ.md
@@ -75,8 +75,8 @@ and/or a tile rendering stack, but neither of these are required for editing wit
 
 Yes. There are three URL hash parameters that cover the common cases:
 
-- `presets_merge=` loads a static JSON file of additional presets (and optionally fields, categories, defaults) and merges them into the running preset library at startup. Use this to add a new entry to the preset picker.
-- `presets=` restricts the built-in preset list to an allowlist (e.g. roads only). It does not add new presets.
+- `presets=https://…` loads a static JSON file of additional presets (and optionally fields, categories, defaults) and merges them into the running preset library at startup. Use this to add a new entry to the preset picker (the value must start with `http://` or `https://`).
+- `presets=id1,id2,…` (comma-separated preset IDs, not a URL) restricts the built-in preset list to an allowlist (e.g. roads only). It does not add new presets.
 - `maprules=` loads a static JSON file of custom validation warnings and errors, useful for enforcing tag conventions without adding a new preset.
 
 The presets shipped to all iD users are still maintained centrally in [`@openstreetmap/id-tagging-schema`](https://github.com/openstreetmap/id-tagging-schema); contribute there if your preset belongs in the global library rather than only in a campaign or organization-internal deployment.

--- a/FAQ.md
+++ b/FAQ.md
@@ -77,7 +77,7 @@ Yes. There are three URL hash parameters that cover the common cases:
 
 - `presets=https://…` loads a static JSON file of additional presets (and optionally fields, categories, defaults) and merges them into the running preset library at startup. Use this to add a new entry to the preset picker (the value must start with `http://` or `https://`).
 - `presets=id1,id2,…` (comma-separated preset IDs, not a URL) restricts the built-in preset list to an allowlist (e.g. roads only). It does not add new presets.
-- `maprules=` loads a static JSON file of custom validation warnings and errors, useful for enforcing tag conventions without adding a new preset.
+- `maprules=` loads a static JSON file of custom validation rules (errors, warnings, optional suggestions, and optional tag quick-fixes), useful for enforcing tag conventions without adding a new preset.
 
 The presets shipped to all iD users are still maintained centrally in [`@openstreetmap/id-tagging-schema`](https://github.com/openstreetmap/id-tagging-schema); contribute there if your preset belongs in the global library rather than only in a campaign or organization-internal deployment.
 

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1536,6 +1536,9 @@ en:
     fix_all:
       title: Fix All
       annotation: Fixed several validation issues.
+    maprules:
+      title: Custom validation rule
+      tip: "Issues raised by a custom validation rule loaded via the `maprules=` URL hash parameter."
     almost_junction:
       title: Almost Junctions
       message: "{feature} is very close but not connected to {feature2}"

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1802,6 +1802,8 @@ en:
         title: Merge these points
       move_points_apart:
         title: Move these points apart
+      maprules_apply_tags:
+        annotation: Applied tags from a custom validation rule.
       move_tags:
         title: Move the tags
         annotation: Moved tags.

--- a/modules/core/context.js
+++ b/modules/core/context.js
@@ -588,9 +588,11 @@ export function coreContext() {
     // Set up objects that might need to access properties of `context`. The order
     // might matter if dependents make calls to each other. Be wary of async calls.
     function initializeDependents() {
+      const presetsHash = context.initialHashParams.presets;
+      const presetsHashIsMergeUrl = presetsHash && /^https?:\/\//i.test(presetsHash.trim());
 
-      if (context.initialHashParams.presets) {
-        presetManager.addablePresetIDs(new Set(context.initialHashParams.presets.split(',')));
+      if (presetsHash && !presetsHashIsMergeUrl) {
+        presetManager.addablePresetIDs(new Set(presetsHash.split(',')));
       }
 
       if (context.initialHashParams.locale) {
@@ -619,8 +621,8 @@ export function coreContext() {
       // Migrate history data from localStorage to IndexedDB
       _history.migrateHistoryData();
 
-      if (context.initialHashParams.presets_merge) {
-        presetManager.mergePresetsMerge(context.initialHashParams.presets_merge);
+      if (presetsHashIsMergeUrl) {
+        presetManager.mergePresets(presetsHash);
       }
 
       if (services.maprules && context.initialHashParams.maprules) {

--- a/modules/core/context.js
+++ b/modules/core/context.js
@@ -620,6 +620,39 @@ export function coreContext() {
       // Migrate history data from localStorage to IndexedDB
       _history.migrateHistoryData();
 
+      if (context.initialHashParams.presets_url) {
+        // Fetch a user-supplied presets file and merge it into the running
+        // preset index after the bundled presets have finished loading. The
+        // JSON file must match the shape that `presetManager.merge` accepts,
+        // which is the same shape used by `id-tagging-schema`:
+        //   { presets?, fields?, categories?, defaults?, featureCollection? }
+        const presetsUrl = context.initialHashParams.presets_url;
+        presetManager.ensureLoaded()
+          .then(function () {
+            return d3_json(presetsUrl);
+          })
+          .then(function (data) {
+            if (!data || typeof data !== 'object' || Array.isArray(data)) {
+              console.warn(  // eslint-disable-line no-console
+                '[presets_url] expected the JSON at ' + presetsUrl +
+                ' to be an object with `presets`/`fields`/`categories`/`defaults` keys, got ' +
+                (Array.isArray(data) ? 'array' : typeof data) + '. No presets loaded.'
+              );
+              return;
+            }
+            presetManager.merge(data);
+            console.info(  // eslint-disable-line no-console
+              '[presets_url] merged custom presets from ' + presetsUrl,
+              data
+            );
+          })
+          .catch(function (err) {
+            console.warn(  // eslint-disable-line no-console
+              '[presets_url] failed to load presets from ' + presetsUrl + ':', err
+            );
+          });
+      }
+
       if (services.maprules && context.initialHashParams.maprules) {
         // Fetch the user-supplied maprules JSON, register each selector
         // with `services.maprules`, and surface success/failure on the

--- a/modules/core/context.js
+++ b/modules/core/context.js
@@ -1,7 +1,6 @@
 import { debounce, throttle } from 'es-toolkit/compat';
 
 import { dispatch as d3_dispatch } from 'd3-dispatch';
-import { json as d3_json } from 'd3-fetch';
 import { select as d3_select } from 'd3-selection';
 
 import packageJSON from '../../package.json';
@@ -621,71 +620,11 @@ export function coreContext() {
       _history.migrateHistoryData();
 
       if (context.initialHashParams.presets_merge) {
-        // Fetch a user-supplied presets file and merge it into the running
-        // preset index after the bundled presets have finished loading. The
-        // JSON file must match the shape that `presetManager.merge` accepts,
-        // which is the same shape used by `id-tagging-schema`:
-        //   { presets?, fields?, categories?, defaults?, featureCollection? }
-        // Hash param name follows the same pattern as `gpx` and `maprules`
-        // (value is a URL; no `_url` suffix). It is not `presets=` because
-        // that parameter is already the built-in-preset allowlist.
-        const presetsMergeUrl = context.initialHashParams.presets_merge;
-        presetManager.ensureLoaded()
-          .then(function () {
-            return d3_json(presetsMergeUrl);
-          })
-          .then(function (data) {
-            if (!data || typeof data !== 'object' || Array.isArray(data)) {
-              console.warn(  // eslint-disable-line no-console
-                '[presets_merge] expected the JSON at ' + presetsMergeUrl +
-                ' to be an object with `presets`/`fields`/`categories`/`defaults` keys, got ' +
-                (Array.isArray(data) ? 'array' : typeof data) + '. No presets loaded.'
-              );
-              return;
-            }
-            presetManager.merge(data);
-            console.info(  // eslint-disable-line no-console
-              '[presets_merge] merged custom presets from ' + presetsMergeUrl,
-              data
-            );
-          })
-          .catch(function (err) {
-            console.warn(  // eslint-disable-line no-console
-              '[presets_merge] failed to load presets from ' + presetsMergeUrl + ':', err
-            );
-          });
+        presetManager.mergePresetsMerge(context.initialHashParams.presets_merge);
       }
 
       if (services.maprules && context.initialHashParams.maprules) {
-        // Fetch the user-supplied maprules JSON, register each selector
-        // with `services.maprules`, and surface success/failure on the
-        // console (the rules silently affect validation, so we want some
-        // dev-visible signal that the file was actually loaded).
-        const maprulesUrl = context.initialHashParams.maprules;
-        d3_json(maprulesUrl)
-          .then(function (mapcss) {
-            services.maprules.init();
-            if (!Array.isArray(mapcss)) {
-              console.warn(  // eslint-disable-line no-console
-                '[maprules] expected the JSON at ' + maprulesUrl +
-                ' to be an array of selector objects, got ' + typeof mapcss +
-                '. No rules loaded.'
-              );
-              return;
-            }
-            mapcss.forEach(function (mapcssSelector) {
-              services.maprules.addRule(mapcssSelector);
-            });
-            console.info(  // eslint-disable-line no-console
-              '[maprules] loaded ' + mapcss.length + ' rule(s) from ' + maprulesUrl,
-              mapcss
-            );
-          })
-          .catch(function (err) {
-            console.warn(  // eslint-disable-line no-console
-              '[maprules] failed to load rules from ' + maprulesUrl + ':', err
-            );
-          });
+        services.maprules.loadFromUrl(context.initialHashParams.maprules);
       }
 
       // if the container isn't available, e.g. when testing, don't load the UI

--- a/modules/core/context.js
+++ b/modules/core/context.js
@@ -621,12 +621,35 @@ export function coreContext() {
       _history.migrateHistoryData();
 
       if (services.maprules && context.initialHashParams.maprules) {
-        d3_json(context.initialHashParams.maprules)
-          .then(mapcss => {
+        // Fetch the user-supplied maprules JSON, register each selector
+        // with `services.maprules`, and surface success/failure on the
+        // console (the rules silently affect validation, so we want some
+        // dev-visible signal that the file was actually loaded).
+        const maprulesUrl = context.initialHashParams.maprules;
+        d3_json(maprulesUrl)
+          .then(function (mapcss) {
             services.maprules.init();
-            mapcss.forEach(mapcssSelector => services.maprules.addRule(mapcssSelector));
+            if (!Array.isArray(mapcss)) {
+              console.warn(  // eslint-disable-line no-console
+                '[maprules] expected the JSON at ' + maprulesUrl +
+                ' to be an array of selector objects, got ' + typeof mapcss +
+                '. No rules loaded.'
+              );
+              return;
+            }
+            mapcss.forEach(function (mapcssSelector) {
+              services.maprules.addRule(mapcssSelector);
+            });
+            console.info(  // eslint-disable-line no-console
+              '[maprules] loaded ' + mapcss.length + ' rule(s) from ' + maprulesUrl,
+              mapcss
+            );
           })
-          .catch(() => { /* ignore */ });
+          .catch(function (err) {
+            console.warn(  // eslint-disable-line no-console
+              '[maprules] failed to load rules from ' + maprulesUrl + ':', err
+            );
+          });
       }
 
       // if the container isn't available, e.g. when testing, don't load the UI

--- a/modules/core/context.js
+++ b/modules/core/context.js
@@ -620,21 +620,24 @@ export function coreContext() {
       // Migrate history data from localStorage to IndexedDB
       _history.migrateHistoryData();
 
-      if (context.initialHashParams.presets_url) {
+      if (context.initialHashParams.presets_merge) {
         // Fetch a user-supplied presets file and merge it into the running
         // preset index after the bundled presets have finished loading. The
         // JSON file must match the shape that `presetManager.merge` accepts,
         // which is the same shape used by `id-tagging-schema`:
         //   { presets?, fields?, categories?, defaults?, featureCollection? }
-        const presetsUrl = context.initialHashParams.presets_url;
+        // Hash param name follows the same pattern as `gpx` and `maprules`
+        // (value is a URL; no `_url` suffix). It is not `presets=` because
+        // that parameter is already the built-in-preset allowlist.
+        const presetsMergeUrl = context.initialHashParams.presets_merge;
         presetManager.ensureLoaded()
           .then(function () {
-            return d3_json(presetsUrl);
+            return d3_json(presetsMergeUrl);
           })
           .then(function (data) {
             if (!data || typeof data !== 'object' || Array.isArray(data)) {
               console.warn(  // eslint-disable-line no-console
-                '[presets_url] expected the JSON at ' + presetsUrl +
+                '[presets_merge] expected the JSON at ' + presetsMergeUrl +
                 ' to be an object with `presets`/`fields`/`categories`/`defaults` keys, got ' +
                 (Array.isArray(data) ? 'array' : typeof data) + '. No presets loaded.'
               );
@@ -642,13 +645,13 @@ export function coreContext() {
             }
             presetManager.merge(data);
             console.info(  // eslint-disable-line no-console
-              '[presets_url] merged custom presets from ' + presetsUrl,
+              '[presets_merge] merged custom presets from ' + presetsMergeUrl,
               data
             );
           })
           .catch(function (err) {
             console.warn(  // eslint-disable-line no-console
-              '[presets_url] failed to load presets from ' + presetsUrl + ':', err
+              '[presets_merge] failed to load presets from ' + presetsMergeUrl + ':', err
             );
           });
       }

--- a/modules/presets/index.js
+++ b/modules/presets/index.js
@@ -197,21 +197,21 @@ export function presetIndex() {
 
   /**
    * Loads custom preset JSON from a remote location (value of the
-   * `#presets_merge=` hash parameter) after bundled presets are loaded, then
-   * merges via `merge`. Logs `[presets_merge]` lines to the
+   * `#presets=` hash parameter when it is an `http`/`https` URL) after bundled
+   * presets are loaded, then merges via `merge`. Logs `[presets]` lines to the
    * console on success or failure.
    *
-   * @param {string} presetsMergeUrl
+   * @param {string} presetsJsonUrl
    */
-  _this.mergePresetsMerge = function (presetsMergeUrl) {
+  _this.mergePresets = function (presetsJsonUrl) {
     _this.ensureLoaded()
       .then(function () {
-        return d3_json(presetsMergeUrl);
+        return d3_json(presetsJsonUrl);
       })
       .then(function (data) {
         if (!data || typeof data !== 'object' || Array.isArray(data)) {
           console.warn(  // eslint-disable-line no-console
-            '[presets_merge] expected the JSON at ' + presetsMergeUrl +
+            '[presets] expected the JSON at ' + presetsJsonUrl +
             ' to be an object with `presets`/`fields`/`categories`/`defaults` keys, got ' +
             (Array.isArray(data) ? 'array' : typeof data) + '. No presets loaded.'
           );
@@ -219,13 +219,13 @@ export function presetIndex() {
         }
         _this.merge(data);
         console.info(  // eslint-disable-line no-console
-          '[presets_merge] merged custom presets from ' + presetsMergeUrl,
+          '[presets] merged custom presets from ' + presetsJsonUrl,
           data
         );
       })
       .catch(function (err) {
         console.warn(  // eslint-disable-line no-console
-          '[presets_merge] failed to load presets from ' + presetsMergeUrl + ':', err
+          '[presets] failed to load presets from ' + presetsJsonUrl + ':', err
         );
       });
   };

--- a/modules/presets/index.js
+++ b/modules/presets/index.js
@@ -1,4 +1,5 @@
 import { dispatch as d3_dispatch } from 'd3-dispatch';
+import { json as d3_json } from 'd3-fetch';
 
 import { prefs } from '../core/preferences';
 import { fileFetcher } from '../core/file_fetcher';
@@ -192,6 +193,41 @@ export function presetIndex() {
     }
 
     return _this;
+  };
+
+  /**
+   * Loads custom preset JSON from a remote location (value of the
+   * `#presets_merge=` hash parameter) after bundled presets are loaded, then
+   * merges via `merge`. Logs `[presets_merge]` lines to the
+   * console on success or failure.
+   *
+   * @param {string} presetsMergeUrl
+   */
+  _this.mergePresetsMerge = function (presetsMergeUrl) {
+    _this.ensureLoaded()
+      .then(function () {
+        return d3_json(presetsMergeUrl);
+      })
+      .then(function (data) {
+        if (!data || typeof data !== 'object' || Array.isArray(data)) {
+          console.warn(  // eslint-disable-line no-console
+            '[presets_merge] expected the JSON at ' + presetsMergeUrl +
+            ' to be an object with `presets`/`fields`/`categories`/`defaults` keys, got ' +
+            (Array.isArray(data) ? 'array' : typeof data) + '. No presets loaded.'
+          );
+          return;
+        }
+        _this.merge(data);
+        console.info(  // eslint-disable-line no-console
+          '[presets_merge] merged custom presets from ' + presetsMergeUrl,
+          data
+        );
+      })
+      .catch(function (err) {
+        console.warn(  // eslint-disable-line no-console
+          '[presets_merge] failed to load presets from ' + presetsMergeUrl + ':', err
+        );
+      });
   };
 
 

--- a/modules/services/maprules.js
+++ b/modules/services/maprules.js
@@ -1,8 +1,20 @@
 import { json as d3_json } from 'd3-fetch';
 
+import { actionChangeTags } from '../actions/change_tags';
+import { t } from '../core/localizer';
+import { validationIssue, validationIssueFix } from '../core/validation';
 import { osmAreaKeys as areaKeys } from '../osm/tags';
 import { utilArrayIntersection } from '../util';
-import { validationIssue } from '../core/validation';
+
+
+/** Keys on a selector that are not tag-condition checks (see #filterRuleChecks). */
+var SELECTOR_META_KEYS = {
+    geometry: true,
+    error: true,
+    warning: true,
+    suggestion: true,
+    fixes: true
+};
 
 
 var buildRuleChecks = function() {
@@ -148,9 +160,10 @@ export default {
     filterRuleChecks: function(selector) {
         var _ruleChecks = this._ruleChecks;
         return Object.keys(selector).reduce(function(rules, key) {
-            if (['geometry', 'error', 'warning'].indexOf(key) === -1) {
-                rules.push(_ruleChecks[key](selector[key]));
+            if (SELECTOR_META_KEYS[key]) {
+                return rules;
             }
+            rules.push(_ruleChecks[key](selector[key]));
             return rules;
         }, []);
     },
@@ -232,6 +245,57 @@ export default {
 
     // adds from mapcss-parse selector check...
     addRule: function(selector) {
+        var hasError = typeof selector.error === 'string' && selector.error.length > 0;
+        var hasWarning = typeof selector.warning === 'string' && selector.warning.length > 0;
+        var hasSuggestion = typeof selector.suggestion === 'string' && selector.suggestion.length > 0;
+        var messageKeyCount = (hasError ? 1 : 0) + (hasWarning ? 1 : 0) + (hasSuggestion ? 1 : 0);
+
+        if (messageKeyCount === 0) {
+            console.warn(  // eslint-disable-line no-console
+                '[maprules] rule skipped: expected a non-empty string in exactly one of error, warning, suggestion',
+                selector
+            );
+            return;
+        }
+
+        if (messageKeyCount > 1) {
+            console.warn(  // eslint-disable-line no-console
+                '[maprules] multiple message keys; using precedence error > warning > suggestion',
+                selector
+            );
+        }
+
+        var severity = hasError ? 'error' : (hasWarning ? 'warning' : 'suggestion');
+        var messageText = hasError ? selector.error : (hasWarning ? selector.warning : selector.suggestion);
+
+        var ruleIndex = this._validationRules.length;
+
+        var validFixes = [];
+        if (Array.isArray(selector.fixes)) {
+            selector.fixes.forEach(function(entry, i) {
+                if (!entry || typeof entry.title !== 'string' || entry.title.length === 0) {
+                    console.warn(  // eslint-disable-line no-console
+                        '[maprules] skipping fix entry ' + i + ': title must be a non-empty string',
+                        entry
+                    );
+                    return;
+                }
+                if (!entry.tags || typeof entry.tags !== 'object' || Array.isArray(entry.tags) ||
+                    Object.keys(entry.tags).length === 0) {
+                    console.warn(  // eslint-disable-line no-console
+                        '[maprules] skipping fix entry ' + i + ': tags must be a non-empty object',
+                        entry
+                    );
+                    return;
+                }
+                validFixes.push({
+                    title: entry.title,
+                    tags: entry.tags,
+                    icon: (typeof entry.icon === 'string' && entry.icon.length > 0) ? entry.icon : null
+                });
+            });
+        }
+
         var rule = {
             // checks relevant to mapcss-selector
             checks: this.filterRuleChecks(selector),
@@ -250,19 +314,15 @@ export default {
                     return this.inferredGeometry === entity.geometry(graph);
                 }
             },
-            // when geometries match and tag matches are present, return a warning...
             findIssues: function (entity, graph, issues) {
                 if (this.geometryMatches(entity, graph) && this.matches(entity)) {
-                    const severity = Object.keys(selector).indexOf('error') > -1
-                            ? 'error'
-                            : 'warning';
-                    const message = selector[severity];
-                    issues.push(new validationIssue({
+                    var issueAttrs = {
                         type: 'maprules',
                         severity: severity,
+                        hash: 'maprules-' + ruleIndex,
                         /**
                          * Returns a renderer that writes the user-supplied
-                         * `message` string into a d3 selection as plain text.
+                         * message string into a d3 selection as plain text.
                          *
                          * The string comes verbatim from the maprules JSON
                          * file and must NOT be passed through the localizer
@@ -273,11 +333,37 @@ export default {
                          */
                         message: function () {
                             return function (selection) {
-                                selection.text(message);
+                                selection.text(messageText);
                             };
                         },
                         entityIds: [entity.id]
-                    }));
+                    };
+
+                    if (validFixes.length > 0) {
+                        issueAttrs.dynamicFixes = function (/* context */) {
+                            return validFixes.map(function(entry, fixIndex) {
+                                return new validationIssueFix({
+                                    id: 'maprules-' + ruleIndex + '-' + fixIndex,
+                                    title: function (selection) {
+                                        selection.text(entry.title);
+                                    },
+                                    icon: entry.icon || undefined,
+                                    onClick: function (context) {
+                                        var id = this.issue.entityIds[0];
+                                        var ent = context.hasEntity(id);
+                                        if (!ent) return;
+                                        var newTags = Object.assign({}, ent.tags, entry.tags);
+                                        context.perform(
+                                            actionChangeTags(id, newTags),
+                                            t('issues.fix.maprules_apply_tags.annotation')
+                                        );
+                                    }
+                                });
+                            });
+                        };
+                    }
+
+                    issues.push(new validationIssue(issueAttrs));
                 }
             }
         };

--- a/modules/services/maprules.js
+++ b/modules/services/maprules.js
@@ -215,15 +215,28 @@ export default {
             // when geometries match and tag matches are present, return a warning...
             findIssues: function (entity, graph, issues) {
                 if (this.geometryMatches(entity, graph) && this.matches(entity)) {
-                    var severity = Object.keys(selector).indexOf('error') > -1
+                    const severity = Object.keys(selector).indexOf('error') > -1
                             ? 'error'
                             : 'warning';
-                    var message = selector[severity];
+                    const message = selector[severity];
                     issues.push(new validationIssue({
                         type: 'maprules',
                         severity: severity,
-                        message: function() {
-                            return message;
+                        /**
+                         * Returns a renderer that writes the user-supplied
+                         * `message` string into a d3 selection as plain text.
+                         *
+                         * The string comes verbatim from the maprules JSON
+                         * file and must NOT be passed through the localizer
+                         * (which would treat it as a translation key and emit
+                         * a "Missing translation" warning).
+                         *
+                         * @returns {(selection: any) => void} d3 text renderer
+                         */
+                        message: function () {
+                            return function (selection) {
+                                selection.text(message);
+                            };
                         },
                         entityIds: [entity.id]
                     }));

--- a/modules/services/maprules.js
+++ b/modules/services/maprules.js
@@ -1,3 +1,5 @@
+import { json as d3_json } from 'd3-fetch';
+
 import { osmAreaKeys as areaKeys } from '../osm/tags';
 import { utilArrayIntersection } from '../util';
 import { validationIssue } from '../core/validation';
@@ -104,6 +106,42 @@ export default {
         this._validationRules = [];
         this._areaKeys = areaKeys;
         this._lineKeys = buildLineKeys();
+    },
+
+    /**
+     * Fetches maprules JSON from a URL (e.g. `#maprules=` hash value),
+     * initializes the service, registers each selector, and logs `[maprules]`
+     * success or failure to the console. Expects a JSON array of selector
+     * objects.
+     *
+     * @param {string} maprulesUrl
+     */
+    loadFromUrl: function (maprulesUrl) {
+        const self = this;
+        d3_json(maprulesUrl)
+          .then(function (mapcss) {
+            self.init();
+            if (!Array.isArray(mapcss)) {
+              console.warn(  // eslint-disable-line no-console
+                '[maprules] expected the JSON at ' + maprulesUrl +
+                ' to be an array of selector objects, got ' + typeof mapcss +
+                '. No rules loaded.'
+              );
+              return;
+            }
+            mapcss.forEach(function (mapcssSelector) {
+              self.addRule(mapcssSelector);
+            });
+            console.info(  // eslint-disable-line no-console
+              '[maprules] loaded ' + mapcss.length + ' rule(s) from ' + maprulesUrl,
+              mapcss
+            );
+          })
+          .catch(function (err) {
+            console.warn(  // eslint-disable-line no-console
+              '[maprules] failed to load rules from ' + maprulesUrl + ':', err
+            );
+          });
     },
 
     // list of rules only relevant to tag checks...

--- a/test/spec/services/maprules.js
+++ b/test/spec/services/maprules.js
@@ -572,7 +572,11 @@ describe('maprules', function() {
 
                     expect(issues.length).to.eql(1);
                     expect(issue.entityIds).to.eql([entity.id]);
-                    expect(issue.message(iD.coreContext())).to.eql(selector[type]);
+                    var renderer = issue.message(iD.coreContext());
+                    expect(renderer).to.be.a('function');
+                    var captured;
+                    renderer({ text: function(value) { captured = value; } });
+                    expect(captured).to.eql(selector[type]);
                     expect(type).to.eql(issue.severity);
                 });
             });

--- a/test/spec/services/maprules.js
+++ b/test/spec/services/maprules.js
@@ -32,6 +32,25 @@ describe('maprules', function() {
             expect(equalsCheck(entityTags)).to.be.true;
             expect(absenceCheck(entityTags)).to.be.true;
         });
+
+        it('ignores suggestion and fixes keys (not tag conditions)', function() {
+            var selector = {
+                geometry: 'node',
+                equals: { amenity: 'bench' },
+                absence: 'backrest',
+                suggestion: 'Consider backrest',
+                fixes: [
+                    { title: 'Yes', tags: { backrest: 'yes' } }
+                ],
+                error: 'must have name'
+            };
+            var filteredChecks = iD.serviceMapRules.filterRuleChecks(selector);
+            expect(filteredChecks.length).to.eql(2);
+            var tags = { amenity: 'bench' };
+            filteredChecks.forEach(function(check) {
+                expect(check(tags)).to.be.true;
+            });
+        });
     });
 
     describe('#buildTagMap', function() {
@@ -161,6 +180,82 @@ describe('maprules', function() {
             expect(iD.serviceMapRules.validationRules().length).to.eql(1);
         });
     });
+
+    describe('#addRule message and fixes', function() {
+        beforeEach(function() {
+            iD.serviceMapRules.clearRules();
+        });
+
+        it('skips selector when error, warning, and suggestion are all missing or empty', function() {
+            iD.serviceMapRules.addRule({
+                geometry: 'node',
+                equals: { foo: 'bar' },
+                warning: ''
+            });
+            expect(iD.serviceMapRules.validationRules()).to.be.empty;
+        });
+
+        it('uses suggestion severity when only suggestion is set', function() {
+            iD.serviceMapRules.addRule({
+                geometry: 'node',
+                equals: { amenity: 'bench' },
+                absence: 'backrest',
+                suggestion: 'Record whether the bench has a backrest'
+            });
+            var rules = iD.serviceMapRules.validationRules();
+            var node = new iD.osmNode({ tags: { amenity: 'bench' } });
+            var graph = new iD.coreGraph([node]);
+            var issues = [];
+            rules[0].findIssues(node, graph, issues);
+            expect(issues.length).to.eql(1);
+            expect(issues[0].severity).to.eql('suggestion');
+            expect(issues[0].hash).to.eql('maprules-0');
+        });
+
+        it('prefers error over warning when both message keys are set', function() {
+            iD.serviceMapRules.addRule({
+                geometry: 'node',
+                equals: { amenity: 'kiosk' },
+                absence: 'name',
+                warning: 'warn',
+                error: 'err'
+            });
+            var rules = iD.serviceMapRules.validationRules();
+            var node = new iD.osmNode({ tags: { amenity: 'kiosk' } });
+            var graph = new iD.coreGraph([node]);
+            var issues = [];
+            rules[0].findIssues(node, graph, issues);
+            expect(issues[0].severity).to.eql('error');
+            var captured;
+            issues[0].message(iD.coreContext())({ text: function(value) { captured = value; } });
+            expect(captured).to.eql('err');
+        });
+
+        it('applies tags when a quick-fix onClick runs', function() {
+            var context = iD.coreContext().assetPath('../dist/').init();
+            var node = new iD.osmNode({ id: 'n1', tags: { amenity: 'bench' }, loc: [0, 0] });
+            context.perform(iD.actionAddEntity(node));
+            // Register rules after context.init — init() calls maprules.init() and clears rules.
+            iD.serviceMapRules.addRule({
+                geometry: 'node',
+                equals: { amenity: 'bench' },
+                absence: 'backrest',
+                warning: 'Missing backrest',
+                fixes: [
+                    { title: 'Set backrest=yes', tags: { backrest: 'yes' } }
+                ]
+            });
+            var rules = iD.serviceMapRules.validationRules();
+            var issues = [];
+            rules[0].findIssues(context.entity('n1'), context.graph(), issues);
+            var fixes = issues[0].fixes(context);
+            var tagFix = fixes.filter(function(f) { return f.id && f.id.indexOf('maprules-') === 0; })[0];
+            expect(tagFix).to.be.ok;
+            tagFix.onClick(context);
+            expect(context.entity('n1').tags.backrest).to.eql('yes');
+        });
+    });
+
     describe('#clearRules', function() {
         it('clears _validationRules array', function() {
             iD.serviceMapRules.clearRules();


### PR DESCRIPTION
Year ago I looked at the options that https://github.com/openstreetmap/iD/pull/5617 promised but sadly never managed to get it working back then. (And apparently 4 years ago [I investigated it again](https://github.com/radiant-maxar/maprules/issues/72).)

Today inspired by https://github.com/openstreetmap/iD/issues/12313#issuecomment-4411702280 I took another look and I was surprised to get it to work quite easily. But also, that the `maprules` "API" does something different (today), than I expected. It is "just" about the rules/validations; it does not touch presets at all (anymore; it used to [according to the old PR](https://github.com/openstreetmap/iD/pull/5617))

---

This draft is a **pure exploration** of the feature. The code is – like the messy commit messages show – not reviewed yet and mostly LLM. My goal is to get feedback on the basic idea – what and how we could like to have in iD. And once that is clear, cleanup and review the code.

---

## Testing

https://pr-12317--ideditor.netlify.app/#presets=https://gist.githubusercontent.com/tordans/549a328ccff34963192899113c73d35a/raw/f575e37198d51350050f661d00e6e02f8461d1f3/bench-presets.json&maprules=https://gist.githubusercontent.com/tordans/549a328ccff34963192899113c73d35a/raw/f575e37198d51350050f661d00e6e02f8461d1f3/bench-rules.json&map=20.00/52.47414/13.44576&disable_features=boundaries&locale=en&background=Berlin-2024&id=n12518261746

(Note to self: Hosting on GitHub Gist means, the URL-Hashes need to be update on every change.)

## **Video:**


https://github.com/user-attachments/assets/e80a57ab-e092-454e-9596-f775a4f8caad


## **Notes on the exploration of `maprules`**

**What it does:**
- This add validation rules to the list of validations

**Status Quo:**
- Right now in iD, the feature is broken; but fixing the translation issue is quite easy

**My take:**
Personally I don't see that big of an impact for this but it is also the part that is already there. We should either clean it up (remove it) or fix it up (which is not too much work).

**Follow up:**
- ATM the rules are not represented in the Rules filter; which we might want to add later.

## **Notes on the exploration of `presets`**

I then looked into if we can follow the same idea and allow custom presets from external, CORS enabled URLs. And that turned out to be not too much code to add as well.

**What it does:**
- This allows to write preset that follow the tagging schema and merge them into the current presets
- The custom presets then behave like any other preset would

**My take:**
This could be a quick and low code change way to enable users to manage custom presets. We have this idea on the list at https://github.com/openstreetmap/iD/issues/11168 but did not discuss it in the way explored here. In the long run, I still think that https://github.com/tordans/editor-settings-schema/tree/main/presets-schema would be the better solution (storing custom presets in the user profile settings on osm.org so they can be shared between sessions and editors); but that is harder to do and this solution opens [the campaigning angle](https://github.com/openstreetmap/iD/issues/12313#issuecomment-4412385495) and is quicker to build.

**Follow up:**
- We might want to add a custom style to those (different color in list and map?)
- We might want to add a group to the preset selection overview list for the custom presets?

## **Hosting the json files**

I explored hosting the json files that iD reads as Github Gist https://gist.github.com/tordans/549a328ccff34963192899113c73d35a
That works nicely when used with the raw file option. It is tedious though, because updates require to change the URL.
Campaigns will likely want to host their files elsewhere, but Netlify and such make this kind of thing super easy nowadays. To be clear, I don't think it needs a service like https://github.com/radiant-maxar/maprules for this to work. I anything, I would say we should create clear docs so users can ask an LLM to generate the JSON files (and provide good errors for debugging).

## **Docs**

In order to explore what is there and how to use it, I asked Cursor LLM to write docs for the feature, which is part of the changes in this PR. I think docs like this would round up this feature quite nicely by being clear about presets for all (via the tagging-schema) but also explain the options to set up custom presets.


---

This would also partially close https://github.com/openstreetmap/iD/issues/5049