### PR TITLE
Netlify preview: Add CORS for iD Staging deployments

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,10 @@
+# Netlify custom response headers — https://docs.netlify.com/routing/headers/
+#
+# Staging deploys bundle id-tagging-schema under /id-tagging-schema/dist/.
+# Allow external tools to fetch preset JSON cross-origin from ideditor.netlify.app.
+# Deploy: .github/workflows/staging.yml
+
+[[headers]]
+  for = "/id-tagging-schema/dist/*"
+  [headers.values]
+    Access-Control-Allow-Origin = "*"


### PR DESCRIPTION
This allow to use the tagging-schema-dist as reference in the schema browser and with that to compare a branch against the latest staging/pre-release version. In the iD Community chat we talked about using the `interem` branch but this seems easier.

See also https://github.com/openstreetmap/id-tagging-schema/pull/2412 and prev. https://github.com/openstreetmap/id-tagging-schema/pull/2328

<details><summary>Full LLM Summary on how the id-tagging-schema merge and iD merge both deploy to the same netlify preview…</summary>
<p>


> # Netlify CORS for id-tagging-schema on ideditor.netlify.app
> 
> ## Problem
> 
> Staging builds bundle a fresh copy of id-tagging-schema under `dist/id-tagging-schema/dist/` and deploy it to [ideditor.netlify.app](https://ideditor.netlify.app) via [`staging.yml`](.github/workflows/staging.yml):
> 
> ```37:38:.github/workflows/staging.yml
>       - name: id-tagging-schema - Create directories
>         run: mkdir dist/id-tagging-schema && mv id-tagging-schema/dist dist/id-tagging-schema/dist
> ```
> 
> ```54:58:.github/workflows/staging.yml
>       - name: Deploy to Netlify
>         ...
>         run: npx netlify-cli deploy --no-build --prod --dir=dist
> ```
> 
> External tools (schema browsers, diff viewers, etc.) fetch JSON from URLs like `https://ideditor.netlify.app/id-tagging-schema/dist/presets.min.json`. Without `Access-Control-Allow-Origin`, the browser blocks those cross-origin requests. The npm/jsDelivr copy already sends `*`; the Netlify staging copy does not.
> 
> The iD repo currently has **no** `netlify.toml`.
> 
> ## What to add (iD repo — primary change)
> 
> Create [`netlify.toml`](netlify.toml) at the iD repo root:
> 
> ```toml
> # Netlify custom response headers — https://docs.netlify.com/routing/headers/
> #
> # Staging deploys bundle id-tagging-schema under /id-tagging-schema/dist/.
> # Allow external tools to fetch preset JSON cross-origin from ideditor.netlify.app.
> # Deploy: .github/workflows/staging.yml
> 
> [[headers]]
>   for = "/id-tagging-schema/dist/*"
>   [headers.values]
>     Access-Control-Allow-Origin = "*"
> ```
> 
> **No `staging.yml` changes required.** `npx netlify-cli deploy` reads `netlify.toml` from the working directory (repo root) and applies header rules to the deploy regardless of `--no-build` or `--dir=dist`.
> 
> ## Why id-tagging-schema also needs updating (not truly optional)
> 
> [id-tagging-schema's `staging.yml`](https://github.com/openstreetmap/id-tagging-schema/blob/main/.github/workflows/staging.yml) deploys to the **same** Netlify site (`NETLIFY_SITE_ID`) with `--dir=iD/dist` — the same URL layout (`/id-tagging-schema/dist/*`). It already has a [`netlify.toml`](https://github.com/openstreetmap/id-tagging-schema/blob/main/netlify.toml), but only for PR previews:
> 
> ```toml
> [[headers]]
>   for = "/dist/*"
>   [headers.values]
>     Access-Control-Allow-Origin = "*"
> ```
> 
> Each production deploy replaces the site's Netlify config with the `netlify.toml` from **whichever repo ran the workflow**. If id-tagging-schema deploys after iD, it would drop the `/id-tagging-schema/dist/*` rule unless that file also defines it.
> 
> **Add a second `[[headers]]` block** in id-tagging-schema's `netlify.toml` (keep the existing `/dist/*` rule):
> 
> ```toml
> [[headers]]
>   for = "/id-tagging-schema/dist/*"
>   [headers.values]
>     Access-Control-Allow-Origin = "*"
> ```
> 
> ## Deployment flow (both repos → one site)
> 
> ```mermaid
> flowchart LR
>   subgraph iD_repo [openstreetmap/iD]
>     iD_staging[staging.yml]
>     iD_toml[netlify.toml]
>   end
>   subgraph schema_repo [openstreetmap/id-tagging-schema]
>     schema_staging[staging.yml]
>     schema_toml[netlify.toml]
>   end
>   netlify[ideditor.netlify.app prod]
>   iD_staging -->|"deploy --dir=dist"| netlify
>   schema_staging -->|"deploy --dir=iD/dist"| netlify
>   iD_toml -.->|headers on deploy| netlify
>   schema_toml -.->|headers on deploy| netlify
> ```
> 
> ## Out of scope / no changes needed
> 
> - **[`deploy-pr-preview.yml`](.github/workflows/deploy-pr-preview.yml)** — PR previews deploy `--dir=.` without bundling id-tagging-schema; no `/id-tagging-schema/dist/*` path to protect.
> - **Netlify UI headers** — only needed if you skip `netlify.toml`; the file-in-repo approach is preferred and version-controlled.
> - **iD `staging.yml` CI** — already correct; config travels with the deploy automatically.
> 
> ## Verification after merge
> 
> After the next staging deploy from iD (push to `main` or `develop`):
> 
> ```bash
> curl -sI https://ideditor.netlify.app/id-tagging-schema/dist/presets.min.json | grep -i access-control
> ```
> 
> Expected: `Access-Control-Allow-Origin: *`
> 
> Optionally confirm in browser DevTools: cross-origin `fetch()` from another origin succeeds.
> 

</p>
</details> 