### PR TITLE
change default type of d3.Selection to HTMLElement

### DIFF
--- a/modules/globals.d.ts
+++ b/modules/globals.d.ts
@@ -33,7 +33,7 @@ declare global {
   }
 
   declare namespace d3 {
-    export type Selection<T = any> = import('d3-selection').Selection<
+    export type Selection<T = HTMLElement> = import('d3-selection').Selection<
       T,
       any,
       any,

--- a/modules/svg/geolocate.ts
+++ b/modules/svg/geolocate.ts
@@ -11,7 +11,7 @@ import type { SvgLayer } from './layers';
 export type WithLoc = Pick<osmNode, 'loc'>;
 
 export function svgGeolocate(projection: Projection): SvgLayer {
-    var layer = d3_select<SVGGElement, 0>(null!);
+    var layer: d3.Selection<SVGGElement> = d3_select(null!);
     var _position: GeolocationPosition;
 
 
@@ -97,7 +97,7 @@ export function svgGeolocate(projection: Projection): SvgLayer {
         layer.select('.geolocate-radius').attr('r', accuracy(_position.coords.accuracy, geolocation.loc));
     }
 
-    function drawLocation(selection: d3.Selection) {
+    function drawLocation(selection: d3.Selection<SVGGElement>) {
         var enabled = svgGeolocate.enabled;
 
         layer = selection.selectAll<SVGGElement, 0>('.layer-geolocate')

--- a/modules/svg/icon.ts
+++ b/modules/svg/icon.ts
@@ -1,5 +1,7 @@
-export function svgIcon(name: string, svgklass: string, useklass?: string) {
-    return function drawIcon(selection: d3.Selection) {
+import { type BaseType } from 'd3';
+
+export function svgIcon<T extends BaseType = HTMLElement>(name: string, svgklass: string, useklass?: string) {
+    return function drawIcon(selection: d3.Selection<T>) {
         selection.selectAll('svg.icon' + (svgklass ? '.' + svgklass.split(' ')[0] : ''))
             .data([0])
             .enter()

--- a/modules/svg/layers.ts
+++ b/modules/svg/layers.ts
@@ -29,7 +29,7 @@ export type LayerDispatch = Dispatch<object, {
 }>
 
 export interface SvgLayer {
-    (selection: d3.Selection): void;
+    (selection: d3.Selection<SVGGElement>): void;
     enabled?(position: GeolocationPosition | boolean, enabled: boolean): boolean | SvgLayer;
 }
 

--- a/modules/svg/midpoints.ts
+++ b/modules/svg/midpoints.ts
@@ -57,7 +57,7 @@ export function svgMidpoints(projection: Projection, context: iD.Context) {
 
     function drawMidpoints(selection: d3.Selection, graph: coreGraph, entities: osmWay[], filter: (way: osmWay) => boolean, extent: geoExtent) {
         var drawLayer = selection.selectAll('.layer-osm.points .points-group.midpoints');
-        var touchLayer = selection.selectAll('.layer-touch.points');
+        var touchLayer = selection.selectAll<HTMLElement, any>('.layer-touch.points');
 
         var mode = context.mode();
         if ((mode && mode.id !== 'select') || !context.map().withinEditableZoom()) {

--- a/modules/svg/tag_classes.ts
+++ b/modules/svg/tag_classes.ts
@@ -23,9 +23,9 @@ export function svgTagClasses<T>() {
     var _tags: TagGetter<any> = function(entity) { return entity.tags; };
 
 
-    const tagClasses = function(selection: d3.Selection) {
+    const tagClasses = function(selection: d3.Selection<SVGGElement>) {
         selection.each(function tagClassesEach(entity) {
-            var value = this.className;
+            var value: any = this.className;
 
             if (value.baseVal !== undefined) {
                 value = value.baseVal;

--- a/modules/svg/touch.ts
+++ b/modules/svg/touch.ts
@@ -2,7 +2,7 @@ import type { SvgLayer } from './layers';
 
 export function svgTouch(): SvgLayer {
 
-    function drawTouch(selection: d3.Selection) {
+    function drawTouch(selection: d3.Selection<SVGGElement>) {
         selection.selectAll('.layer-touch')
             .data(['areas', 'lines', 'points', 'turns', 'markers'])
             .enter()

--- a/modules/ui/fields/check.ts
+++ b/modules/ui/fields/check.ts
@@ -78,7 +78,7 @@ export function uiFieldCheck(field: any, context: iD.Context) {
     }
 
 
-    function reverserSetText(selection: d3.Selection) {
+    function reverserSetText(selection: d3.Selection<HTMLButtonElement>) {
         const entity = _entityIDs.length && context.hasEntity(_entityIDs[0]);
         if (reverserHidden() || !entity) return selection;
 

--- a/modules/util/keybinding.ts
+++ b/modules/util/keybinding.ts
@@ -1,5 +1,6 @@
 import {
-    select as d3_select
+    select as d3_select,
+    type BaseType
 } from 'd3-selection';
 
 import { utilArrayUniq } from './array';
@@ -120,17 +121,17 @@ export function utilKeybinding(namespace: string) {
     }
 
 
-    function keybinding(selection?: d3.Selection) {
-        selection = selection || d3_select(document);
+    function keybinding(selection?: d3.Selection<BaseType>) {
+        selection = selection || d3_select<BaseType, any>(document);
         selection.on('keydown.capture.' + namespace, capture, true);
         selection.on('keydown.bubble.' + namespace, bubble, false);
         return keybinding;
     }
 
     // was: keybinding.off()
-    keybinding.unbind = function(selection?: d3.Selection) {
+    keybinding.unbind = function(selection?: d3.Selection<BaseType>) {
         _keybindings = {};
-        selection = selection || d3_select(document);
+        selection = selection || d3_select<BaseType, any>(document);
         selection.on('keydown.capture.' + namespace, null);
         selection.on('keydown.bubble.' + namespace, null);
         return keybinding;

--- a/modules/util/util.ts
+++ b/modules/util/util.ts
@@ -621,7 +621,7 @@ export function utilFunctor<T>(value: T | (() => T)): () => T {
 
 
 export function utilNoAuto(selection: d3.Selection): d3.Selection {
-    const isText = (selection.size() && selection.node().tagName.toLowerCase() === 'textarea');
+    const isText = (selection.size() && selection.node()!.tagName.toLowerCase() === 'textarea');
 
     return selection
         // assign 'new-password' even for non-password fields to prevent browsers (Chrome) ignoring 'off'

--- a/test/spec/ui/fields/combo.ts
+++ b/test/spec/ui/fields/combo.ts
@@ -3,7 +3,7 @@ import { select as d3_select } from 'd3-selection';
 describe('iD.uiFieldCombo', () => {
     describe('semiCombo', () => {
         let context: iD.Context;
-        let selection: d3.Selection;
+        let selection: d3.Selection<HTMLDivElement>;
 
         beforeEach(() => {
             context = iD.coreContext().assetPath('../dist/').init();

--- a/test/spec/ui/fields/radio.ts
+++ b/test/spec/ui/fields/radio.ts
@@ -3,7 +3,7 @@ import { select as d3_select } from 'd3-selection';
 describe('iD.uiFieldRadio', () => {
     describe('structureRadio', () => {
         let context: iD.Context;
-        let selection: d3.Selection;
+        let selection: d3.Selection<HTMLDivElement>;
 
         beforeEach(() => {
             context = iD.coreContext().assetPath('../dist/').init();
@@ -73,7 +73,7 @@ describe('iD.uiFieldRadio', () => {
 
     describe('radio with strings.options', () => {
         let context: iD.Context;
-        let selection: d3.Selection;
+        let selection: d3.Selection<HTMLDivElement>;
 
         beforeEach(() => {
             context = iD.coreContext().assetPath('../dist/').init();

--- a/test/spec/ui/multiCombo.ts
+++ b/test/spec/ui/multiCombo.ts
@@ -3,7 +3,7 @@ import type { EntityId } from '../../../modules';
 
 describe('iD.uiField as multiCombo', () => {
     let context: iD.Context;
-    let selection: d3.Selection;
+    let selection: d3.Selection<HTMLDivElement>;
     let presetField: any; // not TS yet
 
     beforeEach(() => {


### PR DESCRIPTION
See https://github.com/openstreetmap/iD/pull/12600#discussion_r3632482162 for rationale / benefits.

An alternative would have been to use `BaseType` as the fallback instead of `HTMLElement`, but I think this is more useful in most cases, and whenever we do use a selection of something else (e.g. of `document`, `EnterElement`, etc.), it makes sense to state them explicitly.

(blocked for now by #12601 / #12599, ~~and #12600 to avoid potential conflicts~~)