### PR TITLE
Hide icons that failed to load in the relations list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :bug: Bugfixes
 * Restore dedicated rendering of ski pistes and building parts ([#12297], thanks [@matkoniecz])
 * Pressing backspace while in the feature type selecting mode should not delete the object
+* Hide icons that failed to load in the relations list ([#12320], thanks [@k-yle])
 #### :earth_asia: Localization
 #### :hourglass: Performance
 #### :mortar_board: Walkthrough / Help
@@ -57,6 +58,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#12297]: https://github.com/openstreetmap/iD/issues/12297
 [#12306]: https://github.com/openstreetmap/iD/pull/12306
 [#12307]: https://github.com/openstreetmap/iD/pull/12307
+[#12320]: https://github.com/openstreetmap/iD/pull/12320
 
 
 # 2.40.0

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -2950,6 +2950,10 @@ img.tag-reference-wiki-image {
     margin-left: 5px;
     margin-bottom: -4.5px;
 }
+.section-raw-membership-editor .member-row img.member-entity-icon.hide,
+.section-raw-member-editor .member-row img.member-entity-icon.hide {
+    display: none;
+}
 .section-raw-membership-editor .member-row span.member-entity-ref-color,
 .section-raw-member-editor .member-row span.member-entity-ref-color,
 .feature-list .feature-list-item span.member-entity-ref-color {

--- a/modules/ui/sections/raw_member_editor.js
+++ b/modules/ui/sections/raw_member_editor.js
@@ -207,9 +207,12 @@ export function uiSectionRawMemberEditor(context) {
                         const matched = presetManager.match(d, context.graph());
                         if (matched.suggestion) {
                             // if matching an NSI preset: append icon
-                            d3_select(this)
-                                .append('img')
+                            const img = d3_select(this)
+                                .append('img');
+                            img
                                 .classed('member-entity-icon', true)
+                                .on('load', () => img.classed('hide', false))
+                                .on('error', () => img.classed('hide', true))
                                 .attr('src', matched.imageURL);
                         }
                     });

--- a/modules/ui/sections/raw_membership_editor.js
+++ b/modules/ui/sections/raw_membership_editor.js
@@ -423,9 +423,12 @@ export function uiSectionRawMembershipEditor(context) {
             const matched = presetManager.match(d.relation, context.graph());
             if (matched.suggestion) {
                 // if matching an NSI preset: append icon
-                d3_select(this)
-                    .append('img')
+                const img = d3_select(this)
+                    .append('img');
+                img
                     .classed('member-entity-icon', true)
+                    .on('load', () => img.classed('hide', false))
+                    .on('error', () => img.classed('hide', true))
                     .attr('src', matched.imageURL);
             }
         });


### PR DESCRIPTION
Just tried out the latest iD version and noticed that these new icons don't have any error handling logic, which wastes space for anyone with an adblocker or strict browser:

<img width="289" height="511" alt="image" src="https://github.com/user-attachments/assets/675e7de9-a594-404b-b084-7d07703595f4" />

This PR hides the icons if they failed to load, to match the behaviour of the preset sidebar