### PR TITLE
fix console error

### DIFF
--- a/modules/ui/inspector.js
+++ b/modules/ui/inspector.js
@@ -114,7 +114,7 @@ export function uiInspector(context) {
 
         footer
             .call(uiViewOnOSM(context)
-                .what(context.hasEntity(_entityIDs.length === 1 && _entityIDs[0]))
+                .what(context.hasEntity(_entityIDs?.length === 1 && _entityIDs[0]))
             );
     }
 


### PR DESCRIPTION
when you first open iD the console is full of errors - for example https://pr-12601--ideditor.netlify.app/#

appears to be caused by 4304269, because this line now runs when there's nothing selected

<img width="705" height="305" alt="image" src="https://github.com/user-attachments/assets/4cfe2ef9-3c64-439b-a180-8975b228839a" />
