### PR TITLE
Improve community language display on the post changeset screen

### DIFF
--- a/modules/ui/success.js
+++ b/modules/ui/success.js
@@ -307,8 +307,8 @@ export function uiSuccess(context) {
       .attr('class', 'community-description')
       .html(d.resolved.descriptionHTML);
 
-    // Create an expanding section if any of these are present..
-    if (d.resolved.extendedDescriptionHTML || (d.languageCodes && d.languageCodes.length)) {
+    // Create an expanding section if an extended description is present.
+    if (d.resolved.extendedDescriptionHTML) {
       selection
         .append('div')
         .call(uiDisclosure(context, `community-more-${d.id}`, false)
@@ -317,6 +317,8 @@ export function uiSuccess(context) {
           .label(() => t.append('success.more'))
           .content(showMore)
         );
+    } else {
+      showLanguages(selection);
     }
 
     let nextEvents = (d.events || [])
@@ -365,16 +367,20 @@ export function uiSuccess(context) {
           .html(d.resolved.extendedDescriptionHTML);
       }
 
-      if (d.languageCodes && d.languageCodes.length) {
-        const languageList = d.languageCodes
-          .map(code => localizer.languageName(code))
-          .join(', ');
+      showLanguages(moreEnter);
+    }
 
-        moreEnter
-          .append('div')
-          .attr('class', 'community-languages')
-          .call(t.append('success.languages', { languages: languageList }));
-      }
+    function showLanguages(selection) {
+      if (!d.languageCodes || !d.languageCodes.length) return;
+
+      const languageList = d.languageCodes
+        .map(code => localizer.languageName(code))
+        .join(', ');
+
+      selection
+        .append('div')
+        .attr('class', 'community-languages')
+        .call(t.append('success.languages', { languages: languageList }));
     }
 
 


### PR DESCRIPTION
## Summary

This PR updates the post-changeset community section so the **More** dropdown is only shown when there is an extended description to display.

If a community only has language information, the language list is now shown directly below the description instead of inside the **More** dropdown. If there is an extended description, the **More** dropdown still appears and the language information remains inside it.

Fixes #8937

## Testing

- Ran `npm run lint`
- Ran `npm test`
- All tests passed (137 test files and 2,363 tests)

I also tried to test the change manually using my local development environment. I wasn't able to complete the post-changeset flow because the local server couldn't authenticate with the OpenStreetMap OAuth service due to a redirect URI mismatch. Because of that, I couldn't verify the UI change manually, but the project built successfully and all automated checks passed.