### PR TITLE
feat: make locked fields unlockable via the lock icon (#12330)

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -1479,6 +1479,22 @@ button.preset-reset .label.flash-bg {
     fill: var(--text-color);
 }
 
+/* the lock icon is a toggle button, not a boxed field-label action button - #12330 */
+.field-label .label-textannotation .lock-icon {
+    display: inline-flex;
+    align-items: center;
+    width: auto;
+    border: 0;
+    border-radius: 0;
+    padding: 0;
+    background: none;
+    cursor: pointer;
+}
+.field-label .label-textannotation .lock-icon:hover .icon,
+.field-label .label-textannotation .lock-icon:focus .icon {
+    opacity: .8;
+}
+
 .field-label .modified-icon,
 .field-label .remove-icon,
 .field-label .remove-icon-multilingual {

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -19,6 +19,7 @@ en:
     expand: expand
     collapse: collapse
     plus: add
+    unlock: unlock
   toolbar:
     inspect: Inspect
     undo_redo: Undo / Redo
@@ -768,7 +769,7 @@ en:
     location: Location
     add_fields: "Add field:"
     lock:
-      suggestion: 'The "{label}" field is locked because there is a Wikidata tag. You can delete it or edit the tags in the "Tags" section.'
+      suggestion: 'The "{label}" field is locked because there is a Wikidata tag. Click the lock icon to unlock it for editing.'
     display_name_addr: "{housenumber} {streetOrPlace}"
     display_name_addr_with_unit: "{unit}, {housenumber} {streetOrPlace}"
     display_name:

--- a/modules/ui/field.js
+++ b/modules/ui/field.js
@@ -38,6 +38,8 @@ export function uiField(context, presetField, entityIDs, options) {
     }
 
     var _locked = false;
+    var _lockOverridden = false;   // true once the user has clicked the lock icon to unlock the field
+    var _selection = d3_select(null);
     var _lockedTip = uiTooltip()
         .title(() => t.append('inspector.lock.suggestion', { label: field.label() }))
         .placement('bottom');
@@ -153,7 +155,24 @@ export function uiField(context, presetField, entityIDs, options) {
     }
 
 
+    // Unlocks the field so its value(s) can be edited. Clicking the lock icon
+    // acknowledges the Wikidata-tag warning shown in the tooltip; the field
+    // then behaves like any other unlocked field for the rest of this
+    // editing session (see https://github.com/openstreetmap/iD/issues/12330).
+    function unlock(d3_event) {
+        d3_event.stopPropagation();
+        d3_event.preventDefault();
+        if (!_locked) return;
+
+        _lockOverridden = true;
+        _locked = false;
+        field.render(_selection);
+    }
+
+
     field.render = function(selection) {
+        _selection = selection;
+
         var container = selection.selectAll('.form-field')
             .data([field]);
 
@@ -271,19 +290,22 @@ export function uiField(context, presetField, entityIDs, options) {
                 .classed('present', tagsContainFieldKey());
 
 
-            // show a tip and lock icon if the field is locked
+            // show a tip and a toggleable lock icon if the field is locked
             var annotation = container.selectAll('.field-label .label-textannotation');
-            var icon = annotation.selectAll('.icon')
+            var lockButton = annotation.selectAll('.lock-icon')
                 .data(_locked ? [0]: []);
 
-            icon.exit()
+            lockButton.exit()
                 .remove();
 
-            icon.enter()
-                .append('svg')
-                .attr('class', 'icon')
-                .append('use')
-                .attr('xlink:href', '#fas-lock');
+            var lockButtonEnter = lockButton.enter()
+                .append('button')
+                .attr('class', 'lock-icon')
+                .attr('title', t('icons.unlock'))
+                .call(svgIcon('#fas-lock'));
+
+            lockButtonEnter.merge(lockButton)
+                .on('click', unlock);
 
             container.call(_locked ? _lockedTip : _lockedTip.destroy);
     };
@@ -314,7 +336,9 @@ export function uiField(context, presetField, entityIDs, options) {
 
     field.locked = function(val) {
         if (!arguments.length) return _locked;
-        _locked = val;
+        // once the user has unlocked the field, keep it unlocked regardless
+        // of what the lock computation says on subsequent renders
+        _locked = val && !_lockOverridden;
         return field;
     };
 

--- a/test/spec/ui/field.js
+++ b/test/spec/ui/field.js
@@ -1,0 +1,83 @@
+import { select as d3_select } from 'd3-selection';
+
+describe('iD.uiField', function() {
+    var context, selection;
+
+    beforeEach(function() {
+        context = iD.coreContext().assetPath('../dist/').init();
+        selection = d3_select(document.createElement('div'));
+    });
+
+    // Builds a `name` field (type `localized`) that gets locked because the
+    // entity carries a `wikidata` tag - see modules/ui/fields/localized.js
+    // `calcLocked` and https://github.com/openstreetmap/iD/issues/12330.
+    function createNameField(tags) {
+        var entity = new iD.osmNode({ id: 'n1', tags: tags });
+        context.history().merge([entity]);
+        var presetField = iD.presetField('name', { key: 'name', type: 'localized' });
+        var field = iD.uiField(context, presetField, [entity.id]);
+        field.tags(entity.tags);
+        return { field: field, entity: entity };
+    }
+
+    function clickLockIcon() {
+        selection.selectAll('.lock-icon').node()
+            .dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    }
+
+    it('locks the name field and shows a lock icon when the entity has a wikidata tag', function() {
+        var field = createNameField({ name: 'Foo', wikidata: 'Q1' }).field;
+        selection.call(field.render);
+
+        expect(field.locked()).toBeTruthy();
+        expect(selection.selectAll('.form-field').classed('locked')).toBeTruthy();
+        expect(selection.selectAll('.field-label .lock-icon').size()).toEqual(1);
+        expect(selection.selectAll('.localized-main').attr('readonly')).toEqual('true');
+    });
+
+    it('does not lock or show a lock icon when there is no wikidata tag', function() {
+        var field = createNameField({ name: 'Foo' }).field;
+        selection.call(field.render);
+
+        expect(field.locked()).toBeFalsy();
+        expect(selection.selectAll('.form-field').classed('locked')).toBeFalsy();
+        expect(selection.selectAll('.field-label .lock-icon').size()).toEqual(0);
+        expect(selection.selectAll('.localized-main').attr('readonly')).toBeNull();
+    });
+
+    it('renders the lock icon as a real button so it is keyboard-actionable, matching remove/revert icons', function() {
+        var field = createNameField({ name: 'Foo', wikidata: 'Q1' }).field;
+        selection.call(field.render);
+
+        expect(selection.select('.field-label .lock-icon').node().tagName).toEqual('BUTTON');
+    });
+
+    it('unlocks the field for editing when the lock icon is clicked', function() {
+        var field = createNameField({ name: 'Foo', wikidata: 'Q1' }).field;
+        selection.call(field.render);
+
+        clickLockIcon();
+
+        expect(field.locked()).toBeFalsy();
+        expect(selection.selectAll('.form-field').classed('locked')).toBeFalsy();
+        expect(selection.selectAll('.field-label .lock-icon').size()).toEqual(0);
+        expect(selection.selectAll('.localized-main').attr('readonly')).toBeNull();
+    });
+
+    it('stays unlocked across later re-renders of the same field in this session', function() {
+        var setup = createNameField({ name: 'Foo', wikidata: 'Q1' });
+        var field = setup.field;
+        selection.call(field.render);
+
+        clickLockIcon();
+        expect(field.locked()).toBeFalsy();
+
+        // a later tag edit re-renders the field (as happens on every keystroke) -
+        // the wikidata tag is still present, but the field must not re-lock
+        field.tags(setup.entity.tags);
+        selection.call(field.render);
+
+        expect(field.locked()).toBeFalsy();
+        expect(selection.selectAll('.field-label .lock-icon').size()).toEqual(0);
+    });
+});


### PR DESCRIPTION
<!-- PR title: feat: make locked fields unlockable via the lock icon (#12330) -->

**You set the work.** #12330: "make the lock icon toggleable: a click unlocks the field, allowing to change name, operator, etc." — your own proposed design.

**It's done.** The lock icon is now a real button; clicking it unlocks the field for the rest of the editing session. Fixed at the one place all locked-field types converge, so it covers `name`, `brand`, `network`, `operator`, and `flag` in one change. Five regression tests written before the fix, including the actual case this issue is about: staying unlocked across a later re-render.

**Here's the evidence.**

- Fresh clone at `87376a46` (develop), patch applied, `npm run build` (this repo generates its locale/data files), then the network was disconnected.
- Full suite in a clean `node:22-bookworm` container: **2,368 pass**, 0 fail (16 skipped / 6 todo — matching base) across 138 files.
- eslint and tsc clean.

<details>
<summary><b>Audit trail</b> — an independently checkable record that these checks ran, in this order, before this PR existed</summary>

| | |
|---|---|
| Base commit | `87376a46b56edecdfce8e44c01731c9403de7b51` (develop) |
| Container | `node:22-bookworm@sha256:5647be70…` (linux/arm64), network off during tests |
| The patch, content-addressed | [record](https://gateway.autonolas.tech/ipfs/f01551220cd0ff2c425f29e820f8fc020fbac5a9fa9bf2b97961102831749944abb037d31) |
| The verification result, signed by a second key | [record](https://gateway.autonolas.tech/ipfs/f01551220048d3a99c4797502c4eb5203299d8b63d8547915114d6358e756c296b0ac76d1) |
| Timestamped sequence | [work assigned](https://sepolia.basescan.org/tx/0x5c6b41160cba714851f68099cc721949d7b5b3e2f675d4f02d699959ed0ec77f) → [work delivered](https://sepolia.basescan.org/tx/0xdc0b6698b8278cf9bc034ae12a40c363f49bd262c02ef3c6fbeb907a6bea5a0c) → [checks passed](https://sepolia.basescan.org/tx/0x2be3d0084167149ddd49c83ad3568c795779cc0e4ff27c68460dac295852d3da) |

What this proves: the checks ran, in that order, on exactly this patch, before this PR was opened — none of it can be backdated or swapped afterwards. What it doesn't prove: that the change is *right*. The two signing keys are distinct but run by the same project, and the record lives on a test network. Correctness is your judgement, which is the point.

</details>

Written by an AI agent; reviewed and sent by a human who answers the review. We're testing whether work checked this way is useful to maintainers — blunt feedback welcome, including "don't".

---

## Everything below is written by Claude

Closes #12330.

The lock icon becomes a real `<button class="lock-icon">` (matching the existing `remove-icon`/`modified-icon` button pattern in `modules/ui/field.js` — inherently keyboard-actionable, same hover behaviour). Clicking it sets a `_lockOverridden` flag that clips the per-keystroke `calcLocked()` recomputation; the icon disappears and the field behaves like any normal field. Re-render reuses the existing `field.render()` path — no new machinery. The lock tooltip is reworded (`data/core.yaml`) to explain the new interaction, per your aside about why wikidata blocks the edit.

### Notes for the reviewer

- **Unlock is one-directional**, not a bistate toggle — your comment specifies "a click unlocks"; re-locking would need design decisions (interaction with per-keystroke recomputation) the issue doesn't cover. Happy to extend if you want a true toggle.
- No distinct "unlocked" glyph — the icon simply disappears once unlocked. An open-padlock state is a small buildable change (`faIcons` set in `scripts/build_data.js`) if preferred.
- The tooltip rewording is a judgement call — different copy welcome.
