### PR TITLE
fix: node misplacement when clicking quickly after zooming

### DIFF
--- a/modules/behavior/draw.js
+++ b/modules/behavior/draw.js
@@ -68,7 +68,7 @@ export function behaviorDraw(context) {
             id: d3_event.pointerId || 'mouse',
             pointerLocGetter: pointerLocGetter,
             downTime: +new Date(),
-            downLoc: pointerLocGetter(d3_event)
+            downLoc: context.map().mouse(d3_event) || pointerLocGetter(d3_event)
         };
 
         dispatch.call('down', this, d3_event, datum(d3_event));
@@ -86,7 +86,7 @@ export function behaviorDraw(context) {
         if (downPointer.isCancelled) return;
 
         var t2 = +new Date();
-        var p2 = downPointer.pointerLocGetter(d3_event);
+        var p2 = context.map().mouse(d3_event) || downPointer.pointerLocGetter(d3_event);
         var dist = geoVecLength(downPointer.downLoc, p2);
 
         if (dist < _closeTolerance ||
@@ -111,7 +111,7 @@ export function behaviorDraw(context) {
         if (_downPointer &&
             _downPointer.id === (d3_event.pointerId || 'mouse') &&
             !_downPointer.isCancelled) {
-            var p2 = _downPointer.pointerLocGetter(d3_event);
+            var p2 = context.map().mouse(d3_event) || _downPointer.pointerLocGetter(d3_event);
             var dist = geoVecLength(_downPointer.downLoc, p2);
             if (dist >= _closeTolerance) {
                 _downPointer.isCancelled = true;


### PR DESCRIPTION
Fixes #9156 

## Problem
When zooming in or out, quickly clicking to place a node would position
it far from where the user actually clicked.

## Fix
Replaced `pointerLocGetter(d3_event)` calls with
`context.map().mouse(d3_event)` in `pointerdown`, `pointerup`, and
`pointermove`. 

`map.mouse()` uses `_getMouseCoords`, a closure over
`supersurface`'s base bounding rect captured once at startup (before
any CSS transform), which stays permanently consistent with
`projection.invert()` regardless of any in-flight zoom transforms.
The original `pointerLocGetter` is kept as a fallback.

Video preview of the fix : 

https://github.com/user-attachments/assets/a3e871fc-f470-4c8d-862a-6c51f59fe9f2

