### PR TITLE
Fix child node selection of ways repeating node selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Fix undo and remove buttons for `multiCombo` fields ([#12406], thanks [@RudyTheDev])
 * Fix a crash when cancelling drawing a line while hovering other features with a `directionalCombo` field ([#12467])
 * Make sure rendering of truncated address labels does not result in broken unicode characters ([#12511], thanks [@greymoth-jp])
+* Do not select start/end vertex of an area or closed way multiple times when selecting all vertices of a way using the keyboard shortcut ([#12586], thanks [@RudyTheDev])
 #### :earth_asia: Localization
 * Improve some edge cases of rendering of mixed right-to-left and left-to-right text ([#8713])
 * When labelling features, match locale codes like `zh-CN` to name tags like `name:zh-Hans` ([#10911], thanks [@k-yle])
@@ -85,6 +86,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#12526]: https://github.com/openstreetmap/iD/issues/12526
 [#12531]: https://github.com/openstreetmap/iD/issues/12531
 [#12561]: https://github.com/openstreetmap/iD/pull/12561
+[#12586]: https://github.com/openstreetmap/iD/pull/12586/
 [@brianstrauch]: https://github.com/brianstrauch
 [@greymoth-jp]: https://github.com/greymoth-jp
 

--- a/modules/modes/select.js
+++ b/modules/modes/select.js
@@ -125,6 +125,8 @@ export function modeSelect(context, selectedIDs) {
                 return [];  // selection includes non-area/non-line
             }
             var currChilds = graph.childNodes(entity).map(function(node) { return node.id; });
+            // De-duplicate to exclude revisited nodes
+            currChilds = [...new Set(currChilds)];
             if (!childs.length) {
                 childs = currChilds;
                 continue;

--- a/modules/modes/select.js
+++ b/modules/modes/select.js
@@ -24,7 +24,8 @@ import * as Operations from '../operations/index';
 import { uiCmd } from '../ui/cmd';
 import {
     utilArrayIntersection, utilArrayUnion, utilDeepMemberSelector, utilEntityOrDeepMemberSelector,
-    utilEntitySelector, utilKeybinding, utilTotalExtent, utilGetAllNodes
+    utilEntitySelector, utilKeybinding, utilTotalExtent, utilGetAllNodes,
+    utilArrayUniq
 } from '../util';
 
 
@@ -125,8 +126,7 @@ export function modeSelect(context, selectedIDs) {
                 return [];  // selection includes non-area/non-line
             }
             var currChilds = graph.childNodes(entity).map(function(node) { return node.id; });
-            // De-duplicate to exclude revisited nodes
-            currChilds = [...new Set(currChilds)];
+            currChilds = utilArrayUniq(currChilds);
             if (!childs.length) {
                 childs = currChilds;
                 continue;

--- a/test/spec/modes/select.js
+++ b/test/spec/modes/select.js
@@ -149,5 +149,55 @@ describe('iD.modeSelect', function() {
 
             expect(context.selectedIDs()).toEqual(['r1']);
         });
+
+        it('selects shared child node when two connected ways are selected', function() {
+            const node1 = new iD.osmNode({id: 'n1', loc: [0, 0]});
+            const node2 = new iD.osmNode({id: 'n2', loc: [1, 1]});
+            const node3 = new iD.osmNode({id: 'n3', loc: [2, 2]});
+            const node4 = new iD.osmNode({id: 'n4', loc: [3, 3]});
+
+            const way1 = new iD.osmWay({id: 'w1', nodes: ['n1', 'n2', 'n3']});
+            const way2 = new iD.osmWay({id: 'w2', nodes: ['n3', 'n4']});
+
+            context.perform(
+                iD.actionAddEntity(node1),
+                iD.actionAddEntity(node2),
+                iD.actionAddEntity(node3),
+                iD.actionAddEntity(node4),
+                iD.actionAddEntity(way1),
+                iD.actionAddEntity(way2)
+            );
+
+            context.enter(iD.modeSelect(context, ['w1', 'w2']));
+
+            document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', ctrlKey: true }));
+
+            expect(context.selectedIDs()).toEqual(['n3']);
+        });
+
+        it('does not affect selection when two independent ways are selected', function() {
+            const node1 = new iD.osmNode({id: 'n1', loc: [0, 0]});
+            const node2 = new iD.osmNode({id: 'n2', loc: [1, 1]});
+            const node3 = new iD.osmNode({id: 'n3', loc: [3, 3]});
+            const node4 = new iD.osmNode({id: 'n4', loc: [4, 4]});
+
+            const way1 = new iD.osmWay({id: 'w1', nodes: ['n1', 'n2']});
+            const way2 = new iD.osmWay({id: 'w2', nodes: ['n3', 'n4']});
+
+            context.perform(
+                iD.actionAddEntity(node1),
+                iD.actionAddEntity(node2),
+                iD.actionAddEntity(node3),
+                iD.actionAddEntity(node4),
+                iD.actionAddEntity(way1),
+                iD.actionAddEntity(way2)
+            );
+
+            context.enter(iD.modeSelect(context, ['w1', 'w2']));
+
+            document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', ctrlKey: true }));
+
+            expect(context.selectedIDs()).toEqual(['w1', 'w2']);
+        });
     });
 });

--- a/test/spec/modes/select.js
+++ b/test/spec/modes/select.js
@@ -1,0 +1,153 @@
+import { select as d3_select } from 'd3-selection';
+
+describe('iD.modeSelect', function() {
+    var context, container;
+
+    beforeEach(function() {
+        container = d3_select('body').append('div');
+        context = iD.coreContext().assetPath('../dist/').init().container(container);
+
+        container
+            .append('div')
+            .attr('class', 'main-map')
+            .call(context.map())
+            .append('div')
+            .attr('class', 'inspector-wrap');
+
+        context.enter(iD.modeBrowse(context));
+    });
+
+    afterEach(function() {
+        context.mode().exit();
+        container.remove();
+    });
+
+    describe('selectChild', function() {
+        it('selects all child nodes when an open way is selected', function() {
+            const node1 = new iD.osmNode({id: 'n1', loc: [0, 0]});
+            const node2 = new iD.osmNode({id: 'n2', loc: [1, 1]});
+            const node3 = new iD.osmNode({id: 'n3', loc: [2, 2]});
+
+            const way = new iD.osmWay({id: 'w1', nodes: ['n1', 'n2', 'n3']});
+
+            context.perform(
+                iD.actionAddEntity(node1),
+                iD.actionAddEntity(node2),
+                iD.actionAddEntity(node3),
+                iD.actionAddEntity(way)
+            );
+
+            context.enter(iD.modeSelect(context, ['w1']));
+
+            document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', ctrlKey: true }));
+
+            expect(context.selectedIDs()).toEqual(['n1', 'n2', 'n3']);
+        });
+
+        it('selects all child nodes when a closed way is selected', function() {
+            const node1 = new iD.osmNode({id: 'n1', loc: [0, 0]});
+            const node2 = new iD.osmNode({id: 'n2', loc: [1, 1]});
+            const node3 = new iD.osmNode({id: 'n3', loc: [2, 2]});
+            const node4 = new iD.osmNode({id: 'n4', loc: [0, 0]});
+
+            const area = new iD.osmWay({id: 'w1', nodes: ['n1', 'n2', 'n3', 'n4', 'n1']});
+
+            context.perform(
+                iD.actionAddEntity(node1),
+                iD.actionAddEntity(node2),
+                iD.actionAddEntity(node3),
+                iD.actionAddEntity(node4),
+                iD.actionAddEntity(area)
+            );
+
+            context.enter(iD.modeSelect(context, ['w1']));
+
+            document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', ctrlKey: true }));
+
+            expect(context.selectedIDs()).toEqual(['n1', 'n2', 'n3', 'n4']);
+        });
+
+        it('selects all child nodes when a way with a revisited node is selected', function() {
+            const node1 = new iD.osmNode({id: 'n1', loc: [0, 0]});
+            const node2 = new iD.osmNode({id: 'n2', loc: [1, 1]});
+            const node3 = new iD.osmNode({id: 'n3', loc: [2, 0]});
+            const node4 = new iD.osmNode({id: 'n4', loc: [1, -1]});
+            const node5 = new iD.osmNode({id: 'n5', loc: [0, -2]});
+
+            const selfIntersectingWay = new iD.osmWay({id: 'w1', nodes: ['n1', 'n2', 'n3', 'n4', 'n2', 'n5']});
+
+            context.perform(
+                iD.actionAddEntity(node1),
+                iD.actionAddEntity(node2),
+                iD.actionAddEntity(node3),
+                iD.actionAddEntity(node4),
+                iD.actionAddEntity(node5),
+                iD.actionAddEntity(selfIntersectingWay)
+            );
+
+            context.enter(iD.modeSelect(context, ['w1']));
+
+            document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', ctrlKey: true }));
+
+            expect(context.selectedIDs()).toEqual(['n1', 'n2', 'n3', 'n4', 'n5']);
+        });
+
+        it('does not affect selection when a node is selected', function() {
+            const node1 = new iD.osmNode({id: 'n1', loc: [0, 0]});
+            const node2 = new iD.osmNode({id: 'n2', loc: [1, 1]});
+            const way = new iD.osmWay({id: 'w1', nodes: ['n1', 'n2']});
+
+            context.perform(
+                iD.actionAddEntity(node1),
+                iD.actionAddEntity(node2),
+                iD.actionAddEntity(way)
+            );
+
+            context.enter(iD.modeSelect(context, ['n1']));
+
+            document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', ctrlKey: true }));
+
+            expect(context.selectedIDs()).toEqual(['n1']);
+        });
+
+        it('does not affect selection when a vertex is selected', function() {
+            const node1 = new iD.osmNode({id: 'n1', loc: [0, 0]});
+            const node2 = new iD.osmNode({id: 'n2', loc: [1, 1]});
+            const node3 = new iD.osmNode({id: 'n3', loc: [2, 2]});
+            const way = new iD.osmWay({id: 'w1', nodes: ['n1', 'n2', 'n3']});
+
+            context.perform(
+                iD.actionAddEntity(node1),
+                iD.actionAddEntity(node2),
+                iD.actionAddEntity(node3),
+                iD.actionAddEntity(way)
+            );
+
+            context.enter(iD.modeSelect(context, ['n2']));
+
+            document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', ctrlKey: true }));
+
+            expect(context.selectedIDs()).toEqual(['n2']);
+        });
+
+        it('does not affect selection when a relation is selected', function() {
+            const node1 = new iD.osmNode({id: 'n1', loc: [0, 0]});
+            const node2 = new iD.osmNode({id: 'n2', loc: [1, 1]});
+            const way = new iD.osmWay({id: 'w1', nodes: ['n1', 'n2']});
+            const relation = new iD.osmRelation({id: 'r1', members: [{id: 'w1', type: 'way', role: ''}]});
+
+            context.perform(
+                iD.actionAddEntity(node1),
+                iD.actionAddEntity(node2),
+                iD.actionAddEntity(way),
+                iD.actionAddEntity(relation)
+            );
+
+            context.enter(iD.modeSelect(context, ['r1']));
+
+            document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', ctrlKey: true }));
+
+            expect(context.selectedIDs()).toEqual(['r1']);
+        });
+    });
+});


### PR DESCRIPTION
Per title.

Repro - draw a triangle (closed way) and select it:

<img width="216" height="206" alt="before triangle" src="https://github.com/user-attachments/assets/df8d0541-c4a9-42f1-a28b-199434336c56" />

Selection is this:

<img width="466" height="151" alt="before way" src="https://github.com/user-attachments/assets/a7b65b57-c2b6-4842-84ff-aff11f5cc045" />

Do a Ctrl+Down and observe new selection:

<img width="463" height="280" alt="before children" src="https://github.com/user-attachments/assets/e316a425-32d1-47ad-8b10-38b8fbea94e3" />

Note that there are 4 nodes selected instead of 3.

After the fix:

<img width="473" height="235" alt="after children" src="https://github.com/user-attachments/assets/da42aac0-9da1-4269-91d5-e117a50ba139" />

I added unit tests for the child selection operation. Before/currently:

<img width="553" height="216" alt="child-node-select-fix before" src="https://github.com/user-attachments/assets/aa328efe-1cf5-4eaf-8862-44ab412484a4" />

After fix:

<img width="553" height="216" alt="child-node-select-fix after" src="https://github.com/user-attachments/assets/e716fb17-62ff-4e46-a428-b345f745b2b5" />

Disclaimer: Used LLM to suggest unit test syntax. (Seems it used the same syntax as `add_point.js`.)