### PR TITLE
Copy crossing island tag to crossing nodes

### DIFF
--- a/modules/validations/crossing_ways.js
+++ b/modules/validations/crossing_ways.js
@@ -168,10 +168,13 @@ export function validationCrossingWays(context) {
                         return {};
                     }
                     if (['marked', 'unmarked', 'traffic_signals', 'uncontrolled'].indexOf(pathFeature.tags.crossing) !== -1) {
-                        // if the path is a crossing, match the crossing type and markings
+                        // if the path is a crossing, match the crossing type and details
                         var tags = { highway: 'crossing', crossing: pathFeature.tags.crossing };
                         if ('crossing:markings' in pathFeature.tags) {
                             tags['crossing:markings'] = pathFeature.tags['crossing:markings'];
+                        }
+                        if ('crossing:island' in pathFeature.tags) {
+                            tags['crossing:island'] = pathFeature.tags['crossing:island'];
                         }
                         return tags;
                     }

--- a/test/spec/validations/crossing_ways.js
+++ b/test/spec/validations/crossing_ways.js
@@ -315,8 +315,13 @@ describe('iD.validations.crossing_ways', function () {
         verifySingleCrossingIssue(validate(), { highway: 'crossing', crossing: 'marked', 'crossing:markings': 'zebra' });
     });
 
-    it('does not copy `crossing` and `crossing:markings` if the `crossing` tag has an unknown value', function() {
-        createWaysWithOneCrossingPoint({ highway: 'residential' }, { highway: 'footway', crossing: 'zebra', 'crossing:markings': 'zebra' });
+    it('copies over `crossing:island`', function() {
+        createWaysWithOneCrossingPoint({ highway: 'residential' }, { highway: 'footway', crossing: 'marked', 'crossing:island': 'yes' });
+        verifySingleCrossingIssue(validate(), { highway: 'crossing', crossing: 'marked', 'crossing:island': 'yes' });
+    });
+
+    it('does not copy `crossing`, `crossing:markings`, and `crossing:island` if the `crossing` tag has an unknown value', function() {
+        createWaysWithOneCrossingPoint({ highway: 'residential' }, { highway: 'footway', crossing: 'zebra', 'crossing:markings': 'zebra', 'crossing:island': 'yes' });
         verifySingleCrossingIssue(validate(), { highway: 'crossing' });
     });
 


### PR DESCRIPTION
### Description, Motivation & Context

When iD detects a road/path crossing and suggests creating a missing crossing node, it already copies known crossing details from the crossing way to the generated `highway=crossing` node. This currently includes the crossing type and `crossing:markings`.

This extends that behavior to also copy `crossing:island` from the crossing way to the generated crossing node.

This keeps refuge island information with the crossing node when iD automatically creates or repairs the crossing point, matching the existing behavior for crossing markings.

### Testing

- `npm run lint -- --quiet` passed.
- `npm run test:once -- test/spec/validations/crossing_ways.js` passed its assertions: `83 passed`, including the new `crossing:island` test.
- That focused spec still emitted the same unhandled `SyntaxError: "undefined" is not valid JSON` errors from `history.migrateHistoryData` during `coreContext` setup on my laptop. This matches the baseline local test issue seen in unrelated existing specs.
- Verified in preview environment: correctly copies crossing island tag over
<img width="760" height="146" alt="image" src="https://github.com/user-attachments/assets/a1877fb0-b675-4784-a94f-358d3167afbc" />


### Disclosure

Generated with GPT-5.5 with human oversight.
