### PR TITLE
migrate validators to typescript (part 1)

### DIFF
--- a/modules/core/validation/models.ts
+++ b/modules/core/validation/models.ts
@@ -1,7 +1,35 @@
+import type { coreGraph } from '..';
 import { geoExtent } from '../../geo';
-import { t } from '../../core/localizer';
+import type { Vec2 } from '../../geo/vector';
+import type { EntityId, OsmEntity } from '../../osm';
+import { t, type LocalizedTextRenderer } from '../localizer';
 
-export function validationIssue(attrs) {
+export interface Validator {
+    (entity: OsmEntity, graph: coreGraph): validationIssue[];
+    type: string;
+}
+
+export type CreateValidator = (context: iD.Context) => Validator;
+
+export class validationIssue<T = unknown> {
+    type: string;
+    subtype?: string | null;
+    severity?: 'suggestion' | 'warning' | 'error';
+    message?(context: iD.Context): d3.Selector | string;
+    reference?(selection: d3.Selection): void;
+    entityIds: EntityId[];
+    loc?: Vec2;
+    data?: T;
+    dynamicFixes?(context: iD.Context): validationIssueFix<T>[];
+    hash?: string | number;
+
+    id: string;
+    key: string;
+    autoFix: validationIssueFix<T> | null = null;
+
+
+
+    constructor(attrs: Pick<validationIssue<T>, 'type' | 'subtype' | 'severity' | 'message' | 'reference' | 'entityIds' | 'loc' | 'data' | 'dynamicFixes' | 'hash' | 'extent'>) {
     this.type = attrs.type;                // required - name of rule that created the issue (e.g. 'missing_tag')
     this.subtype = attrs.subtype;          // optional - category of the issue within the type (e.g. 'relation_type' under 'missing_tag')
     this.severity = attrs.severity;        // required - 'suggestion' or 'warning' or 'error'
@@ -12,15 +40,17 @@ export function validationIssue(attrs) {
     this.data = attrs.data;                // optional - object containing extra data for the fixes
     this.dynamicFixes = attrs.dynamicFixes;// optional - function(context) returning fixes
     this.hash = attrs.hash;                // optional - string to further differentiate the issue
-    this.extent = attrs.extent;            // optional - a method that returns the geometric extent of the issue, if absent, it will be calculated from the given entityIds
 
-    this.id = generateID.apply(this);      // generated - see below
-    this.key = generateKey.apply(this);    // generated - see below (call after generating this.id)
+        // optional - a method that returns the geometric extent of the issue, if absent, it will be calculated from the given entityIds
+        if (attrs.extent) this.extent = attrs.extent;
+        this.id = this.generateID();      // generated - see below
+        this.key = this.generateKey();   // generated - see below (call after generating this.id)
+    }
 
     // A unique, deterministic string hash.
     // Issues with identical id values are considered identical.
-    function generateID() {
-        var parts = [this.type];
+    generateID() {
+        var parts: (string | number)[] = [this.type];
 
         if (this.hash) {   // subclasses can pass in their own differentiator
             parts.push(this.hash);
@@ -42,11 +72,11 @@ export function validationIssue(attrs) {
 
     // An identifier suitable for use as the second argument to d3.selection#data().
     // (i.e. this should change whenever the data needs to be refreshed)
-    function generateKey() {
+    generateKey() {
         return this.id + ':' + Date.now().toString();  // include time of creation
     }
 
-    this.extent = this.extent || function(resolver) {
+    extent?(resolver: coreGraph) {
         if (this.loc) {
             return geoExtent(this.loc);
         }
@@ -58,8 +88,9 @@ export function validationIssue(attrs) {
         return null;
     };
 
-    this.fixes = function(context) {
+    fixes(context: iD.Context) {
         var fixes = this.dynamicFixes ? this.dynamicFixes(context) : [];
+        // eslint-disable-next-line @typescript-eslint/no-this-alias
         var issue = this;
 
         if (issue.severity === 'warning' || issue.severity === 'suggestion') {
@@ -70,7 +101,7 @@ export function validationIssue(attrs) {
                     : t.append('issues.fix.ignore_issue.title'),
                 icon: 'iD-icon-close',
                 onClick: function() {
-                    context.validator().ignoreIssue(this.issue.id);
+                    context.validator().ignoreIssue(this.issue!.id);
                 }
             }));
         }
@@ -85,22 +116,32 @@ export function validationIssue(attrs) {
         return fixes;
     };
 
-}
+    static ICONS = {
+        suggestion: '#iD-icon-info',
+        warning: '#iD-icon-alert',
+        error: '#iD-icon-error'
+    };
 
-validationIssue.ICONS = {
-    suggestion: '#iD-icon-info',
-    warning: '#iD-icon-alert',
-    error: '#iD-icon-error'
 };
 
+export class validationIssueFix<T = unknown> {
+    title: LocalizedTextRenderer;
+    id?: string;
+    onClick?(this: validationIssueFix<T>, context: iD.Context, completionHandler: ()=> void): void;
+    disabledReason?: string;
+    icon?: string;
+    entityIds?: EntityId[];
 
-export function validationIssueFix(attrs) {
-    this.title = attrs.title;                   // Required
-    this.id = attrs.id;                         // Optional
-    this.onClick = attrs.onClick;               // Optional - the function to run to apply the fix
-    this.disabledReason = attrs.disabledReason; // Optional - a string explaining why the fix is unavailable, if any
-    this.icon = attrs.icon;                     // Optional - shows 'iD-icon-wrench' if not set
-    this.entityIds = attrs.entityIds || [];     // Optional - used for hover-higlighting.
+    issue: validationIssue<T> | null;
 
-    this.issue = null;    // Generated link - added by validationIssue
+    constructor(attrs: Omit<validationIssueFix<T>, 'issue'>) {
+        this.title = attrs.title;                   // Required
+        this.id = attrs.id;                         // Optional
+        this.onClick = attrs.onClick;               // Optional - the function to run to apply the fix
+        this.disabledReason = attrs.disabledReason; // Optional - a string explaining why the fix is unavailable, if any
+        this.icon = attrs.icon;                     // Optional - shows 'iD-icon-wrench' if not set
+        this.entityIds = attrs.entityIds || [];     // Optional - used for hover-higlighting.
+
+        this.issue = null;    // Generated link - added by validationIssue
+    }
 }

--- a/modules/ui/sections/validation_issues.js
+++ b/modules/ui/sections/validation_issues.js
@@ -52,15 +52,15 @@ export function uiSectionValidationIssues(id, severity, context) {
         const withDistance = _issues.map(issue => {
             const extent = issue.extent(graph);
             return {
-                ...issue,
+                issue,
                 dist: extent ? geoSphericalDistance(center, extent.center()) : 0
             };
         });
         const issues = sortBy(withDistance, [
-            issue => rules.indexOf(issue.type),
-            'subtype',
+            ({ issue }) => rules.indexOf(issue.type),
+            row => row.issue.subtype,
             'dist'
-        ]).slice(0, 1000);
+        ]).slice(0, 1000).map(({ issue }) => issue);
 
         //renderIgnoredIssuesReset(_warningsSelection);
 

--- a/modules/validations/help_request.ts
+++ b/modules/validations/help_request.ts
@@ -1,12 +1,13 @@
 import { t } from '../core/localizer';
 import { utilDisplayLabel } from '../util/utilDisplayLabel';
 import { validationIssue, validationIssueFix } from '../core/validation';
+import type { CreateValidator, Validator } from '../core/validation/models';
 
 
-export function validationHelpRequest(context) {
+export const validationHelpRequest: CreateValidator = (context) => {
     var type = 'help_request';
 
-    var validation = function checkFixmeTag(entity) {
+    const validation: Validator = function checkFixmeTag(entity) {
 
         if (!entity.tags.fixme) return [];
 
@@ -40,7 +41,7 @@ export function validationHelpRequest(context) {
             entityIds: [entity.id]
         })];
 
-        function showReference(selection) {
+        function showReference(selection: d3.Selection) {
             selection.selectAll('.issue-reference')
                 .data([0])
                 .enter()
@@ -53,4 +54,4 @@ export function validationHelpRequest(context) {
     validation.type = type;
 
     return validation;
-}
+};

--- a/modules/validations/incompatible_source.ts
+++ b/modules/validations/incompatible_source.ts
@@ -1,6 +1,7 @@
 import { t } from '../core/localizer';
 import { utilDisplayLabel } from '../util/utilDisplayLabel';
 import { validationIssue, validationIssueFix } from '../core/validation';
+import type { CreateValidator, Validator } from '../core/validation/models';
 
 const incompatibleRules = [
   {
@@ -20,10 +21,9 @@ const incompatibleRules = [
 ];
 
 /**
- * @param {string} str String (e.g. tag value) to check for incompatible sources
- * @returns {{id:string, regex: RegExp, exceptRegex?: RegExp}[]}
+ * @param str String (e.g. tag value) to check for incompatible sources
  */
-export function getIncompatibleSources(str) {
+export function getIncompatibleSources(str: string) {
   return incompatibleRules
     .filter(rule =>
       rule.regex.test(str) &&
@@ -31,10 +31,10 @@ export function getIncompatibleSources(str) {
     );
 }
 
-export function validationIncompatibleSource() {
+export const validationIncompatibleSource: CreateValidator = () => {
   const type = 'incompatible_source';
 
-  const validation = function checkIncompatibleSource(entity) {
+  const validation: Validator = function checkIncompatibleSource(entity) {
     const entitySources = entity.tags && entity.tags.source && entity.tags.source.split(';');
     if (!entitySources) return [];
 
@@ -63,8 +63,8 @@ export function validationIncompatibleSource() {
         }))
       );
 
-      function getReference(id) {
-        return function showReference(selection) {
+      function getReference(id: string) {
+        return function showReference(selection: d3.Selection) {
           selection.selectAll('.issue-reference')
             .data([0])
             .enter()
@@ -78,4 +78,4 @@ export function validationIncompatibleSource() {
     validation.type = type;
 
     return validation;
-}
+};


### PR DESCRIPTION
`validationIssue` and `validationIssueFix` are now proper ES classes. This was nice and simple, because they're already being instantiated with the `new` operator