### PR TITLE
migrate geoExtent to TS

### DIFF
--- a/modules/geo/extent.ts
+++ b/modules/geo/extent.ts
@@ -1,28 +1,60 @@
 import { geoMetersToLat, geoMetersToLon } from './geo';
+import type { Vec2, Vec4 } from './vector';
 
-/** @import { Vec2 } from './vector' */
+export interface BBox {
+    minX: number;
+    minY: number;
+    maxX: number;
+    maxY: number;
+}
 
-/**
- * @param {geoExtent | Vec2 | [Vec2, Vec2]} [min]
- * @param {Vec2} [max]
- */
-export function geoExtent(min, max) {
+declare class geoExtent extends Array<Vec2> {
+    constructor(min?: geoExtent | Vec2 | [Vec2, Vec2], max?: Vec2)
+    equals(obj: geoExtent): boolean;
+    extend(obj: geoExtent | Vec2 | [Vec2, Vec2]): geoExtent;
+    _extend(obj: geoExtent): void;
+    area(): number;
+    center(): Vec2;
+    rectangle(): Vec4;
+    bbox(): BBox;
+    polygon(): Vec2[];
+    contains(other: geoExtent | Vec2 | [Vec2, Vec2]): boolean;
+    intersects(other: geoExtent | Vec2 | [Vec2, Vec2]): boolean;
+    intersection(other: geoExtent | [Vec2, Vec2]): geoExtent;
+    percentContainedIn(other: geoExtent | Vec2 | [Vec2, Vec2]): number;
+    padByMeters(metres: number): geoExtent;
+    toParam(): string;
+    split(): [geoExtent, geoExtent, geoExtent, geoExtent]
+}
+
+function isVec2Tuple(value: Vec2 | [Vec2, Vec2] | undefined): value is [Vec2, Vec2] {
+    return (
+        Array.isArray(value) &&
+        value.length === 2 &&
+        Array.isArray(value[0]) &&
+        value[0].length === 2 &&
+        Array.isArray(value[1]) &&
+        value[1].length === 2
+    );
+}
+
+function geoExtent(this: unknown, min?: geoExtent | Vec2 | [Vec2, Vec2], max?: Vec2) {
     if (!(this instanceof geoExtent)) {
         return new geoExtent(min, max);
     } else if (min instanceof geoExtent) {
-        return /** @type {geoExtent} */ (min);
-    } else if (min && min.length === 2 && min[0].length === 2 && min[1].length === 2) {
-        this[0] = /** @type {Vec2} */ (min[0]);
-        this[1] = /** @type {Vec2} */ (min[1]);
+        return min;
+    } else if (isVec2Tuple(min)) {
+        this[0] = min[0];
+        this[1] = min[1];
     } else {
-        this[0] = /** @type {Vec2} */ (min        || [ Infinity,  Infinity]);
-        this[1] = /** @type {Vec2} */ (max || min || [-Infinity, -Infinity]);
+        this[0] = min        || [ Infinity,  Infinity];
+        this[1] = max || min || [-Infinity, -Infinity];
     }
+    return this;
 }
 
-geoExtent.prototype = new Array(2);
+geoExtent.prototype = <geoExtent> new Array(2);
 
-    /** @param {geoExtent} obj */
     geoExtent.prototype.equals = function (obj) {
         return this[0][0] === obj[0][0] &&
             this[0][1] === obj[0][1] &&
@@ -31,7 +63,6 @@ geoExtent.prototype = new Array(2);
     };
 
 
-    /** @param {geoExtent | Vec2 | [Vec2, Vec2]} obj */
     geoExtent.prototype.extend = function(obj) {
         if (!(obj instanceof geoExtent)) obj = new geoExtent(obj);
         return geoExtent(
@@ -41,7 +72,6 @@ geoExtent.prototype = new Array(2);
     };
 
 
-    /** @param {geoExtent} extent */
     geoExtent.prototype._extend = function(extent) {
         this[0][0] = Math.min(extent[0][0], this[0][0]);
         this[0][1] = Math.min(extent[0][1], this[0][1]);
@@ -55,7 +85,6 @@ geoExtent.prototype = new Array(2);
     };
 
 
-    /** @returns {Vec2} */
     geoExtent.prototype.center = function() {
         return [(this[0][0] + this[1][0]) / 2, (this[0][1] + this[1][1]) / 2];
     };
@@ -71,7 +100,6 @@ geoExtent.prototype = new Array(2);
     };
 
 
-    /** @returns {Vec2[]} */
     geoExtent.prototype.polygon = function() {
         return [
             [this[0][0], this[0][1]],
@@ -83,7 +111,6 @@ geoExtent.prototype = new Array(2);
     };
 
 
-    /** @param {geoExtent | Vec2 | [Vec2, Vec2]} obj */
     geoExtent.prototype.contains = function(obj) {
         if (!(obj instanceof geoExtent)) obj = new geoExtent(obj);
         return obj[0][0] >= this[0][0] &&
@@ -93,7 +120,6 @@ geoExtent.prototype = new Array(2);
     };
 
 
-    /** @param {geoExtent | Vec2 | [Vec2, Vec2]} obj */
     geoExtent.prototype.intersects = function(obj) {
         if (!(obj instanceof geoExtent)) obj = new geoExtent(obj);
         return obj[0][0] <= this[1][0] &&
@@ -103,7 +129,6 @@ geoExtent.prototype = new Array(2);
     };
 
 
-    /** @param {geoExtent | [Vec2, Vec2]} obj */
     geoExtent.prototype.intersection = function(obj) {
         if (!this.intersects(obj)) return new geoExtent();
         return new geoExtent(
@@ -113,7 +138,6 @@ geoExtent.prototype = new Array(2);
     };
 
 
-    /** @param {geoExtent | Vec2 | [Vec2, Vec2]} obj */
     geoExtent.prototype.percentContainedIn = function(obj) {
         if (!(obj instanceof geoExtent)) obj = new geoExtent(obj);
         var a1 = this.intersection(obj).area();
@@ -132,7 +156,6 @@ geoExtent.prototype = new Array(2);
     };
 
 
-    /** @param {number} meters */
     geoExtent.prototype.padByMeters = function(meters) {
         var dLat = geoMetersToLat(meters);
         var dLon = geoMetersToLon(meters, this.center()[1]);
@@ -156,3 +179,5 @@ geoExtent.prototype = new Array(2);
             geoExtent([this[0][0], center[1]], [center[0], this[1][1]])
         ];
     };
+
+export { geoExtent };

--- a/modules/geo/vector.ts
+++ b/modules/geo/vector.ts
@@ -1,5 +1,6 @@
 export type Vec2 = [x: number, y: number];
 export type Vec3 = [x: number, y: number, z: number];
+export type Vec4 = [a: number, b: number, c: number, d: number];
 
 // vector equals
 export function geoVecEqual(a: Vec2, b: Vec2, epsilon?: number) {


### PR DESCRIPTION
I finally found a proper solution for this file, which removes the weird JSDoc syntax added in #11654

This unblocks #12089, by removing the JSDoc hack that TypeScript is dropping support for