### PR TITLE
Extract address tags from address-only buildings

### DIFF
--- a/modules/actions/extract.ts
+++ b/modules/actions/extract.ts
@@ -10,6 +10,44 @@ export interface ActionExtract extends Action<boolean> {
     getExtractedNodeID(): NodeId;
 }
 
+const keysToCopyAndRetain = ['source', 'wheelchair'];
+const keysToRetain = ['area'];
+const buildingKeysToRetain = ['architect', 'building', 'height', 'layer', 'nycdoitt:bin', 'ref:GB:uprn', 'ref:linz:building_id'];
+
+function isAddressKey(key: string) {
+    return /^addr:.{1,}/.test(key);
+}
+
+function isBuildingKey(key: string) {
+    return buildingKeysToRetain.indexOf(key) !== -1 ||
+        /^building:.{1,}/.test(key) ||
+        /^roof:.{1,}/.test(key);
+}
+
+export function actionExtractMovesAddressTags(entity: OsmEntity) {
+    var isBuilding = (entity.tags.building && entity.tags.building !== 'no') ||
+        (entity.tags['building:part'] && entity.tags['building:part'] !== 'no');
+
+    if (!isBuilding) return false;
+
+    var hasAddressTags = false;
+    for (var key in entity.tags) {
+        if (entity.type === 'relation' && key === 'type') continue;
+        if (keysToRetain.indexOf(key) !== -1) continue;
+        if (keysToCopyAndRetain.indexOf(key) !== -1) continue;
+        if (isBuildingKey(key)) continue;
+
+        if (isAddressKey(key)) {
+            hasAddressTags = true;
+            continue;
+        }
+
+        return false;
+    }
+
+    return hasAddressTags;
+}
+
 export function actionExtract(entityID: NodeId, projection: Projection): ActionExtract {
 
     var extractedNodeID: NodeId;
@@ -52,10 +90,6 @@ export function actionExtract(entityID: NodeId, projection: Projection): ActionE
 
         var fromGeometry = entity.geometry(graph);
 
-        var keysToCopyAndRetain = ['source', 'wheelchair'];
-        var keysToRetain = ['area'];
-        var buildingKeysToRetain = ['architect', 'building', 'height', 'layer', 'nycdoitt:bin', 'ref:GB:uprn', 'ref:linz:building_id'];
-
         var extractedLoc = d3_geoPath(projection).centroid(entity.asGeoJSON(graph));
         extractedLoc = extractedLoc && projection.invert(extractedLoc);
         if (!extractedLoc  || !isFinite(extractedLoc[0]) || !isFinite(extractedLoc[1])) {
@@ -74,6 +108,7 @@ export function actionExtract(entityID: NodeId, projection: Projection): ActionE
             (entity.tags['building:part'] && entity.tags['building:part'] !== 'no');
 
         var isIndoorArea = fromGeometry === 'area' && entity.tags.indoor && indoorAreaValues[entity.tags.indoor];
+        var moveAddressTags = actionExtractMovesAddressTags(entity);
 
         var entityTags = { ...entity.tags };  // shallow copy
         var pointTags: Tags = {};
@@ -90,9 +125,7 @@ export function actionExtract(entityID: NodeId, projection: Projection): ActionE
 
             if (isBuilding) {
                 // don't transfer building-related tags
-                if (buildingKeysToRetain.indexOf(key) !== -1 ||
-                    key.match(/^building:.{1,}/) ||
-                    key.match(/^roof:.{1,}/)) continue;
+                if (isBuildingKey(key)) continue;
             }
             // leave `indoor` tag on the area
             if (isIndoorArea && key === 'indoor') {
@@ -104,7 +137,7 @@ export function actionExtract(entityID: NodeId, projection: Projection): ActionE
 
             // leave addresses and some other tags so they're on both features
             if (keysToCopyAndRetain.indexOf(key) !== -1 ||
-                key.match(/^addr:.{1,}/)) {
+                (isAddressKey(key) && !moveAddressTags)) {
                 continue;
             } else if (isIndoorArea && key === 'level') {
                 // leave `level` on both features

--- a/modules/operations/extract.ts
+++ b/modules/operations/extract.ts
@@ -1,4 +1,4 @@
-import { actionExtract } from '../actions/extract';
+import { actionExtract, actionExtractMovesAddressTags } from '../actions/extract';
 import { behaviorOperation } from '../behavior/operation';
 import { modeSelect } from '../modes/select';
 import { t } from '../core/localizer';
@@ -28,7 +28,7 @@ export const operationExtract: CreateOperation = (context, selectedIDs) => {
             // @ts-expect-error -- will be fixed in a different PR
             var preset = presetManager.match(entity, graph);
             // only allow extraction from ways/relations if the preset supports points
-            if (preset.geometry.indexOf('point') === -1) return null;
+            if (preset.geometry.indexOf('point') === -1 && !actionExtractMovesAddressTags(entity)) return null;
         }
 
         _extent = _extent ? _extent.extend(entity.extent(graph)) : entity.extent(graph);

--- a/test/spec/actions/extract.js
+++ b/test/spec/actions/extract.js
@@ -553,6 +553,50 @@ describe('iD.actionExtract', function () {
         });
     });
 
+    describe('building area', function () {
+        var projection = iD.geoRawMercator().scale(150);
+        var nodes = [
+            new iD.osmNode({ id: 'a', loc: [0, 0] }),
+            new iD.osmNode({ id: 'b', loc: [1, 0] }),
+            new iD.osmNode({ id: 'c', loc: [1, 1] }),
+            new iD.osmNode({ id: 'd', loc: [0, 1] })
+        ];
+
+        it('moves address tags from address-only buildings to the extracted node', function () {
+            var graph = new iD.coreGraph(nodes.concat([
+                new iD.osmWay({
+                    id: '-',
+                    nodes: ['a', 'b', 'c', 'd', 'a'],
+                    tags: { building: 'yes', 'addr:housenumber': '123', 'addr:street': 'Main Street' }
+                })
+            ]));
+            var action = iD.actionExtract('-', projection);
+            var assertionGraph = action(graph);
+            var building = assertionGraph.entity('-');
+            var extractedNode = assertionGraph.entity(action.getExtractedNodeID());
+
+            expect(building.tags).toEqual({ building: 'yes' });
+            expect(extractedNode.tags).toEqual({ 'addr:housenumber': '123', 'addr:street': 'Main Street' });
+        });
+
+        it('keeps address tags on buildings with point tags', function () {
+            var graph = new iD.coreGraph(nodes.concat([
+                new iD.osmWay({
+                    id: '-',
+                    nodes: ['a', 'b', 'c', 'd', 'a'],
+                    tags: { building: 'yes', amenity: 'restaurant', 'addr:housenumber': '123', 'addr:street': 'Main Street' }
+                })
+            ]));
+            var action = iD.actionExtract('-', projection);
+            var assertionGraph = action(graph);
+            var building = assertionGraph.entity('-');
+            var extractedNode = assertionGraph.entity(action.getExtractedNodeID());
+
+            expect(building.tags).toEqual({ building: 'yes', 'addr:housenumber': '123', 'addr:street': 'Main Street' });
+            expect(extractedNode.tags).toEqual({ amenity: 'restaurant', 'addr:housenumber': '123', 'addr:street': 'Main Street' });
+        });
+    });
+
 
     describe('with relation', function () {
         var graph;

--- a/test/spec/operations/extract.js
+++ b/test/spec/operations/extract.js
@@ -58,6 +58,23 @@ describe('iD.operationExtract', function () {
             expect(result).toBeFalsy();
         });
 
+        it('is available for address-only building areas', function () {
+            graph = new iD.coreGraph([
+                new iD.osmNode({ id: 'a', loc: [0, 0] }),
+                new iD.osmNode({ id: 'b', loc: [1, 0] }),
+                new iD.osmNode({ id: 'c', loc: [1, 1] }),
+                new iD.osmNode({ id: 'd', loc: [0, 1] }),
+                new iD.osmWay({
+                    id: 'x',
+                    nodes: ['a', 'b', 'c', 'd', 'a'],
+                    tags: { building: 'yes', 'addr:housenumber': '123', 'addr:street': 'Main Street' }
+                })
+            ]);
+
+            var result = iD.operationExtract(fakeContext, ['x']).available();
+            expect(result).toBeTruthy();
+        });
+
         it('is not available for selected node with tags, no parent way', function () {
             var result = iD.operationExtract(fakeContext, ['e']).available();
             expect(result).toBeFalsy();


### PR DESCRIPTION
Generated using CHATGPT 5.5, with 70% completion rate.
Closes #12447.\n\nThis updates the Extract operation so address-only buildings can be extracted into address nodes. For buildings that also have point/POI tags, the existing behavior is preserved and address tags remain on both features.\n\nTests run:\n- npm run build:data\n- npm run build:js\n- npm run test:typecheck\n- npx eslint modules/actions/extract.ts modules/operations/extract.ts test/spec/actions/extract.js test/spec/operations/extract.js\n- npx vitest run --no-isolate test/spec/actions/extract.js test/spec/operations/extract.js