### PR TITLE
Refactor legacy code with modern syntax

### DIFF
--- a/modules/osm/abstract-entity.ts
+++ b/modules/osm/abstract-entity.ts
@@ -84,7 +84,7 @@ export abstract class OsmAbstractEntity implements OsmEntityProps {
     }
 
     isNew() {
-        var osmId = osmIdManager.toOSM(this.id);
+        const osmId = osmIdManager.toOSM(this.id);
         return osmId.length === 0 || osmId[0] === '-';
     }
 
@@ -131,7 +131,7 @@ export abstract class OsmAbstractEntity implements OsmEntityProps {
     }
 
     hasNonGeometryTags() {
-        return Object.keys(this.tags).some(function(k) { return k !== 'area'; });
+        return Object.keys(this.tags).some(k => k !== 'area');
     }
 
     hasParentRelations(resolver: coreGraph) {

--- a/modules/osm/changeset.ts
+++ b/modules/osm/changeset.ts
@@ -38,9 +38,7 @@ export class osmChangeset extends OsmAbstractEntity {
         return {
             osm: {
                 changeset: {
-                    tag: Object.keys(this.tags).map(function(k) {
-                        return { '@k': k, '@v': this.tags[k] };
-                    }, this),
+                    tag: Object.keys(this.tags).map(k => ({ '@k': k, '@v': this.tags[k] })),
                     '@version': 0.6,
                     '@generator': 'iD'
                 }

--- a/modules/renderer/background_source.js
+++ b/modules/renderer/background_source.js
@@ -22,7 +22,7 @@ window.matchMedia?.(`
 
 
 function vintageRange(vintage) {
-    var s;
+    let s;
     if (vintage.start || vintage.end) {
         s = (vintage.start || '?');
         if (vintage.start !== vintage.end) {
@@ -34,12 +34,12 @@ function vintageRange(vintage) {
 
 
 export function rendererBackgroundSource(data) {
-    var source = Object.assign({}, data);   // shallow copy
-    var _offset = [0, 0];
-    var _name = source.name;
-    var _description = source.description;
-    var _best = !!source.best;
-    var _template = source.template;
+    const source = { ...data };   // shallow copy
+    let _offset = [0, 0];
+    const _name = source.name;
+    const _description = source.description;
+    const _best = !!source.best;
+    let _template = source.template;
 
     source.tileSize = data.tileSize || 256;
     source.zoomExtent = data.zoomExtent || [0, 22];
@@ -60,26 +60,26 @@ export function rendererBackgroundSource(data) {
 
 
     source.name = function() {
-        var id_safe = source.id.replace(/\./g, '<TX_DOT>');
+        const id_safe = source.id.replace(/\./g, '<TX_DOT>');
         return t('imagery.' + id_safe + '.name', { default: _name });
     };
 
 
     source.label = function() {
-        var id_safe = source.id.replace(/\./g, '<TX_DOT>');
+        const id_safe = source.id.replace(/\./g, '<TX_DOT>');
         return t.append('imagery.' + id_safe + '.name', { default: _name });
     };
 
 
     source.hasDescription = function() {
-        var id_safe = source.id.replace(/\./g, '<TX_DOT>');
-        var descriptionText = localizer.tInfo('imagery.' + id_safe + '.description', { default: _description }).texts.join('');
+        const id_safe = source.id.replace(/\./g, '<TX_DOT>');
+        const descriptionText = localizer.tInfo('imagery.' + id_safe + '.description', { default: _description }).texts.join('');
         return !!descriptionText;
     };
 
 
     source.description = function() {
-        var id_safe = source.id.replace(/\./g, '<TX_DOT>');
+        const id_safe = source.id.replace(/\./g, '<TX_DOT>');
         return t.append('imagery.' + id_safe + '.description', { default: _description });
     };
 
@@ -91,7 +91,7 @@ export function rendererBackgroundSource(data) {
 
     source.area = function() {
         if (!data.polygon) return Number.MAX_VALUE;  // worldwide
-        var area = d3_geoArea({ type: 'MultiPolygon', coordinates: [ data.polygon ] });
+        const area = d3_geoArea({ type: 'MultiPolygon', coordinates: [ data.polygon ] });
         return isNaN(area) ? 0 : area;
     };
 
@@ -478,8 +478,9 @@ rendererBackgroundSource.Esri = function(data) {
             .then(function(result) {
                 delete inflight[tileID];
 
-                result = result.features.map(f => f.attributes)
-                    .filter(a => a.MinMapLevel <= zoom && a.MaxMapLevel >= zoom)[0];
+                result = result.features
+                    .map(f => f.attributes)
+                    .find(a => a.MinMapLevel <= zoom && a.MaxMapLevel >= zoom);
 
                 if (!result) {
                     throw new Error('Unknown Error');


### PR DESCRIPTION
## Summary
- replace a few var declarations with const/let where bindings are not reassigned
- use object spread for a shallow copy
- use arrow callbacks and Array.find for simple transformations

## Testing
- npm run test:typecheck
- npx eslint modules/osm/abstract-entity.ts modules/osm/changeset.ts modules/renderer/background_source.js

Not run fully locally:
- npm run lint: blocked by LF/CRLF linebreak-style errors from the Windows checkout
- npm run all / npm run test:once: build:data could not fetch remote data from raw.githubusercontent.com in this environment