### PR TITLE
show titles and descriptions when searching for wikidata items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Make tags like `contact:instagram` clickable if they contain a plain username, or a full URL ([#12306], thanks [@k-yle])
 * Show suggestions in combobox dropdown also when the entered text contains a few typos ([#8802])
 * Render the `side` arrow of cyclist waiting aid features ([#12374], thanks [@RudyTheDev])
+* Show titles and descriptions when searching for wikidata items ([#12436], thanks [@k-yle])
+
 #### :scissors: Operations
 #### :camera: Street-Level
 * Add high-resolution toggle for Mapilio photo viewer ([#12353], thanks [@sezerbozbiyik])
@@ -85,6 +87,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#12374]: https://github.com/openstreetmap/iD/pull/12374
 [#12386]: https://github.com/openstreetmap/iD/pull/12386
 [#12429]: https://github.com/openstreetmap/iD/pull/12429
+[#12436]: https://github.com/openstreetmap/iD/pull/12436
 [@FloEdelmann]: https://github.com/FloEdelmann
 
 

--- a/modules/ui/fields/wikidata.js
+++ b/modules/ui/fields/wikidata.js
@@ -162,7 +162,7 @@ export function uiFieldWikidata(field, context) {
                         .attr('lang', item.display.label.language)
                         .text(item.display.label.value),
                     description: item.display.description && item.display.description.value,
-                    title: item.aliases,
+                    title: item.aliases.join(', '),
                     terms: item.aliases
                 };
             });

--- a/modules/ui/fields/wikidata.js
+++ b/modules/ui/fields/wikidata.js
@@ -161,7 +161,8 @@ export function uiFieldWikidata(field, context) {
                         .attr('class', 'localized-text')
                         .attr('lang', item.display.label.language)
                         .text(item.display.label.value),
-                    title: item.display.description && item.display.description.value,
+                    description: item.display.description && item.display.description.value,
+                    title: item.aliases,
                     terms: item.aliases
                 };
             });


### PR DESCRIPTION
I know #11876 is controversial, but i think it would be super helpful for the `*:wikidata` fields, where it's common to have many results with the same name.

<table>
<tr>
<td>Before</td>
<td>After</td>
</tr>
<tr>
<td><img width="368" height="332" alt="image" src="https://github.com/user-attachments/assets/601e857e-09b5-4a00-b530-fc1f702161f3" /></td>
<td><img width="381" height="496" alt="image" src="https://github.com/user-attachments/assets/4c553fb3-e68d-49d8-a5c6-276863475c28" /></td>
</tr>
</table>

The same cannot be done for the `wikipedia=*` input field, due to API limitations, see [phab:T241437](https://phabricator.wikimedia.org/T241437) for context.