### PR TITLE
Fix minor styling issues in the presets list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :bug: Bugfixes
 * Restore dedicated rendering of ski pistes and building parts ([#12297], thanks [@matkoniecz])
 * Pressing backspace while in the feature type selecting mode should not delete the object
+* Fix minor styling issues in the presets list ([#12321], thanks [@k-yle])
 #### :earth_asia: Localization
 #### :hourglass: Performance
 #### :mortar_board: Walkthrough / Help
@@ -57,6 +58,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#12297]: https://github.com/openstreetmap/iD/issues/12297
 [#12306]: https://github.com/openstreetmap/iD/pull/12306
 [#12307]: https://github.com/openstreetmap/iD/pull/12307
+[#12321]: https://github.com/openstreetmap/iD/pull/12321
 
 
 # 2.40.0

--- a/css/30_highways.css
+++ b/css/30_highways.css
@@ -600,8 +600,8 @@ path.line.casing.tag-highway-path.tag-bicycle-designated.tag-foot-designated:not
 }
 path.line.stroke.tag-highway-cycleway.tag-foot-designated,
 path.line.stroke.tag-highway-path.tag-bicycle-designated.tag-foot-designated,
-.preset-icon-container path.casing.tag-highway-cycleway.tag-foot-designated,
-.preset-icon-container path.casing.tag-highway-path.tag-bicycle-designated.tag-foot-designated {
+.preset-icon-container path.line.casing.tag-highway-cycleway.tag-foot-designated:not(.tag-crossing),
+.preset-icon-container path.line.casing.tag-highway-path.tag-bicycle-designated.tag-foot-designated:not(.tag-crossing) {
     stroke: #b458ed;
 }
 .preset-icon-container path.stroke.tag-highway-cycleway.tag-foot-designated:not(.tag-crossing),

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -1115,10 +1115,10 @@ summary.hide-toggle::-webkit-details-marker {
     object-fit: contain;
     border-radius: 2px;
     z-index: 2;
-    visibility: hidden;
+    display: none;
 }
 .preset-icon-container.showing-img img.image-icon {
-    visibility: visible;
+    display: initial;
 }
 .preset-icon-container.showing-img *:not(.image-icon) {
     display: none;


### PR DESCRIPTION
Closes https://github.com/openstreetmap/id-tagging-schema/issues/2272

<table>
<tr>
<td>Before
<td>After

<tr>
<td><img width="304" height="155" alt="image" src="https://github.com/user-attachments/assets/fd829f8c-6391-427d-8485-65bca3f05051" /></td>
<td><img width="302" height="157" alt="image" src="https://github.com/user-attachments/assets/5af78d79-c991-4943-b097-51fe438ca842" /></td>
</tr>

<tr>
<td><img width="298" height="231" alt="image" src="https://github.com/user-attachments/assets/cb99b73d-c3e8-49d3-9d20-25c55200e01b" /></td>
<td><img width="296" height="231" alt="image" src="https://github.com/user-attachments/assets/b199af35-40f2-43bb-b9f8-4662426be0a7" /></td>

</tr>
</table>


1. caused by the CSS selector being less specific than the earlier selector, which was taking precendence
2. caused by the broken 3rd party icon[^1] still existing in the DOM, pushing the other element to the side. 

[^1]: can test this with Microsoft Edge (which blocks facebook icons but not wikimedia commons). presumably third party adblockers do the same