### PR TITLE
fix broken link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -235,7 +235,7 @@ of each new section of documentation should be of the form
 This will be used for navigation and as its title in iD. To add a new piece
 of documentation, simply add to [/data/core.yaml](/data/core.yaml) in the
 same format as the rest, include your new corresponding `docKey` in
-[/modules/ui/help.js](/modules/ui/help.js) and call `npm run build`.
+[/modules/ui/panes/help.js](/modules/ui/panes/help.js) and call `npm run build`.
 
 
 ## Editing Presets or Tagging


### PR DESCRIPTION
`docKey` is still there, though no idea is otherwise this documentation useful and up to date

I verified file move at 

https://github.com/openstreetmap/iD/commits/develop/modules/ui/panes/help.js

https://github.com/openstreetmap/iD/commits/develop/modules/ui/help.js