### PR TITLE
fix: Respect embankment:side / cutting:side when determining sidedness

### DIFF
--- a/modules/osm/way.ts
+++ b/modules/osm/way.ts
@@ -184,8 +184,7 @@ export class osmWay extends OsmAbstractEntity {
             if (key in osmSidednessTags && (value in osmSidednessTags[key])) {
                 if (osmSidednessTags[key][value] === true) {
                     return key;
-                } 
-                
+                }
                 // embankment=yes/dyke/both and cutting=yes/both are both-sided
                 // by default, but a separate `embankment:side=*` or
                 // `cutting:side=*` tag can narrow it to just one side.
@@ -195,7 +194,6 @@ export class osmWay extends OsmAbstractEntity {
                         return `${key}-${side}`;
                     }
                 }
-               
                 // if the map's value is something other than a
                 // literal true, we should use it so we can
                 // special case some keys (e.g. natural=coastline

--- a/modules/osm/way.ts
+++ b/modules/osm/way.ts
@@ -184,13 +184,23 @@ export class osmWay extends OsmAbstractEntity {
             if (key in osmSidednessTags && (value in osmSidednessTags[key])) {
                 if (osmSidednessTags[key][value] === true) {
                     return key;
-                } else {
-                    // if the map's value is something other than a
-                    // literal true, we should use it so we can
-                    // special case some keys (e.g. natural=coastline
-                    // is handled differently to other naturals).
-                    return osmSidednessTags[key][value];
+                } 
+                
+                // embankment=yes/dyke/both and cutting=yes/both are both-sided
+                // by default, but a separate `embankment:side=*` or
+                // `cutting:side=*` tag can narrow it to just one side.
+                if ((key === 'embankment' || key === 'cutting') && osmSidednessTags[key][value] === key) {
+                    const side = this.tags[`${realKey}:side`];
+                    if (side === 'left' || side === 'right') {
+                        return `${key}-${side}`;
+                    }
                 }
+               
+                // if the map's value is something other than a
+                // literal true, we should use it so we can
+                // special case some keys (e.g. natural=coastline
+                // is handled differently to other naturals).
+                return osmSidednessTags[key][value];
             }
         }
 


### PR DESCRIPTION
fixes #12656 

Fixes sidednessIdentifier() in modules/osm/way.ts so that when a way has embankment=yes/dyke/both or cutting=yes/both (which normally render both-sided triangle markers), it now also checks for a companion embankment:side=* / cutting:side=* tag. If that tag is left or right, the function returns the corresponding one-sided category (embankment-left/embankment-right/cutting-left/cutting-right) instead of the generic both-sided one, so the renderer picks the correct one-sided marker (these markers already existed in modules/svg/defs.ts, they just weren't reachable via the documented :side tag).