### PR TITLE
Add invert filter for background imagery

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -836,6 +836,7 @@ en:
     contrast: Contrast
     saturation: Saturation
     sharpness: Sharpness
+    invert: Invert
     minimap:
       description: Show Minimap
       tooltip: Show a zoomed out map to help locate the area currently displayed.

--- a/modules/renderer/background.js
+++ b/modules/renderer/background.js
@@ -28,6 +28,7 @@ export function rendererBackground(context) {
   let _contrast = 1;
   let _saturation = 1;
   let _sharpness = 1;
+  let _invert = 0;
 
 
   function ensureImageryIndex() {
@@ -125,6 +126,9 @@ export function rendererBackground(context) {
     }
     if (_saturation !== 1) {
       baseFilter += ` saturate(${_saturation})`;
+    }
+    if (_invert !== 0) {
+      baseFilter += ` invert(${_invert})`;
     }
     if (_sharpness < 1) {  // gaussian blur
       const blur = d3_interpolateNumber(0.5, 5)(1 - _sharpness);
@@ -432,6 +436,13 @@ export function rendererBackground(context) {
   background.sharpness = function(d) {
     if (!arguments.length) return _sharpness;
     _sharpness = d;
+    if (context.mode()) dispatch.call('change');
+    return background;
+  };
+
+  background.invert = function(d) {
+    if (!arguments.length) return _invert;
+    _invert = d;
     if (context.mode()) dispatch.call('change');
     return background;
   };

--- a/modules/ui/sections/background_display_options.js
+++ b/modules/ui/sections/background_display_options.js
@@ -16,17 +16,19 @@ export function uiSectionBackgroundDisplayOptions(context) {
         .disclosureContent(renderDisclosureContent);
 
     var _storedOpacity = prefs('background-opacity');
-    var _sliders = ['brightness', 'contrast', 'saturation', 'sharpness'];
+    var _sliders = ['brightness', 'contrast', 'saturation', 'sharpness', 'invert'];
 
     var _options = {
         brightness: {
+            def: 1,
             val: _storedOpacity !== null ? +_storedOpacity : 1,
             min: 0,
             max: 3
         },
-        contrast: { val: 1, min: 0, max: 3 },
-        saturation: { val: 1, min: 0, max: 3 },
-        sharpness: { val: 1, min: 0, max: 3 }
+        contrast: { def: 1, val: 1, min: 0, max: 3 },
+        saturation: { def: 1, val: 1, min: 0, max: 3 },
+        sharpness: { def: 1, val: 1, min: 0, max: 3 },
+        invert: { def: 0, val: 0, min: 0, max: 1 }
     };
 
     function updateValue(d, val) {
@@ -89,7 +91,7 @@ export function uiSectionBackgroundDisplayOptions(context) {
             .attr('class', function(d) { return 'display-option-reset display-option-reset-' + d; })
             .on('click', function(d3_event, d) {
                 if (d3_event.button !== 0) return;
-                updateValue(d, 1);
+                updateValue(d, _options[d].def);
             })
             .call(svgIcon('#iD-icon-' + (localizer.textDirection() === 'rtl' ? 'redo' : 'undo')));
 
@@ -103,7 +105,8 @@ export function uiSectionBackgroundDisplayOptions(context) {
             .on('click', function(d3_event) {
                 d3_event.preventDefault();
                 for (var i = 0; i < _sliders.length; i++) {
-                    updateValue(_sliders[i], 1);
+                    var slider = _sliders[i];
+                    updateValue(slider, _options[slider].def);
                 }
             });
 

--- a/modules/ui/sections/background_display_options.js
+++ b/modules/ui/sections/background_display_options.js
@@ -121,7 +121,7 @@ export function uiSectionBackgroundDisplayOptions(context) {
             .text(function(d) { return Math.floor(_options[d].val * 100) + '%'; });
 
         container.selectAll('.display-option-reset')
-            .classed('disabled', function(d) { return _options[d].val === 1; });
+            .classed('disabled', function(d) { return _options[d].val === _options[d].def; });
 
         // first time only, set brightness if needed
         if (containerEnter.size() && _options.brightness.val !== 1) {

--- a/modules/ui/sections/background_display_options.js
+++ b/modules/ui/sections/background_display_options.js
@@ -16,22 +16,23 @@ export function uiSectionBackgroundDisplayOptions(context) {
         .disclosureContent(renderDisclosureContent);
 
     var _storedOpacity = prefs('background-opacity');
-    var _minVal = 0;
-    var _maxVal = 3;
-
     var _sliders = ['brightness', 'contrast', 'saturation', 'sharpness'];
 
     var _options = {
-        brightness: (_storedOpacity !== null ? (+_storedOpacity) : 1),
-        contrast: 1,
-        saturation: 1,
-        sharpness: 1
+        brightness: {
+            val: _storedOpacity !== null ? +_storedOpacity : 1,
+            min: 0,
+            max: 3
+        },
+        contrast: { val: 1, min: 0, max: 3 },
+        saturation: { val: 1, min: 0, max: 3 },
+        sharpness: { val: 1, min: 0, max: 3 }
     };
 
     function updateValue(d, val) {
-        val = clamp(val, _minVal, _maxVal);
+        val = clamp(val, _options[d].min, _options[d].max);
 
-        _options[d] = val;
+        _options[d].val = val;
         context.background()[d](val);
 
         if (d === 'brightness') {
@@ -71,8 +72,8 @@ export function uiSectionBackgroundDisplayOptions(context) {
             .append('input')
             .attr('class', function(d) { return 'display-option-input display-option-input-' + d; })
             .attr('type', 'range')
-            .attr('min', _minVal)
-            .attr('max', _maxVal)
+            .attr('min', function(d) { return _options[d].min; })
+            .attr('max', function(d) { return _options[d].max; })
             .attr('step', '0.01')
             .on('input', function(d3_event, d) {
                 var val = d3_select(this).property('value');
@@ -111,17 +112,17 @@ export function uiSectionBackgroundDisplayOptions(context) {
             .merge(container);
 
         container.selectAll('.display-option-input')
-            .property('value', function(d) { return _options[d]; });
+            .property('value', function(d) { return _options[d].val; });
 
         container.selectAll('.display-option-value')
-            .text(function(d) { return Math.floor(_options[d] * 100) + '%'; });
+            .text(function(d) { return Math.floor(_options[d].val * 100) + '%'; });
 
         container.selectAll('.display-option-reset')
-            .classed('disabled', function(d) { return _options[d] === 1; });
+            .classed('disabled', function(d) { return _options[d].val === 1; });
 
         // first time only, set brightness if needed
-        if (containerEnter.size() && _options.brightness !== 1) {
-            context.background().brightness(_options.brightness);
+        if (containerEnter.size() && _options.brightness.val !== 1) {
+            context.background().brightness(_options.brightness.val);
         }
     }
 

--- a/modules/ui/sections/background_display_options.js
+++ b/modules/ui/sections/background_display_options.js
@@ -32,7 +32,7 @@ export function uiSectionBackgroundDisplayOptions(context) {
     };
 
     function updateValue(d, val) {
-        val = clamp(val, _options[d].min, _options[d].max);
+        val = clamp(+val, _options[d].min, _options[d].max);
 
         _options[d].val = val;
         context.background()[d](val);


### PR DESCRIPTION
I've been doing some mapping lately in areas where the aerial imagery is pretty outdated, so I've had to rely on geodetic plans. The problem is those plans are mostly white, which makes it super hard to see what I'm drawing and just starts to hurt my eyes after a while.

I started adding `filter: invert(1);` through the browser dev tools and I figured I'd just build it in as a feature instead of doing it every time. I know the contributing guide says to open an issue for discussion first, but this felt like such a small, specific addition that I just went for it.

I tried to keep the changes as minimal as possible and stuck to the existing coding style in the files I was editing so I didn't mess up the formatting.

<img width="1227" height="570" alt="image" src="https://github.com/user-attachments/assets/e8184d87-c29d-4473-a6ee-470c82ec2951" />