### PR TITLE
render embankments and cuttings with triangle markers

### DIFF
--- a/css/50_misc.css
+++ b/css/50_misc.css
@@ -360,30 +360,6 @@ path.line.casing.tag-location-underwater {
 }
 
 
-/* embankments / cuttings */
-path.line.shadow.tag-embankment,
-path.line.shadow.tag-cutting {
-    stroke-width: 28;
-}
-path.line.casing.tag-embankment,
-path.line.casing.tag-cutting {
-    stroke-opacity: 0.5;
-    stroke: #000;
-    stroke-width: 22;
-    stroke-dasharray: 2, 4;
-    stroke-linecap: butt;
-}
-
-.low-zoom path.line.shadow.tag-embankment,
-.low-zoom path.line.shadow.tag-cutting {
-    stroke-width: 14;
-}
-.low-zoom path.line.casing.tag-embankment,
-.low-zoom path.line.casing.tag-cutting {
-    stroke-width: 10;
-}
-
-
 /* Surface - unpaved */
 path.line.casing.tag-unpaved {
     stroke: #ccc;

--- a/css/50_misc.css
+++ b/css/50_misc.css
@@ -360,6 +360,20 @@ path.line.casing.tag-location-underwater {
 }
 
 
+/* embankments / cuttings */
+/* see also #ideditor-sided-marker-embankment */
+path.line.stroke.tag-man_made-embankment {
+    stroke: #444;
+    stroke-width: 2px;
+}
+path.line.casing.tag-man_made-embankment {
+    stroke: rgba(200, 200, 200, 0.75);
+    stroke-linecap: butt;
+    stroke-dasharray: none;
+    stroke-width: 2.5px;
+}
+
+
 /* Surface - unpaved */
 path.line.casing.tag-unpaved {
     stroke: #ccc;

--- a/modules/osm/tags.ts
+++ b/modules/osm/tags.ts
@@ -271,7 +271,20 @@ export const osmSemipavedTags: TagDictionary<boolean> = {
     }
 };
 
-export const osmRightSideIsInsideTags: TagDictionary<true | string> = {
+/**
+ * `true` means that the right side of the way is representing the "interesting"
+ * side of the feature, e.g.:
+ *   - the face of a cliff
+ *   - the steep side of a retaining wall
+ *   - the road side of a kerb
+ *   - the downstream side of a weir
+ * strings indicate special cases:
+ *   - coastlines have the land on the right hand side, but we want to mark the ocean
+ *   - guard rails have the road on the right, but we use dedicated markers that represent the posts of the guard rail
+ *   - embankments can be on either or (typically) both sides of a road  or railway
+ *   - cuttings (see embankments, and they also) use inverted triangles as markers
+ */
+export const osmSidednessTags: TagDictionary<true | string> = {
     'natural': {
         'cliff': true,
         'coastline': 'coastline'
@@ -288,7 +301,20 @@ export const osmRightSideIsInsideTags: TagDictionary<true | string> = {
     },
     'waterway': {
         'weir': true
-    }
+    },
+    'cutting': {
+        'yes': 'cutting',
+        'both': 'cutting',
+        'left': 'cutting-left',
+        'right': 'cutting-right'
+    },
+    'embankment': {
+        'yes': 'embankment',
+        'dyke': 'embankment',
+        'both': 'embankment',
+        'left': 'embankment-left',
+        'right': 'embankment-right'
+    },
 };
 
 // "highway" tag values for pedestrian or vehicle right-of-ways that make up the routable network

--- a/modules/osm/tags.ts
+++ b/modules/osm/tags.ts
@@ -296,7 +296,7 @@ export const osmSidednessTags: TagDictionary<true | string> = {
         'city_wall': true,
     },
     'man_made': {
-        'embankment': true,
+        'embankment': 'embankment-man_made',
         'quay': true
     },
     'waterway': {

--- a/modules/osm/way.js
+++ b/modules/osm/way.js
@@ -3,7 +3,7 @@ import { geoArea as d3_geoArea } from 'd3-geo';
 import { geoExtent, geoVecCross } from '../geo';
 import { osmEntity } from './entity';
 import { osmLanes } from './lanes';
-import { osmTagSuggestingArea, osmRightSideIsInsideTags, osmRemoveLifecyclePrefix, osmOneWayBiDirectionalTags, osmOneWayBackwardTags, osmOneWayForwardTags, osmOneWayTags } from './tags';
+import { osmTagSuggestingArea, osmSidednessTags, osmRemoveLifecyclePrefix, osmOneWayBiDirectionalTags, osmOneWayBackwardTags, osmOneWayForwardTags, osmOneWayTags } from './tags';
 import { utilArrayUniq, utilCheckTagDictionary } from '../util';
 import { osmIdManager } from './id_manager';
 
@@ -176,15 +176,15 @@ const prototype = {
         for (const realKey in this.tags) {
             const value = this.tags[realKey];
             const key = osmRemoveLifecyclePrefix(realKey);
-            if (key in osmRightSideIsInsideTags && (value in osmRightSideIsInsideTags[key])) {
-                if (osmRightSideIsInsideTags[key][value] === true) {
+            if (key in osmSidednessTags && (value in osmSidednessTags[key])) {
+                if (osmSidednessTags[key][value] === true) {
                     return key;
                 } else {
                     // if the map's value is something other than a
                     // literal true, we should use it so we can
                     // special case some keys (e.g. natural=coastline
                     // is handled differently to other naturals).
-                    return osmRightSideIsInsideTags[key][value];
+                    return osmSidednessTags[key][value];
                 }
             }
         }

--- a/modules/svg/defs.js
+++ b/modules/svg/defs.js
@@ -52,6 +52,11 @@ export function svgDefs(context) {
 
 
         function addSidedMarker(name, color, offset, style) {
+            const path = {
+                circle: 'M 0,0.5 a 0.5,0.5 0 1,0 1,0 a 0.5,0.5 0 1,0 -1,0',
+                mirrored: 'M 0,1 l 1,-1 l 1,1 z',
+                default: 'M 0,0 l 1,1 l 1,-1 z'
+            }[style || 'default'];
             _defsSelection
                 .append('marker')
                 .attr('id', 'ideditor-sided-marker-' + name)
@@ -64,9 +69,7 @@ export function svgDefs(context) {
                 .attr('orient', 'auto')
                 .append('path')
                 .attr('class', 'sided-marker-path sided-marker-' + name + '-path')
-                .attr('d', style === 'circle'
-                    ? 'M 0,0.5 a 0.5,0.5 0 1,0 1,0 a 0.5,0.5 0 1,0 -1,0'
-                    : 'M 0,0 L 1,1 L 2,0 z')
+                .attr('d', path)
                 .attr('stroke', 'none')
                 .attr('fill', color);
         }
@@ -83,6 +86,36 @@ export function svgDefs(context) {
         // marker on opposite side, circles instead of triangles
         addSidedMarker('guard_rail', '#ddd', -1.5, 'circle');
         addSidedMarker('man_made', '#fff', 0);
+        function addBothSidedMarker(name, color, offset) {
+            let mirror = false;
+            if (offset < 0) {
+                offset = Math.abs(offset);
+                mirror = true;
+            }
+            _defsSelection
+                .append('marker')
+                .attr('id', 'ideditor-sided-marker-' + name)
+                .attr('viewBox', `0,-${1+offset}, 2,${2*(1+offset)}`)
+                .attr('refX', 1)
+                .attr('refY', 0)
+                .attr('markerWidth', 1.5)
+                .attr('markerHeight', 1.5 * (2 + offset))
+                .attr('markerUnits', 'strokeWidth')
+                .attr('orient', 'auto')
+                .append('path')
+                .attr('class', 'sided-marker-path sided-marker-' + name + '-path')
+                .attr('d', mirror
+                    ? `M 0,${-offset-1} l 1,1 l 1,-1 z M 0,${1+offset} l 1,-1 l 1,1 z`
+                    : `M 0,${offset} l 1,1 l 1,-1 z M 0,${-offset} l 1,-1 l 1,1 z`)
+                .attr('stroke', 'none')
+                .attr('fill', color);
+        }
+        addBothSidedMarker('embankment', '#444', 1.5);
+        addBothSidedMarker('cutting', '#444', -1.5);
+        addSidedMarker('embankment-right', '#444', 1.5);
+        addSidedMarker('embankment-left', '#444', -2.5, 'mirrored');
+        addSidedMarker('cutting-right', '#444', 1.5, 'mirrored');
+        addSidedMarker('cutting-left', '#444', -2.5);
 
         _defsSelection
             .append('marker')

--- a/modules/svg/defs.js
+++ b/modules/svg/defs.js
@@ -51,18 +51,18 @@ export function svgDefs(context) {
         addOnewayMarker('gray', '#eee'); // for railway lines
 
 
-        function addSidedMarker(name, color, offset, style) {
+        function addSidedMarker(name, options) {
             const path = {
                 circle: 'M 0,0.5 a 0.5,0.5 0 1,0 1,0 a 0.5,0.5 0 1,0 -1,0',
                 mirrored: 'M 0,1 l 1,-1 l 1,1 z',
                 default: 'M 0,0 l 1,1 l 1,-1 z'
-            }[style || 'default'];
+            }[options.style || 'default'];
             _defsSelection
                 .append('marker')
                 .attr('id', 'ideditor-sided-marker-' + name)
                 .attr('viewBox', '0 0 2 2')
                 .attr('refX', 1)
-                .attr('refY', -offset)
+                .attr('refY', -options.offset)
                 .attr('markerWidth', 1.5)
                 .attr('markerHeight', 1.5)
                 .attr('markerUnits', 'strokeWidth')
@@ -70,52 +70,59 @@ export function svgDefs(context) {
                 .append('path')
                 .attr('class', 'sided-marker-path sided-marker-' + name + '-path')
                 .attr('d', path)
-                .attr('stroke', 'none')
-                .attr('fill', color);
+                .attr('stroke', options.strokeColor || 'none')
+                .attr('stroke-width', options.strokeColor ? 0.1 : 0)
+                .attr('fill', options.color);
         }
-        addSidedMarker('natural', 'rgb(170, 170, 170)', 0);
+        addSidedMarker('natural', { color: 'rgb(170, 170, 170)', offset: 0 });
         // for a coastline, the arrows are (somewhat unintuitively) on
         // the water side, so let's color them blue (with a gap) to
         // give a stronger indication
-        addSidedMarker('coastline', '#77dede', 1);
-        addSidedMarker('waterway', '#77dede', 1);
+        addSidedMarker('coastline', { color: '#77dede', offset: 1 });
+        addSidedMarker('waterway', { color: '#77dede', offset: 1 });
         // barriers have a dashed line, and separating the triangle
         // from the line visually suits that
-        addSidedMarker('barrier', '#ddd', 1);
+        addSidedMarker('barrier', { color: '#ddd', offset: 1 });
         // dedicated style for guard rails (#9594):
         // marker on opposite side, circles instead of triangles
-        addSidedMarker('guard_rail', '#ddd', -1.5, 'circle');
-        addSidedMarker('man_made', '#fff', 0);
-        function addBothSidedMarker(name, color, offset) {
+        addSidedMarker('guard_rail', { color: '#ddd', offset: -1.5, style: 'circle' });
+        addSidedMarker('man_made', { color: '#fff', offset: 0 });
+        function addBothSidedMarker(name, options) {
             let mirror = false;
-            if (offset < 0) {
-                offset = Math.abs(offset);
+            if (options.offset < 0) {
+                options.offset = Math.abs(options.offset);
                 mirror = true;
             }
             _defsSelection
                 .append('marker')
                 .attr('id', 'ideditor-sided-marker-' + name)
-                .attr('viewBox', `0,-${1+offset}, 2,${2*(1+offset)}`)
+                .attr('viewBox', `0,-${1+options.offset}, 2,${2*(1+options.offset)}`)
                 .attr('refX', 1)
                 .attr('refY', 0)
                 .attr('markerWidth', 1.5)
-                .attr('markerHeight', 1.5 * (2 + offset))
+                .attr('markerHeight', 1.5 * (2 + options.offset))
                 .attr('markerUnits', 'strokeWidth')
                 .attr('orient', 'auto')
                 .append('path')
                 .attr('class', 'sided-marker-path sided-marker-' + name + '-path')
                 .attr('d', mirror
-                    ? `M 0,${-offset-1} l 1,1 l 1,-1 z M 0,${1+offset} l 1,-1 l 1,1 z`
-                    : `M 0,${offset} l 1,1 l 1,-1 z M 0,${-offset} l 1,-1 l 1,1 z`)
-                .attr('stroke', 'none')
-                .attr('fill', color);
+                    ? `M 0,${-options.offset-1} l 1,1 l 1,-1 z M 0,${1+options.offset} l 1,-1 l 1,1 z`
+                    : `M 0,${options.offset} l 1,1 l 1,-1 z M 0,${-options.offset} l 1,-1 l 1,1 z`)
+                .attr('stroke', options.strokeColor || 'none')
+                .attr('stroke-width', options.strokeColor ? 0.1 : 0)
+                .attr('fill', options.color);
         }
-        addBothSidedMarker('embankment', '#444', 1.5);
-        addBothSidedMarker('cutting', '#444', -1.5);
-        addSidedMarker('embankment-right', '#444', 1.5);
-        addSidedMarker('embankment-left', '#444', -2.5, 'mirrored');
-        addSidedMarker('cutting-right', '#444', 1.5, 'mirrored');
-        addSidedMarker('cutting-left', '#444', -2.5);
+        const embankmentColors = {
+            color: '#444',
+            strokeColor: 'rgba(200, 200, 200, 0.75)'
+        };
+        addBothSidedMarker('embankment', { ...embankmentColors, offset: 1.5 });
+        addSidedMarker('embankment-right', { ...embankmentColors, offset: 1.5 });
+        addSidedMarker('embankment-left', { ...embankmentColors, offset: -2.5, style: 'mirrored' });
+        addSidedMarker('embankment-man_made', { ...embankmentColors, offset: 1 });
+        addBothSidedMarker('cutting', { ...embankmentColors, offset: -1.5 });
+        addSidedMarker('cutting-right', { ...embankmentColors, offset: 1.5, style: 'mirrored' });
+        addSidedMarker('cutting-left', { ...embankmentColors, offset: -2.5 });
 
         _defsSelection
             .append('marker')

--- a/modules/svg/defs.js
+++ b/modules/svg/defs.js
@@ -113,8 +113,8 @@ export function svgDefs(context) {
                 .attr('fill', options.color);
         }
         const embankmentColors = {
-            color: '#444',
-            strokeColor: 'rgba(200, 200, 200, 0.75)'
+            strokeColor: '#444',
+            color: 'rgba(200, 200, 200, 0.75)'
         };
         addBothSidedMarker('embankment', { ...embankmentColors, offset: 1.5 });
         addSidedMarker('embankment-right', { ...embankmentColors, offset: 1.5 });

--- a/modules/svg/tag_classes.js
+++ b/modules/svg/tag_classes.js
@@ -11,7 +11,7 @@ export function svgTagClasses() {
     ];
     const statuses = Object.keys(osmLifecyclePrefixes);
     const secondaries = [
-        'oneway', 'bridge', 'tunnel', 'embankment', 'cutting', 'barrier',
+        'oneway', 'bridge', 'tunnel', 'barrier',
         'surface', 'tracktype', 'footway', 'crossing', 'service', 'sport',
         'public_transport', 'location', 'parking', 'golf', 'type', 'leisure',
         'man_made', 'indoor', 'construction', 'proposed', 'bicycle', 'foot'

--- a/test/spec/osm/way.js
+++ b/test/spec/osm/way.js
@@ -357,7 +357,7 @@ describe('iD.osmWay', function() {
             expect(new iD.osmWay({tags: { barrier: 'kerb' }}).sidednessIdentifier()).to.eql('barrier');
             expect(new iD.osmWay({tags: { barrier: 'guard_rail' }}).sidednessIdentifier()).to.eql('guard_rail');
             expect(new iD.osmWay({tags: { barrier: 'city_wall' }}).sidednessIdentifier()).to.eql('barrier');
-            expect(new iD.osmWay({tags: { man_made: 'embankment' }}).sidednessIdentifier()).to.eql('man_made');
+            expect(new iD.osmWay({tags: { man_made: 'quay' }}).sidednessIdentifier()).to.eql('man_made');
             expect(new iD.osmWay({tags: { 'abandoned:barrier': 'retaining_wall' }}).sidednessIdentifier()).to.eql('barrier');
         });
 

--- a/test/spec/svg/lines.js
+++ b/test/spec/svg/lines.js
@@ -192,7 +192,7 @@ describe('iD.svgLines', function () {
             var i_n = new iD.osmWay({id: 'implied-natural', tags: {natural: 'cliff'}, nodes: [a.id, b.id]});
             var i_nc = new iD.osmWay({id: 'implied-coastline', tags: {natural: 'coastline'}, nodes: [a.id, c.id]});
             var i_b = new iD.osmWay({id: 'implied-barrier', tags: {barrier: 'city_wall'}, nodes: [a.id, d.id]});
-            var i_mm = new iD.osmWay({id: 'implied-man_made', tags: {man_made: 'embankment'}, nodes: [b.id, c.id]});
+            var i_mm = new iD.osmWay({id: 'implied-man_made', tags: {man_made: 'quay'}, nodes: [b.id, c.id]});
 
             var graph = new iD.coreGraph([a, b, c, d, i_n, i_nc, i_b, i_mm]);
 


### PR DESCRIPTION
Using the same markers as cliffs, coastlines, retaining walls, etc. which intuitively indicate the "downward/outside" direction of the respective features. This replaces using wide casings to indicate embankments and cuttings, which are arguably unintuitive for this property and also applied somewhat inconsistently as they can be influenced by casing properties coming from other tags (e.g. dashing of unpaved roads)

In addition, this also supports single-sided embankments/cuttings, which are used to map cases where e.g. a road mapped as a dual carriageway that share a common embankment.

### Examples (before/after):

#### complex intersection

<img width="360" src="https://github.com/user-attachments/assets/1c89a273-85f2-4c7d-89a0-bb47a313c449" />
<img width="360" src="https://github.com/user-attachments/assets/0f2bd128-9ad9-46c6-95c3-daf6a8aad34e" />

#### section of road has `surface=unpaved`

<img width="260" src="https://github.com/user-attachments/assets/884311f4-b7be-4711-b55c-8e0b0758972f" />
<img width="260" src="https://github.com/user-attachments/assets/811978f6-72ed-407f-8709-bb0ffb0c5fa0" />

#### cycle/foot paths

<img width="360" src="https://github.com/user-attachments/assets/05c64cef-968e-486a-bf5c-5ddaeda8eaba" />
<img width="360" src="https://github.com/user-attachments/assets/f9203d2b-68a5-4d27-95ec-f25446c5bd3f" />
