### PR TITLE
migrate the extract action & operation to typescript

### DIFF
--- a/modules/actions/extract.ts
+++ b/modules/actions/extract.ts
@@ -1,13 +1,20 @@
 import { geoPath as d3_geoPath } from 'd3-geo';
 
 import { osmNode } from '../osm/node';
+import type { Action } from '../core/history';
+import type { NodeId, OsmEntity } from '../osm';
+import type { Projection } from '../geo/raw_mercator';
+import type { coreGraph } from '../core';
 
-export function actionExtract(entityID, projection) {
+export interface ActionExtract extends Action<boolean> {
+    getExtractedNodeID(): NodeId;
+}
 
-    var extractedNodeID;
+export function actionExtract(entityID: NodeId, projection: Projection): ActionExtract {
 
-    /** @param {boolean} shiftKeyPressed */
-    var action = function(graph, shiftKeyPressed) {
+    var extractedNodeID: NodeId;
+
+    const action: ActionExtract = function(graph, _t, shiftKeyPressed) {
         var entity = graph.entity(entityID);
 
         if (entity.type === 'node') {
@@ -17,8 +24,7 @@ export function actionExtract(entityID, projection) {
         return extractFromWayOrRelation(entity, graph);
     };
 
-    /** @param {boolean} shiftKeyPressed */
-    function extractFromNode(node, graph, shiftKeyPressed) {
+    function extractFromNode(node: osmNode, graph: coreGraph, shiftKeyPressed: boolean | undefined) {
 
         extractedNodeID = node.id;
 
@@ -42,7 +48,7 @@ export function actionExtract(entityID, projection) {
             }, graph);
     }
 
-    function extractFromWayOrRelation(entity, graph) {
+    function extractFromWayOrRelation(entity: OsmEntity, graph: coreGraph) {
 
         var fromGeometry = entity.geometry(graph);
 
@@ -56,7 +62,7 @@ export function actionExtract(entityID, projection) {
             extractedLoc = entity.extent(graph).center();
         }
 
-        var indoorAreaValues = {
+        var indoorAreaValues: Record<TagValue, boolean> = {
             area: true,
             corridor: true,
             elevator: true,
@@ -69,8 +75,8 @@ export function actionExtract(entityID, projection) {
 
         var isIndoorArea = fromGeometry === 'area' && entity.tags.indoor && indoorAreaValues[entity.tags.indoor];
 
-        var entityTags = Object.assign({}, entity.tags);  // shallow copy
-        var pointTags = {};
+        var entityTags = { ...entity.tags };  // shallow copy
+        var pointTags: Tags = {};
         for (var key in entityTags) {
 
             if (entity.type === 'relation' &&

--- a/modules/core/history.js
+++ b/modules/core/history.js
@@ -15,8 +15,9 @@ import {
 import { osmIdManager } from '../osm';
 
 /**
- * @import { WayId, OsmEntity } from '../osm';
+ * @import { WayId, OsmEntity, EntityId } from '../osm';
  * @import { coreGraph } from './graph';
+ * @import { TRenderLocalizedText } from './localizer';
  * @import { Vec2 } from '../geo/vector';
  * @template [T = never]
  * @typedef {{
@@ -30,6 +31,33 @@ import { osmIdManager } from '../osm';
     useLongAxis?: GetSet<this, boolean>;
     getReflectAxis?(graph: coreGraph): Vec2[];
  }} Action */
+
+/** @typedef {{
+    (event?: KeyboardEvent): void;
+    available(situation: string): boolean | string | undefined;
+    disabled(): false | string;
+    tooltip(): TRenderLocalizedText;
+    annotation(): string;
+    availableForKeypress?(): boolean;
+    icon?(): string;
+    id: string;
+    keys: string[];
+    title: TRenderLocalizedText;
+    behavior?: unknown;
+    mouseOnly?: boolean;
+    relatedEntityIds?(): EntityId[];
+    point?(point: Vec2): unknown;
+    getAuxiliaryGeometry?(): {
+        id: string;
+        path: string;
+        klass: string;
+    }[];
+    interrupts?: {
+        [interruptId: string]: () => Promise<void>;
+    };
+}} Operation */
+
+/** @typedef {(context: iD.Context, selectedIDs: EntityId[]) => Operation} CreateOperation */
 
 
 export function coreHistory(context) {

--- a/modules/core/history.js
+++ b/modules/core/history.js
@@ -17,7 +17,7 @@ import { osmIdManager } from '../osm';
 /**
  * @import { WayId, OsmEntity, EntityId } from '../osm';
  * @import { coreGraph } from './graph';
- * @import { TRenderLocalizedText } from './localizer';
+ * @import { LocalizedTextRenderer } from './localizer';
  * @import { Vec2 } from '../geo/vector';
  * @template [T = never]
  * @typedef {{
@@ -36,13 +36,13 @@ import { osmIdManager } from '../osm';
     (event?: KeyboardEvent): void;
     available(situation: string): boolean | string | undefined;
     disabled(): false | string;
-    tooltip(): TRenderLocalizedText;
+    tooltip(): LocalizedTextRenderer;
     annotation(): string;
     availableForKeypress?(): boolean;
     icon?(): string;
     id: string;
     keys: string[];
-    title: TRenderLocalizedText;
+    title: LocalizedTextRenderer;
     behavior?: unknown;
     mouseOnly?: boolean;
     relatedEntityIds?(): EntityId[];

--- a/modules/core/localizer.js
+++ b/modules/core/localizer.js
@@ -33,7 +33,7 @@ export {
 
 /** @typedef {unknown} Translations */
 
-/** @typedef {any} TRenderLocalizedText */
+/** @typedef {any} LocalizedTextRenderer */
 
 //
 // coreLocalizer manages language and locale parameters including translated strings

--- a/modules/core/localizer.js
+++ b/modules/core/localizer.js
@@ -33,6 +33,8 @@ export {
 
 /** @typedef {unknown} Translations */
 
+/** @typedef {any} TRenderLocalizedText */
+
 //
 // coreLocalizer manages language and locale parameters including translated strings
 //

--- a/modules/globals.d.ts
+++ b/modules/globals.d.ts
@@ -48,6 +48,13 @@ declare global {
         keys<T>(o: T extends Record<infer K, unknown> ? [K] extends [string] ? T : never : never): (keyof T)[];
     }
 
+    // override to make Array#filter(Boolean) work,
+    // from https://github.com/mattpocock/ts-reset
+    type NonFalsy<T> = T extends false | 0 | 0n | '' | null | undefined ? never : T;
+    interface Array<T> {
+        filter<S extends T>(predicate: BooleanConstructor, thisArg?: any): NonFalsy<S>[];
+    }
+
     interface ParentNode extends Node {
         /** used internally by d3 to store the values passed to `.data()` */
         __data__: any;

--- a/modules/operations/extract.ts
+++ b/modules/operations/extract.ts
@@ -4,8 +4,11 @@ import { modeSelect } from '../modes/select';
 import { t } from '../core/localizer';
 import { presetManager } from '../presets';
 import { utilArrayUniq } from '../util/array';
+import type { Action, CreateOperation, Operation } from '../core/history';
+import type { geoExtent } from '../geo';
+import type { NodeId } from '../osm';
 
-export function operationExtract(context, selectedIDs) {
+export const operationExtract: CreateOperation = (context, selectedIDs) => {
 
     var _amount = selectedIDs.length === 1 ? 'single' : 'multiple';
     var _geometries = utilArrayUniq(selectedIDs.map(function(entityID) {
@@ -13,7 +16,7 @@ export function operationExtract(context, selectedIDs) {
     }).filter(Boolean));
     var _geometryID = _geometries.length === 1 ? _geometries[0] : 'feature';
 
-    var _extent;
+    var _extent: geoExtent | undefined;
     var _actions = selectedIDs.map(function(entityID) {
         var graph = context.graph();
         var entity = graph.hasEntity(entityID);
@@ -22,6 +25,7 @@ export function operationExtract(context, selectedIDs) {
         if (entity.type === 'node' && graph.parentWays(entity).length === 0) return null;
 
         if (entity.type !== 'node') {
+            // @ts-expect-error -- will be fixed in a different PR
             var preset = presetManager.match(entity, graph);
             // only allow extraction from ways/relations if the preset supports points
             if (preset.geometry.indexOf('point') === -1) return null;
@@ -29,16 +33,15 @@ export function operationExtract(context, selectedIDs) {
 
         _extent = _extent ? _extent.extend(entity.extent(graph)) : entity.extent(graph);
 
-        return actionExtract(entityID, context.projection);
+        return actionExtract(entityID as NodeId, context.projection);
     }).filter(Boolean);
 
-    /** @param {KeyboardEvent | undefined} d3_event */
-    var operation = function (d3_event) {
+    const operation: Operation = function (d3_event: KeyboardEvent | undefined) {
         const shiftKeyPressed = d3_event?.shiftKey || false;
 
-        var combinedAction = function(graph) {
+        var combinedAction: Action = function(graph) {
             _actions.forEach(function(action) {
-                graph = action(graph, shiftKeyPressed);
+                graph = action(graph, undefined, shiftKeyPressed);
             });
             return graph;
         };
@@ -52,7 +55,7 @@ export function operationExtract(context, selectedIDs) {
 
 
     operation.available = function () {
-        return _actions.length && selectedIDs.length === _actions.length;
+        return !!_actions.length && selectedIDs.length === _actions.length;
     };
 
 
@@ -92,4 +95,4 @@ export function operationExtract(context, selectedIDs) {
 
 
     return operation;
-}
+};

--- a/modules/renderer/map.js
+++ b/modules/renderer/map.js
@@ -981,6 +981,7 @@ export function rendererMap(context) {
     };
 
 
+    /** @type {GetSet<typeof map, geoExtent>} */
     map.extent = function(val) {
         if (!arguments.length) {
             return new geoExtent(

--- a/test/spec/actions/extract.js
+++ b/test/spec/actions/extract.js
@@ -587,7 +587,7 @@ describe('iD.actionExtract', function () {
         });
 
         it('detached node not a member of relation', function () {
-            var assertionGraph = iD.actionExtract('b')(graph, true);
+            var assertionGraph = iD.actionExtract('b')(graph, undefined, true);
 
             var targetNode = assertionGraph.entity('b');
             // Confirm is not a member of the relation
@@ -595,7 +595,7 @@ describe('iD.actionExtract', function () {
         });
 
         it('new node is a member of relation', function () {
-            var assertionGraph = iD.actionExtract('b')(graph, true);
+            var assertionGraph = iD.actionExtract('b')(graph, undefined, true);
 
             // Find the new node
             var targetWay = assertionGraph.entity('-');
@@ -610,7 +610,7 @@ describe('iD.actionExtract', function () {
         });
 
         it('Relation membership has the same properties', function () {
-            var assertionGraph = iD.actionExtract('b')(graph, true);
+            var assertionGraph = iD.actionExtract('b')(graph, undefined, true);
 
             // Find the new node
             var targetWay = assertionGraph.entity('-');


### PR DESCRIPTION
this one is a bit annoying. In #9816, i used the 2nd argument for the new parameter, but it should ideally have been the 3rd argument. 

We want all actions and operations to have the same method signature, so the 2nd argument must be reserved for _`t`_.

This PR:
 - moves `shiftKeyPressed` to the 3rd argument
 - converts both the action and the operation to typescript, in the same PR

I tested the extract option and confirmed that it still works. (1. via <kbd>E</kbd>, 2. via <kbd>↑ Shift</kbd> <kbd>E</kbd>, and 3. via the `mismatched_geometry` validator)