### PR TITLE
Enhance OSM API error messages with specific HTTP status handling

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -596,13 +596,13 @@ en:
   osm_api_status:
     message:
       error: Unable to reach the OpenStreetMap API. Your edits are safe locally. Check your network connection.
-      error_400: "Bad Request: The server could not understand your request."
-      error_401: "Unauthorized: Please ensure you are logged in."
-      error_403: "Forbidden: You don't have permission to perform this action."
-      error_404: "Not Found: The requested data could not be found."
-      error_502: "Bad Gateway: The OpenStreetMap API is experiencing issues."
-      error_503: "Service Unavailable: The OpenStreetMap API is temporarily down for maintenance."
-      error_504: "Gateway Timeout: The OpenStreetMap API is taking too long to respond."
+      error_400: "Bad Request: The server could not understand your request. Your edits are safe locally."
+      error_401: "Unauthorized: Please ensure you are logged in. Your edits are safe locally."
+      error_403: "Forbidden: You don't have permission to perform this action. Your edits are safe locally."
+      error_404: "Not Found: The requested data could not be found. Your edits are safe locally."
+      error_502: "Bad Gateway: The OpenStreetMap API is experiencing issues. Your edits are safe locally."
+      error_503: "Service Unavailable: The OpenStreetMap API is temporarily down for maintenance. Your edits are safe locally."
+      error_504: "Gateway Timeout: The OpenStreetMap API is taking too long to respond. Your edits are safe locally."
       offline: The OpenStreetMap API is offline. Your edits are safe locally. Please come back later.
       readonly: The OpenStreetMap API is currently read-only. You can continue editing, but must wait to save your changes.
       rateLimit: The OpenStreetMap API is limiting anonymous connections. You can fix this by logging in.

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -596,6 +596,13 @@ en:
   osm_api_status:
     message:
       error: Unable to reach the OpenStreetMap API. Your edits are safe locally. Check your network connection.
+      error_400: "Bad Request: The server could not understand your request."
+      error_401: "Unauthorized: Please ensure you are logged in."
+      error_403: "Forbidden: You don't have permission to perform this action."
+      error_404: "Not Found: The requested data could not be found."
+      error_502: "Bad Gateway: The OpenStreetMap API is experiencing issues."
+      error_503: "Service Unavailable: The OpenStreetMap API is temporarily down for maintenance."
+      error_504: "Gateway Timeout: The OpenStreetMap API is taking too long to respond."
       offline: The OpenStreetMap API is offline. Your edits are safe locally. Please come back later.
       readonly: The OpenStreetMap API is currently read-only. You can continue editing, but must wait to save your changes.
       rateLimit: The OpenStreetMap API is limiting anonymous connections. You can fix this by logging in.

--- a/modules/ui/status.js
+++ b/modules/ui/status.js
@@ -1,6 +1,6 @@
 import { throttle } from 'es-toolkit';
 
-import { t } from '../core/localizer';
+import { localizer, t } from '../core/localizer';
 import { svgIcon } from '../svg/icon';
 
 
@@ -48,10 +48,13 @@ export function uiStatus(context) {
                         osm.reloadApiStatus();
                     }, 2000);
 
-                    // eslint-disable-next-line no-warning-comments
-                    // TODO: nice messages for different error types
+                    let msgKey = 'osm_api_status.message.error';
+                    if (err && err.status && localizer.hasTextForStringId('osm_api_status.message.error_' + err.status)) {
+                        msgKey = 'osm_api_status.message.error_' + err.status;
+                    }
+
                     selection
-                        .call(t.append('osm_api_status.message.error', { suffix: ' ' }))
+                        .call(t.append(msgKey, { suffix: ' ' }))
                         .append('a')
                         .attr('href', '#')
                         // let the user manually retry their connection directly


### PR DESCRIPTION
## Description
This PR addresses an existing `TODO` in `modules/ui/status.js` regarding the display of nicer error messages based on different error types from the OpenStreetMap API. 

Previously, any non-rate-limited and non-connection-switched error would fall back to a generic "Unable to reach the OpenStreetMap API" message. This update introduces specific, user-friendly localization strings for common HTTP error codes.

## Changes Made
- Added specific HTTP error translations to `data/core.yaml` (e.g., 400 Bad Request, 401 Unauthorized, 403 Forbidden, 404 Not Found, 502 Bad Gateway, 503 Service Unavailable, and 504 Gateway Timeout).
- Imported `localizer` into `modules/ui/status.js`.
- Modified the status update function to check `err.status`. If a specific `error_XXX` localized message exists, it displays that; otherwise, it gracefully falls back to the original generic error message.

### Testing Instructions:
1. Trigger a network failure or mock an API response to return one of the handled HTTP statuses (e.g., 403 or 503).
2. Verify that the application's bottom-right status bar displays the user-friendly specific message instead of the generic one.
