### PR TITLE
fix incorrect use of NSI's `buildIDPresets()`

### DIFF
--- a/modules/presets/index.js
+++ b/modules/presets/index.js
@@ -39,6 +39,7 @@ export function presetIndex() {
 
   let _this = presetCollection([POINT, LINE, AREA, RELATION]);
   let _presets = { point: POINT, line: LINE, area: AREA, relation: RELATION };
+  const _rawPresets = {};
 
   let _defaults = {
     point: presetCollection([POINT]),
@@ -119,6 +120,7 @@ export function presetIndex() {
 
         if (p) {   // add or replace
           const isAddable = !_addablePresetIDs || _addablePresetIDs.has(presetID);
+          _rawPresets[presetID] = p;
           p = presetPreset(presetID, p, isAddable, _fields, _presets);
           if (p.locationSet) newLocationSets.push(p);
           _presets[presetID] = p;
@@ -127,6 +129,7 @@ export function presetIndex() {
           const existing = _presets[presetID];
           if (existing && !existing.isFallback()) {
             delete _presets[presetID];
+            delete _rawPresets[presetID];
           }
         }
       });
@@ -471,6 +474,8 @@ export function presetIndex() {
     );
   };
 
+
+  _this.getRawPresets = () => _rawPresets;
 
   _this.getPresets = () => {
     return _presets;

--- a/modules/services/nsi.js
+++ b/modules/services/nsi.js
@@ -83,7 +83,7 @@ function loadNsiPresets() {
     ]) => {
       const allPresets = presetManager.getPresets();
       const nsiPresets = buildIDPresets(nsi_data.nsi, {
-        sourcePresets: allPresets,
+        sourcePresets: presetManager.getRawPresets(),
         wikidata: nsi_wikidata.wikidata,
         dissolved: nsi_dissolved.dissolved,
       }).presets;


### PR DESCRIPTION
currently we pass the preset _class_ to `buildIDPresets()`, but we should actually be passing the raw preset _object_, not the class.

This matters because iD overrides some properites like `fields`. In the JSON schema, `fields` is an array. In iD's class, `fields` is a function.

Currently NSI does not do access `fields`/`moreFields`. But it [might in the future](https://github.com/osmlab/name-suggestion-index/pull/12449), which will cause iD to crash.

RapiD [does it correctly](https://github.com/bhousel/Rapid/blob/56caeaf32df9bdfb4b653a87747016d420f8902c/modules/services/NsiService.ts#L516), so it's not affected.