### PR TITLE
remove redundant polyfills

### DIFF
--- a/modules/id.js
+++ b/modules/id.js
@@ -1,7 +1,3 @@
-// polyfill window.fetch and AbortController (not included in core-js)
-import 'whatwg-fetch';
-import 'abortcontroller-polyfill/dist/polyfill-patch-fetch';
-
 // polyfill idle callback functions (not included in core-js)
 window.requestIdleCallback = window.requestIdleCallback ||
     function(cb) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@tmcw/togeojson": "^7.1.2",
         "@turf/bbox": "^7.2.0",
         "@turf/bbox-clip": "^7.2.0",
-        "abortcontroller-polyfill": "^1.7.8",
         "alif-toolkit": "^1.3.0",
         "diacritics": "1.3.0",
         "es-toolkit": "^1.45.0",
@@ -32,7 +31,6 @@
         "pbf": "^5.0.0",
         "polyclip-ts": "^0.16.8",
         "rbush": "4.0.1",
-        "whatwg-fetch": "^3.6.20",
         "which-polygon": "2.2.1"
       },
       "devDependencies": {
@@ -3173,12 +3171,6 @@
       "engines": {
         "node": ">=10.0.0"
       }
-    },
-    "node_modules/abortcontroller-polyfill": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.8.tgz",
-      "integrity": "sha512-9f1iZ2uWh92VcrU9Y8x+LdM4DLj75VE0MJB8zuF1iUnroEptStw+DQ8EQPMUdfe5k+PkB1uUfDQfWbhstH8LrQ==",
-      "license": "MIT"
     },
     "node_modules/acorn": {
       "version": "8.16.0",
@@ -10089,12 +10081,6 @@
       "resolved": "https://registry.npmjs.org/wgs84/-/wgs84-0.0.0.tgz",
       "integrity": "sha512-ANHlY4Rb5kHw40D0NJ6moaVfOCMrp9Gpd1R/AIQYg2ko4/jzcJ+TVXYYF6kXJqQwITvEZP4yEthjM7U6rYlljQ==",
       "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-fetch": {
-      "version": "3.6.20",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
-      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
-      "license": "MIT"
     },
     "node_modules/whatwg-mimetype": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "@tmcw/togeojson": "^7.1.2",
     "@turf/bbox": "^7.2.0",
     "@turf/bbox-clip": "^7.2.0",
-    "abortcontroller-polyfill": "^1.7.8",
     "alif-toolkit": "^1.3.0",
     "diacritics": "1.3.0",
     "es-toolkit": "^1.45.0",
@@ -74,7 +73,6 @@
     "pbf": "^5.0.0",
     "polyclip-ts": "^0.16.8",
     "rbush": "4.0.1",
-    "whatwg-fetch": "^3.6.20",
     "which-polygon": "2.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
[`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch#browser_compatibility) and [`AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController#browser_compatibility) have been supported by all major browsers since 2017 and 2019, respectively. We use many newer features without polyfills, so these can safely be removed