### PR TITLE
Render cyclist waiting aid side arrow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 
 #### :sparkles: Usability & Accessibility
 * Make tags like `contact:instagram` clickable if they contain a plain username, or a full URL ([#12306], thanks [@k-yle])
+* Render the `side` arrow of cyclist waiting aid features ([#12374], thanks [@RudyTheDev])
 #### :scissors: Operations
 #### :camera: Street-Level
 * Add high-resolution toggle for Mapilio photo viewer ([#12353], thanks [@sezerbozbiyik])
@@ -69,6 +70,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#12321]: https://github.com/openstreetmap/iD/pull/12321
 [#12337]: https://github.com/openstreetmap/iD/issues/12337
 [#12353]: https://github.com/openstreetmap/iD/pull/12353
+[#12374]: https://github.com/openstreetmap/iD/pull/12374
 
 
 # 2.40.0

--- a/modules/osm/node.js
+++ b/modules/osm/node.js
@@ -97,18 +97,17 @@ const prototype = {
         } else {
             // generic side tag
 
-            // unfortunately, the proposal for highway=cyclist_waiting_aid used
-            // an ambiguous definition for `side`, which basically makes the tag
-            // useless in the situation where the parent way (the cycleway) is
-            // bidirectional. It's impossible for software to determine which
-            // direction the mapper is referring to…
-            const hideSideTag = (
+            // for `highway=cyclist_waiting_aid`, `side` (i.e. from cyclist's perspective) will be ambiguous
+            // unless the `direction` is explicitly specified (even on one-way roads).
+            const isSideTagAmbiguous = (
                 this.tags.highway === 'cyclist_waiting_aid' &&
-                resolver.parentWays(this).some(way => !way.isOneWayForwards())
+                this.tags.side !== 'both' &&
+                this.tags.direction !== 'forward' &&
+                this.tags.direction !== 'backward'
             );
 
             const sideTag = SIDE_TAGS.map(key => this.tags[key]).find(Boolean);
-            if (SIDES.has(sideTag?.toLowerCase()) && !hideSideTag) {
+            if (SIDES.has(sideTag?.toLowerCase()) && !isSideTagAmbiguous) {
                 rawValues.push({
                     type: 'side',
                     value: sideTag?.toLowerCase(),
@@ -196,6 +195,12 @@ const prototype = {
 
                 const isSide = type === 'side' && SIDES.has(v);
 
+                // In case of `highway=cyclist_waiting_aid`, if the `side` is to be shown, then
+                // it will be explicitly specified by the `direction` from the cyclist's perspective (not way's perspective)
+                const isSideFlipped = isSide &&
+                    this.tags.highway === 'cyclist_waiting_aid' &&
+                    this.tags.direction === 'backward';
+
                 // string direction - inspect parent ways
                 const lookBackward =
                     (this.tags['traffic_sign:backward'] || v === (isSide ? 'left' : 'backward') || v === 'both' || v === 'all');
@@ -212,7 +217,7 @@ const prototype = {
                     // +90 because geoAngle returns angle from X axis, not Y (north)
                     results.push({
                         type: isSide ? 'side' : 'direction',
-                        angle: (geoAngle(this, resolver.entity(nodeId), projection) * (180 / Math.PI)) + (isSide ? 0 : 90)
+                        angle: (geoAngle(this, resolver.entity(nodeId), projection) * (180 / Math.PI)) + (isSide ? (isSideFlipped ? 180 : 0) : 90)
                     });
                 }, this);
             }


### PR DESCRIPTION
This PR allows the side arrow to render for cyclist waiting aids when unambiguous, i.e. `direction` is given:

<img alt="cwa side cases" src="https://github.com/user-attachments/assets/ec0e24ce-ba37-499f-97f6-aceae2b4d137" />

This makes mapping the `side` less confusing, especially since waiting aids use a different meaning of "side".

Original PR where rendering exception occurred #10303. Some relevant side-related comments and discussion at #10128. In short: the proposal used a non-standard meaning of `side`; it could've been changed, but wasn't; now waiting aids have unique meaning of `side`.

---

The [comment in code](https://github.com/openstreetmap/iD/commit/0a351fa93f1736b39ba193bbc0eafd28d14365dc#diff-9e0fb29b62a2af32e56479f07a425bdd4995d191046479b79b7cd797b838c8d9L100) previously implied that it is impossible to determine the side arrow because the proposal's use of `side` is ambiguous. However, that is not technically correct. The `side` here means "relative to cyclist" (unlike other features where it is "relative to way"). So it is not ambiguous if the direction of the waiting aid is known. This is basically what this PR implements - if the `direction` is known, then the `side` is not ambiguous, therefore the arrow can be rendered. The caveat is to flip it around if the `direction=backward`. The way's actual direction is ignored/irrelevant.

The code previously also assumed that this wouldn't be ambiguous for one-way ways - but it is actually ambiguous in those cases too (e.g. road with `oneway=yes`, `oneway:bicycle=no` and waiting aid in the "opposite" direction). In fact, the code always showed the side arrow based on the way's direction, regardless if the `direction` was actually set, leading to a case where it would be wrong:

<img alt="cwa side on oneway wrong" src="https://github.com/user-attachments/assets/80d9639b-38b3-4944-babf-2f876c298e0b" />

Thankfully, this would only be wrong in that specific rare condition, so I doubt there is any significant number of mistagged features due to this.

I think the intent here was that iD could use way directionality like it does for other features that use `side`, but that assumption doesn't really work. Like, the meaning of `side` is not wrong for waiting aids - it's different. Anyway, I removed this way "sidedness" assumption based on the way being one-way. I think it's best that the mapper just specifies `direction` in those rare cases so nothing has to be assumed. I don't think iD should hard-code (any more) assumptions.

Also, technically the case where `side=both` is also unambiguous, because `direction` doesn't matter - it's both sides however you look at it. So I included this case too (although the preset doesn't even show that option). There are apparently cases like that, e.g. [example](https://www.openstreetmap.org/node/11932470578) - [mapillary](https://www.mapillary.com/app/?pKey=1287710125863818&focus=photo). So it will render `side=both` pretty much always:

<img alt="cwa both sided" src="https://github.com/user-attachments/assets/f47cdf6a-e24f-4f9c-8b10-ee9173fb098b" />

No LLM code used in this one.