### PR TITLE
fix wrong variable `t` passed to history._act

### DIFF
--- a/modules/operations/circularize.js
+++ b/modules/operations/circularize.js
@@ -132,7 +132,7 @@ export function operationCircularize(context, selectedIDs) {
         let previewGraph = context.graph();
         return _actions.map(action => {
             if (!action.disabled?.(previewGraph)) {
-                previewGraph = action(previewGraph, t);
+                previewGraph = action(previewGraph);
                 if (action.id !== 'circularize') return false;
                 const way = previewGraph.hasEntity(action.getWayId());
                 const getPath = svgPath(context.projection, previewGraph, false);

--- a/modules/operations/orthogonalize.js
+++ b/modules/operations/orthogonalize.js
@@ -121,7 +121,7 @@ export function operationOrthogonalize(context, selectedIDs) {
         const graph = context.graph();
         return _actions.map((action, idx) => {
             if (!action.disabled(graph)) {
-                const previewGraph = action(graph, t);
+                const previewGraph = action(graph);
                 const way = previewGraph.hasEntity(selectedIDs[idx]);
                 const getPath = svgPath(context.projection, previewGraph, false);
                 return {


### PR DESCRIPTION
discovered while testing #12425 against a fork where the entire core is written in TS

---

the variable `t` exists [twice](https://eslint.org/docs/latest/rules/no-shadow) in these files. 

one of the `t` variables referes to the localizer, the other `t` refers to the history's transitionable/tween parameter. 

this line is passing the localizer into `history._act`, which is unintentional. but it has no impact, because this code is just for the `previewGraph`, which is not stored in the history stack.