### PR TITLE
add # 12300 to git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -3,3 +3,6 @@
 
 # use the `new` operator to instantiate coreGraph & osmEntity classes (#12151)
 547b60149c1383f93185c1e28173bb48b6f82334
+
+# Install `@vitest/eslint-plugin` (#12300)
+52f577e68c8bab069476a5fe920a9bf86ceaf1e7


### PR DESCRIPTION
now that #12300 is merged, we can add the (squashed) commit hash to this file
