### PR TITLE
[typescript] make osm id handling symetric, explicit with return types

### DIFF
--- a/modules/osm/id_manager.ts
+++ b/modules/osm/id_manager.ts
@@ -1,4 +1,8 @@
-export type FeatureType = 'node' | 'way' | 'relation';
+export type OsmType = 'node' | 'way' | 'relation';
+/**
+ * Combined internal representation of the OSM type and OSM id of an entity.
+ */
+export type EntityId = string;
 
 /**
  * All newly created features need an ID, so this singleton
@@ -13,29 +17,29 @@ class OsmIdManager {
         relation: -1,
     };
 
-    fromOSM(type: FeatureType, id: number) {
+    fromOSM(type: OsmType, id: number): EntityId {
         return type[0] + id;
     }
 
-    toOSM(id: string) {
+    toOSM(id: EntityId): number {
         var match = id.match(/^[cnwr](-?\d+)$/);
         if (match) {
-            return match[1];
+            return +match[1];
         }
-        return '';
+        return NaN;
     }
 
-    type(id: string) {
-        return <FeatureType>(
+    type(id: EntityId): OsmType {
+        return <OsmType>(
             { c: 'changeset', n: 'node', w: 'way', r: 'relation' }[id[0]]
         );
     }
 
-    key(entity: iD.OsmEntity) {
+    key(entity: iD.OsmEntity): string {
         return entity.id + 'v' + (entity.v || 0);
     }
 
-    newId(type: FeatureType) {
+    newId(type: OsmType): EntityId {
         return this.fromOSM(type, this.next[type]--);
     }
 }

--- a/modules/osm/relation.js
+++ b/modules/osm/relation.js
@@ -6,7 +6,7 @@ import { geoExtent, geoPolygonContainsPolygon, geoPolygonIntersectsPolygon } fro
 import { osmIdManager } from './id_manager';
 
 /**
- * @typedef {{ type: import('./id_manager').FeatureType; id: string; role: string }} RelationMember
+ * @typedef {{ type: import('./id_manager').OsmType; id: string; role: string }} RelationMember
  */
 
 /**


### PR DESCRIPTION
Previously `fromOSM` expected a number for the `id`, but `toOSM` returned a string.

We should be consistently using numbers for the id part wherever it makes sense. This prevents bugs like #12442 which are caused by iD internally sometimes storing the id of a thing as a string, but the OSM API returning it as a number (when using JSON endpoints), which then in turn causes statements like `_note.id === context.selectedNoteID()` to be false just because of mismatching types.