### PR TITLE
Show conflicting tags in merge operation tooltip

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -325,6 +325,7 @@ en:
       relation: These features can't be merged because they have conflicting relation roles.
       incomplete_relation: These features can't be merged because at least one hasn't been fully downloaded.
       conflicting_tags: These features can't be merged because some of their tags have conflicting values.
+      conflicting_tags_details: "These features can't be merged because some of their tags have conflicting values: {keys}"
       conflicting_relations: These features can't be merged because they belong to conflicting relations.
       paths_intersect: These features can't be merged because the resulting path would intersect itself.
       too_many_vertices: These features can't be merged because the resulting path would have too many points.

--- a/modules/actions/join.js
+++ b/modules/actions/join.js
@@ -179,6 +179,7 @@ export function actionJoin(ids) {
         var relation;
         var tags = {};
         var conflicting = false;
+        var conflictingKeys = [];
 
         joined[0].forEach(function(way) {
             var parents = graph.parentRelations(way);
@@ -194,6 +195,9 @@ export function actionJoin(ids) {
                 } else if (canSumTags(k, tags, way.tags)) {
                     tags[k] = (+tags[k] + +way.tags[k]).toString();
                 } else if (tags[k] && osmIsInterestingTag(k) && tags[k] !== way.tags[k]) {
+                    if (!conflictingKeys.includes(k)) {
+                        conflictingKeys.push(k);
+                    }
                     conflicting = true;
                 }
             }
@@ -204,7 +208,7 @@ export function actionJoin(ids) {
         }
 
         if (conflicting) {
-            return 'conflicting_tags';
+            return { type: 'conflicting_tags', keys: conflictingKeys };
         }
     };
 

--- a/modules/operations/merge.js
+++ b/modules/operations/merge.js
@@ -59,7 +59,7 @@ export function operationMerge(context, selectedIDs) {
 
     operation.disabled = function() {
         var actionDisabled = _action.disabled(context.graph());
-        if (actionDisabled) return actionDisabled;
+        if (actionDisabled) return actionDisabled.type || actionDisabled;
 
         var osm = context.connection();
         if (osm &&
@@ -80,6 +80,13 @@ export function operationMerge(context, selectedIDs) {
             if (disabled === 'restriction' || disabled === 'connectivity') {
                 return t.append('operations.merge.damage_relation',
                     { relation: presetManager.item('type/' + disabled).name() });
+            }
+            if (disabled === 'conflicting_tags') {
+                var actionDisabled = _action.disabled(context.graph());
+                if (actionDisabled.keys && actionDisabled.keys.length) {
+                    return t.append('operations.merge.conflicting_tags_details',
+                        { keys: actionDisabled.keys.join(', ') });
+                }
             }
             return t.append('operations.merge.' + disabled);
         }

--- a/test/spec/actions/join.js
+++ b/test/spec/actions/join.js
@@ -267,7 +267,7 @@ describe('iD.actionJoin', function () {
                 new iD.osmWay({id: '=', nodes: ['b', 'c'], tags: {highway: 'secondary'}})
             ]);
 
-            expect(iD.actionJoin(['-', '=']).disabled(graph)).to.equal('conflicting_tags');
+            expect(iD.actionJoin(['-', '=']).disabled(graph)).to.deep.include({ type: 'conflicting_tags' });
         });
 
         it('takes tag reversals into account when calculating conflicts', function () {
@@ -619,7 +619,7 @@ describe('iD.actionJoin', function () {
             new iD.osmWay({ id: '-', nodes: ['a', 'b'], tags: { highway: 'steps', step_count: 'many' } }),
             new iD.osmWay({ id: '=', nodes: ['b', 'c'], tags: { highway: 'steps', step_count: '10' } })
         ]);
-        expect(iD.actionJoin(['-', '=']).disabled(graph)).to.equal('conflicting_tags');
+        expect(iD.actionJoin(['-', '=']).disabled(graph)).to.deep.include({ type: 'conflicting_tags' });
     });
 
     it('returns conflicting_tags when the second way has a non-numeric summable tag', function () {
@@ -630,7 +630,7 @@ describe('iD.actionJoin', function () {
             new iD.osmWay({ id: '-', nodes: ['a', 'b'], tags: { highway: 'steps', step_count: '10' } }),
             new iD.osmWay({ id: '=', nodes: ['b', 'c'], tags: { highway: 'steps', step_count: 'bbb' } })
         ]);
-        expect(iD.actionJoin(['-', '=']).disabled(graph)).to.equal('conflicting_tags');
+        expect(iD.actionJoin(['-', '=']).disabled(graph)).to.deep.include({ type: 'conflicting_tags' });
     });
 
     it('returns conflicting_tags when both ways have non-numeric summable tags', function () {
@@ -641,7 +641,7 @@ describe('iD.actionJoin', function () {
             new iD.osmWay({ id: '-', nodes: ['a', 'b'], tags: { highway: 'steps', step_count: 'many' } }),
             new iD.osmWay({ id: '=', nodes: ['b', 'c'], tags: { highway: 'steps', step_count: 'lots' } })
         ]);
-        expect(iD.actionJoin(['-', '=']).disabled(graph)).to.equal('conflicting_tags');
+        expect(iD.actionJoin(['-', '=']).disabled(graph)).to.deep.include({ type: 'conflicting_tags' });
     });
 
 


### PR DESCRIPTION
Fixes #11406 
When merging ways, tags are checked to see if a conflict exists. The tool tip did not give hints on which tags were conflicting. Now the conflicting tags are listed in the conflicting tag merge operation tool tip.

**Before**
"These features can't be merged because some of their tags have conflicting values."

**After**
"These features can't be merged because some of their tags have conflicting values: natural, surface"

Example screenshot:
<img width="1030" height="804" alt="Screenshot 2026-05-21 at 4 27 20 pm" src="https://github.com/user-attachments/assets/1d674384-6c92-4406-be94-fef69164bdf5" />