### PR TITLE
Feature/sidebar width (Remember left sidebar width  #12548)

### DIFF
--- a/modules/ui/sidebar.js
+++ b/modules/ui/sidebar.js
@@ -40,10 +40,11 @@ export function uiSidebar(context) {
         var dragOffset;
 
         // Set the initial width constraints
+        var savedWidth = prefs('sidebar-width');
         selection
             .style('min-width', minWidth + 'px')
-            .style('max-width', '400px')
-            .style('width', prefs('sidebar-width') || '33.3333%');
+            .style('max-width', savedWidth ? '85%' : '400px')
+            .style('width', (savedWidth || 33.3333) + '%');
 
         // Restore collapsed state
         if (prefs('sidebar-collapsed') === 'true') {
@@ -156,7 +157,7 @@ export function uiSidebar(context) {
             prefs('sidebar-collapsed', isCollapsed);
             if (!isCollapsed && containerWidth) {
                 var widthPct = (sidebarWidth / containerWidth) * 100;
-                prefs('sidebar-width', widthPct + '%');
+                prefs('sidebar-width', widthPct);
             }
 
             inspectorWrap.call(inspector, { redrawEntityEditor: true });

--- a/modules/ui/sidebar.js
+++ b/modules/ui/sidebar.js
@@ -15,6 +15,7 @@ import { uiInspector } from './inspector';
 import { uiOsmoseEditor } from './osmose_editor';
 import { uiNoteEditor } from './note_editor';
 import { localizer } from '../core/localizer';
+import { prefs } from '../core/preferences';
 
 
 export function uiSidebar(context) {
@@ -42,7 +43,12 @@ export function uiSidebar(context) {
         selection
             .style('min-width', minWidth + 'px')
             .style('max-width', '400px')
-            .style('width', '33.3333%');
+            .style('width', prefs('sidebar-width') || '33.3333%');
+
+        // Restore collapsed state
+        if (prefs('sidebar-collapsed') === 'true') {
+            selection.classed('collapsed', true);
+        }
 
         var resizer = selection
             .append('div')
@@ -144,6 +150,14 @@ export function uiSidebar(context) {
                 .on('touchmove.sidebar-resizer', null)
                 .on(_pointerPrefix + 'move.sidebar-resizer', null)
                 .on(_pointerPrefix + 'up.sidebar-resizer pointercancel.sidebar-resizer', null);
+
+            // Save the current sidebar width and collapsed state
+            var isCollapsed = selection.classed('collapsed');
+            prefs('sidebar-collapsed', isCollapsed);
+            if (!isCollapsed && containerWidth) {
+                var widthPct = (sidebarWidth / containerWidth) * 100;
+                prefs('sidebar-width', widthPct + '%');
+            }
 
             inspectorWrap.call(inspector, { redrawEntityEditor: true });
         }
@@ -400,6 +414,9 @@ export function uiSidebar(context) {
                         // hide the sidebar's content after it transitions offscreen
                         selection.classed('collapsed', isCollapsing);
                     }
+
+                    // Save the collapsed state
+                    prefs('sidebar-collapsed', selection.classed('collapsed'));
 
                     // switch back from px to %
                     if (!isCollapsing) {


### PR DESCRIPTION
Remember left sidebar width
 #12548
The iD editor does not remember the width setting of the left sidebar, unlike other settings such as recently used presets, backgrounds or map features. It would be beneficial when working with long values or relation names.
so i made this to save size locally and work .

Before fix.

https://github.com/user-attachments/assets/a49f9664-9c4b-465e-8614-94bd6f382e78

After fix .
https://github.com/user-attachments/assets/13b73104-59c3-4756-b8a4-1473623d1fc4

