### PR TITLE
Fix flash message overflow

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -4865,22 +4865,40 @@ img.tile-debug {
     flex: 0 0 100%;
     flex-flow: row nowrap;
     justify-content: space-between;
-    height: 100%;
     position: absolute;
     right: 0;
     left: 0;
 }
+.main-footer-wrap {
+    height: 100%;
+}
 
-.footer-show {
-    bottom: 0px;
+.flash-wrap {
+    height: auto;
+    min-height: 100%;
+    bottom: 0;
+    transition: transform 75ms linear;
+}
+
+.main-footer-wrap.footer-show {
+    bottom: 0;
     transition: bottom 75ms linear;
 }
 
-.footer-hide {
+.main-footer-wrap.footer-hide {
     bottom: -100%;
     transition: bottom 75ms linear;
 }
 
+.flash-wrap.footer-show {
+    bottom: 0;
+    transform: translateY(0);
+}
+
+.flash-wrap.footer-hide {
+    bottom: 0;
+    transform: translateY(100%);
+}
 
 /* Attribution
 ------------------------------------------------------- */
@@ -4948,9 +4966,11 @@ img.tile-debug {
 ------------------------------------------------------- */
 .flash-content {
     display: flex;
-    flex: 1 0 auto;
+    flex: 1 1 0;
     flex-flow: row nowrap;
     align-items: center;
+    min-width: 0;
+    width: 100%;
     padding: 2px;
 }
 
@@ -4980,6 +5000,9 @@ img.tile-debug {
 
 .flash-text {
     flex: 1 1 auto;
+    min-width: 0;
+    white-space: normal;
+    overflow-wrap: anywhere;
 }
 
 /* Scale bar


### PR DESCRIPTION
## Description

This pull request fixes the flash message overflow issue described in #9072.

When a long follow mode error message is displayed in a narrow browser window, the message is now allowed to wrap onto multiple lines instead of being cut off. The hide animation was also updated so multiline flash messages move completely out of view when dismissed, preventing any portion of the message from remaining visible in the footer.

Fixes #9072

## Testing

- Reproduced the follow mode flash message overflow issue in Mozilla Firefox on Linux Mint using a narrow browser window.
- Verified that long follow mode error messages wrap onto multiple lines and remain fully readable.
- Verified that flash messages disappear completely after the display duration without leaving any text visible in the footer.
- Ran `npm test`.

Test results:
- 137 test files passed
- 2362 tests passed