### PR TITLE
Add a split tool for touch editing

### DIFF
--- a/modules/ui/tools/index.ts
+++ b/modules/ui/tools/index.ts
@@ -2,4 +2,5 @@ export * from './modes';
 export * from './notes';
 export * from './save';
 export * from './sidebar_toggle';
+export * from './split';
 export * from './undo_redo';

--- a/modules/ui/tools/split.js
+++ b/modules/ui/tools/split.js
@@ -1,0 +1,169 @@
+import { select as d3_select } from 'd3-selection';
+
+import { t } from '../../core/localizer';
+import { svgIcon } from '../../svg';
+
+
+function isMobileViewport() {
+    return typeof window.matchMedia === 'function' ?
+        window.matchMedia('(max-width: 767px)').matches :
+        window.innerWidth <= 767;
+}
+
+
+function isTouchPointer(context) {
+    var pointer = typeof context.lastPointerType === 'function' ?
+        context.lastPointerType() :
+        context.container().attr('pointer');
+    return pointer === 'touch' || pointer === 'pen';
+}
+
+
+export function uiToolSplit(context) {
+    var tool = {
+        id: 'split',
+        label: t.append('operations.split.title')
+    };
+
+    var _button = d3_select(null);
+    var _toolbarItem = d3_select(null);
+    var _operation = null;
+    var _lastPointerUpType = null;
+
+    function currentOperation() {
+        var mode = context.mode();
+        if (!mode || mode.id !== 'select' || !mode.operations) return null;
+        return mode.operations().find(function(operation) {
+            return operation.id === 'split';
+        }) || null;
+    }
+
+    function showButton() {
+        return (isMobileViewport() || isTouchPointer(context)) &&
+            context.map().withinEditableZoom() &&
+            _operation &&
+            _operation.available();
+    }
+
+    function disabledReason() {
+        return _operation && _operation.disabled && _operation.disabled();
+    }
+
+    function operationIcon() {
+        return _operation && _operation.icon ? _operation.icon() : '#iD-operation-split';
+    }
+
+    function pointerup(d3_event) {
+        _lastPointerUpType = d3_event.pointerType;
+    }
+
+    function click(d3_event) {
+        d3_event.preventDefault();
+
+        if (!_operation) return;
+
+        var operation = _operation;
+        var icon = operationIcon();
+        var title = operation.title;
+        var tooltip = operation.tooltip ? operation.tooltip() : t('operations.split.title');
+        var annotation = operation.annotation ? operation.annotation() : null;
+        var pointerType = _lastPointerUpType;
+        _lastPointerUpType = null;
+
+        var disabled = disabledReason();
+        if (disabled) {
+            var interrupt = operation.interrupts && operation.interrupts[disabled];
+            if (interrupt) {
+                interrupt();
+                return;
+            }
+
+            if (context.ui && context.ui().flash) {
+                context.ui().flash
+                    .duration(4000)
+                    .iconName(icon)
+                    .iconClass('operation disabled')
+                    .label(tooltip)();
+            }
+            return;
+        }
+
+        operation();
+
+        if (context.ui && context.ui().flash && (
+            pointerType === 'touch' ||
+            pointerType === 'pen'
+        )) {
+            context.ui().flash
+                .duration(2000)
+                .iconName(icon)
+                .iconClass('operation')
+                .label(annotation || title)();
+        }
+    }
+
+    function update() {
+        _operation = currentOperation();
+
+        var show = showButton();
+        _toolbarItem.classed('hide', !show);
+
+        var buttons = _button.selectAll('button')
+            .data(show ? [_operation] : []);
+
+        buttons.exit()
+            .remove();
+
+        var buttonsEnter = buttons.enter()
+            .append('button')
+            .attr('type', 'button')
+            .attr('class', 'split-button bar-button')
+            .on('pointerup', pointerup)
+            .on('click', click);
+
+        buttons = buttonsEnter.merge(buttons);
+
+        var disabled = disabledReason();
+        var interrupt = disabled && _operation.interrupts && _operation.interrupts[disabled];
+
+        buttons
+            .each(function() {
+                d3_select(this)
+                    .call(svgIcon(operationIcon()));
+            })
+            .classed('disabled', !!disabled && !interrupt)
+            .attr('aria-disabled', !!disabled && !interrupt ? 'true' : null)
+            .attr('aria-label', t('operations.split.title'))
+            .attr('title', _operation ? _operation.tooltip() : t('operations.split.title'));
+
+        if (context.ui && context.ui().checkOverflow) {
+            context.ui().checkOverflow('.top-toolbar', true);
+        }
+    }
+
+    tool.render = function(selection) {
+        _button = selection;
+        _toolbarItem = d3_select(selection.node().parentNode);
+
+        update();
+
+        context
+            .on('enter.split', update);
+        context.history()
+            .on('change.split', update);
+    };
+
+    tool.uninstall = function() {
+        context
+            .on('enter.split', null);
+        context.history()
+            .on('change.split', null);
+
+        _button = d3_select(null);
+        _toolbarItem = d3_select(null);
+        _operation = null;
+        _lastPointerUpType = null;
+    };
+
+    return tool;
+}

--- a/modules/ui/top_toolbar.js
+++ b/modules/ui/top_toolbar.js
@@ -3,13 +3,14 @@ import {
 } from 'd3-selection';
 
 import { debounce } from 'es-toolkit';
-import { uiToolDrawModes, uiToolNotes, uiToolSave, uiToolSidebarToggle, uiToolUndoRedo } from './tools';
+import { uiToolDrawModes, uiToolNotes, uiToolSave, uiToolSidebarToggle, uiToolSplit, uiToolUndoRedo } from './tools';
 
 
 export function uiTopToolbar(context) {
 
     var sidebarToggle = uiToolSidebarToggle(context),
         modes = uiToolDrawModes(context),
+        split = uiToolSplit(context),
         notes = uiToolNotes(context),
         undoRedo = uiToolUndoRedo(context),
         save = uiToolSave(context);
@@ -40,7 +41,8 @@ export function uiTopToolbar(context) {
             var tools = [
                 sidebarToggle,
                 'spacer',
-                modes
+                modes,
+                split
             ];
 
             tools.push('spacer');

--- a/test/spec/ui/tools/split.js
+++ b/test/spec/ui/tools/split.js
@@ -1,0 +1,119 @@
+import { select as d3_select } from 'd3-selection';
+
+import { uiToolSplit } from '../../../../modules/ui/tools/split';
+
+
+describe('iD.uiToolSplit', function() {
+    var originalMatchMedia = window.matchMedia;
+
+    afterEach(function() {
+        window.matchMedia = originalMatchMedia;
+        d3_select(document.body).selectAll('.toolbar-item, .split-test-container').remove();
+    });
+
+    function makeFlashRecorder() {
+        const flash = vi.fn(() => flash);
+        flash.duration = vi.fn(() => flash);
+        flash.iconName = vi.fn(() => flash);
+        flash.iconClass = vi.fn(() => flash);
+        flash.label = vi.fn(() => flash);
+        return flash;
+    }
+
+    function makeContext(operation, options) {
+        const toolbar = d3_select(document.body)
+            .append('div')
+            .attr('class', 'toolbar-item split');
+        const buttonWrap = toolbar.append('div');
+        const container = d3_select(document.body)
+            .append('div')
+            .attr('class', 'split-test-container')
+            .attr('pointer', options.pointer || 'mouse');
+        const flash = makeFlashRecorder();
+        const ui = {
+            flash,
+            checkOverflow: vi.fn()
+        };
+        const history = {
+            on: vi.fn(() => history)
+        };
+
+        const context = {
+            container: () => container,
+            history: () => history,
+            lastPointerType: () => options.lastPointerType || 'mouse',
+            map: () => ({
+                withinEditableZoom: () => true
+            }),
+            mode: () => ({
+                id: 'select',
+                operations: () => [operation]
+            }),
+            on: vi.fn(() => context),
+            ui: () => ui
+        };
+
+        return { buttonWrap, context, flash, toolbar };
+    }
+
+    function makeSplitOperation(action) {
+        const operation = action || function() {};
+        operation.id = 'split';
+        operation.available = () => true;
+        operation.disabled = () => false;
+        operation.tooltip = () => 'Split tip';
+        operation.annotation = () => 'Split annotation';
+        operation.icon = () => '#iD-operation-split';
+        operation.title = 'Split';
+        operation.interrupts = {};
+        return operation;
+    }
+
+    it('shows on touch devices even when the pointer attr is still mouse', function() {
+        window.matchMedia = () => ({ matches: false });
+
+        const operation = makeSplitOperation();
+        const { buttonWrap, context, toolbar } = makeContext(operation, {
+            lastPointerType: 'touch',
+            pointer: 'mouse'
+        });
+        const tool = uiToolSplit(context);
+
+        buttonWrap.call(tool.render);
+
+        expect(toolbar.classed('hide')).toBe(false);
+        expect(buttonWrap.select('button.split-button').empty()).toBe(false);
+    });
+
+    it('keeps split feedback stable when the operation mutates during click', function() {
+        window.matchMedia = () => ({ matches: false });
+
+        let called = 0;
+        const operation = makeSplitOperation(function() {
+            called++;
+            operation.icon = () => '#iD-operation-split-mutated';
+            operation.title = 'Changed title';
+            operation.annotation = () => 'Changed annotation';
+        });
+
+        const { buttonWrap, context, flash } = makeContext(operation, {
+            lastPointerType: 'touch',
+            pointer: 'mouse'
+        });
+        const tool = uiToolSplit(context);
+
+        buttonWrap.call(tool.render);
+
+        const button = buttonWrap.select('button.split-button').node();
+        const pointerUp = new Event('pointerup', { bubbles: true, cancelable: true });
+        Object.defineProperty(pointerUp, 'pointerType', { value: 'touch' });
+
+        button.dispatchEvent(pointerUp);
+        button.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+        expect(called).toBe(1);
+        expect(flash.duration).toHaveBeenCalledWith(2000);
+        expect(flash.iconName).toHaveBeenCalledWith('#iD-operation-split');
+        expect(flash.label).toHaveBeenCalledWith('Split annotation');
+    });
+});


### PR DESCRIPTION
## Summary
- add a dedicated split tool to the top toolbar for touch and pen editing
- show it only while split is available in select mode on touch/mobile contexts
- keep touch feedback stable even if the operation mutates selection state while running

## Testing
- npm run test:once -- test/spec/ui/tools/split.js
- npx eslint modules/ui/tools/split.js modules/ui/top_toolbar.js modules/ui/tools/index.ts test/spec/ui/tools/split.js
- git diff --check