### PR TITLE
Fix outbound one-way direction cones at intersections

### DIFF
--- a/modules/osm/node.js
+++ b/modules/osm/node.js
@@ -79,11 +79,32 @@ const prototype = {
 
     // Inspect tags and geometry to determine which direction(s) this node/vertex points
     directions: function(resolver, projection) {
+        const hasPartialOneway = way => {
+            if (!way?.tags) return false;
+
+            for (const key of Object.keys(way.tags)) {
+                if (!key.startsWith('oneway:')) continue;
+
+                const value = (way.tags[key] || '').toLowerCase();
+                if (value === 'no') return true;
+                if (value === '-1' && way.isOneWayForwards()) return true;
+                if (value === 'yes' && way.isOneWayBackwards()) return true;
+            }
+            return false;
+        };
+
         /** @type {{ type: 'side' | 'turnout_side' | 'direction'; value: string }[]} */
         const rawValues = [];
+        const isAllWayStopIntersection =
+            this.isHighwayIntersection(resolver) &&
+            this.tags.highway === 'stop' &&
+            (this.tags.stop || '').toLowerCase() === 'all';
+        const isTrafficSignalsIntersection =
+            this.isHighwayIntersection(resolver) &&
+            this.tags.highway === 'traffic_signals';
 
         // which tag to use?
-        if (this.isHighwayIntersection(resolver) && (this.tags.stop || '').toLowerCase() === 'all') {
+        if (isAllWayStopIntersection) {
             // all-way stop tag on a highway intersection
             rawValues.push({
                 type: 'direction',
@@ -137,14 +158,27 @@ const prototype = {
         /** @type {{ type: 'side' | 'direction'; angle: number }[]} */
         const results = [];
 
-        const neighborNodeReducer = (neighbor, { lookBackward = true, lookForward = true } = {}) => function(collection, { nodes }) {
+        const neighborNodeReducer = (neighbor, { lookBackward = true, lookForward = true, filterOutbound = false } = {}) => function(collection, way) {
+            const nodes = way.nodes;
             nodes.forEach((_, i) => {
                 if (nodes[i] !== neighbor.id) return;  // not a match of current entity
 
-                if (lookForward && i > 0) {
+                let inboundFromPrev = true;
+                let inboundFromNext = true;
+                const isStrictOneWay = filterOutbound && way.isOneWay() && !way.isBiDirectional() && !hasPartialOneway(way);
+
+                if (isStrictOneWay) {
+                    if (way.isOneWayForwards()) {
+                        inboundFromNext = false;
+                    } else if (way.isOneWayBackwards()) {
+                        inboundFromPrev = false;
+                    }
+                }
+
+                if (lookForward && i > 0 && inboundFromPrev) {
                     collection[nodes[i - 1]] = true;  // look back to prev node
                 }
-                if (lookBackward && i < nodes.length - 1) {
+                if (lookBackward && i < nodes.length - 1 && inboundFromNext) {
                     collection[nodes[i + 1]] = true;  // look ahead to next node
                 }
             });
@@ -203,10 +237,11 @@ const prototype = {
                     (this.tags['traffic_sign:forward'] || v === (isSide ? 'right' : 'forward') || v === 'both' || v === 'all');
 
                 if (!lookForward && !lookBackward) return;
+                const shouldFilterOutbound = (isAllWayStopIntersection || isTrafficSignalsIntersection) && lookForward && lookBackward;
 
                 const nodeIds = resolver.parentWays(this)
                     .filter(way => osmShouldRenderDirection(this.tags, way.tags))
-                    .reduce(neighborNodeReducer(this, { lookForward, lookBackward }), {});
+                    .reduce(neighborNodeReducer(this, { lookForward, lookBackward, filterOutbound: shouldFilterOutbound }), {});
 
                 Object.keys(nodeIds).forEach(function(nodeId) {
                     // +90 because geoAngle returns angle from X axis, not Y (north)

--- a/test/spec/osm/node.js
+++ b/test/spec/osm/node.js
@@ -610,6 +610,62 @@ describe('iD.osmNode', function () {
             expect(node2.directions(graph, projection)).to.eql([]);
         });
 
+        it('does not return outbound one-way directions for an all-way stop', function () {
+            var node1 = new iD.osmNode({ id: 'n1', loc: [-1, 0] });
+            var node2 = new iD.osmNode({ id: 'n2', loc: [0, 0], tags: { highway: 'stop', stop: 'all' } });
+            var node3 = new iD.osmNode({ id: 'n3', loc: [1, 0] });
+            var node4 = new iD.osmNode({ id: 'n4', loc: [0, -1] });
+            var node5 = new iD.osmNode({ id: 'n5', loc: [0, 1] });
+            var way1 = new iD.osmWay({ id: 'w1', nodes: ['n1', 'n2', 'n3'], tags: { highway: 'residential', oneway: 'yes' } });
+            var way2 = new iD.osmWay({ id: 'w2', nodes: ['n4', 'n2', 'n5'], tags: { highway: 'residential' } });
+            var graph = new iD.coreGraph([node1, node2, node3, node4, node5, way1, way2]);
+
+            var angles = node2.directions(graph, projection).map(d => d.angle).sort((a, b) => a - b);
+            expect(angles).to.eql([0, 180, 270]);
+        });
+
+        it('does not return outbound oneway=-1 directions for an all-way stop', function () {
+            var node1 = new iD.osmNode({ id: 'n1', loc: [-1, 0] });
+            var node2 = new iD.osmNode({ id: 'n2', loc: [0, 0], tags: { highway: 'stop', stop: 'all' } });
+            var node3 = new iD.osmNode({ id: 'n3', loc: [1, 0] });
+            var node4 = new iD.osmNode({ id: 'n4', loc: [0, -1] });
+            var node5 = new iD.osmNode({ id: 'n5', loc: [0, 1] });
+            var way1 = new iD.osmWay({ id: 'w1', nodes: ['n1', 'n2', 'n3'], tags: { highway: 'residential', oneway: '-1' } });
+            var way2 = new iD.osmWay({ id: 'w2', nodes: ['n4', 'n2', 'n5'], tags: { highway: 'residential' } });
+            var graph = new iD.coreGraph([node1, node2, node3, node4, node5, way1, way2]);
+
+            var angles = node2.directions(graph, projection).map(d => d.angle).sort((a, b) => a - b);
+            expect(angles).to.eql([0, 180, 270]);
+        });
+
+        it('respects partial oneway tags for an all-way stop', function () {
+            var node1 = new iD.osmNode({ id: 'n1', loc: [-1, 0] });
+            var node2 = new iD.osmNode({ id: 'n2', loc: [0, 0], tags: { highway: 'stop', stop: 'all' } });
+            var node3 = new iD.osmNode({ id: 'n3', loc: [1, 0] });
+            var node4 = new iD.osmNode({ id: 'n4', loc: [0, -1] });
+            var node5 = new iD.osmNode({ id: 'n5', loc: [0, 1] });
+            var way1 = new iD.osmWay({ id: 'w1', nodes: ['n1', 'n2', 'n3'], tags: { highway: 'residential', oneway: 'yes', 'oneway:bicycle': 'no' } });
+            var way2 = new iD.osmWay({ id: 'w2', nodes: ['n4', 'n2', 'n5'], tags: { highway: 'residential' } });
+            var graph = new iD.coreGraph([node1, node2, node3, node4, node5, way1, way2]);
+
+            var angles = node2.directions(graph, projection).map(d => d.angle).sort((a, b) => a - b);
+            expect(angles).to.eql([0, 90, 180, 270]);
+        });
+
+        it('does not return outbound one-way directions for intersection traffic signals', function () {
+            var node1 = new iD.osmNode({ id: 'n1', loc: [-1, 0] });
+            var node2 = new iD.osmNode({ id: 'n2', loc: [0, 0], tags: { highway: 'traffic_signals', 'traffic_signals:direction': 'all' } });
+            var node3 = new iD.osmNode({ id: 'n3', loc: [1, 0] });
+            var node4 = new iD.osmNode({ id: 'n4', loc: [0, -1] });
+            var node5 = new iD.osmNode({ id: 'n5', loc: [0, 1] });
+            var way1 = new iD.osmWay({ id: 'w1', nodes: ['n1', 'n2', 'n3'], tags: { highway: 'residential', oneway: 'yes' } });
+            var way2 = new iD.osmWay({ id: 'w2', nodes: ['n4', 'n2', 'n5'], tags: { highway: 'residential' } });
+            var graph = new iD.coreGraph([node1, node2, node3, node4, node5, way1, way2]);
+
+            var angles = node2.directions(graph, projection).map(d => d.angle).sort((a, b) => a - b);
+            expect(angles).to.eql([0, 180, 270]);
+        });
+
         it('supports multiple directions delimited by ;', function () {
             var node1 = new iD.osmNode({ loc: [0, 0], tags: { direction: '0;45' }});
             var node2 = new iD.osmNode({ loc: [0, 0], tags: { direction: '45;north' }});


### PR DESCRIPTION
Closes #9879

## Summary
- Prevent outbound one-way direction cones for intersection-mapped highway=stop + stop=all
- Apply the same outbound filtering for intersection-mapped highway=traffic_signals
- Handle oneway=-1 and partial oneway:* exceptions

## Test
- npx vitest run --no-isolate test/spec/osm/node.js

## Screenshots
| Before | After |
|---|---|
| <img width="189" height="212" alt="Before" src="https://github.com/user-attachments/assets/919e1590-3878-4336-97e0-99b454d58c9b" /> | <img width="219" height="205" alt="After" src="https://github.com/user-attachments/assets/981801f1-375b-42b2-85b1-c76034075aab" /> |
