### PR TITLE
Filter combo field options by optionsLocationSet

### DIFF
--- a/modules/presets/index.js
+++ b/modules/presets/index.js
@@ -96,6 +96,7 @@ export function presetIndex() {
   //}
   _this.merge = (d) => {
     let newLocationSets = [];
+    let newOptionLocationSets = [];   // [{ field, value, wrapper }]
 
     // Merge Fields
     if (d.fields) {
@@ -105,6 +106,14 @@ export function presetIndex() {
         if (f) {   // add or replace
           f = presetField(fieldID, f);
           if (f.locationSet) newLocationSets.push(f);
+          if (f.optionsLocationSet) {
+            f.optionsLocationSetID = {};
+            Object.keys(f.optionsLocationSet).forEach(value => {
+              const wrapper = { locationSet: f.optionsLocationSet[value] };
+              newLocationSets.push(wrapper);
+              newOptionLocationSets.push({ field: f, value: value, wrapper: wrapper });
+            });
+          }
           _fields[fieldID] = f;
 
         } else {   // remove
@@ -193,6 +202,11 @@ export function presetIndex() {
     if (newLocationSets.length) {
       locationManager.registerLocationSets(newLocationSets);
     }
+
+    // Copy each option's resolved locationSetID back onto its field.
+    newOptionLocationSets.forEach(({ field, value, wrapper }) => {
+      field.optionsLocationSetID[value] = wrapper.locationSetID;
+    });
 
     return _this;
   };

--- a/modules/ui/fields/combo.js
+++ b/modules/ui/fields/combo.js
@@ -5,6 +5,7 @@ import * as countryCoder from '@rapideditor/country-coder';
 
 import { fileFetcher } from '../../core/file_fetcher';
 import { localizer, t } from '../../core/localizer';
+import { locationManager } from '../../core/location_manager';
 import { services } from '../../services';
 import { fuzzyMatch, uiCombobox } from '../combobox';
 import { svgIcon } from '../../svg/icon';
@@ -278,6 +279,21 @@ export function uiFieldCombo(field, context) {
             ? field.t(`options.${value}.description`) : undefined;
     }
 
+    // Some combo options are only offered in specific regions (`optionsLocationSet` on the field).
+    // An option with no entry there, or when we can't tell where we are, is allowed everywhere.
+    /** @param {string} value @returns {boolean} */
+    function optionAllowedHere(value) {
+        if (!field.optionsLocationSetID) return true;
+        const locationSetID = field.optionsLocationSetID[value];
+        if (!locationSetID) return true;
+
+        const extent = combinedEntityExtent();
+        if (!extent) return true;
+
+        const validHere = locationManager.locationSetsAt(extent.center());
+        return validHere.has(locationSetID);
+    }
+
     function getOptions(allOptions) {
         const localeCode = localizer.localeCode();
         // Get dropdown list for language: key via localizer instead of taginfo
@@ -346,6 +362,7 @@ export function uiFieldCombo(field, context) {
         } else {
             options = [].concat(field.options, field.options).filter(Boolean);
         }
+        options = options.filter(optionAllowedHere);
         const result = options.map(function(v) {
             const labelId = getLabelId(field, v);
             return {
@@ -435,6 +452,16 @@ export function uiFieldCombo(field, context) {
                     value = value.slice(field.key.length);
                 }
                 return value === restrictTagValueSpelling(value);
+            });
+
+            // don't show options that are region-restricted and we're outside their region
+            // (taginfo doesn't know about optionsLocationSet, so this can't be left to it)
+            data = data.filter(d => {
+                var value = d.value;
+                if (_isMulti) {
+                    value = value.slice(field.key.length);
+                }
+                return optionAllowedHere(value);
             });
 
             var deprecatedValues = deprecatedTagValuesByKey(_dataDeprecated)[field.key];

--- a/test/spec/presets/index.js
+++ b/test/spec/presets/index.js
@@ -426,6 +426,52 @@ describe('iD.presetIndex', function () {
         });
     });
 
+    describe('#merge (field optionsLocationSet)', () => {
+        it('resolves optionsLocationSetID for combo field options with a locationSet', () => {
+            const testIndex = presetIndex();
+
+            testIndex.merge({
+                fields: {
+                    surface: {
+                        key: 'surface',
+                        type: 'combo',
+                        label: 'Surface',
+                        options: ['dirt', 'laterite'],
+                        optionsLocationSet: {
+                            laterite: { include: ['th', 'in'] }
+                        }
+                    }
+                }
+            });
+
+            const field = testIndex.field('surface');
+            expect(field.optionsLocationSetID).toBeDefined();
+            // `laterite` has its own locationSet, so it gets a real, non-world id
+            expect(field.optionsLocationSetID.laterite).toBeDefined();
+            expect(field.optionsLocationSetID.laterite).not.toEqual('+[Q2]');
+            // `dirt` has no entry in optionsLocationSet, so it's never restricted
+            expect(field.optionsLocationSetID.dirt).toBeUndefined();
+        });
+
+        it('leaves optionsLocationSetID undefined for fields without optionsLocationSet', () => {
+            const testIndex = presetIndex();
+
+            testIndex.merge({
+                fields: {
+                    surface: {
+                        key: 'surface',
+                        type: 'combo',
+                        label: 'Surface',
+                        options: ['dirt', 'laterite']
+                    }
+                }
+            });
+
+            const field = testIndex.field('surface');
+            expect(field.optionsLocationSetID).toBeUndefined();
+        });
+    });
+
     describe('PresetIndex.recents', () => {
         it('fills all recent slots even when some remembered presets are not available in the current region (#11405)', () => {
             const testIndex = presetIndex();

--- a/test/spec/ui/fields/combo.ts
+++ b/test/spec/ui/fields/combo.ts
@@ -1,6 +1,82 @@
 import { select as d3_select } from 'd3-selection';
+import { locationManager } from '../../../../modules';
+
+function simulateKeydown(input: d3.Selection<HTMLInputElement>, keyCode: number) {
+    input.node()!.dispatchEvent(new KeyboardEvent('keydown', { keyCode }));
+}
 
 describe('iD.uiFieldCombo', () => {
+    describe('combo (optionsLocationSet)', () => {
+        let context: iD.Context;
+        let body: d3.Selection<HTMLElement>;
+        let container: d3.Selection<HTMLElement>;
+        let selection: d3.Selection<HTMLDivElement>;
+        let realLocationSetsAt: typeof locationManager.locationSetsAt;
+
+        beforeEach(() => {
+            body = d3_select('body');
+            container = body.append<HTMLElement>('div').attr('class', 'ideditor');
+            context = iD.coreContext().assetPath('../dist/').init().container(container);
+            selection = container.append('div');
+            realLocationSetsAt = locationManager.locationSetsAt;
+        });
+
+        afterEach(() => {
+            locationManager.locationSetsAt = realLocationSetsAt;
+            body.selectAll('.combobox').remove();
+            container.remove();
+        });
+
+        function makeField() {
+            const field = iD.presetField('surface', {
+                key: 'surface',
+                type: 'combo',
+                label: 'Surface',
+                options: ['dirt', 'laterite'],
+                autoSuggestions: false
+            });
+            // normally set by presetIndex#merge; set directly here to isolate the combo.js behavior
+            field.optionsLocationSetID = { laterite: '+[Q869]' }; // Thailand, arbitrary id for this test
+            return field;
+        }
+
+        async function openSuggestions(instance: ReturnType<typeof iD.uiFieldCombo>) {
+            const node = new iD.osmNode({ id: 'n1', loc: [2.3, 48.8] }); // Paris
+            context.history().merge([node]);
+            instance.entityIDs([node.id]);
+
+            selection.call(instance);
+            // let setStaticValues' setTimeout(0) run
+            await new Promise(resolve => { setTimeout(resolve, 10); });
+
+            const input = selection.selectAll('input') as d3.Selection<HTMLInputElement>;
+            input.node()!.focus(); // triggers a synchronous fetchComboData('')
+            simulateKeydown(input, 40); // ↓ arrow, opens the dropdown and renders suggestions
+
+            return body.selectAll('.combobox-option').nodes().map(n => (n as HTMLElement).textContent);
+        }
+
+        it('excludes an option restricted to a region we are not in', async () => {
+            locationManager.locationSetsAt = () => new Map(Object.entries({ '+[Q2]': 1 })); // world only
+
+            const instance = iD.uiFieldCombo(makeField(), context);
+            const optionTexts = await openSuggestions(instance);
+
+            expect(optionTexts).toContain('dirt');
+            expect(optionTexts).not.toContain('laterite');
+        });
+
+        it('includes the option when we are inside its region', async () => {
+            locationManager.locationSetsAt = () => new Map(Object.entries({ '+[Q2]': 1, '+[Q869]': 1 }));
+
+            const instance = iD.uiFieldCombo(makeField(), context);
+            const optionTexts = await openSuggestions(instance);
+
+            expect(optionTexts).toContain('dirt');
+            expect(optionTexts).toContain('laterite');
+        });
+    });
+
     describe('semiCombo', () => {
         let context: iD.Context;
         let selection: d3.Selection<HTMLDivElement>;


### PR DESCRIPTION
This came out of a discussion on [openstreetmap/id-tagging-schema#2332](https://github.com/openstreetmap/id-tagging-schema/issues/2332), where a maintainer asked whether a single `surface` combo option (`laterite`, a tropical soil type essentially absent outside a specific belt of countries) could be scoped to only the regions where it's actually relevant, instead of appearing in the dropdown everywhere. Field-level `locationSet` already exists for hiding a whole field by region (`modules/ui/field.js`), but there's nothing equivalent for a single option inside a shared combo field like `surface`, which is used across most highway presets globally.

id-tagging-schema's schema gained an `optionsLocationSet` property to carry this (companion PR: [openstreetmap/schema-builder#349](https://github.com/openstreetmap/schema-builder/pull/349)), a map from option value to a `locationSet` object. This PR wires that data up on the iD side.

## What changed

- **`modules/presets/index.js`**: when merging a field with an `optionsLocationSet`, each option's `locationSet` gets pushed through `locationManager.registerLocationSets()` (the same call already used for whole-field/preset/category `locationSet`s), and the resulting `locationSetID`s land on `field.optionsLocationSetID`, keyed by option value.
- **`modules/ui/fields/combo.js`**: adds `optionAllowedHere(value)`, which checks the current entity's location against the option's `locationSetID` the same way `modules/ui/field.js`'s `isAllowed()` already does for whole fields (same `combinedEntityExtent()` / `locationManager.locationSetsAt()` pattern). Applied in both suggestion paths:
  - the static options list (`getOptions()`)
  - the live taginfo-backed suggestions, since taginfo has no concept of this restriction and would otherwise surface a globally-popular value (`laterite` currently has 700+ uses) regardless of where you're editing

An option with no entry in `optionsLocationSetID`, or when the entity's location can't be determined (e.g. no entity yet), is offered everywhere, unchanged from today. Typing a value directly is still always possible (`customValues`), this only affects what gets suggested, matching how whole-field `locationSet` filtering already behaves (it hides the field, but doesn't retroactively invalidate already-tagged data).

## Testing

- `modules/presets/index.js`: unit test confirming `optionsLocationSetID` resolves correctly on merge, and that fields without `optionsLocationSet` are unaffected.
- `modules/ui/fields/combo.js`: two end-to-end tests exercising the real DOM/combobox path (render the field, focus, simulate a `↓` keypress to open the dropdown, read the actual rendered `.combobox-option` elements), confirming a region-restricted option is excluded when `locationSetsAt()` doesn't include its id, and included when it does.
- Full suite passes locally (`npm run lint`, `tsc`, `vitest run`, 2367 passed).

This is the iD half of a three-repo change; a follow-up id-tagging-schema PR will apply `optionsLocationSet` to `laterite` once this and the schema-builder PR both land. Happy to adjust the approach if you'd prefer something different.