### PR TITLE
Add zoom controls to photo viewers

### DIFF
--- a/css/60_photos.css
+++ b/css/60_photos.css
@@ -593,8 +593,21 @@ label.streetside-hires {
     pointer-events: initial;
 }
 
+.photo-zoom-controls {
+    position: absolute;
+    right: 14px;
+    bottom: 90px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    z-index: 10;
+    pointer-events: none;
+}
+
 .photo-controls button,
-.photo-controls button:focus {
+.photo-controls button:focus,
+.photo-zoom-controls button,
+.photo-zoom-controls button:focus {
     height: 18px;
     width: 18px;
     line-height: 18px;
@@ -602,18 +615,29 @@ label.streetside-hires {
     color: #eee;
     border-radius: 0;
 }
+.photo-zoom-controls button {
+    pointer-events: initial;
+}
 .photo-controls button:first-of-type {
     border-radius: 3px 0 0 3px;
 }
 .photo-controls button:last-of-type {
     border-radius: 0 3px 3px 0;
 }
-.photo-controls button:active {
+.photo-zoom-controls button:first-of-type {
+    border-radius: 3px 3px 0 0;
+}
+.photo-zoom-controls button:last-of-type {
+    border-radius: 0 0 3px 3px;
+}
+.photo-controls button:active,
+.photo-zoom-controls button:active {
     background: rgba(0,0,0,0.85);
     color: #fff;
 }
 @media (hover: hover) {
-    .photo-controls button:hover {
+    .photo-controls button:hover,
+    .photo-zoom-controls button:hover {
         background: rgba(0,0,0,0.85);
         color: #fff;
     }

--- a/modules/services/kartaview.js
+++ b/modules/services/kartaview.js
@@ -10,6 +10,7 @@ import { services } from './';
 import { searchLimited } from '../util/partition';
 import { localeDateString } from '../util/date';
 import { patchHash } from '../behavior';
+import { photoZoom } from './photo_zoom';
 
 
 var apibase = 'https://kartaview.org';
@@ -267,6 +268,8 @@ export default {
             .append('button')
             .on('click.forward', step(1))
             .text('►');
+
+        controlsEnter.call(photoZoom(imgZoom, wrapEnter));
 
         wrapEnter
             .append('div')

--- a/modules/services/kartaview.js
+++ b/modules/services/kartaview.js
@@ -269,7 +269,7 @@ export default {
             .on('click.forward', step(1))
             .text('►');
 
-        controlsEnter.call(photoZoom(imgZoom, wrapEnter));
+        wrapEnter.call(photoZoom(imgZoom, wrapEnter));
 
         wrapEnter
             .append('div')

--- a/modules/services/mapilio.js
+++ b/modules/services/mapilio.js
@@ -13,6 +13,7 @@ import { services } from './';
 import { searchLimited } from '../util/partition';
 import { localeDateString } from '../util/date';
 import { patchHash } from '../behavior';
+import { photoZoom } from './photo_zoom';
 
 const apiUrl = 'https://end.mapilio.com';
 const imageBaseUrl = 'https://cdn.mapilio.com/im';
@@ -412,6 +413,9 @@ export default {
         wrap
             .selectAll('button.forward')
             .classed('hide', !_cache.images.forImageId.hasOwnProperty(+id + 1));
+        wrap
+            .selectAll('button.photo-zoom')
+            .classed('hide', d.isPano);
 
 
         function loadTheImage(){
@@ -511,12 +515,16 @@ export default {
             .append('div')
             .attr('id', 'ideditor-viewer-mapilio-pnlm');
 
-        wrapEnter
+        const photoWrap = wrapEnter
             .append('div')
             .attr('id', 'ideditor-viewer-mapilio-simple-wrap')
-            .call(imgZoom.on('zoom', zoomPan))
+            .call(imgZoom.on('zoom', zoomPan));
+
+        photoWrap
             .append('div')
             .attr('id', 'ideditor-viewer-mapilio-simple');
+
+        controlsEnter.call(photoZoom(imgZoom, photoWrap));
 
 
 

--- a/modules/services/mapilio.js
+++ b/modules/services/mapilio.js
@@ -524,7 +524,7 @@ export default {
             .append('div')
             .attr('id', 'ideditor-viewer-mapilio-simple');
 
-        controlsEnter.call(photoZoom(imgZoom, photoWrap));
+        wrapEnter.call(photoZoom(imgZoom, photoWrap));
 
 
 

--- a/modules/services/pannellum_photo.js
+++ b/modules/services/pannellum_photo.js
@@ -98,6 +98,9 @@ export async function pannellumPhotoFrame(context, selection) {
                 .classed('hide', false);
         }
 
+        context.selectAll('button.photo-zoom')
+            .classed('hide', true);
+
         return module;
     };
 

--- a/modules/services/photo_zoom.js
+++ b/modules/services/photo_zoom.js
@@ -1,0 +1,52 @@
+import { zoomTransform as d3_zoomTransform } from 'd3-zoom';
+
+import { t } from '../core/localizer';
+
+
+const zoomControls = [{
+    id: 'photo-zoom-in',
+    label: '+',
+    title: 'zoom.in',
+    factor: 2
+}, {
+    id: 'photo-zoom-out',
+    label: '−',
+    title: 'zoom.out',
+    factor: 0.5
+}];
+
+
+export function photoZoom(zoom, target) {
+    return function(selection) {
+        let buttons = selection.selectAll('button.photo-zoom')
+            .data(zoomControls);
+
+        buttons.exit()
+            .remove();
+
+        const buttonsEnter = buttons.enter()
+            .append('button')
+            .attr('type', 'button')
+            .attr('class', d => `photo-zoom ${d.id}`)
+            .attr('title', d => t(d.title))
+            .attr('aria-label', d => t(d.title))
+            .on('click.photo-zoom', function(d3_event, d) {
+                d3_event.preventDefault();
+                d3_event.stopPropagation();
+                target.call(zoom.scaleBy, d.factor);
+            })
+            .text(d => d.label);
+
+        buttons = buttonsEnter.merge(buttons);
+
+        function updateButtons(transform) {
+            const [minScale, maxScale] = zoom.scaleExtent();
+            buttons.property('disabled', d => {
+                return d.factor > 1 ? transform.k >= maxScale : transform.k <= minScale;
+            });
+        }
+
+        zoom.on('zoom.photo-controls', d3_event => updateButtons(d3_event.transform));
+        updateButtons(d3_zoomTransform(target.node()));
+    };
+}

--- a/modules/services/photo_zoom.js
+++ b/modules/services/photo_zoom.js
@@ -18,7 +18,15 @@ const zoomControls = [{
 
 export function photoZoom(zoom, target) {
     return function(selection) {
-        let buttons = selection.selectAll('button.photo-zoom')
+        let controls = selection.selectAll('.photo-zoom-controls')
+            .data([0]);
+
+        controls = controls.enter()
+            .append('div')
+            .attr('class', 'photo-zoom-controls')
+            .merge(controls);
+
+        let buttons = controls.selectAll('button.photo-zoom')
             .data(zoomControls);
 
         buttons.exit()

--- a/modules/services/plane_photo.js
+++ b/modules/services/plane_photo.js
@@ -1,6 +1,7 @@
 import { dispatch as d3_dispatch } from 'd3-dispatch';
 import { zoom as d3_zoom, zoomIdentity as d3_zoomIdentity } from 'd3-zoom';
 import { utilSetTransform, utilRebind } from '../util';
+import { photoZoom } from './photo_zoom';
 
 
 export async function planePhotoFrame(context, selection) {
@@ -12,6 +13,7 @@ export async function planePhotoFrame(context, selection) {
     let _photo;
     let _imageWrapper;
     let _planeWrapper;
+    let _zoomControls;
     let _viewerDimensions = [];
     let _photoDimensions = [];
     const _imgZoom = d3_zoom()
@@ -66,6 +68,11 @@ export async function planePhotoFrame(context, selection) {
       .append('img')
       .attr('class', 'plane-photo');
 
+    const controls = selection.select('.photo-controls-wrap > div');
+    controls.call(photoZoom(_imgZoom, _planeWrapper));
+    _zoomControls = controls.selectAll('button.photo-zoom')
+        .classed('hide', true);
+
     context.ui().photoviewer.on('resize.plane', function(dimensions) {
       _viewerDimensions = dimensions;
       updateTransform();
@@ -90,6 +97,8 @@ export async function planePhotoFrame(context, selection) {
                 .classed('hide', false);
         }
 
+        _zoomControls.classed('hide', false);
+
         // set initial viewer size
         _viewerDimensions = context.ui().photoviewer.viewerSize();
         updateTransform();
@@ -105,6 +114,8 @@ export async function planePhotoFrame(context, selection) {
         context
             .select('photo-frame.plane-frame')
             .classed('hide', false);
+
+        _zoomControls.classed('hide', true);
 
         return module;
     };

--- a/modules/services/plane_photo.js
+++ b/modules/services/plane_photo.js
@@ -68,9 +68,8 @@ export async function planePhotoFrame(context, selection) {
       .append('img')
       .attr('class', 'plane-photo');
 
-    const controls = selection.select('.photo-controls-wrap > div');
-    controls.call(photoZoom(_imgZoom, _planeWrapper));
-    _zoomControls = controls.selectAll('button.photo-zoom')
+    selection.call(photoZoom(_imgZoom, _planeWrapper));
+    _zoomControls = selection.selectAll('button.photo-zoom')
         .classed('hide', true);
 
     context.ui().photoviewer.on('resize.plane', function(dimensions) {

--- a/test/spec/services/photo_zoom.js
+++ b/test/spec/services/photo_zoom.js
@@ -1,0 +1,130 @@
+import { select as d3_select } from 'd3-selection';
+import { zoom as d3_zoom, zoomTransform as d3_zoomTransform } from 'd3-zoom';
+
+import { photoZoom } from '../../../modules/services/photo_zoom';
+import { pannellumPhotoFrame } from '../../../modules/services/pannellum_photo';
+import { planePhotoFrame } from '../../../modules/services/plane_photo';
+
+
+describe('photoZoom', function() {
+    let controls, target, zoom;
+
+    beforeEach(function() {
+        const container = d3_select('body')
+            .append('div')
+            .attr('class', 'photo-zoom-test');
+
+        controls = container.append('div');
+        target = container.append('div');
+        zoom = d3_zoom()
+            .extent([[0, 0], [100, 100]])
+            .scaleExtent([1, 4]);
+
+        target.call(zoom);
+        controls.call(photoZoom(zoom, target));
+    });
+
+    afterEach(function() {
+        d3_select('.photo-zoom-test')
+            .remove();
+    });
+
+    it('renders accessible zoom buttons', function() {
+        const zoomIn = controls.select('button.photo-zoom-in');
+        const zoomOut = controls.select('button.photo-zoom-out');
+
+        expect(zoomIn.text()).toEqual('+');
+        expect(zoomIn.attr('aria-label')).toEqual('Zoom In');
+        expect(zoomOut.text()).toEqual('−');
+        expect(zoomOut.attr('aria-label')).toEqual('Zoom Out');
+    });
+
+    it('zooms the target and disables buttons at the scale extent', function() {
+        const zoomIn = controls.select('button.photo-zoom-in');
+        const zoomOut = controls.select('button.photo-zoom-out');
+
+        expect(zoomOut.property('disabled')).toBeTruthy();
+
+        zoomIn.dispatch('click');
+        expect(d3_zoomTransform(target.node()).k).toEqual(2);
+        expect(zoomOut.property('disabled')).toBeFalsy();
+
+        zoomIn.dispatch('click');
+        expect(d3_zoomTransform(target.node()).k).toEqual(4);
+        expect(zoomIn.property('disabled')).toBeTruthy();
+
+        zoomOut.dispatch('click');
+        expect(d3_zoomTransform(target.node()).k).toEqual(2);
+        expect(zoomIn.property('disabled')).toBeFalsy();
+    });
+
+    it('adds controls to plane photo frames and shows them with the frame', async function() {
+        const frameContainer = d3_select('.photo-zoom-test')
+            .append('div');
+        frameContainer
+            .append('div')
+            .attr('class', 'photo-controls-wrap')
+            .append('div')
+            .attr('class', 'photo-controls');
+
+        const photoviewer = {
+            on: () => photoviewer,
+            viewerSize: () => [100, 100]
+        };
+        const context = {
+            ui: () => ({ photoviewer })
+        };
+        const frame = await planePhotoFrame(context, frameContainer);
+        const photo = frameContainer.select('img.plane-photo');
+
+        Object.defineProperties(photo.node(), {
+            naturalWidth: { value: 200 },
+            naturalHeight: { value: 100 }
+        });
+        frame.selectPhoto({ image_path: 'photo.jpg' });
+        photo.dispatch('load');
+        await Promise.resolve();
+
+        const buttons = frameContainer.selectAll('button.photo-zoom');
+        expect(buttons.size()).toEqual(2);
+        expect(buttons.classed('hide')).toBeTruthy();
+
+        frame.showPhotoFrame(frameContainer);
+        expect(buttons.classed('hide')).toBeFalsy();
+    });
+
+    it('hides plane zoom controls when a panorama frame is shown', async function() {
+        const originalPannellum = window.pannellum;
+        const viewer = {
+            on: () => viewer,
+            resize: () => {}
+        };
+        Reflect.set(window, 'pannellum', {
+            viewer: () => viewer
+        });
+
+        try {
+            const frameContainer = d3_select('.photo-zoom-test')
+                .append('div');
+            const button = frameContainer
+                .append('button')
+                .attr('class', 'photo-zoom');
+            const photoviewer = {
+                on: () => photoviewer
+            };
+            const context = {
+                ui: () => ({ photoviewer })
+            };
+            const frame = await pannellumPhotoFrame(context, frameContainer);
+
+            frame.showPhotoFrame(frameContainer);
+            expect(button.classed('hide')).toBeTruthy();
+        } finally {
+            if (originalPannellum) {
+                Reflect.set(window, 'pannellum', originalPannellum);
+            } else {
+                Reflect.deleteProperty(window, 'pannellum');
+            }
+        }
+    });
+});

--- a/test/spec/services/photo_zoom.js
+++ b/test/spec/services/photo_zoom.js
@@ -30,9 +30,11 @@ describe('photoZoom', function() {
     });
 
     it('renders accessible zoom buttons', function() {
+        const zoomControls = controls.select('.photo-zoom-controls');
         const zoomIn = controls.select('button.photo-zoom-in');
         const zoomOut = controls.select('button.photo-zoom-out');
 
+        expect(zoomControls.empty()).toBeFalsy();
         expect(zoomIn.text()).toEqual('+');
         expect(zoomIn.attr('aria-label')).toEqual('Zoom In');
         expect(zoomOut.text()).toEqual('−');
@@ -87,6 +89,7 @@ describe('photoZoom', function() {
 
         const buttons = frameContainer.selectAll('button.photo-zoom');
         expect(buttons.size()).toEqual(2);
+        expect(frameContainer.select('.photo-controls button.photo-zoom').empty()).toBeTruthy();
         expect(buttons.classed('hide')).toBeTruthy();
 
         frame.showPhotoFrame(frameContainer);


### PR DESCRIPTION
Closes #8576

This adds explicit zoom-in and zoom-out buttons to flat photo viewers while preserving their existing wheel and drag behavior.

- The shared plane photo frame covers Panoramax, Vegbilder, and local photos.
- KartaView and Mapilio use the same control with their existing zoom behaviors.
- 360° photos continue to use Pannellum's native zoom controls.
- The buttons use existing translations, expose accessible labels, and disable at the configured scale limits.

Tests cover rendering, scale changes and limits, shared plane photo frames, and switching to panorama frames.
