### PR TITLE
Apply a proper intended logic fix for incorrect loop increment variable

### DIFF
--- a/modules/actions/move.js
+++ b/modules/actions/move.js
@@ -327,10 +327,12 @@ export function actionMove(moveIDs, tryDelta, projection, cache) {
             var unmovedPath = unmovedNodes.map(function(n) { return projection(n.loc); });
             var hits = geoPathIntersections(movedPath, unmovedPath);
 
-            for (var j = 0; i < hits.length; i++) {
-                if (geoVecEqual(hits[j], end)) continue;
+            if (hits.length) {
+                // snap delta back to the edge we are attached to, so we only move along the edge,
+                // not away from it since that causes intersection(s)
                 var edge = geoChooseEdge(unmovedNodes, end, projection);
                 _delta = geoVecSubtract(projection(edge.loc), start);
+                break; // any further attempts/intersections will result in the same calculation
             }
         }
     }

--- a/test/spec/actions/move.js
+++ b/test/spec/actions/move.js
@@ -71,4 +71,59 @@ describe('iD.actionMove', function() {
         expect(loc[0]).to.be.closeTo( 1.440, 0.001);
         expect(loc[1]).to.be.closeTo(-2.159, 0.001);
     });
+
+    it('prevents intersections', function() {
+        const epsilon = 1E-6;
+        // Use a simple planar projection so we can reason about intersections in 2D.
+        const planar = p => p;
+        planar.invert = p => p;
+
+        // u3 ------------- u2
+        //                  |
+        //          d       |
+        //          |       |
+        // u0 ----- b ----- u1
+
+        const b = iD.osmNode({ loc: [0, 0] });
+        const d = iD.osmNode({ loc: [0, 8] });
+        const moved = iD.osmWay({ nodes: [b.id, d.id] });
+
+        const u0 = iD.osmNode({ loc: [-10,  0] });
+        const u1 = iD.osmNode({ loc: [ 10,  0] });
+        const u2 = iD.osmNode({ loc: [ 10, 10] });
+        const u3 = iD.osmNode({ loc: [-10, 10] });
+        const unmoved = iD.osmWay({ nodes: [u0.id, b.id, u1.id, u2.id, u3.id] });
+
+        const graph = new iD.coreGraph([
+            b, d, moved,
+            u0, u1, u2, u3, unmoved
+        ]);
+
+        function tryDelta(delta, expectedDelta) {
+            const action = iD.actionMove([moved.id], delta, planar);
+            const result = action(graph);
+
+            const limitedDelta = action.delta();
+
+            expect(limitedDelta[0]).to.be.closeTo(expectedDelta[0], epsilon);
+            expect(limitedDelta[1]).to.be.closeTo(expectedDelta[1], epsilon);
+
+            expect(result.entity(d.id).loc[0]).to.be.closeTo(
+                graph.entity(d.id).loc[0] + expectedDelta[0], epsilon);
+            expect(result.entity(d.id).loc[1]).to.be.closeTo(
+                graph.entity(d.id).loc[1] + expectedDelta[1], epsilon);
+        }
+
+        // small movement: no clamping necessary
+        tryDelta([0, 1], [0, 1]);
+        // small movement, but would intersect other part of unmoved way:
+        // stay snapped to original segment
+        tryDelta([0, 3], [0, 0]);
+        // larger movement: snap to top segment of unmoved way
+        tryDelta([0, 6], [0, 10]);
+        // large movement: move beyond top segment
+        tryDelta([0, 12], [0, 12]);
+        // movement perpendicular: no restrictions
+        tryDelta([6, 0], [6, 0]);
+    });
 });


### PR DESCRIPTION
The original issue report #12128 points out that the inner loop is using the outer loop's counter variable in `move.js`'s `limitDelta` function. The PR fix #12129 indeed corrects this. However the author didn't explain what the observed problem was.

So this is the kind of scenario we are talking about, where a way is connected to another way and we attempt to move it:

<img width="390" height="275" alt="snap1" src="https://github.com/user-attachments/assets/16276c97-af83-4bd0-a8b5-f918e3012f15" />

As we move it without intersecting the attached way, everything is fine:

<img width="390" height="275" alt="snap2" src="https://github.com/user-attachments/assets/768f23d2-ae8a-4e6b-9308-670e32fb412c" />

But as soon as we touch the attached way, the moved way is snapped back to attached way, only preserving movement along the attached way:

<img width="390" height="275" alt="snap3" src="https://github.com/user-attachments/assets/895a6748-540b-4f28-b538-90ab090d3f08" />

Just to emphasize the point, this is one very specific edge case that this whole function is considering. There are tons of ways all of this behaves weirdly that have nothing to do with this function and loop:

<img width="513" height="387" alt="current behaviour" src="https://github.com/user-attachments/assets/42b86f08-e097-47a4-b45e-455859d49a14" />

Anyway, after the fix, the behavior is exactly the same as it was before. I explain this [in the comment on that PR](https://github.com/openstreetmap/iD/pull/12129#issuecomment-4583397670). The short version that the calculation always results in the same delta, regardless what intersections are present. In other words, this method potentially finds the first conflicting intersection (i.e. not a connected point) and if so - snaps back.

It is almost impossible to reproduce this "issue" as a user-facing bug, which is why no one ever saw or reported it. (Since the original issue and PR are all AI slop, the reported "Observe inconsistent or incorrect behavior in how movement is restricted" is nonsense.) The only way to reproduce this would be to have a convoluted synthetic test that will never happen in real-world.

So in essence this PR fixes some redundant sub-optimal looping in the code and makes the code's intention more clear.