### PR TITLE
Add segregated combo box field for segregated surface sub-keys

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 * text=auto
 *.bat eol=crlf
 *.js eol=lf
+*.ts eol=lf
 *.mjs eol=lf

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -1637,11 +1637,11 @@ input.date-selector {
 .form-field ul.rows li button {
     border-width: 0;
 }
-.ideditor[dir='ltr'] .form-field ul.rows li.labeled-input input,
+.ideditor[dir='ltr'] .form-field ul.rows li.labeled-input:has(> .label) input,
 .ideditor[dir='ltr'] .form-field ul.rows li button {
     border-left-width: 1px;
 }
-.ideditor[dir='rtl'] .form-field ul.rows li.labeled-input input,
+.ideditor[dir='rtl'] .form-field ul.rows li.labeled-input:has(> .label) input,
 .ideditor[dir='rtl'] .form-field ul.rows li button {
     border-right-width: 1px;
 }

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -1621,10 +1621,12 @@ input.date-selector {
     flex-flow: row nowrap;
 }
 .form-field ul.rows li.labeled-input > div {
+    display: flex;
     flex: 1 1 auto;
     width: 100%;
     border-radius: 0;
     line-height: 0.95rem;
+    align-items: center;
 }
 .form-field ul.rows li input {
     border-radius: 0;

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -1594,7 +1594,7 @@ input.date-selector {
 /* Field - Access, DirectionalCombo
 ------------------------------------------------------- */
 .form-field-input-access,
-.form-field-input-directionalcombo {
+.form-field-input-directionalCombo {
     flex: 1 1 auto;
     display: flex;
     flex-flow: row wrap;

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -1591,10 +1591,11 @@ input.date-selector {
 }
 
 
-/* Field - Access, DirectionalCombo
+/* Field - Access, DirectionalCombo, SegregatedCombo
 ------------------------------------------------------- */
 .form-field-input-access,
-.form-field-input-directionalCombo {
+.form-field-input-directionalCombo,
+.form-field-input-segregatedCombo {
     flex: 1 1 auto;
     display: flex;
     flex-flow: row wrap;

--- a/modules/ui/field.js
+++ b/modules/ui/field.js
@@ -102,10 +102,16 @@ export function uiField(context, presetField, entityIDs, options) {
                 }
             }
 
-            // For segregatedCombo, only the sub-keys (not the main/fallback key) count as
-            // "having a value" for the purpose of bypassing `prerequisiteTag` checks.
-            // e.g. `surface=asphalt` alone doesn't suppress the `segregated=yes` prerequisite
-            if (field.type === 'segregatedCombo' && field.fallbackKey && key === field.keys[0]) return false;
+            if (field.type === 'segregatedCombo' && field.fallbackKey) {
+                // For segregatedCombo with a fallback, only the sub-keys (not the main/fallback key) count as
+                // "having a value" for the purpose of bypassing `prerequisiteTag` checks.
+                // e.g. `surface=asphalt` alone doesn't suppress the `segregated=yes` prerequisite.
+
+                if (key === field.keys[0]) return false; // not the main/fallback key
+                return Array.isArray(_tags)
+                    ? _tags.some(function(entityTags) { return entityTags && entityTags[key] !== undefined; }) // multiple entities
+                    : _tags[key] !== undefined; // one entity
+            }
 
             return _tags[key] !== undefined;
         });

--- a/modules/ui/field.js
+++ b/modules/ui/field.js
@@ -348,7 +348,14 @@ export function uiField(context, presetField, entityIDs, options) {
             !tagsContainFieldKey() && // ignore tagging prerequisites if a value is already present
             prerequisiteTag) {
 
-            if (!entityIDs.every(function(entityID) {
+           var prerequisiteCheck =
+               // For segregatedCombo, show the field if any entity satisfies the prerequisite
+               // e.g. still show `surface_segregated` even if not all entities have `segregated=yes`
+               field.type === 'segregatedCombo'
+                    ? entityIDs.some.bind(entityIDs)
+                    : entityIDs.every.bind(entityIDs);
+
+            if (!prerequisiteCheck(function(entityID) {
                 var entity = context.graph().entity(entityID);
                 if (prerequisiteTag.key) {
                     var value = entity.tags[prerequisiteTag.key] || '';

--- a/modules/ui/field.js
+++ b/modules/ui/field.js
@@ -101,6 +101,12 @@ export function uiField(context, presetField, entityIDs, options) {
                     }
                 }
             }
+
+            // For segregatedCombo, only the sub-keys (not the main/fallback key) count as
+            // "having a value" for the purpose of bypassing `prerequisiteTag` checks.
+            // e.g. `surface=asphalt` alone doesn't suppress the `segregated=yes` prerequisite
+            if (field.type === 'segregatedCombo' && field.fallbackKey && key === field.keys[0]) return false;
+
             return _tags[key] !== undefined;
         });
     }

--- a/modules/ui/field.js
+++ b/modules/ui/field.js
@@ -317,6 +317,12 @@ export function uiField(context, presetField, entityIDs, options) {
     // A non-allowed field is hidden from the user altogether
     field.isAllowed = function() {
 
+        // A fallback field is not allowed if the primary field is shown.
+        // e.g. "surface" is potentially allowed only when "surface_segregated" is not shown.
+        if (options.fallbackFor) {
+            return !options.fallbackFor.isAllowed();
+        }
+
         if (entityIDs &&
             entityIDs.length > 1 &&
             uiFields[field.type].supportsMultiselection === false) return false;

--- a/modules/ui/fields/combo.js
+++ b/modules/ui/fields/combo.js
@@ -1175,6 +1175,9 @@ export function uiFieldCombo(field, context) {
     };
 
 
+    combo.displayValue = displayValue;
+
+
     combo.focus = function() {
         _input.node().focus();
     };

--- a/modules/ui/fields/index.js
+++ b/modules/ui/fields/index.js
@@ -4,6 +4,7 @@ export * from './input';
 export * from './access';
 export * from './address';
 export * from './directional_combo';
+export * from './segregated_combo';
 export * from './lanes';
 export * from './localized';
 export * from './roadheight';
@@ -48,6 +49,7 @@ import {
 import { uiFieldAccess } from './access';
 import { uiFieldAddress } from './address';
 import { uiFieldDirectionalCombo } from './directional_combo';
+import { uiFieldSegregatedCombo } from './segregated_combo';
 import { uiFieldLanes } from './lanes';
 import { uiFieldLocalized } from './localized';
 import { uiFieldRoadheight } from './roadheight';
@@ -67,6 +69,7 @@ export var uiFields = {
     date: uiFieldText,
     defaultCheck: uiFieldDefaultCheck,
     directionalCombo: uiFieldDirectionalCombo,
+    segregatedCombo: uiFieldSegregatedCombo,
     email: uiFieldEmail,
     identifier: uiFieldIdentifier,
     lanes: uiFieldLanes,

--- a/modules/ui/fields/segregated_combo.js
+++ b/modules/ui/fields/segregated_combo.js
@@ -86,10 +86,12 @@ export function uiFieldSegregatedCombo(field, context) {
     }
 
 
-    segregatedCombo.tags = function(_ignored) {
-        const entityTags = context.selectedIDs()
-            .map(id => context.graph().hasEntity(id)?.tags)
-            .filter(Boolean);
+    segregatedCombo.tags = function(_ignored, __test_tags /* for unit tests only */) {
+        const entityTags = Array.isArray(__test_tags)
+            ? __test_tags // for unit tests only
+            : context.selectedIDs()
+                .map(id => context.graph().hasEntity(id)?.tags)
+                .filter(Boolean);
 
         for (const key of Object.keys(_combos)) {
             const values = entityTags.map(tags => tags[key]);

--- a/modules/ui/fields/segregated_combo.js
+++ b/modules/ui/fields/segregated_combo.js
@@ -1,0 +1,110 @@
+import { dispatch as d3_dispatch } from 'd3-dispatch';
+import { select as d3_select } from 'd3-selection';
+
+import { utilRebind } from '../../util';
+import { uiFieldCombo } from './combo';
+
+
+export function uiFieldSegregatedCombo(field, context) {
+    var dispatch = d3_dispatch('change');
+    var items = d3_select(null);
+    var wrap = d3_select(null);
+
+    /** @type {Record<string, ReturnType<typeof uiFieldCombo>>} */
+    const _combos = {};
+
+
+    function segregatedCombo(selection) {
+
+        function stripcolon(s) {
+            return s.replaceAll(':', '');
+        }
+
+
+        wrap = selection.selectAll('.form-field-input-wrap')
+            .data([0]);
+
+        wrap = wrap.enter()
+            .append('div')
+            .attr('class', 'form-field-input-wrap form-field-input-' + field.type)
+            .merge(wrap);
+
+
+        var primaryDiv = wrap.selectAll('ul')
+            .data([0]);
+
+        primaryDiv = primaryDiv.enter()
+            .append('ul')
+            .attr('class', 'rows') // not `rows-table` because first item shouldn't have a label
+            .merge(primaryDiv);
+
+        items = primaryDiv.selectAll('li')
+            .data(field.keys);
+
+        var enter = items.enter()
+            .append('li')
+            .attr('class', function(d) { return 'labeled-input preset-segregatedcombo-' + stripcolon(d); });
+
+        enter
+            .filter(function(_, i) { return i !== 0; }) // skip label for the first/main key (e.g. `surface` itself)
+            .append('div')
+            .attr('class', 'label preset-label-segregatedcombo')
+            .attr('for', function(d) { return 'preset-input-segregatedcombo-' + stripcolon(d); })
+            .each(function(d) {
+                d3_select(this).call(field.t.append('types.' + d));
+            });
+
+        enter
+            .append('div')
+            .attr('class', 'preset-input-segregatedcombo-wrap form-field-input-wrap')
+            .each(function(key) {
+                const subField = {
+                    ...field,
+                    type: 'combo',
+                    key
+                };
+                const combo = uiFieldCombo(subField, context);
+                combo.on('change', t => change(key, t[key]));
+                _combos[key] = combo;
+                d3_select(this).call(combo);
+            });
+
+        items = items.merge(enter);
+
+        // Update
+        wrap.selectAll('.preset-input-directionalcombo')
+            .on('change', change)
+            .on('blur', change);
+    }
+
+
+    function change(key, newValue) {
+        dispatch.call('change', this, tags => {
+            tags[key] = newValue;
+            return tags;
+        });
+    }
+
+
+    segregatedCombo.tags = function(_ignored) {
+        const entityTags = context.selectedIDs()
+            .map(id => context.graph().hasEntity(id)?.tags)
+            .filter(Boolean);
+
+        for (const key of Object.keys(_combos)) {
+            const values = entityTags.map(tags => tags[key]);
+            const uniqueValues = [...new Set(values)];
+            _combos[key].tags({ [key]: uniqueValues.length > 1 ? uniqueValues : uniqueValues[0] });
+        }
+    };
+
+
+    segregatedCombo.focus = function() {
+        var node = wrap.selectAll('input').node();
+        if (node) node.focus();
+    };
+
+
+    return utilRebind(segregatedCombo, dispatch, 'on');
+}
+

--- a/modules/ui/fields/segregated_combo.js
+++ b/modules/ui/fields/segregated_combo.js
@@ -14,12 +14,12 @@ export function uiFieldSegregatedCombo(field, context) {
     const _combos = {};
 
 
+    function stripcolon(s) {
+        return s.replaceAll(':', '');
+    }
+
+
     function segregatedCombo(selection) {
-
-        function stripcolon(s) {
-            return s.replaceAll(':', '');
-        }
-
 
         wrap = selection.selectAll('.form-field-input-wrap')
             .data([0]);
@@ -93,10 +93,23 @@ export function uiFieldSegregatedCombo(field, context) {
                 .map(id => context.graph().hasEntity(id)?.tags)
                 .filter(Boolean);
 
+        const mainKey = field.keys[0]; // e.g. `surface`
+        const uniqueMainValues = [...new Set(entityTags.map(tags => tags[mainKey]))]; // e.g. [ 'asphalt' ] or [ 'asphalt', 'concrete' ]
+        const sharedMainValue = uniqueMainValues.length === 1 ? uniqueMainValues[0] : null; // e.g. 'asphalt' or `null`
+
         for (const key of Object.keys(_combos)) {
-            const values = entityTags.map(tags => tags[key]);
-            const uniqueValues = [...new Set(values)];
-            _combos[key].tags({ [key]: uniqueValues.length > 1 ? uniqueValues : uniqueValues[0] });
+            const uniqueValues = [...new Set(entityTags.map(tags => tags[key]))]; // e.g. for `cycleway:surface` => [ undefined ]
+            const tagValue = uniqueValues.length > 1 ? uniqueValues : uniqueValues[0]; // e.g. for `cycleway:surface` => undefined
+            // Apply values to combo display
+            _combos[key].tags({ [key]: tagValue });
+
+            // When sub-key is unset but main key has a value, show it as an implied placeholder
+            // e.g. if `surface` is `asphalt` but `cycleway:surface` is unset, show `asphalt` as a placeholder for `cycleway:surface`
+            if (key !== mainKey && !tagValue && sharedMainValue) {
+                const displayValue = _combos[mainKey].displayValue(sharedMainValue); // e.g. `asphalt` to "Asphalt" (same as combobox would do for a set value)
+                wrap.select('.preset-segregatedcombo-' + stripcolon(key) + ' input')
+                    .attr('placeholder', displayValue);
+            }
         }
     };
 

--- a/modules/ui/sections/preset_fields.js
+++ b/modules/ui/sections/preset_fields.js
@@ -48,6 +48,23 @@ export function uiSectionPresetFields(context) {
                 var fields = preset.fields(loc);
                 var moreFields = preset.moreFields(loc);
 
+                if (_presets.length > 1) {
+                    // If there is a mix of presets, use fallback field unless every preset supports the field
+                    // e.g. "surface_segregated" will map back to "surface" as common field unless every preset uses it
+                    fields = fields.map(function (field) {
+                        if (field.fallbackKey) {
+                            if (_presets.some(function (p) {
+                                return p !== preset && !p.fields(loc).some(function (f) {
+                                    return f.fallbackKey === field.fallbackKey;
+                                })
+                            })) {
+                                return presetsManager.field(field.fallbackKey);
+                            }
+                        }
+                        return field;
+                    });
+                }
+
                 allFields = utilArrayUnion(allFields, fields);
                 allMoreFields = utilArrayUnion(allMoreFields, moreFields);
 

--- a/modules/ui/sections/preset_fields.js
+++ b/modules/ui/sections/preset_fields.js
@@ -71,9 +71,21 @@ export function uiSectionPresetFields(context) {
 
             sharedFields.forEach(function(field) {
                 if (field.matchAllGeometry(geometries)) {
-                    _fieldsArr.push(
-                        uiField(context, field, _entityIDs)
-                    );
+                    var mainField = uiField(context, field, _entityIDs);
+                    _fieldsArr.push(mainField);
+
+                    // If a fallback field is specified, add it as well
+                    // e.g. "surface_segregated" has "surface" as fallback when it's not shown itself
+                    if (field.fallbackKey) {
+                        if (!sharedFields.some(function (f) { return f.id === field.fallbackKey; })) {
+                            var fallbackField = presetsManager.field(field.fallbackKey);
+                            if (fallbackField) {
+                                _fieldsArr.push(
+                                    uiField(context, fallbackField, _entityIDs, {fallbackFor: mainField})
+                                );
+                            }
+                        }
+                    }
                 }
             });
 

--- a/modules/ui/sections/preset_fields.js
+++ b/modules/ui/sections/preset_fields.js
@@ -56,7 +56,7 @@ export function uiSectionPresetFields(context) {
                             if (_presets.some(function (p) {
                                 return p !== preset && !p.fields(loc).some(function (f) {
                                     return f.fallbackKey === field.fallbackKey;
-                                })
+                                });
                             })) {
                                 return presetsManager.field(field.fallbackKey);
                             }

--- a/test/spec/ui/fields/segregated_combo.js
+++ b/test/spec/ui/fields/segregated_combo.js
@@ -283,5 +283,39 @@ describe('iD.uiFieldSegregatedCombo', () => {
             const fallbackField = makeFallbackField(uiField);
             expect(fallbackField.isAllowed()).toBe(true);
         });
+
+        function makeFieldForMultiple(tags1, tags2) {
+            const node1 = new iD.osmNode({ loc: [0, 0], tags: tags1 });
+            const node2 = new iD.osmNode({ loc: [0, 0], tags: tags2 });
+            context.perform(iD.actionAddEntity(node1));
+            context.perform(iD.actionAddEntity(node2));
+            const uiField = iD.uiField(context, presetField, [node1.id, node2.id]);
+            uiField.tags([ tags1, tags2 ]);
+            return uiField;
+        }
+
+        it('is allowed when all entities have segregated=yes', () => {
+            const uiField = makeFieldForMultiple({ segregated: 'yes' }, { segregated: 'yes' });
+            expect(uiField.isAllowed()).toBe(true);
+
+            const fallbackField = makeFallbackField(uiField);
+            expect(fallbackField.isAllowed()).toBe(false);
+        });
+
+        it('is allowed when at least one entity has segregated=yes', () => {
+            const uiField = makeFieldForMultiple({ segregated: 'yes' }, { segregated: 'no' });
+            expect(uiField.isAllowed()).toBe(true);
+
+            const fallbackField = makeFallbackField(uiField);
+            expect(fallbackField.isAllowed()).toBe(false);
+        });
+
+        it('is not allowed when no entities have segregated=yes', () => {
+            const uiField = makeFieldForMultiple({ segregated: 'no' }, { segregated: 'no' });
+            expect(uiField.isAllowed()).toBe(false);
+
+            const fallbackField = makeFallbackField(uiField);
+            expect(fallbackField.isAllowed()).toBe(true);
+        });
     });
 });

--- a/test/spec/ui/fields/segregated_combo.js
+++ b/test/spec/ui/fields/segregated_combo.js
@@ -181,14 +181,6 @@ describe('iD.uiFieldSegregatedCombo', () => {
             prerequisiteTag: { key: 'segregated', value: 'yes' },
         });
 
-        function makeField(tags) {
-            const node = new iD.osmNode({ loc: [0, 0], tags });
-            context.perform(iD.actionAddEntity(node));
-            const uiField = iD.uiField(context, presetField, [node.id]);
-            uiField.tags(tags);
-            return uiField;
-        }
-
         // Mock up plain "surface" field
         const fallbackPresetField = iD.presetField('surface', { key: 'surface', type: 'combo' });
 
@@ -196,126 +188,220 @@ describe('iD.uiFieldSegregatedCombo', () => {
             return iD.uiField(context, fallbackPresetField, mainField.entityIDs, { fallbackFor: mainField });
         }
 
-        it('is allowed when segregated=yes', () => {
-            const uiField = makeField({ segregated: 'yes' });
-            expect(uiField.isAllowed()).toBe(true);
+        describe('single element', () => {
 
-            const fallbackField = makeFallbackField(uiField);
-            expect(fallbackField.isAllowed()).toBe(false);
+            function makeField(tags) {
+                const node = new iD.osmNode({ loc: [0, 0], tags });
+                context.perform(iD.actionAddEntity(node));
+                const uiField = iD.uiField(context, presetField, [node.id]);
+                uiField.tags(tags);
+                return uiField;
+            }
+
+
+            it('is allowed when segregated=yes', () => {
+                const uiField = makeField({ segregated: 'yes' });
+                expect(uiField.isAllowed()).toBe(true);
+
+                const fallbackField = makeFallbackField(uiField);
+                expect(fallbackField.isAllowed()).toBe(false);
+            });
+
+            it('is allowed when segregated=yes and also surface is set', () => {
+                const uiField = makeField({ segregated: 'yes', surface: 'asphalt' });
+                expect(uiField.isAllowed()).toBe(true);
+
+                const fallbackField = makeFallbackField(uiField);
+                expect(fallbackField.isAllowed()).toBe(false);
+            });
+
+            it('is allowed when segregated=yes and also cycleway:surface is set', () => {
+                const uiField = makeField({ segregated: 'yes', 'cycleway:surface': 'asphalt' });
+                expect(uiField.isAllowed()).toBe(true);
+
+                const fallbackField = makeFallbackField(uiField);
+                expect(fallbackField.isAllowed()).toBe(false);
+            });
+
+            it('is allowed when segregated=yes and also both surface and cycleway:surface are set', () => {
+                const uiField = makeField({ segregated: 'yes', surface: 'paved', 'cycleway:surface': 'asphalt' });
+                expect(uiField.isAllowed()).toBe(true);
+
+                const fallbackField = makeFallbackField(uiField);
+                expect(fallbackField.isAllowed()).toBe(false);
+            });
+
+            it('is not allowed when segregated=no', () => {
+                const uiField = makeField({ segregated: 'no' });
+                expect(uiField.isAllowed()).toBe(false);
+
+                const fallbackField = makeFallbackField(uiField);
+                expect(fallbackField.isAllowed()).toBe(true);
+            });
+
+            it('is not allowed when segregated=no even if surface is set', () => {
+                const uiField = makeField({ segregated: 'no', surface: 'asphalt' });
+                expect(uiField.isAllowed()).toBe(false);
+
+                const fallbackField = makeFallbackField(uiField);
+                expect(fallbackField.isAllowed()).toBe(true);
+            });
+
+            it('is allowed when segregated=no, but cycleway:surface is set', () => {
+                const uiField = makeField({ segregated: 'no', 'cycleway:surface': 'asphalt' });
+                expect(uiField.isAllowed()).toBe(true);
+
+                const fallbackField = makeFallbackField(uiField);
+                expect(fallbackField.isAllowed()).toBe(false);
+            });
+
+            it('is not allowed when segregated is not set', () => {
+                const uiField = makeField({});
+                expect(uiField.isAllowed()).toBe(false);
+
+                const fallbackField = makeFallbackField(uiField);
+                expect(fallbackField.isAllowed()).toBe(true);
+            });
+
+            it('is not allowed when segregated is not set even if surface is set', () => {
+                const uiField = makeField({ surface: 'asphalt' });
+                expect(uiField.isAllowed()).toBe(false);
+
+                const fallbackField = makeFallbackField(uiField);
+                expect(fallbackField.isAllowed()).toBe(true);
+            });
+
+            it('is allowed when segregated is not set, but cycleway:surface is set', () => {
+                const uiField = makeField({ 'cycleway:surface': 'asphalt' });
+                expect(uiField.isAllowed()).toBe(true);
+
+                const fallbackField = makeFallbackField(uiField);
+                expect(fallbackField.isAllowed()).toBe(false);
+            });
+
+            it('is not allowed when segregated is an unknown values', () => {
+                const uiField = makeField({ segregated: 'perhaps' });
+                expect(uiField.isAllowed()).toBe(false);
+
+                const fallbackField = makeFallbackField(uiField);
+                expect(fallbackField.isAllowed()).toBe(true);
+            });
         });
 
-        it('is allowed when segregated=yes and also surface is set', () => {
-            const uiField = makeField({ segregated: 'yes', surface: 'asphalt' });
-            expect(uiField.isAllowed()).toBe(true);
+        describe('multiple elements with compatible preset', () => {
 
-            const fallbackField = makeFallbackField(uiField);
-            expect(fallbackField.isAllowed()).toBe(false);
+            function makeFieldForMultiple(tags1, tags2) {
+                const node1 = new iD.osmNode({ loc: [0, 0], tags: tags1 });
+                const node2 = new iD.osmNode({ loc: [0, 0], tags: tags2 });
+                context.perform(iD.actionAddEntity(node1));
+                context.perform(iD.actionAddEntity(node2));
+                const uiField = iD.uiField(context, presetField, [node1.id, node2.id]);
+                uiField.tags([ tags1, tags2 ]);
+                return uiField;
+            }
+
+            it('is allowed when all entities have segregated=yes', () => {
+                const uiField = makeFieldForMultiple({ segregated: 'yes' }, { segregated: 'yes' });
+                expect(uiField.isAllowed()).toBe(true);
+
+                const fallbackField = makeFallbackField(uiField);
+                expect(fallbackField.isAllowed()).toBe(false);
+            });
+
+            it('is allowed when at least one entity has segregated=yes', () => {
+                const uiField = makeFieldForMultiple({ segregated: 'yes' }, { segregated: 'no' });
+                expect(uiField.isAllowed()).toBe(true);
+
+                const fallbackField = makeFallbackField(uiField);
+                expect(fallbackField.isAllowed()).toBe(false);
+            });
+
+            it('is not allowed when no entities have segregated=yes', () => {
+                const uiField = makeFieldForMultiple({ segregated: 'no' }, { segregated: 'no' });
+                expect(uiField.isAllowed()).toBe(false);
+
+                const fallbackField = makeFallbackField(uiField);
+                expect(fallbackField.isAllowed()).toBe(true);
+            });
         });
 
-        it('is allowed when segregated=yes and also cycleway:surface is set', () => {
-            const uiField = makeField({ segregated: 'yes', 'cycleway:surface': 'asphalt' });
-            expect(uiField.isAllowed()).toBe(true);
+        describe('mixed elements with different presets', () => {
 
-            const fallbackField = makeFallbackField(uiField);
-            expect(fallbackField.isAllowed()).toBe(false);
-        });
+            describe('entity 2 has compatible preset', () => {
 
-        it('is allowed when segregated=yes and also both surface and cycleway:surface are set', () => {
-            const uiField = makeField({ segregated: 'yes', surface: 'paved', 'cycleway:surface': 'asphalt' });
-            expect(uiField.isAllowed()).toBe(true);
+                function makeExtraCompatibleField(tags1, tags2) {
+                    const node1 = new iD.osmNode({ loc: [0, 0], tags: tags1 });
+                    const node2 = new iD.osmNode({ loc: [0, 0], tags: tags2 });
+                    context.perform(iD.actionAddEntity(node1));
+                    context.perform(iD.actionAddEntity(node2));
+                    const uiField = iD.uiField(context, presetField, [node1.id, node2.id]);
+                    uiField.tags([tags1, tags2]);
+                    return uiField;
+                }
 
-            const fallbackField = makeFallbackField(uiField);
-            expect(fallbackField.isAllowed()).toBe(false);
-        });
+                it('segregated field is shown for two different but compatible presets with segregated=yes', () => {
+                    const uiField = makeExtraCompatibleField({ segregated: 'yes' }, { segregated: 'yes' });
+                    expect(uiField.isAllowed()).toBe(true);
 
-        it('is not allowed when segregated=no', () => {
-            const uiField = makeField({ segregated: 'no' });
-            expect(uiField.isAllowed()).toBe(false);
+                    const fallbackField = makeFallbackField(uiField);
+                    expect(fallbackField.isAllowed()).toBe(false);
+                });
 
-            const fallbackField = makeFallbackField(uiField);
-            expect(fallbackField.isAllowed()).toBe(true);
-        });
+                it('segregated field is shown even when one doesn\'t have segregated=yes', () => {
+                    const uiField = makeExtraCompatibleField({ }, { segregated: 'yes' });
+                    expect(uiField.isAllowed()).toBe(true);
 
-        it('is not allowed when segregated=no even if surface is set', () => {
-            const uiField = makeField({ segregated: 'no', surface: 'asphalt' });
-            expect(uiField.isAllowed()).toBe(false);
+                    const fallbackField = makeFallbackField(uiField);
+                    expect(fallbackField.isAllowed()).toBe(false);
+                });
 
-            const fallbackField = makeFallbackField(uiField);
-            expect(fallbackField.isAllowed()).toBe(true);
-        });
+                it('segregated field is not shown if neither preset has segregated=yes', () => {
+                    const uiField = makeExtraCompatibleField({ }, { });
+                    expect(uiField.isAllowed()).toBe(false);
 
-        it('is allowed when segregated=no, but cycleway:surface is set', () => {
-            const uiField = makeField({ segregated: 'no', 'cycleway:surface': 'asphalt' });
-            expect(uiField.isAllowed()).toBe(true);
+                    const fallbackField = makeFallbackField(uiField);
+                    expect(fallbackField.isAllowed()).toBe(true);
+                });
 
-            const fallbackField = makeFallbackField(uiField);
-            expect(fallbackField.isAllowed()).toBe(false);
-        });
+                it('segregated field is shown without segregated=yes if subkey is set on both', () => {
+                    const uiField = makeExtraCompatibleField({ 'cycleway:surface': 'asphalt' }, { 'cycleway:surface': 'concrete' });
+                    expect(uiField.isAllowed()).toBe(true);
 
-        it('is not allowed when segregated is not set', () => {
-            const uiField = makeField({});
-            expect(uiField.isAllowed()).toBe(false);
+                    const fallbackField = makeFallbackField(uiField);
+                    expect(fallbackField.isAllowed()).toBe(false);
+                });
 
-            const fallbackField = makeFallbackField(uiField);
-            expect(fallbackField.isAllowed()).toBe(true);
-        });
+                it('segregated field is shown without segregated=yes even if subkey is only set on one', () => {
+                    const uiField = makeExtraCompatibleField({ 'cycleway:surface': 'asphalt' }, { });
+                    expect(uiField.isAllowed()).toBe(true);
 
-        it('is not allowed when segregated is not set even if surface is set', () => {
-            const uiField = makeField({ surface: 'asphalt' });
-            expect(uiField.isAllowed()).toBe(false);
+                    const fallbackField = makeFallbackField(uiField);
+                    expect(fallbackField.isAllowed()).toBe(false);
+                });
+            });
 
-            const fallbackField = makeFallbackField(uiField);
-            expect(fallbackField.isAllowed()).toBe(true);
-        });
+            describe('entity 2 has incompatible preset', () => {
 
-        it('is allowed when segregated is not set, but cycleway:surface is set', () => {
-            const uiField = makeField({ 'cycleway:surface': 'asphalt' });
-            expect(uiField.isAllowed()).toBe(true);
+                function makeExtraIncompatibleField(tags1, tags2) {
+                    const node1 = new iD.osmNode({ loc: [0, 0], tags: tags1 });
+                    const node2 = new iD.osmNode({ loc: [0, 0], tags: tags2 });
+                    context.perform(iD.actionAddEntity(node1));
+                    context.perform(iD.actionAddEntity(node2));
+                    const uiField = iD.uiField(context, fallbackPresetField, [node1.id, node2.id]);
+                    uiField.tags([tags1, tags2]);
+                    return uiField;
+                }
 
-            const fallbackField = makeFallbackField(uiField);
-            expect(fallbackField.isAllowed()).toBe(false);
-        });
+                it('fallback surface field is shown instead of segregated', () => {
+                    const uiField = makeExtraIncompatibleField({ }, { });
+                    expect(uiField.isAllowed()).toBe(true);
+                });
 
-        it('is not allowed when segregated is an unknown values', () => {
-            const uiField = makeField({ segregated: 'perhaps' });
-            expect(uiField.isAllowed()).toBe(false);
-
-            const fallbackField = makeFallbackField(uiField);
-            expect(fallbackField.isAllowed()).toBe(true);
-        });
-
-        function makeFieldForMultiple(tags1, tags2) {
-            const node1 = new iD.osmNode({ loc: [0, 0], tags: tags1 });
-            const node2 = new iD.osmNode({ loc: [0, 0], tags: tags2 });
-            context.perform(iD.actionAddEntity(node1));
-            context.perform(iD.actionAddEntity(node2));
-            const uiField = iD.uiField(context, presetField, [node1.id, node2.id]);
-            uiField.tags([ tags1, tags2 ]);
-            return uiField;
-        }
-
-        it('is allowed when all entities have segregated=yes', () => {
-            const uiField = makeFieldForMultiple({ segregated: 'yes' }, { segregated: 'yes' });
-            expect(uiField.isAllowed()).toBe(true);
-
-            const fallbackField = makeFallbackField(uiField);
-            expect(fallbackField.isAllowed()).toBe(false);
-        });
-
-        it('is allowed when at least one entity has segregated=yes', () => {
-            const uiField = makeFieldForMultiple({ segregated: 'yes' }, { segregated: 'no' });
-            expect(uiField.isAllowed()).toBe(true);
-
-            const fallbackField = makeFallbackField(uiField);
-            expect(fallbackField.isAllowed()).toBe(false);
-        });
-
-        it('is not allowed when no entities have segregated=yes', () => {
-            const uiField = makeFieldForMultiple({ segregated: 'no' }, { segregated: 'no' });
-            expect(uiField.isAllowed()).toBe(false);
-
-            const fallbackField = makeFallbackField(uiField);
-            expect(fallbackField.isAllowed()).toBe(true);
+                it('fallback surface field is shown even if compatible preset has segregated=yes', () => {
+                    const uiField = makeExtraIncompatibleField({ segregated: 'yes' }, { });
+                    expect(uiField.isAllowed()).toBe(true);
+                });
+            });
         });
     });
 });

--- a/test/spec/ui/fields/segregated_combo.js
+++ b/test/spec/ui/fields/segregated_combo.js
@@ -1,0 +1,140 @@
+describe('iD.uiFieldSegregatedCombo', () => {
+    /** @type {iD.Context} */
+    let context;
+    /** @type {import("d3-selection").Selection} */
+    let selection;
+
+    beforeEach(() => {
+        context = iD.coreContext().assetPath('../dist/').init();
+        selection = d3.select(document.createElement('div'));
+    });
+
+    const field = iD.presetField('surface_segregated', {
+        key: 'surface',
+        keys: ['surface', 'cycleway:surface', 'footway:surface'],
+    });
+
+    describe('values shown by inputs', () => {
+        it('with no values set, all inputs are empty', () => {
+            const instance = iD.uiFieldSegregatedCombo(field, context);
+            selection.call(instance);
+            instance.tags(undefined, [{}]);
+
+            expect(selection.selectAll('input').nodes()).toHaveLength(3);
+            const [mainInput, cyclewayInput, footwayInput] = selection.selectAll('input').nodes();
+            expect(mainInput.value).toBe('');
+            expect(cyclewayInput.value).toBe('');
+            expect(footwayInput.value).toBe('');
+        });
+
+        it('with only surface set, only the surface input shows the value', () => {
+            const instance = iD.uiFieldSegregatedCombo(field, context);
+            selection.call(instance);
+            instance.tags(undefined, [{ 'surface': 'paved' }]);
+
+            const [mainInput, cyclewayInput, footwayInput] = selection.selectAll('input').nodes();
+            expect(mainInput.value).toBe('paved');
+            expect(cyclewayInput.value).toBe('');
+            expect(footwayInput.value).toBe('');
+        });
+
+        it('with only cycleway:surface set, only the cycleway:surface input shows the value', () => {
+            const instance = iD.uiFieldSegregatedCombo(field, context);
+            selection.call(instance);
+            instance.tags(undefined, [{ 'cycleway:surface': 'asphalt' }]);
+
+            const [mainInput, cyclewayInput, footwayInput] = selection.selectAll('input').nodes();
+            expect(mainInput.value).toBe('');
+            expect(cyclewayInput.value).toBe('asphalt');
+            expect(footwayInput.value).toBe('');
+        });
+
+        it('with only footway:surface set, only the footway:surface input shows the value', () => {
+            const instance = iD.uiFieldSegregatedCombo(field, context);
+            selection.call(instance);
+            instance.tags(undefined, [{ 'footway:surface': 'paving_stones' }]);
+
+            const [mainInput, cyclewayInput, footwayInput] = selection.selectAll('input').nodes();
+            expect(mainInput.value).toBe('');
+            expect(cyclewayInput.value).toBe('');
+            expect(footwayInput.value).toBe('paving_stones');
+        });
+
+        it('with all three keys set, each input shows its respective value', () => {
+            const instance = iD.uiFieldSegregatedCombo(field, context);
+            selection.call(instance);
+            instance.tags(undefined, [{ 'surface': 'paved', 'cycleway:surface': 'asphalt', 'footway:surface': 'paving_stones' }]);
+
+            expect(selection.selectAll('input').nodes()).toHaveLength(3);
+            const [mainInput, cyclewayInput, footwayInput] = selection.selectAll('input').nodes();
+            expect(mainInput.value).toBe('paved');
+            expect(cyclewayInput.value).toBe('asphalt');
+            expect(footwayInput.value).toBe('paving_stones');
+        });
+    });
+
+    describe('no alteration of other keys on change', () => {
+        it.each([
+            { label: 'empty', initialTags: {} },
+            { label: 'filled', initialTags: { 'cycleway:surface': 'asphalt', 'footway:surface': 'paving_stones' } },
+        ])('setting surface doesn\'t alter $label cycleway:surface or footway:surface', ({ initialTags }) => {
+            const instance = iD.uiFieldSegregatedCombo(field, context);
+            selection.call(instance);
+            let tags = { ...initialTags };
+            instance.tags(undefined, [tags]);
+
+            const onChange = vi.fn();
+            instance.on('change', v => onChange(tags = v(tags)));
+
+            const [mainInput] = selection.selectAll('input').nodes();
+
+            mainInput.value = 'paved';
+            d3.select(mainInput).dispatch('change');
+
+            expect(onChange).toHaveBeenCalledTimes(1);
+            expect(onChange).toHaveBeenNthCalledWith(1, { ...initialTags, 'surface': 'paved' });
+        });
+
+        it.each([
+            { label: 'empty', initialTags: {} },
+            { label: 'filled', initialTags: { 'surface': 'paved', 'footway:surface': 'paving_stones' } },
+        ])('setting cycleway:surface doesn\'t alter $label surface or footway:surface', ({ initialTags }) => {
+            const instance = iD.uiFieldSegregatedCombo(field, context);
+            selection.call(instance);
+            let tags = { ...initialTags };
+            instance.tags(undefined, [tags]);
+
+            const onChange = vi.fn();
+            instance.on('change', v => onChange(tags = v(tags)));
+
+            const [, cyclewayInput] = selection.selectAll('input').nodes();
+
+            cyclewayInput.value = 'asphalt';
+            d3.select(cyclewayInput).dispatch('change');
+
+            expect(onChange).toHaveBeenCalledTimes(1);
+            expect(onChange).toHaveBeenNthCalledWith(1, { ...initialTags, 'cycleway:surface': 'asphalt' });
+        });
+
+        it.each([
+            { label: 'empty', initialTags: {} },
+            { label: 'filled', initialTags: { 'surface': 'paved', 'cycleway:surface': 'asphalt' } },
+        ])('setting footway:surface doesn\'t alter $label cycleway:surface or surface', ({ initialTags }) => {
+            const instance = iD.uiFieldSegregatedCombo(field, context);
+            selection.call(instance);
+            let tags = { ...initialTags };
+            instance.tags(undefined, [tags]);
+
+            const onChange = vi.fn();
+            instance.on('change', v => onChange(tags = v(tags)));
+
+            const [,, footwayInput] = selection.selectAll('input').nodes();
+
+            footwayInput.value = 'paving_stones';
+            d3.select(footwayInput).dispatch('change');
+
+            expect(onChange).toHaveBeenCalledTimes(1);
+            expect(onChange).toHaveBeenNthCalledWith(1, { ...initialTags, 'footway:surface': 'paving_stones' });
+        });
+    });
+});

--- a/test/spec/ui/fields/segregated_combo.js
+++ b/test/spec/ui/fields/segregated_combo.js
@@ -138,6 +138,38 @@ describe('iD.uiFieldSegregatedCombo', () => {
         });
     });
 
+    describe('placeholder value for subkeys', () => {
+
+        function getSubkeyPlaceholders(...entityTagsList) {
+            const instance = iD.uiFieldSegregatedCombo(field, context);
+            selection.call(instance);
+            instance.tags(undefined, entityTagsList);
+            const [, cyclewayInput, footwayInput] = selection.selectAll('input').nodes();
+            return [
+                cyclewayInput.getAttribute('placeholder'),
+                footwayInput.getAttribute('placeholder')
+            ];
+        }
+
+        it('shows the main value as placeholder on unset subkeys', () => {
+            const [cycleway, footway] = getSubkeyPlaceholders({ 'surface': 'asphalt' });
+            expect(cycleway).toBe('asphalt');
+            expect(footway).toBe('asphalt');
+        });
+
+        it('does not set a placeholder on a subkey with value', () => {
+            const [cycleway, footway] = getSubkeyPlaceholders({ 'surface': 'asphalt', 'cycleway:surface': 'asphalt' });
+            expect(cycleway).not.toBe('asphalt');
+            expect(footway).toBe('asphalt');
+        });
+
+        it('does not set a placeholder when the main value is not set', () => {
+            const [cycleway, footway] = getSubkeyPlaceholders({});
+            expect(cycleway).toBeFalsy();
+            expect(footway).toBeFalsy();
+        });
+    });
+
     describe('widget display allowance', () => {
 
         // Mock up "surface_segregated" field

--- a/test/spec/ui/fields/segregated_combo.js
+++ b/test/spec/ui/fields/segregated_combo.js
@@ -137,4 +137,79 @@ describe('iD.uiFieldSegregatedCombo', () => {
             expect(onChange).toHaveBeenNthCalledWith(1, { ...initialTags, 'footway:surface': 'paving_stones' });
         });
     });
+
+    describe('widget display allowance', () => {
+
+        // Mock up "surface_segregated" field
+        const presetField = iD.presetField('surface_segregated', {
+            key: 'surface',
+            keys: ['surface', 'cycleway:surface', 'footway:surface'],
+            type: 'segregatedCombo',
+            fallbackKey: 'surface',
+            prerequisiteTag: { key: 'segregated', value: 'yes' },
+        });
+
+        function makeField(tags) {
+            const node = new iD.osmNode({ loc: [0, 0], tags });
+            context.perform(iD.actionAddEntity(node));
+            const uiField = iD.uiField(context, presetField, [node.id]);
+            uiField.tags(tags);
+            return uiField;
+        }
+
+        it('is allowed when segregated=yes', () => {
+            const uiField = makeField({ segregated: 'yes' });
+            expect(uiField.isAllowed()).toBe(true);
+        });
+
+        it('is allowed when segregated=yes and also surface is set', () => {
+            const uiField = makeField({ segregated: 'yes', surface: 'asphalt' });
+            expect(uiField.isAllowed()).toBe(true);
+        });
+
+        it('is allowed when segregated=yes and also cycleway:surface is set', () => {
+            const uiField = makeField({ segregated: 'yes', 'cycleway:surface': 'asphalt' });
+            expect(uiField.isAllowed()).toBe(true);
+        });
+
+        it('is allowed when segregated=yes and also both surface and cycleway:surface are set', () => {
+            const uiField = makeField({ segregated: 'yes', surface: 'paved', 'cycleway:surface': 'asphalt' });
+            expect(uiField.isAllowed()).toBe(true);
+        });
+
+        it('is not allowed when segregated=no', () => {
+            const uiField = makeField({ segregated: 'no' });
+            expect(uiField.isAllowed()).toBe(false);
+        });
+
+        it('is not allowed when segregated=no even if surface is set', () => {
+            const uiField = makeField({ segregated: 'no', surface: 'asphalt' });
+            expect(uiField.isAllowed()).toBe(false);
+        });
+
+        it('is allowed when segregated=no, but cycleway:surface is set', () => {
+            const uiField = makeField({ segregated: 'no', 'cycleway:surface': 'asphalt' });
+            expect(uiField.isAllowed()).toBe(true);
+        });
+
+        it('is not allowed when segregated is not set', () => {
+            const uiField = makeField({});
+            expect(uiField.isAllowed()).toBe(false);
+        });
+
+        it('is not allowed when segregated is not set even if surface is set', () => {
+            const uiField = makeField({ surface: 'asphalt' });
+            expect(uiField.isAllowed()).toBe(false);
+        });
+
+        it('is allowed when segregated is not set, but cycleway:surface is set', () => {
+            const uiField = makeField({ 'cycleway:surface': 'asphalt' });
+            expect(uiField.isAllowed()).toBe(true);
+        });
+
+        it('is not allowed when segregated is an unknown values', () => {
+            const uiField = makeField({ segregated: 'perhaps' });
+            expect(uiField.isAllowed()).toBe(false);
+        });
+    });
 });

--- a/test/spec/ui/fields/segregated_combo.js
+++ b/test/spec/ui/fields/segregated_combo.js
@@ -157,59 +157,99 @@ describe('iD.uiFieldSegregatedCombo', () => {
             return uiField;
         }
 
+        // Mock up plain "surface" field
+        const fallbackPresetField = iD.presetField('surface', { key: 'surface', type: 'combo' });
+
+        function makeFallbackField(mainField) {
+            return iD.uiField(context, fallbackPresetField, mainField.entityIDs, { fallbackFor: mainField });
+        }
+
         it('is allowed when segregated=yes', () => {
             const uiField = makeField({ segregated: 'yes' });
             expect(uiField.isAllowed()).toBe(true);
+
+            const fallbackField = makeFallbackField(uiField);
+            expect(fallbackField.isAllowed()).toBe(false);
         });
 
         it('is allowed when segregated=yes and also surface is set', () => {
             const uiField = makeField({ segregated: 'yes', surface: 'asphalt' });
             expect(uiField.isAllowed()).toBe(true);
+
+            const fallbackField = makeFallbackField(uiField);
+            expect(fallbackField.isAllowed()).toBe(false);
         });
 
         it('is allowed when segregated=yes and also cycleway:surface is set', () => {
             const uiField = makeField({ segregated: 'yes', 'cycleway:surface': 'asphalt' });
             expect(uiField.isAllowed()).toBe(true);
+
+            const fallbackField = makeFallbackField(uiField);
+            expect(fallbackField.isAllowed()).toBe(false);
         });
 
         it('is allowed when segregated=yes and also both surface and cycleway:surface are set', () => {
             const uiField = makeField({ segregated: 'yes', surface: 'paved', 'cycleway:surface': 'asphalt' });
             expect(uiField.isAllowed()).toBe(true);
+
+            const fallbackField = makeFallbackField(uiField);
+            expect(fallbackField.isAllowed()).toBe(false);
         });
 
         it('is not allowed when segregated=no', () => {
             const uiField = makeField({ segregated: 'no' });
             expect(uiField.isAllowed()).toBe(false);
+
+            const fallbackField = makeFallbackField(uiField);
+            expect(fallbackField.isAllowed()).toBe(true);
         });
 
         it('is not allowed when segregated=no even if surface is set', () => {
             const uiField = makeField({ segregated: 'no', surface: 'asphalt' });
             expect(uiField.isAllowed()).toBe(false);
+
+            const fallbackField = makeFallbackField(uiField);
+            expect(fallbackField.isAllowed()).toBe(true);
         });
 
         it('is allowed when segregated=no, but cycleway:surface is set', () => {
             const uiField = makeField({ segregated: 'no', 'cycleway:surface': 'asphalt' });
             expect(uiField.isAllowed()).toBe(true);
+
+            const fallbackField = makeFallbackField(uiField);
+            expect(fallbackField.isAllowed()).toBe(false);
         });
 
         it('is not allowed when segregated is not set', () => {
             const uiField = makeField({});
             expect(uiField.isAllowed()).toBe(false);
+
+            const fallbackField = makeFallbackField(uiField);
+            expect(fallbackField.isAllowed()).toBe(true);
         });
 
         it('is not allowed when segregated is not set even if surface is set', () => {
             const uiField = makeField({ surface: 'asphalt' });
             expect(uiField.isAllowed()).toBe(false);
+
+            const fallbackField = makeFallbackField(uiField);
+            expect(fallbackField.isAllowed()).toBe(true);
         });
 
         it('is allowed when segregated is not set, but cycleway:surface is set', () => {
             const uiField = makeField({ 'cycleway:surface': 'asphalt' });
             expect(uiField.isAllowed()).toBe(true);
+
+            const fallbackField = makeFallbackField(uiField);
+            expect(fallbackField.isAllowed()).toBe(false);
         });
 
         it('is not allowed when segregated is an unknown values', () => {
             const uiField = makeField({ segregated: 'perhaps' });
             expect(uiField.isAllowed()).toBe(false);
+
+            const fallbackField = makeFallbackField(uiField);
+            expect(fallbackField.isAllowed()).toBe(true);
         });
     });
 });

--- a/test/spec_helpers.ts
+++ b/test/spec_helpers.ts
@@ -103,6 +103,12 @@ cached.locale_tagging_en = {
               description: 'Access allowed only with a valid permit or license'
             }
           }
+        },
+        surface_segregated: {
+          types: {
+            'cycleway:surface': 'Cycleway',
+            'footway:surface': 'Footway'
+          }
         }
       }
     }


### PR DESCRIPTION
This PR implements a new field input widget "segregated combo" for combined use by `surface`, `cycleway:surface` and `footway:surface`.

<img alt="subprime example" src="https://github.com/user-attachments/assets/3b6717f1-d004-4347-a022-56af79cd9ff5" />

<img alt="prime example" src="https://github.com/user-attachments/assets/2f63b5ce-b2fb-44d9-9de2-6ff0efa14abe" />

The field is shown and replaces the regular `surface` field when `segregated=yes` is set or if either `cycleway:surface` or `footway:surface` are already set.

From user's perspective it's still the "same" field, just a different variant that shows extra related values.

Here are the various scenarios:

| Scenario | Preview |
| ------------- | ------------- |
| Disabled by default - `segregated` not specified | <img alt="disabled by default" src="https://github.com/user-attachments/assets/410cbafe-86d0-42e3-aa4b-d05f50bf75b0" /> |
| Disabled on `segregated=no` | <img alt="disabled on nonsegregated" src="https://github.com/user-attachments/assets/f3e9ec80-86db-4e3a-8107-b6a5b4a24ce5" /> |
| Enabled on `segregated=yes` | <img alt="enabled on segregated" src="https://github.com/user-attachments/assets/bb9c7568-bb6d-4bf8-91af-eafbb61dd69c" /> |
| Enabled when either sub-key is already set, regardless of `segregated` value | <img alt="enabled when subkeys" src="https://github.com/user-attachments/assets/505a02e7-206a-4726-868a-7eb574f7beb8" /> |
| Enabled for multiple selection where every preset supports it if any individual selection would have shown it | <img alt="enabled if any selection supports" src="https://github.com/user-attachments/assets/c343d0c3-d742-441b-95da-e751c3e563d0" />|
| Disabled for multiple selection unless every preset supports it | <img alt="disabled for mixed selection" src="https://github.com/user-attachments/assets/4e107e3d-bb37-4f72-871d-ed2d1f81b08e" /> |

Since this is based on combo box and directional combo box, it should work for RTL by default - I didn't do anything special for it:

<img alt="RTL" src="https://github.com/user-attachments/assets/3e59ead5-42c4-48ef-9824-11edfdfdc1a9" />

Also, when setting the main value, it shows it as empty sub-key placeholders (similar to how access field does it):

<img alt="placeholders" src="https://github.com/user-attachments/assets/bcdd6e7d-b43a-4648-9e29-3fbb15b011b8" />

I added a bunch of unit tests to check most of these cases and assumptions. In particular, that tag values aren't messed up by the new widget and that widget displays when expected.

It's currently added for "Cycle & Foot Path" and "Cycle & Foot Crossing" presets (though technically "Cycle & Foot Crossing" doesn't use the `segregated` field for some reason).

This PR implements https://github.com/openstreetmap/id-tagging-schema/issues/205 and supersedes https://github.com/openstreetmap/id-tagging-schema/pull/1998 with a more targeted solution.

This PR relies on <s>schema repo update (https://github.com/ideditor/schema-builder/pull/302) and afterwards requires</s> (_Edit: schema stuff now part of tagging PR after repo merge._) tagging repo update (https://github.com/openstreetmap/id-tagging-schema/pull/2249).

This PR focuses on cycleway surfaces, but this will potentially similarly work for other fields like `smoothness`. In fact, this can potentially support stuff like `maxspeed:backward` and `lanes:forward` (for example, when `lanes=3`) and such.

I also encountered a couple minor existing issues that I fixed. See comments below.

AI Disclaimer: I used LLM assistance with various code suggestions. I read and checked any such additions or changes and further refactored and updated them manually. All text like this PR was written by me.