### PR TITLE
Focus the selected indoor level

### DIFF
--- a/css/20_map.css
+++ b/css/20_map.css
@@ -67,6 +67,20 @@
     stroke-linejoin: round;
 }
 
+.ideditor.indoor-focus .main-map .layer-background,
+.ideditor.indoor-focus .main-map .layer-overlay,
+.ideditor.indoor-focus .map-in-map-overlay {
+    filter: grayscale(45%) brightness(82%);
+}
+
+.ideditor.indoor-focus .map-in-map-background {
+    filter: url(#alpha-slope5) grayscale(45%) brightness(82%);
+}
+
+.ideditor.indoor-focus .main-map .layer-osm .indoor-dim {
+    opacity: 0.18 !important;
+}
+
 .ideditor[pointer='pen'] .way.target {
     stroke-width: 18;
 }

--- a/modules/renderer/map.js
+++ b/modules/renderer/map.js
@@ -7,7 +7,7 @@ import { select as d3_select } from 'd3-selection';
 import { zoom as d3_zoom, zoomIdentity as d3_zoomIdentity } from 'd3-zoom';
 
 import { prefs } from '../core/preferences';
-import { geoExtent, geoRawMercator, geoScaleToZoom, geoZoomToScale } from '../geo';
+import { geoExtent, geoPointInPolygon, geoRawMercator, geoScaleToZoom, geoZoomToScale } from '../geo';
 import { modeBrowse } from '../modes/browse';
 import { svgAreas, svgLabels, svgLayers, svgLines, svgMidpoints, svgPoints, svgVertices } from '../svg';
 import { utilFastMouse, utilFunctor, utilSetTransform, utilEntityAndDeepMemberIDs } from '../util/util';
@@ -58,6 +58,7 @@ export function rendererMap(context) {
     var _getMouseCoords;
     var _lastPointerEvent;
     var _lastWithinEditableZoom;
+    var _indoorFocusActive = false;
 
     // whether a pointerdown event started the zoom
     var _pointerDown = false;
@@ -276,6 +277,8 @@ export function rendererMap(context) {
                 .call(drawAreas, graph, data, filter)
                 .call(drawMidpoints, graph, data, filter, map.trimmedExtent());
 
+            updateIndoorFocus(context.history().intersects(map.extent()), graph);
+
             dispatch.call('drawn', this, { full: false });
 
             // redraw everything else later
@@ -387,7 +390,126 @@ export function rendererMap(context) {
             .call(drawPoints, graph, data, filter)
             .call(drawLabels, graph, data, filter, _dimensions, fullRedraw);
 
+        updateIndoorFocus(all, graph);
+
         dispatch.call('drawn', this, {full: true});
+    }
+
+    function updateIndoorFocus(data, graph) {
+        const selected = context.selectedIDs()
+            .map(id => graph.hasEntity(id))
+            .filter(Boolean);
+
+        const focusValues = { level: new Set(), layer: new Set() };
+        const focusEntities = new Set();
+        let isIndoorSelection = false;
+
+        function collect(entity) {
+            if (!entity || focusEntities.has(entity.id)) return;
+            focusEntities.add(entity.id);
+            const tags = entity.tags || {};
+            isIndoorSelection ||= Boolean(tags.indoor && tags.indoor !== 'no') ||
+                Boolean(tags.indoormark && tags.indoormark !== 'no') ||
+                tags.level !== undefined ||
+                tags.layer !== undefined;
+
+            for (const key of ['level', 'layer']) {
+                String(tags[key] || '').split(/[;,]/)
+                    .map(value => value.trim())
+                    .filter(Boolean)
+                    .forEach(value => focusValues[key].add(value));
+            }
+        }
+
+        for (const entity of selected) {
+            collect(entity);
+            graph.parentWays(entity).forEach(collect);
+            graph.parentRelations(entity).forEach(collect);
+        }
+
+        function datumEntity(d) {
+            return d?.properties?.entity || d?.entity || (d?.tags && d?.id ? d : null);
+        }
+
+        function sortAreaPaths(focusTest) {
+            surface.selectAll('.layer-osm.areas .areagroup')
+                .selectAll('path.area')
+                .sort((a, b) => {
+                    const entityA = datumEntity(a);
+                    const entityB = datumEntity(b);
+                    if (focusTest) {
+                        const focusedA = focusTest(entityA);
+                        const focusedB = focusTest(entityB);
+                        if (focusedA !== focusedB) return focusedA ? 1 : -1;
+                    }
+                    const areaA = entityA?.area ? Math.abs(entityA.area(graph)) : 0;
+                    const areaB = entityB?.area ? Math.abs(entityB.area(graph)) : 0;
+                    return areaB - areaA;
+                });
+        }
+
+        const hasFocusValue = focusValues.level.size || focusValues.layer.size;
+        const active = Boolean(selected.length && isIndoorSelection && hasFocusValue);
+        const wasActive = _indoorFocusActive;
+        _indoorFocusActive = active;
+        _selection.classed('indoor-focus', active);
+        context.container().classed('indoor-focus', active);
+        if (!active) {
+            surface.selectAll('.indoor-dim').classed('indoor-dim', false);
+            if (wasActive) sortAreaPaths();
+            return;
+        }
+
+        const keep = new Set(focusEntities);
+        for (const entity of selected) {
+            utilEntityAndDeepMemberIDs([entity.id], graph).forEach(id => keep.add(id));
+            if (entity.type === 'way') entity.nodes.forEach(id => keep.add(id));
+        }
+
+        const center = selected[0].extent(graph).center();
+        for (const entity of data) {
+            if (!entity.tags.building) continue;
+            let containsFocus = false;
+            if (entity.type === 'way') {
+                const polygon = entity.nodes
+                    .map(id => graph.hasEntity(id))
+                    .filter(Boolean)
+                    .map(node => node.loc);
+                containsFocus = polygon.length > 3 && geoPointInPolygon(center, polygon);
+            } else if (entity.type === 'relation') {
+                containsFocus = entity.extent(graph).contains(center);
+            }
+            if (!containsFocus) continue;
+
+            utilEntityAndDeepMemberIDs([entity.id], graph).forEach(id => keep.add(id));
+            if (entity.type === 'way') entity.nodes.forEach(id => keep.add(id));
+        }
+
+        const focusCache = new Map();
+        function onFocusLevel(entity) {
+            if (!entity) return true;
+            if (keep.has(entity.id)) return true;
+            if (focusCache.has(entity.id)) return focusCache.get(entity.id);
+
+            const candidates = [entity]
+                .concat(graph.parentWays(entity))
+                .concat(graph.parentRelations(entity));
+            const result = candidates.some(candidate => {
+                const tags = candidate.tags || {};
+                return ['level', 'layer'].some(key => {
+                    if (!focusValues[key].size) return false;
+                    return String(tags[key] || '').split(/[;,]/)
+                        .map(value => value.trim())
+                        .some(value => focusValues[key].has(value));
+                });
+            });
+            focusCache.set(entity.id, result);
+            return result;
+        }
+
+        surface.selectAll('.layer-osm *')
+            .classed('indoor-dim', d => !onFocusLevel(datumEntity(d)));
+        sortAreaPaths(onFocusLevel);
     }
 
     map.init = function() {

--- a/test/spec/renderer/indoor_focus.js
+++ b/test/spec/renderer/indoor_focus.js
@@ -1,0 +1,119 @@
+import { select as d3_select } from 'd3-selection';
+
+
+describe('iD.rendererMap indoor focus', function() {
+    let content;
+    let context;
+    let surface;
+
+    beforeEach(function() {
+        content = d3_select('body').append('div');
+        context = iD.coreContext().assetPath('../dist/').init().container(content);
+        content.call(context.map());
+        context.map()
+            .dimensions([1000, 1000])
+            .centerZoom([0, 0], 20);
+        surface = content.node();
+    });
+
+    afterEach(function() {
+        content.remove();
+    });
+
+    it('keeps the selected indoor level above other floors', function() {
+        const selected = new iD.osmNode({
+            id: 'n-indoor-selected',
+            loc: [0, 0],
+            tags: { indoor: 'room', level: '1' }
+        });
+        const sameLevel = new iD.osmNode({
+            id: 'n-indoor-same',
+            loc: [0.00001, 0],
+            tags: { indoor: 'room', level: '1' }
+        });
+        const otherLevel = new iD.osmNode({
+            id: 'n-indoor-other',
+            loc: [0.00002, 0],
+            tags: { indoor: 'room', level: '2' }
+        });
+        const corners = [
+            new iD.osmNode({ id: 'n-building-1', loc: [-0.0001, -0.0001] }),
+            new iD.osmNode({ id: 'n-building-2', loc: [0.0001, -0.0001] }),
+            new iD.osmNode({ id: 'n-building-3', loc: [0.0001, 0.0001] }),
+            new iD.osmNode({ id: 'n-building-4', loc: [-0.0001, 0.0001] })
+        ];
+        const building = new iD.osmWay({
+            id: 'w-indoor-building',
+            nodes: corners.map(node => node.id).concat(corners[0].id),
+            tags: { building: 'yes' }
+        });
+        const focusedFloor = new iD.osmWay({
+            id: 'w-indoor-focused-floor',
+            nodes: building.nodes,
+            tags: { area: 'yes', indoor: 'level', level: '1' }
+        });
+        const otherFloor = new iD.osmWay({
+            id: 'w-indoor-other-floor',
+            nodes: building.nodes,
+            tags: { area: 'yes', indoor: 'level', level: '2' }
+        });
+
+        context.history().merge([
+            selected, sameLevel, otherLevel, ...corners, building, focusedFloor, otherFloor
+        ]);
+
+        const layer = d3_select(surface).select('.layer-osm');
+        const selectedMark = layer.append('path').datum(selected);
+        const sameLevelMark = layer.append('path').datum(sameLevel);
+        const otherLevelMark = layer.append('path').datum(otherLevel);
+        const buildingMark = layer.append('path').datum(building);
+
+        context.map().redrawEnable(true);
+        context.map().pan([0, 0]);
+
+        const areaFill = d3_select(surface).select('.layer-osm.areas .area-fill');
+        areaFill.append('path')
+            .attr('class', `way area fill ${focusedFloor.id}`)
+            .datum(focusedFloor);
+        areaFill.append('path')
+            .attr('class', `way area fill ${otherFloor.id}`)
+            .datum(otherFloor);
+
+        context.enter(iD.modeSelect(context, [selected.id]));
+
+        expect(content.classed('indoor-focus')).toBe(true);
+        expect(selectedMark.classed('indoor-dim')).toBe(false);
+        expect(sameLevelMark.classed('indoor-dim')).toBe(false);
+        expect(buildingMark.classed('indoor-dim')).toBe(false);
+        expect(otherLevelMark.classed('indoor-dim')).toBe(true);
+        const floorOrder = areaFill.selectAll('path.area').nodes()
+            .map(node => node.__data__.id)
+            .filter(id => id === focusedFloor.id || id === otherFloor.id);
+        expect(floorOrder).toEqual([otherFloor.id, focusedFloor.id]);
+    });
+
+    it('does not focus indoor features without level or layer values', function() {
+        const selected = new iD.osmNode({
+            id: 'n-indoor-no-level',
+            loc: [0, 0],
+            tags: { indoor: 'room' }
+        });
+        const other = new iD.osmNode({
+            id: 'n-indoor-other',
+            loc: [0.00001, 0],
+            tags: { indoor: 'room', level: '2' }
+        });
+
+        context.history().merge([selected, other]);
+
+        const layer = d3_select(surface).select('.layer-osm');
+        const otherMark = layer.append('path').datum(other);
+
+        context.map().redrawEnable(true);
+        context.map().pan([0, 0]);
+        context.enter(iD.modeSelect(context, [selected.id]));
+
+        expect(content.classed('indoor-focus')).toBe(false);
+        expect(otherMark.classed('indoor-dim')).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary
- focus the selected indoor level or layer when the selection has level/layer information
- dim other visible floors while keeping the selected feature, same-floor features, and containing building context visible
- sort focused indoor area fills above other floors

## Testing
- npm run test:once -- test/spec/renderer/indoor_focus.js
- npx eslint modules/renderer/map.js test/spec/renderer/indoor_focus.js
- git diff --check