### PR TITLE
Preserve valid Wikidata Q-IDs on blur

### DIFF
--- a/modules/ui/fields/wikidata.js
+++ b/modules/ui/fields/wikidata.js
@@ -69,6 +69,12 @@ export function uiFieldWikidata(field, context) {
                 node.setSelectionRange(0, node.value.length);
             })
             .on('blur', function() {
+                var value = _searchInput.property('value').trim();
+                if (/^Q\d+$/i.test(value)) {
+                    _qid = value.toUpperCase();
+                    change();
+                    return;
+                }
                 setLabelForEntity();
             })
             .call(combobox.fetcher(fetchWikidataItems));


### PR DESCRIPTION
Fix #12331

Thanks for the hint in #8863 ([comment](https://github.com/openstreetmap/iD/issues/8863#issuecomment-4438427383)).

Added a regex match on blur to check whether the input follows a valid Wikidata QID pattern. If the pattern matches, the value is accepted immediately instead of waiting for entity resolution from the API.

Works correct locally after testing multiple valid QID inputs