### PR TITLE
Fix radio field crash with nested option strings

### DIFF
--- a/modules/ui/fields/radio.js
+++ b/modules/ui/fields/radio.js
@@ -66,7 +66,12 @@ export function uiFieldRadio(field, context) {
 
         enter
             .append('span')
-            .each(function(d) { strings.t.append('options.' + d, { 'default': d })(d3_select(this)); });
+            .each(function(d) {
+                const labelId = strings.hasTextForStringId('options.' + d + '.title')
+                    ? 'options.' + d + '.title'
+                    : 'options.' + d;
+                strings.t.append(labelId, { 'default': d })(d3_select(this));
+            });
 
         labels = labels
             .merge(enter);

--- a/test/spec/ui/fields/radio.ts
+++ b/test/spec/ui/fields/radio.ts
@@ -68,4 +68,33 @@ describe('iD.uiFieldRadio', () => {
             expect(onChange).toHaveBeenNthCalledWith(1, toTags);
         });
     });
+
+    describe('radio with stringsCrossReference', () => {
+        let context: iD.Context;
+        let selection: d3.Selection;
+
+        beforeEach(() => {
+            context = iD.coreContext().assetPath('../dist/').init();
+            selection = d3.select(document.createElement('div'));
+        });
+
+        it('renders option labels from .title when the referenced field has nested title/description option strings', () => {
+            const accessField = iD.presetField('access', { type: 'combo', key: 'access' });
+            const field = iD.presetField('access_boolean', {
+                type: 'radio',
+                key: 'access',
+                stringsCrossReference: '{access}',
+                options: ['yes', 'no'],
+            }, { access: accessField });
+
+            const instance = iD.uiFieldRadio(field, context);
+
+            expect(() => selection.call(instance)).not.toThrow();
+
+            const labels = selection.selectAll<HTMLLabelElement, unknown>('label').nodes();
+            expect(labels).toHaveLength(2);
+            expect(labels[0].querySelector('.localized-text')?.innerHTML).toBe('Allowed');
+            expect(labels[1].querySelector('.localized-text')?.innerHTML).toBe('Prohibited');
+        });
+    });
 });


### PR DESCRIPTION
When a `radio` field uses `stringsCrossReference` to reference another field whose option strings are structured as `{ title, description }` objects (rather than flat strings), rendering the field throws:

```
TypeError: callback.apply is not a function
```

This happens because `tInfo` returns the raw `{ title, description }` object in `texts`, and `t.append` then calls `selection.call(object)` — but D3's `selection.call()` expects a function.

The `combo` field already handles this correctly via its `getLabelId` helper, which checks for a `.title` sub-key first. The `radio` field was missing equivalent logic.

This issue was exposed by [openstreetmap/id-tagging-schema#2268](https://github.com/openstreetmap/id-tagging-schema/pull/2268), which changes the `parking_entrance` field from type `combo` to type `radio`. The `parking` field it references via `stringsCrossReference` uses nested `{ title, description }` option strings.