### PR TITLE
delete `field.overrideLabel`

### DIFF
--- a/modules/presets/field.js
+++ b/modules/presets/field.js
@@ -39,10 +39,8 @@ export function presetField(fieldID, field, allFields) {
     return _this;
   };
 
-  _this.title = () => _this.overrideLabel || _this.resolveReference('label').t('label', { 'default': fieldID });
-  _this.label = () => _this.overrideLabel ?
-      selection => selection.text(_this.overrideLabel) :
-      _this.resolveReference('label').t.append('label', { 'default': fieldID });
+  _this.title = () => _this.resolveReference('label').t('label', { 'default': fieldID });
+  _this.label = () => _this.resolveReference('label').t.append('label', { 'default': fieldID });
 
   _this.placeholder = () => _this.resolveReference('placeholder').t('placeholder', { 'default': '' });
 

--- a/test/spec/presets/index.js
+++ b/test/spec/presets/index.js
@@ -365,7 +365,6 @@ describe('iD.presetIndex', function () {
                 '2161a712': {
                     'key': 'building',
                     'label': 'Building',
-                    'overrideLabel': 'Building',
                     'type': 'text'
                 }
             }


### PR DESCRIPTION
it seems to be dead code. there are no other search results in [org:openstreetmap](https://github.com/search?q=org%3Aopenstreetmap%20overrideLabel&type=code), [org:osmlab](https://github.com/search?q=org%3Aosmlab%20overrideLabel&type=code), [org:ideditor](https://github.com/search?q=org%3Aideditor%20overrideLabel&type=code), [org:rapideditor](https://github.com/search?q=org%3Arapideditor%20overrideLabel&type=code). so i think this can be safely deleted