### PR TITLE
Warn about traffic calming on crossing ways

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1646,6 +1646,12 @@ en:
       title: Mismatched Geometry
       tip: "Find features with conflicting tags and geometry"
       reference: Most features are limited to certain geometry types.
+    misplaced_tag:
+      title: Misplaced Tags
+      tip: "Find tags that belong on a different feature"
+      traffic_calming_on_crossing_way:
+        message: "{feature} has traffic calming tags"
+        reference: "Traffic calming affects vehicle traffic. To map a raised crossing, add traffic_calming to the crossing point or the main road, not the crossing way."
     missing_role:
       title: Missing Roles
       message: "{member} has no role within {relation}"

--- a/modules/core/validator.js
+++ b/modules/core/validator.js
@@ -349,7 +349,7 @@ export function coreValidator(context) {
   validator.getSharedEntityIssues = (entityIDs, options) => {
     const orderedIssueTypes = [                 // Show some issue types in a particular order:
       'missing_tag', 'missing_role',            // - missing data first
-      'outdated_tags', 'mismatched_geometry',   // - identity issues
+      'outdated_tags', 'mismatched_geometry', 'misplaced_tag',   // - identity issues
       'crossing_ways', 'almost_junction',       // - geometry issues where fixing them might solve connectivity issues
       'disconnected_way', 'impossible_oneway'   // - finally connectivity issues
     ];

--- a/modules/validations/index.js
+++ b/modules/validations/index.js
@@ -8,6 +8,7 @@ export { validationImpossibleOneway } from './impossible_oneway';
 export { validationIncompatibleSource } from './incompatible_source';
 export { validationMaprules } from './maprules';
 export { validationMismatchedGeometry } from './mismatched_geometry';
+export { validationMisplacedTag } from './misplaced_tag';
 export { validationMissingRole } from './missing_role';
 export { validationMissingTag } from './missing_tag';
 export { validationMutuallyExclusiveTags } from './mutually_exclusive_tags';

--- a/modules/validations/misplaced_tag.js
+++ b/modules/validations/misplaced_tag.js
@@ -1,0 +1,64 @@
+import { actionChangeTags } from '../actions/change_tags';
+import { t } from '../core/localizer';
+import { utilDisplayLabel } from '../util/utilDisplayLabel';
+import { validationIssue, validationIssueFix } from '../core/validation';
+
+
+export function validationMisplacedTag() {
+    var type = 'misplaced_tag';
+
+    function isCrossingWay(entity) {
+        return entity.type === 'way' && (
+            entity.tags.footway === 'crossing' ||
+            entity.tags.cycleway === 'crossing' ||
+            entity.tags.path === 'crossing'
+        );
+    }
+
+    var validation = function checkMisplacedTag(entity /*, graph */) {
+        if (!isCrossingWay(entity) || !entity.tags.traffic_calming) return [];
+
+        return [new validationIssue({
+            type: type,
+            subtype: 'traffic_calming_on_crossing_way',
+            severity: 'warning',
+            message: function(context) {
+                var entity = context.hasEntity(this.entityIds[0]);
+                return entity ? t.append('issues.misplaced_tag.traffic_calming_on_crossing_way.message', {
+                    feature: utilDisplayLabel(entity, context.graph())
+                }) : '';
+            },
+            reference: showReference,
+            entityIds: [entity.id],
+            dynamicFixes: function() {
+                return [new validationIssueFix({
+                    icon: 'iD-operation-delete',
+                    title: t.append('issues.fix.remove_named_tag.title', { tag: 'traffic_calming' }),
+                    onClick: function(context) {
+                        var entityId = this.issue.entityIds[0];
+                        var entity = context.entity(entityId);
+                        var tags = Object.assign({}, entity.tags);  // shallow copy
+                        delete tags.traffic_calming;
+                        context.perform(
+                            actionChangeTags(entityId, tags),
+                            t('issues.fix.remove_named_tag.annotation', { tag: 'traffic_calming' })
+                        );
+                    }
+                })];
+            }
+        })];
+    };
+
+    validation.type = type;
+
+    return validation;
+
+    function showReference(selection) {
+        selection.selectAll('.issue-reference')
+            .data([0])
+            .enter()
+            .append('div')
+            .attr('class', 'issue-reference')
+            .call(t.append('issues.misplaced_tag.traffic_calming_on_crossing_way.reference'));
+    }
+}

--- a/test/spec/validations/misplaced_tag.js
+++ b/test/spec/validations/misplaced_tag.js
@@ -1,0 +1,85 @@
+describe('iD.validations.misplaced_tag', function () {
+    var graph;
+
+    beforeEach(function() {
+        graph = new iD.coreGraph();
+    });
+
+    function createWay(tags) {
+        var n1 = new iD.osmNode({id: 'n-1', loc: [4,4]});
+        var n2 = new iD.osmNode({id: 'n-2', loc: [4,5]});
+        var w = new iD.osmWay({id: 'w-1', nodes: ['n-1', 'n-2'], tags: tags});
+
+        graph = new iD.coreGraph([n1, n2, w]);
+    }
+
+    function validate() {
+        var validator = iD.validationMisplacedTag();
+        var entities = Object.values(graph.base().entities);
+        var issues = [];
+        entities.forEach(function(entity) {
+            issues = issues.concat(validator(entity, graph));
+        });
+        return issues;
+    }
+
+    function contextStub() {
+        return {
+            entity: function(entityId) { return graph.entity(entityId); },
+            graph: function() { return graph; },
+            hasEntity: function(entityId) { return graph.hasEntity(entityId); },
+            perform: function(action) { graph = action(graph); }
+        };
+    }
+
+    it('has no errors on init', function() {
+        var issues = validate();
+        expect(issues).to.have.lengthOf(0);
+    });
+
+    it('flags traffic_calming on footway=crossing ways', function() {
+        createWay({ highway: 'footway', footway: 'crossing', traffic_calming: 'table' });
+        var issues = validate();
+        expect(issues).to.have.lengthOf(1);
+        expect(issues[0].type).to.eql('misplaced_tag');
+        expect(issues[0].subtype).to.eql('traffic_calming_on_crossing_way');
+        expect(issues[0].severity).to.eql('warning');
+        expect(issues[0].entityIds).to.eql(['w-1']);
+    });
+
+    it('flags traffic_calming on cycleway=crossing ways', function() {
+        createWay({ highway: 'cycleway', cycleway: 'crossing', traffic_calming: 'table' });
+        var issues = validate();
+        expect(issues).to.have.lengthOf(1);
+        expect(issues[0].type).to.eql('misplaced_tag');
+    });
+
+    it('flags traffic_calming on path=crossing ways', function() {
+        createWay({ highway: 'path', path: 'crossing', traffic_calming: 'table' });
+        var issues = validate();
+        expect(issues).to.have.lengthOf(1);
+        expect(issues[0].type).to.eql('misplaced_tag');
+    });
+
+    it('ignores crossing ways without traffic_calming', function() {
+        createWay({ highway: 'footway', footway: 'crossing' });
+        var issues = validate();
+        expect(issues).to.have.lengthOf(0);
+    });
+
+    it('ignores traffic_calming on roads', function() {
+        createWay({ highway: 'residential', traffic_calming: 'table' });
+        var issues = validate();
+        expect(issues).to.have.lengthOf(0);
+    });
+
+    it('removes traffic_calming from the crossing way', function() {
+        createWay({ highway: 'footway', footway: 'crossing', traffic_calming: 'table' });
+        var issue = validate()[0];
+        var fixes = issue.dynamicFixes();
+        expect(fixes).to.have.lengthOf(1);
+
+        fixes[0].onClick.call({ issue: issue }, contextStub());
+        expect(graph.entity('w-1').tags).to.eql({ highway: 'footway', footway: 'crossing' });
+    });
+});


### PR DESCRIPTION
### Description, Motivation & Context

This adds an iD validation warning for crossing ways tagged with `traffic_calming=*`.

The new warning triggers on ways tagged as crossing ways, specifically:
- `footway=crossing`
- `cycleway=crossing`
- `path=crossing`

when they also have `traffic_calming=*`.

The warning explains that traffic calming affects vehicle traffic and that raised crossings should be mapped by placing `traffic_calming` on the crossing point or the main road, not on the crossing way. It also offers a one-click fix to remove `traffic_calming` from the crossing way.

This complements openstreetmap/id-tagging-schema#2314, which keeps the raised crossing field on `highway=crossing` node presets but removes it from crossing way presets.

### Evidence

The OSM Wiki documents `highway=crossing` as a node and includes `traffic_calming=table` in the raised crossing example for that crossing node:
- https://wiki.openstreetmap.org/wiki/Tag:highway%3Dcrossing

The `traffic_calming` key is defined as measures on roads for slowing down or reducing motor-vehicle traffic:
- https://wiki.openstreetmap.org/wiki/Key:traffic_calming

Separately mapped crossing ways such as `footway=crossing` represent the pedestrian/cycle/path crossing geometry:
- https://wiki.openstreetmap.org/wiki/Tag:footway%3Dcrossing

Relevant Taginfo snapshot from `data_until=2026-06-08T01:00:00Z`:
- `traffic_calming=table`: 311,461 total objects: 244,458 nodes, 67,002 ways, 1 relation. https://taginfo.openstreetmap.org/api/4/tag/stats?key=traffic_calming&value=table
- `traffic_calming=table` + `highway=crossing` on nodes: 110,850 nodes. https://taginfo.openstreetmap.org/api/4/tag/combinations?key=traffic_calming&value=table&filter=nodes&query=highway
- `traffic_calming=table` + `footway=crossing` on ways: 24,924 ways. https://taginfo.openstreetmap.org/api/4/tag/combinations?key=traffic_calming&value=table&filter=ways&query=footway
- `traffic_calming=table` + `cycleway=crossing` on ways: 2,611 ways. https://taginfo.openstreetmap.org/api/4/tag/combinations?key=traffic_calming&value=table&filter=ways&query=cycleway

Taginfo combination stats are pairwise co-occurrence stats, so they do not express more complex triple conditions such as `highway=footway` + `footway=crossing` + `traffic_calming=table`.

### Testing

- `npm run lint -- --quiet` passed.
- `npm run test:once -- test/spec/validations/misplaced_tag.js` passed.
- `npm test` did not complete on my laptop because many existing tests that initialize `coreContext` fail with `SyntaxError: "undefined" is not valid JSON` in `history.migrateHistoryData` while parsing localStorage-backed saved history. The same failure pattern reproduced in existing validation specs unrelated to this change. The new focused spec avoids full `coreContext` initialization and passes cleanly.
- Verified working in preview environment:
<img width="744" height="340" alt="image" src="https://github.com/user-attachments/assets/39feb681-5a77-4bc0-9831-ea291b2d8c71" />


### Disclosure

Generated with GPT-5.5 with human oversight.
