### PR TITLE
throw errors instead of objects

### DIFF
--- a/modules/core/context.js
+++ b/modules/core/context.js
@@ -20,6 +20,7 @@ import { rendererBackground, rendererFeatures, rendererMap, rendererPhotos } fro
 import { services } from '../services';
 import { uiInit } from '../ui/init';
 import { utilKeybinding, utilRebind, utilStringQs, utilCleanOsmString } from '../util';
+import { ApiError } from '../util/error';
 
 
 export function coreContext() {
@@ -136,7 +137,7 @@ export function coreContext() {
 
       } else if (_connection && _connection.getConnectionId() !== cid) {
         if (typeof callback === 'function') {
-          callback({ message: 'Connection Switched', status: -1 });
+          callback(new ApiError('Connection Switched', -1));
         }
         return;
 

--- a/modules/services/osm.js
+++ b/modules/services/osm.js
@@ -11,6 +11,7 @@ import { osmIdManager, osmNode, osmNote, osmRelation, osmWay } from '../osm';
 import { utilArrayChunk, utilArrayGroupBy, utilArrayUniq, utilObjectOmit, utilRebind, utilTiler, utilQsString } from '../util';
 import { localizer } from '../core/localizer.js';
 import { utilGzip } from '../util/util';
+import { ApiError } from '../util/error';
 import { osmApiConnections } from '../../config/id.js';
 
 
@@ -178,17 +179,17 @@ var jsonparsers = {
 function parseJSON(payload, callback, options) {
     options = Object.assign({ skipSeen: true }, options);
     if (!payload)  {
-        return callback({ message: 'No JSON', status: -1 });
+        return callback(new ApiError('No JSON', -1));
     }
 
     var json = payload;
     if (typeof json !== 'object') json = JSON.parse(payload);
 
-    if (!json.elements) return callback({ message: 'No JSON', status: -1 });
+    if (!json.elements) return callback(new ApiError('No JSON', -1));
 
     if (typeof json.elements.at(-1)?.error === 'string') {
         const errorMessage = payload.elements.at(-1).error;
-        return callback({ message: errorMessage, status: -1 });
+        return callback(new ApiError(errorMessage, -1));
     }
 
     var children = json.elements;
@@ -224,13 +225,13 @@ function parseJSON(payload, callback, options) {
 function parseUserJSON(payload, callback, options) {
     options = Object.assign({ skipSeen: true }, options);
     if (!payload)  {
-        return callback({ message: 'No JSON', status: -1 });
+        return callback(new ApiError('No JSON', -1));
     }
 
     var json = payload;
     if (typeof json !== 'object') json = JSON.parse(payload);
 
-    if (!json.users && !json.user) return callback({ message: 'No JSON', status: -1 });
+    if (!json.users && !json.user) return callback(new ApiError('No JSON', -1));
 
     var objs = json.users || [json];
 
@@ -262,7 +263,7 @@ function parseUserJSON(payload, callback, options) {
 function parseNoteJSON(payload, callback, _options) {
     const options = { skipSeen: true, ..._options };
     if (!payload)  {
-        return callback({ message: 'No JSON', status: -1 });
+        return callback(new ApiError('No JSON', -1));
     }
 
     const features = payload.type === 'FeatureCollection' ? payload.features : [payload];
@@ -321,7 +322,7 @@ function wrapcb(thisArg, callback, cid) {
             return callback.call(thisArg, err);
 
         } else if (thisArg.getConnectionId() !== cid) {
-            return callback.call(thisArg, { message: 'Connection Switched', status: -1 });
+            return callback.call(thisArg, new ApiError('Connection Switched', -1));
 
         } else {
             return callback.call(thisArg, err, result);
@@ -426,7 +427,7 @@ export default {
 
         function done(err, payloadString) {
             if (that.getConnectionId() !== cid) {
-                if (callback) callback({ message: 'Connection Switched', status: -1 });
+                if (callback) callback(new ApiError('Connection Switched', -1));
                 return;
             }
 
@@ -474,7 +475,7 @@ export default {
                     // https://github.com/d3/d3-fetch/issues/27
                     var match = err.message.match(/^\d{3}/);
                     if (match) {
-                        done({ status: +match[0], statusText: err.message });
+                        done(new ApiError(err.message, +match[0], { cause: err }));
                     } else {
                         done(err.message);
                     }
@@ -584,7 +585,7 @@ export default {
         var cid = _connectionID;
 
         if (_changeset.inflight) {
-            return callback({ message: 'Changeset already inflight', status: -2 }, changeset);
+            return callback(new ApiError('Changeset already inflight', -2), changeset);
 
         } else if (_changeset.open) {   // reuse existing open changeset..
             return createdChangeset.call(this, null, _changeset.open);
@@ -1001,10 +1002,10 @@ export default {
     // POST /api/0.6/notes?params
     postNoteCreate: function(note, callback) {
         if (!this.authenticated()) {
-            return callback({ message: 'Not Authenticated', status: -3 }, note);
+            return callback(new ApiError('Not Authenticated', -3), note);
         }
         if (_noteCache.inflightPost[note.id]) {
-            return callback({ message: 'Note update already inflight', status: -2 }, note);
+            return callback(new ApiError('Note update already inflight', -2), note);
         }
 
         if (!note.loc[0] || !note.loc[1] || !note.newComment) return; // location & description required
@@ -1045,10 +1046,10 @@ export default {
     // POST /api/0.6/notes/#id/reopen?text=comment
     postNoteUpdate: function(note, newStatus, callback) {
         if (!this.authenticated()) {
-            return callback({ message: 'Not Authenticated', status: -3 }, note);
+            return callback(new ApiError('Not Authenticated', -3), note);
         }
         if (_noteCache.inflightPost[note.id]) {
-            return callback({ message: 'Note update already inflight', status: -2 }, note);
+            return callback(new ApiError('Note update already inflight', -2), note);
         }
 
         var action;
@@ -1221,7 +1222,7 @@ export default {
                 return;
             }
             if (that.getConnectionId() !== cid) {
-                if (callback) callback({ message: 'Connection Switched', status: -1 });
+                if (callback) callback(new ApiError('Connection Switched', -1));
                 return;
             }
             _rateLimitError = undefined;

--- a/modules/services/osmose.js
+++ b/modules/services/osmose.js
@@ -12,6 +12,7 @@ import { localizer } from '../core/localizer';
 import { geoExtent, geoVecAdd } from '../geo';
 import { QAItem } from '../osm';
 import { utilRebind, utilTiler, utilQsString } from '../util';
+import { ApiError } from '../util/error';
 
 const tiler = utilTiler();
 const dispatch = d3_dispatch('loaded');
@@ -283,7 +284,7 @@ export default {
 
   postUpdate(issue, callback) {
     if (_cache.inflightPost[issue.id]) {
-      return callback({ message: 'Issue update already inflight', status: -2 }, issue);
+      return callback(new ApiError('Issue update already inflight', -2), issue);
     }
 
     // UI sets the status to either 'done' or 'false'

--- a/modules/util/error.ts
+++ b/modules/util/error.ts
@@ -1,0 +1,9 @@
+/** an {@link Error} with a `status` code */
+export class ApiError extends Error {
+    status: number;
+
+    constructor(message: string, status: number, options?: ErrorOptions) {
+        super(message, options);
+        this.status = status;
+    }
+}


### PR DESCRIPTION
throwing anything other than an `Error` is [discouraged](https://eslint.org/docs/latest/rules/no-throw-literal). debugging is much easier when you have a stack trace. 

i did not manually test every single case, because this change is fairly safe. `Error` is also an object with the same two properties. 