### PR TITLE
chore: update name-suggestion-index to v7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :rocket: Presets
 #### :hammer: Development
 * Remove redundant software dependencies to reduce the amount of the code that is bundled with iD ([#11634], [#12307], thanks [@k-yle])
+* Update name-suggestion-index to v7.2 ([#12337], thanks [@bjornstar])
 
 [#11634]: https://github.com/openstreetmap/iD/pull/11634
 [#12297]: https://github.com/openstreetmap/iD/issues/12297
@@ -63,6 +64,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#12307]: https://github.com/openstreetmap/iD/pull/12307
 [#12320]: https://github.com/openstreetmap/iD/pull/12320
 [#12321]: https://github.com/openstreetmap/iD/pull/12321
+[#12337]: https://github.com/openstreetmap/iD/issues/12337
 
 
 # 2.40.0

--- a/modules/presets/index.js
+++ b/modules/presets/index.js
@@ -472,6 +472,11 @@ export function presetIndex() {
   };
 
 
+  _this.getPresets = () => {
+    return _presets;
+  };
+
+
   function RibbonItem(preset, source) {
     let item = {};
     item.preset = preset;

--- a/modules/services/nsi.js
+++ b/modules/services/nsi.js
@@ -1,4 +1,4 @@
-import { Matcher } from 'name-suggestion-index';
+import { Matcher, buildIDPresets } from 'name-suggestion-index';
 import { fileFetcher, locationManager } from '../core';
 import { presetManager } from '../presets';
 
@@ -52,9 +52,9 @@ function setNsiSources() {
     'nsi_dissolved': cdn + 'dist/wikidata/dissolved.min.json',
     'nsi_features': cdn + 'dist/json/featureCollection.min.json',
     'nsi_generics': cdn + 'dist/json/genericWords.min.json',
-    'nsi_presets': cdn + 'dist/presets/nsi-id-presets.min.json',
     'nsi_replacements': cdn + 'dist/json/replacements.min.json',
-    'nsi_trees': cdn + 'dist/json/trees.min.json'
+    'nsi_trees': cdn + 'dist/json/trees.min.json',
+    'nsi_wikidata': cdn + 'dist/wikidata/wikidata.min.json',
   };
 
   let fileMap = fileFetcher.fileMap();
@@ -70,18 +70,33 @@ function setNsiSources() {
 function loadNsiPresets() {
   return (
     Promise.all([
-      fileFetcher.get('nsi_presets'),
-      fileFetcher.get('nsi_features')
+      fileFetcher.get('nsi_data'),
+      fileFetcher.get('nsi_dissolved'),
+      fileFetcher.get('nsi_features'),
+      fileFetcher.get('nsi_wikidata'),
     ])
-    .then(vals => {
+    .then(([
+        nsi_data,
+        nsi_dissolved,
+        nsi_features,
+        nsi_wikidata
+    ]) => {
+      const nsiPresets = buildIDPresets(nsi_data.nsi, {
+        sourcePresets: presetManager.getPresets(),
+        wikidata: nsi_wikidata.wikidata,
+        dissolved: nsi_dissolved.dissolved,
+      }).presets;
+
       // Add `suggestion=true` to all the nsi presets
       // The preset json schema doesn't include it, but the iD code still uses it
-      Object.values(vals[0].presets).forEach(preset => preset.suggestion = true);
+      for (const preset of Object.values(nsiPresets)) {
+        preset.suggestion = true;
+      }
 
       // nsi does not specify *:wikipedia (anymore):
       // clean up previous values to prevent that the wikidata/wikipedia information
       // is going to be out of sync, see #9103
-      Object.values(vals[0].presets).forEach(preset => {
+      for (const preset of Object.values(nsiPresets)) {
         if (preset.tags['brand:wikidata']) {
           preset.removeTags = {'brand:wikipedia': '*', ...(preset.removeTags || preset.addTags || preset.tags)};
         }
@@ -91,11 +106,11 @@ function loadNsiPresets() {
         if (preset.tags['network:wikidata']) {
           preset.removeTags = {'network:wikipedia': '*', ...(preset.removeTags || preset.addTags || preset.tags)};
         }
-      });
+      }
 
       presetManager.merge({
-        presets: vals[0].presets,
-        featureCollection: vals[1]
+        presets: nsiPresets,
+        featureCollection: nsi_features
       });
     })
   );
@@ -113,22 +128,25 @@ function loadNsiData() {
       fileFetcher.get('nsi_replacements'),
       fileFetcher.get('nsi_trees')
     ])
-    .then(vals => {
+    .then(([
+        nsi_data,          // the raw name-suggestion-index data
+        nsi_dissolved,     // list of dissolved items
+        nsi_replacements,  // trivial old->new qid replacements
+        nsi_trees          // metadata about trees, main tags
+    ]) => {
       _nsi = {
-        data:          vals[0].nsi,            // the raw name-suggestion-index data
-        dissolved:     vals[1].dissolved,      // list of dissolved items
-        replacements:  vals[2].replacements,   // trivial old->new qid replacements
-        trees:         vals[3].trees,          // metadata about trees, main tags
-        kvt:           new Map(),              // Map (k -> Map (v -> t) )
-        qids:          new Map(),              // Map (wd/wp tag values -> qids)
-        ids:           new Map()               // Map (id -> NSI item)
+        data:          nsi_data.nsi,
+        dissolved:     nsi_dissolved.dissolved,
+        replacements:  nsi_replacements.replacements,
+        trees:         nsi_trees.trees,
+        kvt:           new Map(),  // Map (k -> Map (v -> t) )
+        qids:          new Map(),  // Map (wd/wp tag values -> qids)
+        ids:           new Map()   // Map (id -> NSI item)
       };
 
       const matcher = new Matcher();
       _nsi.matcher = matcher;
       matcher.buildMatchIndex(_nsi.data);
-
-
       matcher.buildLocationIndex(_nsi.data, locationManager);
 
       Object.keys(_nsi.data).forEach(tkv => {

--- a/modules/services/nsi.js
+++ b/modules/services/nsi.js
@@ -128,66 +128,8 @@ function loadNsiData() {
       _nsi.matcher = matcher;
       matcher.buildMatchIndex(_nsi.data);
 
-// *** BEGIN HACK ***
 
-// old - built in matcher will set up the locationindex by resolving all the locationSets one-by-one
-      // matcher.buildLocationIndex(_nsi.data, locationManager.loco());
-
-// new - Use the location manager instead of redoing that work
-// It has already processed the presets at this point
-
-// We need to monkeypatch a few of the collections that the NSI matcher depends on.
-// The `itemLocation` structure maps itemIDs to locationSetIDs
-matcher.itemLocation = new Map();
-
-// The `locationSets` structure maps locationSetIDs to GeoJSON
-// We definitely need this, but don't need full geojson, just { properties: { area: xxx }}
-matcher.locationSets = new Map();
-
-Object.keys(_nsi.data).forEach(tkv => {
-  const items = _nsi.data[tkv].items;
-  if (!Array.isArray(items) || !items.length) return;
-
-  items.forEach(item => {
-    if (matcher.itemLocation.has(item.id)) return;   // we've seen item id already - shouldn't be possible?
-
-
-  function tryGettingLocationSetID(locationSet) {
-    try {
-      return locationManager.validateLocationSet(locationSet).id;
-    } catch {
-      return '+[Q2]';  // the world
-    }
-  }
-    const locationSetID = tryGettingLocationSetID(item.locationSet);
-    matcher.itemLocation.set(item.id, locationSetID);
-
-    if (matcher.locationSets.has(locationSetID)) return;   // we've seen this locationSet before..
-
-    const fakeFeature = { id: locationSetID, properties: { id: locationSetID, area: 1 } };
-    matcher.locationSets.set(locationSetID, fakeFeature);
-  });
-});
-
-// The `locationIndex` is an instance of which-polygon spatial index for the locationSets.
-// We only really need this to _look like_ which-polygon query `_wp.locationIndex(bbox, true);`
-// i.e. it needs to return the properties of the locationsets
-matcher.locationIndex = (bbox) => {
-  const validHere = locationManager.locationSetsAt([bbox[0], bbox[1]]);
-  const results = [];
-
-  for (const [locationSetID, area] of Object.entries(validHere)) {
-    const fakeFeature = matcher.locationSets.get(locationSetID);
-    if (fakeFeature) {
-      fakeFeature.properties.area = area;
-      results.push(fakeFeature);
-    }
-  }
-  return results;
-};
-
-// *** END HACK ***
-
+      matcher.buildLocationIndex(_nsi.data, locationManager);
 
       Object.keys(_nsi.data).forEach(tkv => {
         const category = _nsi.data[tkv];

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
         "jsdom": "^29.0.0",
         "json-stringify-pretty-compact": "^3.0.0",
         "mapillary-js": "4.1.2",
-        "name-suggestion-index": "~7.0",
+        "name-suggestion-index": "~7.2",
         "nise": "^6.1.1",
         "npm-run-all": "^4.0.0",
         "osm-community-index": "6.0.0",
@@ -5386,6 +5386,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -7401,17 +7418,20 @@
       }
     },
     "node_modules/name-suggestion-index": {
-      "version": "7.0.20251229",
-      "resolved": "https://registry.npmjs.org/name-suggestion-index/-/name-suggestion-index-7.0.20251229.tgz",
-      "integrity": "sha512-R4lH2Bj9g3534HWxKZxQ01Q5501E+k0Y9wQ+vCjzoG7++wScPQ35vo1M9s6BxXQMkGFwKW6WpRYXrg8U8FfHZw==",
+      "version": "7.2.20260515",
+      "resolved": "https://registry.npmjs.org/name-suggestion-index/-/name-suggestion-index-7.2.20260515.tgz",
+      "integrity": "sha512-2PeyJS5Br9651r/rGjyuMzeYQ9NsGnNgjf9od+ZX3z+r8nmCxa1QBJzPsYGmlDc2ch6dwEtj74lf7GXl58GR2Q==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
+        "@rapideditor/location-conflation": "^3.0.1",
+        "@types/diacritics": "^1.3.3",
+        "@types/geojson": "^7946.0.16",
         "diacritics": "^1.3.0",
-        "which-polygon": "^2.2.1"
+        "fast-xml-builder": "^1.2.0"
       },
       "engines": {
-        "bun": ">=1.3.0"
+        "bun": ">=1.3.13"
       }
     },
     "node_modules/nanoid": {
@@ -7947,6 +7967,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/path-is-absolute": {
@@ -10375,6 +10411,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xmlchars": {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "jsdom": "^29.0.0",
     "json-stringify-pretty-compact": "^3.0.0",
     "mapillary-js": "4.1.2",
-    "name-suggestion-index": "~7.0",
+    "name-suggestion-index": "~7.2",
     "nise": "^6.1.1",
     "npm-run-all": "^4.0.0",
     "osm-community-index": "6.0.0",

--- a/test/spec/validations/suspicious_name.js
+++ b/test/spec/validations/suspicious_name.js
@@ -3,10 +3,10 @@ describe('iD.validations.suspicious_name', function () {
 
     before(function() {
         iD.services.nsi = iD.serviceNsi;
-        iD.fileFetcher.cache().nsi_presets = { presets: {} };
         iD.fileFetcher.cache().nsi_features = { type: 'FeatureCollection', features: [] };
         iD.fileFetcher.cache().nsi_dissolved = { dissolved: {} };
         iD.fileFetcher.cache().nsi_replacements = { replacements: {} };
+        iD.fileFetcher.cache().nsi_wikidata = { wikidata: {} };
 
         iD.fileFetcher.cache().nsi_trees = {
           trees: {


### PR DESCRIPTION
Removed the hack which should no longer be necessary according to [the changes in v7.1](https://github.com/osmlab/name-suggestion-index/blob/main/CHANGELOG.md#71yyyymmdd)

Recommend @bhousel to take a look.

Tested locally and got good, locally appropriate suggestions.