### PR TITLE
provide change event on hash behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :hammer: Development
 * Remove redundant software dependencies to reduce the amount of the code that is bundled with iD ([#11634], [#12307], thanks [@k-yle])
 * Update name-suggestion-index to v7.2 ([#12337], thanks [@bjornstar])
+* Introduce location hash `change` events ([#12429])
 
 [#8848]: https://github.com/openstreetmap/iD/issues/8848
 [#11634]: https://github.com/openstreetmap/iD/pull/11634
@@ -73,6 +74,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#12353]: https://github.com/openstreetmap/iD/pull/12353
 [#12374]: https://github.com/openstreetmap/iD/pull/12374
 [#12386]: https://github.com/openstreetmap/iD/pull/12386
+[#12429]: https://github.com/openstreetmap/iD/pull/12429
 
 
 # 2.40.0

--- a/modules/behavior/hash.js
+++ b/modules/behavior/hash.js
@@ -1,15 +1,19 @@
 import { throttle } from 'es-toolkit';
 
 import { select as d3_select } from 'd3-selection';
+import { dispatch as d3_dispatch } from 'd3-dispatch';
 
 import { geoSphericalDistance } from '../geo';
 import { modeBrowse } from '../modes/browse';
 import { modeSelect, modeSelectNote } from '../modes';
-import { utilQsString, utilStringQs } from '../util';
+import { utilQsString, utilRebind, utilStringQs } from '../util';
 import { utilArrayIdentical } from '../util/array';
 import { utilDisplayLabel } from '../util/utilDisplayLabel';
 import { localizer, t } from '../core/localizer';
 import { prefs } from '../core/preferences';
+
+
+const dispatch = d3_dispatch('change');
 
 function getNewHash(arg) {
     const original = utilStringQs(window.location.hash);
@@ -44,9 +48,13 @@ export function patchHash(updater) {
     // though unavoidably creating a browser history entry
     window.history.replaceState(null, '', latestHash);
 
+    // trigger change event
+    dispatch.call('change');
+
     // save last used map location for future
     const { map } = utilStringQs(latestHash);
     if (map) prefs('map-location', map);
+
     return true;
 }
 
@@ -260,5 +268,5 @@ export function behaviorHash(context) {
         window.location.hash = '';
     };
 
-    return behavior;
+    return utilRebind(behavior, dispatch, 'on');
 }

--- a/test/spec/behavior/hash.js
+++ b/test/spec/behavior/hash.js
@@ -1,4 +1,5 @@
 import { setTimeout } from 'node:timers/promises';
+import { fn } from '@vitest/spy';
 
 describe('iD.behaviorHash', function () {
 
@@ -80,10 +81,23 @@ describe('iD.behaviorHash', function () {
 
     it('accepts default changeset comment as hash parameter', function () {
         window.location.hash = '#comment=foo+bar%20%2B1';
-        var container = d3.select(document.createElement('div'));
-        context = iD.coreContext().assetPath('../dist/').init().container(container);
+        const container = d3.select(document.createElement('div'));
+        const context = iD.coreContext().assetPath('../dist/').init().container(container);
         iD.behaviorHash(context);
         expect(context.defaultChangesetComment()).to.eql('foo bar +1');
-        hash.off();
+    });
+
+    it('dispatches a (throttled) change event', async () => {
+        await setTimeout(100); // wait a bit to let previous tests settle down
+        const spy = fn();
+        hash();
+        hash.on('change', spy);
+        context.map().center([45.98, 7.66]);
+        await setTimeout(10);
+        // too little time passed -> no event yet
+        expect(spy).to.have.not.been.called;
+        await setTimeout(600);
+        // enough time has passed -> event should have been triggered
+        expect(spy).to.have.been.called;
     });
 });


### PR DESCRIPTION
closes #12426, unblocks https://github.com/openstreetmap/openstreetmap-website/pull/6811

@hlfan: on the osm website, this should allow you to hook into it as follows:

```js
id.ui().hash.on("change.embed", function() {
```