### PR TITLE
show field label (or tag key) in invalid URL validation message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,12 +41,15 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :scissors: Operations
 #### :camera: Street-Level
 #### :white_check_mark: Validation
+* Show which field (or tag) produced an _invalid URL_ validation message ([#12449])
 #### :bug: Bugfixes
 #### :earth_asia: Localization
 #### :hourglass: Performance
 #### :mortar_board: Walkthrough / Help
 #### :rocket: Presets
 #### :hammer: Development
+
+[#12449]: https://github.com/openstreetmap/iD/pull/12449
 
 
 # 2.41.0

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1637,8 +1637,8 @@ en:
         message_multi: '{feature} has multiple invalid email addresses'
         reference: 'Email addresses must look like "user@example.com".'
       website:
-        message: '{feature} has an invalid URL'
-        message_multi: '{feature} has multiple invalid URLs'
+        message: '{feature} has an invalid URL in {where}'
+        message_multi: '{feature} has multiple invalid URLs in {where}'
         reference: 'URLs must start with "http://" or "https://".'
       wikimedia_commons:
         message: '{feature} has a suspicious Wikimedia Commons tag'

--- a/modules/validations/invalid_format.js
+++ b/modules/validations/invalid_format.js
@@ -4,10 +4,10 @@ import { validationIssue, validationIssueFix } from '../core/validation';
 import { actionChangeTags } from '../actions/change_tags';
 import { osmUrlKeys } from '../osm/tags';
 import { showTagDiffReference } from './outdated_tags';
-import { utilTagDiff } from '../util';
-import { utilIsValidURL as isValidURL } from '../util/util';
+import { utilTagDiff, utilIsValidURL as isValidURL } from '../util/util';
+import { presetManager } from '../presets';
 
-export function validationFormatting() {
+export function validationFormatting(context) {
     var type = 'invalid_format';
 
     var validation = function(entity) {
@@ -64,14 +64,18 @@ export function validationFormatting() {
                 .call(t.append('issues.invalid_format.website.reference'));
         }
 
-        const websiteValidationIssueBase = {
+        const createWebsiteValidationIssueBase = keyOrField => ({
             type: type,
             subtype: 'website',
             severity: 'warning',
             message: function(context) {
                 const entity = context.hasEntity(this.entityIds[0]);
-                return entity ? t.append('issues.invalid_format.website.message' + (this.data?.count > 1 ? '_multi' : ''),
-                    { feature: utilDisplayLabel(entity, context.graph()), site: this.data?.value }) : '';
+                return entity ? t.append('issues.invalid_format.website.message' + (this.data?.count > 1 ? '_multi' : ''), {
+                    feature: utilDisplayLabel(entity, context.graph()), site: this.data?.value,
+                    where: typeof keyOrField === 'string'
+                        ? selection => selection.append('code').text(keyOrField)
+                        : keyOrField.label()
+                }) : '';
             },
             dynamicFixes: function(context) {
                 if (this.data?.count > 1) return [];
@@ -97,7 +101,7 @@ export function validationFormatting() {
                     }));
             },
             entityIds: [entity.id]
-        };
+        });
 
         function websiteReferenceWithDiff(oldTags, newTags) {
             return selection => showTagDiffReference(
@@ -124,8 +128,17 @@ export function validationFormatting() {
                 .map(s => s.trim())
                 .map(s => isValidURL(s) || !isFixableURL(s) ? s : `{protocol}://${s}`)
                 .join(';');
+            const graph = context.graph();
+            const entityExtent = entity.extent(graph);
+            const preset = presetManager.match(entity, graph);
+            const allFields = [
+                ...preset.fields(entityExtent.center()),
+                ...preset.moreFields(entityExtent.center()),
+                ...presetManager.universal()
+            ];
+            let keyOrField = allFields.find(f => f.key === key || f.keys?.includes(key)) || key;
             return {
-                ...websiteValidationIssueBase,
+                ...createWebsiteValidationIssueBase(keyOrField),
                 data: {
                     key,
                     isFixable,
@@ -247,8 +260,9 @@ export function validationFormatting() {
                     severity: 'warning',
                     message: function(context) {
                         var entity = context.hasEntity(this.entityIds[0]);
-                        return entity ? t.append('issues.invalid_format.email.message' + this.data,
-                            { feature: utilDisplayLabel(entity, context.graph()), email: emails.join(', ') }) : '';
+                        return entity ? t.append('issues.invalid_format.email.message' + this.data, {
+                            feature: utilDisplayLabel(entity, context.graph()), email: emails.join(', ')
+                        }) : '';
                     },
                     reference: showReferenceEmail,
                     entityIds: [entity.id],


### PR DESCRIPTION
addresses another point raised in #12366: sometimes, the tag diff is not available to indicate which tag is actually causing an _invalid URL_ warning (e.g. when the value does not look like a URL at all, or there are multiple invalid URLs in the semicolon-separated tag value). This shows the field name (or tag key if no field is rendered for the particular tag) in the message:

<img width="400" src="https://github.com/user-attachments/assets/4317d972-8641-4cfa-a064-e2d4e0b879b1" />
