### PR TITLE
Add rotate action for points with `direction`

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -2928,12 +2928,10 @@ button.raw-tag-option svg.icon {
 .tag-reference-link .icon:first-child {
     margin-left: 0;
 }
-.tag-reference-separator {
+.tag-reference-shortcut-hint {
     border-top: 1px solid var(--border-color);
-    margin: 8px 0;
-}
-.shortcut-hint {
-    margin: 0;
+    margin: 8px 0 0;
+    padding-top: 8px;
 }
 
 img.tag-reference-wiki-image {

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -2928,6 +2928,13 @@ button.raw-tag-option svg.icon {
 .tag-reference-link .icon:first-child {
     margin-left: 0;
 }
+.tag-reference-separator {
+    border-top: 1px solid var(--border-color);
+    margin: 8px 0;
+}
+.shortcut-hint {
+    margin: 0;
+}
 
 img.tag-reference-wiki-image {
     float: right;

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -412,6 +412,7 @@ en:
       key: R
       annotation:
         point: Rotated a point.
+        vertex: Rotated a node in a way.
         line: Rotated a line.
         area: Rotated an area.
         relation: Rotated a relation.

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -733,6 +733,7 @@ en:
     edit_reference: "edit/translate documentation"
     wiki_reference: View documentation
     wiki_en_reference: View documentation in English
+    direction_rotate_help: "Press {key} to adjust this value on the map."
     key_value: "key=value"
     empty: (empty)
     multiple_values: Multiple Values

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -410,6 +410,7 @@ en:
         multiple: Rotate these features around their center point.
       key: R
       annotation:
+        point: Rotated a point.
         line: Rotated a line.
         area: Rotated an area.
         relation: Rotated a relation.

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -406,6 +406,7 @@ en:
     rotate:
       title: Rotate
       description:
+        point: Adjust this point's numeric direction tag.
         single: Rotate this feature around its center point.
         multiple: Rotate these features around their center point.
       key: R
@@ -1405,7 +1406,7 @@ en:
       orthogonalize: "{orthogonalize_icon} **{orthogonalize}** snaps the corners of areas and lines to 90°. You can square individual corners or entire features."
       circularize: "{circularize_icon} **{circularize}** turns areas and closed lines into circles."
       move: "{move_icon} **{move}** lets you drag features around the map."
-      rotate: "{rotate_icon} **{rotate}** lets you swivel features around their center points."
+      rotate: "{rotate_icon} **{rotate}** lets you swivel features around their center points. For a point with a numeric direction tag, it adjusts that direction instead."
       reflect: "{reflect_short_icon} **{reflect_short}** and {reflect_long_icon} **{reflect_long}** reflect features over their short and long axes."
       continue: "{continue_icon} **{continue}** lets you extend existing lines from their endpoints."
       reverse: "{reverse_icon} **{reverse}** changes the direction of features. The direction matters for things like one-way roads, traffic signs, waterways, and cliffs."
@@ -2255,7 +2256,7 @@ en:
         nudge_more: "Nudge selected features by a lot"
         scale: "Scale selected features"
         scale_more: "Scale selected features by a lot"
-        rotate: "Rotate selected features"
+        rotate: "Rotate selected features, or adjust a point's numeric direction"
         orthogonalize: "Square corners of a line or area"
         straighten: "Straighten a line or points"
         circularize: "Circularize a closed line or area"

--- a/modules/actions/index.ts
+++ b/modules/actions/index.ts
@@ -30,6 +30,7 @@ export { actionRestrictTurn } from './restrict_turn';
 export { actionReverse } from './reverse';
 export { actionRevert } from './revert';
 export { actionRotate } from './rotate';
+export { actionRotatePointDirection } from './rotate_point_direction';
 export { actionScale } from './scale';
 export { actionSplit } from './split';
 export { actionStraightenNodes } from './straighten_nodes';

--- a/modules/actions/reverse.ts
+++ b/modules/actions/reverse.ts
@@ -1,7 +1,7 @@
 import type { coreGraph } from '../core';
 import type { Action } from '../core/history';
-import type { EntityId, OsmEntity, osmWay } from '../osm';
-import { presetManager } from '../presets';
+import type { EntityId, osmWay } from '../osm';
+import { utilDirectionFieldKey } from '../util/direction_field';
 
 export interface ActionReverse extends Action {
     entityID(): EntityId;
@@ -160,31 +160,6 @@ export function actionReverse(entityID: EntityId, options?: ReverseOptions): Act
         return valueReplacements[value] || value;
     }
 
-    /** @returns false or the name of the direction key */
-    function supportsDirectionField(node: OsmEntity, graph: coreGraph): false | TagKey {
-        // @ts-expect-error -- will be fixed in a different PR
-        const preset = presetManager.match(node, graph);
-        const loc = node.extent(graph).center();
-        const geometry = node.geometry(graph);
-
-        const fields = [...preset.fields(loc), ...preset.moreFields(loc)];
-
-        const maybeDirectionField = fields.find(field => {
-            const isDirectionField = field.key && (field.key === 'direction' || field.key.endsWith(':direction'));
-            // some direction fields are for angles, so ensure that the
-            // direction field on this preset is not a numeric field.
-            const isRelativeDirection = field.type !== 'number';
-
-            // the field's geometry might be restricted to a subset of the preset's geometry
-            const isGeometryValid = !field.geometry || field.geometry.includes(geometry);
-
-            return isDirectionField && isRelativeDirection && isGeometryValid;
-        });
-
-        return maybeDirectionField?.key || false;
-    }
-
-
     // Reverse the direction of tags attached to the nodes - #3076
     function reverseNodeTags(graph: coreGraph, nodeIDs: EntityId[]) {
         for (var i = 0; i < nodeIDs.length; i++) {
@@ -206,7 +181,7 @@ export function actionReverse(entityID: EntityId, options?: ReverseOptions): Act
 
             // for features whose presets have a direction field,
             // the first flip just adds the direction tag.
-            const directionKey = supportsDirectionField(node, graph);
+            const directionKey = utilDirectionFieldKey(node, graph, false);
             if (node.id === entityID && !anyChanges && directionKey) {
                 tags[directionKey] = 'forward';
             }
@@ -265,7 +240,7 @@ export function actionReverse(entityID: EntityId, options?: ReverseOptions): Act
         // exception for features whose presets have a direction
         // field - they're flipable even if they don't have a
         // direction tag.
-        if (supportsDirectionField(entity, graph)) return false;
+        if (utilDirectionFieldKey(entity, graph, false)) return false;
 
         return 'nondirectional_node';
     };

--- a/modules/actions/rotate_point_direction.ts
+++ b/modules/actions/rotate_point_direction.ts
@@ -1,11 +1,12 @@
 import type { Action } from '../core/history';
 import type { EntityId } from '../osm';
 import { utilRotatePointDirectionKey } from '../util/direction_field';
-import { utilWrap } from '../util';
+import { utilRetargetDirectionDegreesValue } from '../util/direction_degrees';
 
 
 /**
- * Set a node's numeric direction tag to `degrees` (OSM azimuth, clockwise from north).
+ * Set a node's direction tag so it aims at `degrees` (OSM azimuth, clockwise from north).
+ * Multi-value tags keep relative offsets; cardinals become numeric degrees.
  */
 export function actionRotatePointDirection(
     entityID: EntityId,
@@ -19,8 +20,10 @@ export function actionRotatePointDirection(
         const directionKey = key || utilRotatePointDirectionKey(entity, graph);
         if (!directionKey) return graph;
 
-        // Keep values aligned with iD direction tagging (whole degrees, [0, 360)).
-        const nextDirection = Math.round(utilWrap(degrees, 360)).toString();
+        const nextDirection = utilRetargetDirectionDegreesValue(
+            entity.tags[directionKey],
+            degrees
+        );
         if (nextDirection === entity.tags[directionKey]) return graph;
 
         const tags = Object.assign({}, entity.tags, { [directionKey]: nextDirection });

--- a/modules/actions/rotate_point_direction.ts
+++ b/modules/actions/rotate_point_direction.ts
@@ -1,0 +1,21 @@
+import type { Action } from '../core/history';
+import type { EntityId } from '../osm';
+import { utilWrap } from '../util';
+
+
+export function actionRotatePointDirection(entityID: EntityId, deltaDegrees: number): Action {
+    return function(graph) {
+        const entity = graph.hasEntity(entityID);
+        if (!entity || entity.type !== 'node') return graph;
+
+        const direction = Number(entity.tags.direction);
+        if (!isFinite(direction)) return graph;
+
+        // Keep values aligned with iD direction tagging (whole degrees, [0, 360)).
+        const nextDirection = Math.round(utilWrap(direction + deltaDegrees, 360)).toString();
+        if (nextDirection === entity.tags.direction) return graph;
+
+        const tags = Object.assign({}, entity.tags, { direction: nextDirection });
+        return graph.replace(entity.update({ tags: tags }));
+    };
+}

--- a/modules/actions/rotate_point_direction.ts
+++ b/modules/actions/rotate_point_direction.ts
@@ -1,21 +1,29 @@
 import type { Action } from '../core/history';
 import type { EntityId } from '../osm';
+import { utilRotatePointDirectionKey } from '../util/direction_field';
 import { utilWrap } from '../util';
 
 
-export function actionRotatePointDirection(entityID: EntityId, deltaDegrees: number): Action {
+/**
+ * Set a node's numeric direction tag to `degrees` (OSM azimuth, clockwise from north).
+ */
+export function actionRotatePointDirection(
+    entityID: EntityId,
+    degrees: number,
+    key?: TagKey
+): Action {
     return function(graph) {
         const entity = graph.hasEntity(entityID);
         if (!entity || entity.type !== 'node') return graph;
 
-        const direction = Number(entity.tags.direction);
-        if (!isFinite(direction)) return graph;
+        const directionKey = key || utilRotatePointDirectionKey(entity, graph);
+        if (!directionKey) return graph;
 
         // Keep values aligned with iD direction tagging (whole degrees, [0, 360)).
-        const nextDirection = Math.round(utilWrap(direction + deltaDegrees, 360)).toString();
-        if (nextDirection === entity.tags.direction) return graph;
+        const nextDirection = Math.round(utilWrap(degrees, 360)).toString();
+        if (nextDirection === entity.tags[directionKey]) return graph;
 
-        const tags = Object.assign({}, entity.tags, { direction: nextDirection });
+        const tags = Object.assign({}, entity.tags, { [directionKey]: nextDirection });
         return graph.replace(entity.update({ tags: tags }));
     };
 }

--- a/modules/core/context.ts
+++ b/modules/core/context.ts
@@ -32,7 +32,7 @@ type EventMap = {
 export interface Mode {
     id: string;
     enter(): void;
-    exit(): void;
+    exit(nextMode?: Mode): void;
     selectedIDs?(): EntityId[];
     activeID?(): EntityId;
 }
@@ -467,7 +467,7 @@ export function coreContext(this: object): coreContext {
   context.mode = () => _mode;
   context.enter = (newMode) => {
     if (_mode) {
-      _mode.exit();
+      _mode.exit(newMode);
       dispatch.call('exit', this, _mode);
     }
 

--- a/modules/modes/rotate.js
+++ b/modules/modes/rotate.js
@@ -22,7 +22,9 @@ import { operationMove } from '../operations/move';
 import { operationOrthogonalize } from '../operations/orthogonalize';
 import { operationReflectLong, operationReflectShort } from '../operations/reflect';
 
+import { utilSelectedRotatePointDirectionKey } from '../util/direction_field';
 import { utilKeybinding } from '../util/keybinding';
+import { utilWrap } from '../util';
 import { utilFastMouse, utilGetAllNodes } from '../util/util';
 
 
@@ -53,7 +55,7 @@ export function modeRotate(context, entityIDs) {
     var _prevAngle;
     var _prevTransform;
     var _pivot;
-    let _pointDirectionRotate = false;
+    let _pointDirectionKey = false;
 
     // use pointer events on supported platforms; fallback to mouse events
     var _pointerPrefix = 'PointerEvent' in window ? 'pointer' : 'mouse';
@@ -83,20 +85,22 @@ export function modeRotate(context, entityIDs) {
 
 
         var currMouse = context.map().mouse(d3_event);
-        var currAngle = Math.atan2(currMouse[1] - _pivot[1], currMouse[0] - _pivot[0]);
 
-        if (typeof _prevAngle === 'undefined') _prevAngle = currAngle;
-        var delta = currAngle - _prevAngle;
-
-        if (_pointDirectionRotate) {
-            const deltaDegrees = delta * (180 / Math.PI);
-            fn(actionRotatePointDirection(entityIDs[0], deltaDegrees));
+        if (_pointDirectionKey) {
+            // Point the direction at the mouse: OSM azimuth 0 = north, clockwise.
+            const dx = currMouse[0] - _pivot[0];
+            const dy = currMouse[1] - _pivot[1];
+            const absoluteDegrees = utilWrap(Math.atan2(dx, -dy) * (180 / Math.PI), 360);
+            fn(actionRotatePointDirection(entityIDs[0], absoluteDegrees, _pointDirectionKey));
         } else {
+            const currAngle = Math.atan2(currMouse[1] - _pivot[1], currMouse[0] - _pivot[0]);
+            if (typeof _prevAngle === 'undefined') _prevAngle = currAngle;
+            const delta = currAngle - _prevAngle;
             fn(actionRotate(entityIDs, _pivot, delta, projection));
+            _prevAngle = currAngle;
         }
 
         _prevTransform = currTransform;
-        _prevAngle = currAngle;
         _prevGraph = context.graph();
     }
 
@@ -115,18 +119,6 @@ export function modeRotate(context, entityIDs) {
             }
         }
         return _pivot;
-    }
-
-
-    function isPointDirectionRotate(graph) {
-        if (entityIDs.length !== 1) return false;
-
-        const entity = graph.hasEntity(entityIDs[0]);
-        if (!entity || entity.type !== 'node') return false;
-        if (graph.geometry(entity.id) !== 'point') return false;
-
-        const direction = Number(entity.tags.direction);
-        return isFinite(direction);
     }
 
 
@@ -150,7 +142,7 @@ export function modeRotate(context, entityIDs) {
 
     mode.enter = function() {
         _prevGraph = null;
-        _pointDirectionRotate = isPointDirectionRotate(context.graph());
+        _pointDirectionKey = utilSelectedRotatePointDirectionKey(entityIDs, context.graph());
         context.features().forceVisible(entityIDs);
 
         behaviors.forEach(context.install);

--- a/modules/modes/rotate.js
+++ b/modules/modes/rotate.js
@@ -188,7 +188,7 @@ export function modeRotate(context, entityIDs) {
     };
 
 
-    mode.exit = function() {
+    mode.exit = function(nextMode) {
         behaviors.forEach(context.uninstall);
 
         context.surface()
@@ -204,6 +204,11 @@ export function modeRotate(context, entityIDs) {
         d3_select(document)
             .call(keybinding.unbind);
 
+        // select.enter will refresh the editor; hide only when leaving selection
+        // entirely (e.g. undo → browse).
+        if (!nextMode || nextMode.id !== 'select') {
+            context.ui().sidebar.hide();
+        }
         context.features().forceVisible([]);
     };
 

--- a/modules/modes/rotate.js
+++ b/modules/modes/rotate.js
@@ -72,11 +72,11 @@ export function modeRotate(context, entityIDs) {
         // projection changed, recalculate _pivot
         var projection = context.projection;
         var currTransform = projection.transform();
-        if (!_prevTransform ||
+        const transformChanged = !_prevTransform ||
             currTransform.k !== _prevTransform.k ||
             currTransform.x !== _prevTransform.x ||
-            currTransform.y !== _prevTransform.y) {
-
+            currTransform.y !== _prevTransform.y;
+        if (transformChanged) {
             var nodes = utilGetAllNodes(entityIDs, context.graph());
             var points = nodes.map(function(n) { return projection(n.loc); });
             _pivot = getPivot(points);
@@ -87,11 +87,15 @@ export function modeRotate(context, entityIDs) {
         var currMouse = context.map().mouse(d3_event);
 
         if (_pointDirectionKey) {
-            // Point the direction at the mouse: OSM azimuth 0 = north, clockwise.
-            const dx = currMouse[0] - _pivot[0];
-            const dy = currMouse[1] - _pivot[1];
-            const absoluteDegrees = utilWrap(Math.atan2(dx, -dy) * (180 / Math.PI), 360);
-            fn(actionRotatePointDirection(entityIDs[0], absoluteDegrees, _pointDirectionKey));
+            // Skip the first move after pan/zoom so the direction does not jump
+            // (geometry rotate does the same via a zero delta).
+            if (!transformChanged) {
+                // Point the direction at the mouse: OSM azimuth 0 = north, clockwise.
+                const dx = currMouse[0] - _pivot[0];
+                const dy = currMouse[1] - _pivot[1];
+                const absoluteDegrees = utilWrap(Math.atan2(dx, -dy) * (180 / Math.PI), 360);
+                fn(actionRotatePointDirection(entityIDs[0], absoluteDegrees, _pointDirectionKey));
+            }
         } else {
             const currAngle = Math.atan2(currMouse[1] - _pivot[1], currMouse[0] - _pivot[0]);
             if (typeof _prevAngle === 'undefined') _prevAngle = currAngle;

--- a/modules/modes/rotate.js
+++ b/modules/modes/rotate.js
@@ -9,6 +9,7 @@ import {
 
 import { t } from '../core/localizer';
 import { actionRotate } from '../actions/rotate';
+import { actionRotatePointDirection } from '../actions/rotate_point_direction';
 import { actionNoop } from '../actions/noop';
 import { behaviorEdit } from '../behavior/edit';
 import { geoVecInterp, geoVecLength } from '../geo/vector';
@@ -52,6 +53,7 @@ export function modeRotate(context, entityIDs) {
     var _prevAngle;
     var _prevTransform;
     var _pivot;
+    let _pointDirectionRotate = false;
 
     // use pointer events on supported platforms; fallback to mouse events
     var _pointerPrefix = 'PointerEvent' in window ? 'pointer' : 'mouse';
@@ -86,7 +88,12 @@ export function modeRotate(context, entityIDs) {
         if (typeof _prevAngle === 'undefined') _prevAngle = currAngle;
         var delta = currAngle - _prevAngle;
 
-        fn(actionRotate(entityIDs, _pivot, delta, projection));
+        if (_pointDirectionRotate) {
+            const deltaDegrees = delta * (180 / Math.PI);
+            fn(actionRotatePointDirection(entityIDs[0], deltaDegrees));
+        } else {
+            fn(actionRotate(entityIDs, _pivot, delta, projection));
+        }
 
         _prevTransform = currTransform;
         _prevAngle = currAngle;
@@ -111,6 +118,18 @@ export function modeRotate(context, entityIDs) {
     }
 
 
+    function isPointDirectionRotate(graph) {
+        if (entityIDs.length !== 1) return false;
+
+        const entity = graph.hasEntity(entityIDs[0]);
+        if (!entity || entity.type !== 'node') return false;
+        if (graph.geometry(entity.id) !== 'point') return false;
+
+        const direction = Number(entity.tags.direction);
+        return isFinite(direction);
+    }
+
+
     function finish(d3_event) {
         d3_event.stopPropagation();
         context.replace(actionNoop(), annotation);
@@ -131,6 +150,7 @@ export function modeRotate(context, entityIDs) {
 
     mode.enter = function() {
         _prevGraph = null;
+        _pointDirectionRotate = isPointDirectionRotate(context.graph());
         context.features().forceVisible(entityIDs);
 
         behaviors.forEach(context.install);

--- a/modules/modes/select.js
+++ b/modules/modes/select.js
@@ -644,7 +644,7 @@ export function modeSelect(context, selectedIDs) {
     };
 
 
-    mode.exit = function() {
+    mode.exit = function(nextMode) {
 
         // we could enter the mode multiple times but it's only new the first time
         _newFeature = false;
@@ -689,7 +689,10 @@ export function modeSelect(context, selectedIDs) {
             .classed('related', false);
 
         context.map().on('drawn.select', null);
-        context.ui().sidebar.hide();
+        // Keep the feature editor open when entering rotate (same selection).
+        if (!nextMode || nextMode.id !== 'rotate') {
+            context.ui().sidebar.hide();
+        }
         context.features().forceVisible([]);
 
         var entity = singular();

--- a/modules/operations/rotate.js
+++ b/modules/operations/rotate.js
@@ -1,6 +1,7 @@
 import { t } from '../core/localizer';
 import { behaviorOperation } from '../behavior/operation';
 import { modeRotate } from '../modes/rotate';
+import { utilSelectedRotatePointDirectionKey } from '../util/direction_field';
 import { utilGetAllNodes, utilTotalExtent } from '../util/util';
 
 
@@ -11,17 +12,6 @@ export function operationRotate(context, selectedIDs) {
     var coords = nodes.map(function(n) { return n.loc; });
     const extent = utilTotalExtent(selectedIDs, graph);
 
-    function isPointDirectionRotate() {
-        if (selectedIDs.length !== 1) return false;
-
-        const entity = graph.hasEntity(selectedIDs[0]);
-        if (!entity || entity.type !== 'node') return false;
-        if (graph.geometry(entity.id) !== 'point') return false;
-
-        const direction = Number(entity.tags.direction);
-        return isFinite(direction);
-    }
-
 
     var operation = function() {
         context.enter(modeRotate(context, selectedIDs));
@@ -29,7 +19,7 @@ export function operationRotate(context, selectedIDs) {
 
 
     operation.available = function() {
-        return nodes.length >= 2 || isPointDirectionRotate();
+        return nodes.length >= 2 || !!utilSelectedRotatePointDirectionKey(selectedIDs, graph);
     };
 
 
@@ -73,7 +63,7 @@ export function operationRotate(context, selectedIDs) {
         if (disable) {
             return t.append('operations.rotate.' + disable + '.' + multi);
         }
-        if (isPointDirectionRotate()) {
+        if (utilSelectedRotatePointDirectionKey(selectedIDs, graph)) {
             return t.append('operations.rotate.description.point');
         }
         return t.append('operations.rotate.description.' + multi);

--- a/modules/operations/rotate.js
+++ b/modules/operations/rotate.js
@@ -6,9 +6,21 @@ import { utilGetAllNodes, utilTotalExtent } from '../util/util';
 
 export function operationRotate(context, selectedIDs) {
     var multi = (selectedIDs.length === 1 ? 'single' : 'multiple');
-    var nodes = utilGetAllNodes(selectedIDs, context.graph());
+    const graph = context.graph();
+    const nodes = utilGetAllNodes(selectedIDs, graph);
     var coords = nodes.map(function(n) { return n.loc; });
-    var extent = utilTotalExtent(selectedIDs, context.graph());
+    const extent = utilTotalExtent(selectedIDs, graph);
+
+    function isPointDirectionRotate() {
+        if (selectedIDs.length !== 1) return false;
+
+        const entity = graph.hasEntity(selectedIDs[0]);
+        if (!entity || entity.type !== 'node') return false;
+        if (graph.geometry(entity.id) !== 'point') return false;
+
+        const direction = Number(entity.tags.direction);
+        return isFinite(direction);
+    }
 
 
     var operation = function() {
@@ -17,7 +29,7 @@ export function operationRotate(context, selectedIDs) {
 
 
     operation.available = function() {
-        return nodes.length >= 2;
+        return nodes.length >= 2 || isPointDirectionRotate();
     };
 
 
@@ -51,7 +63,7 @@ export function operationRotate(context, selectedIDs) {
 
         function incompleteRelation(id) {
             var entity = context.entity(id);
-            return entity.type === 'relation' && !entity.isComplete(context.graph());
+            return entity.type === 'relation' && !entity.isComplete(graph);
         }
     };
 

--- a/modules/operations/rotate.js
+++ b/modules/operations/rotate.js
@@ -69,10 +69,14 @@ export function operationRotate(context, selectedIDs) {
 
 
     operation.tooltip = function() {
-        var disable = operation.disabled();
-        return disable ?
-            t.append('operations.rotate.' + disable + '.' + multi) :
-            t.append('operations.rotate.description.' + multi);
+        const disable = operation.disabled();
+        if (disable) {
+            return t.append('operations.rotate.' + disable + '.' + multi);
+        }
+        if (isPointDirectionRotate()) {
+            return t.append('operations.rotate.description.point');
+        }
+        return t.append('operations.rotate.description.' + multi);
     };
 
 

--- a/modules/ui/field.js
+++ b/modules/ui/field.js
@@ -232,10 +232,11 @@ export function uiField(context, presetField, entityIDs, options) {
                         referenceKey = referenceKey.replace(/:$/, ':*');
                     }
 
-                    var referenceOptions = d.reference || {
+                    const referenceOptions = d.reference ? Object.assign({}, d.reference) : {
                         key: referenceKey,
                         value: _tags[referenceKey]
                     };
+                    referenceOptions.fieldType = d.type;
                     reference = uiTagReference(referenceOptions, context);
                     if (_state === 'hover') {
                         reference.showing(false);

--- a/modules/ui/tag_reference.js
+++ b/modules/ui/tag_reference.js
@@ -5,6 +5,7 @@ import {
 import { t } from '../core/localizer';
 import { services } from '../services';
 import { svgIcon } from '../svg/icon';
+import { utilIsDirectionKey } from '../util/direction_field';
 import { uiCmd } from './cmd';
 
 
@@ -94,15 +95,11 @@ export function uiTagReference(what) {
               .call(t.append(docs.wiki.text));
         }
 
-        // Rotate (R) adjusts numeric direction=* on standalone points.
-        if (what.key === 'direction') {
-            _body
-                .append('div')
-                .attr('class', 'tag-reference-separator');
-
+        // Rotate (R) adjusts numeric direction / *:direction on the map.
+        if (utilIsDirectionKey(what.key)) {
             _body
                 .append('p')
-                .attr('class', 'shortcut-hint')
+                .attr('class', 'tag-reference-shortcut-hint')
                 .call(t.append('inspector.direction_rotate_help', {
                     key: uiCmd.display(t('operations.rotate.key'))
                 }));

--- a/modules/ui/tag_reference.js
+++ b/modules/ui/tag_reference.js
@@ -5,6 +5,7 @@ import {
 import { t } from '../core/localizer';
 import { services } from '../services';
 import { svgIcon } from '../svg/icon';
+import { uiCmd } from './cmd';
 
 
 // Pass `what` object of the form:
@@ -91,6 +92,20 @@ export function uiTagReference(what) {
               .call(svgIcon('#iD-icon-out-link', 'inline'))
               .append('span')
               .call(t.append(docs.wiki.text));
+        }
+
+        // Rotate (R) adjusts numeric direction=* on standalone points.
+        if (what.key === 'direction') {
+            _body
+                .append('div')
+                .attr('class', 'tag-reference-separator');
+
+            _body
+                .append('p')
+                .attr('class', 'shortcut-hint')
+                .call(t.append('inspector.direction_rotate_help', {
+                    key: uiCmd.display(t('operations.rotate.key'))
+                }));
         }
 
         // Add link to info about "good changeset comments" - #2923

--- a/modules/ui/tag_reference.js
+++ b/modules/ui/tag_reference.js
@@ -5,7 +5,7 @@ import {
 import { t } from '../core/localizer';
 import { services } from '../services';
 import { svgIcon } from '../svg/icon';
-import { utilIsDirectionKey } from '../util/direction_field';
+import { utilShowsDirectionRotateHint } from '../util/direction_field';
 import { uiCmd } from './cmd';
 
 
@@ -96,7 +96,7 @@ export function uiTagReference(what) {
         }
 
         // Rotate (R) adjusts numeric direction / *:direction on the map.
-        if (utilIsDirectionKey(what.key)) {
+        if (utilShowsDirectionRotateHint(what)) {
             _body
                 .append('p')
                 .attr('class', 'tag-reference-shortcut-hint')

--- a/modules/util/direction_degrees.ts
+++ b/modules/util/direction_degrees.ts
@@ -1,0 +1,72 @@
+import { cardinal } from '../osm/node';
+
+
+/**
+ * Normalize an angle in degrees to the range [0, 360).
+ */
+export function utilNormalizeAzimuthDegrees(degrees: number): number {
+    return ((degrees % 360) + 360) % 360;
+}
+
+
+/**
+ * Parse one direction segment (cardinal or number) to degrees in [0, 360).
+ * Locale-agnostic (`parseFloat`); dial UI can wrap with a locale parser later.
+ */
+export function utilParseDirectionDegreesSegment(value: string): number | null {
+    const directionText = (value || '').trim().toLowerCase();
+    if (!directionText) return null;
+
+    if (cardinal[directionText] !== undefined) {
+        return cardinal[directionText];
+    }
+
+    const parsed = parseFloat(directionText);
+    if (!isFinite(parsed)) return null;
+
+    return utilNormalizeAzimuthDegrees(parsed);
+}
+
+
+/**
+ * True if any `;`-separated segment parses as a cardinal or numeric angle.
+ */
+export function utilHasDirectionDegrees(value: string | undefined): boolean {
+    if (value === undefined || value === '') return false;
+
+    return value.split(';').some(segment => utilParseDirectionDegreesSegment(segment) !== null);
+}
+
+
+/**
+ * Rewrite a direction tag so the first parseable segment aims at `targetDegrees`,
+ * applying the same delta to every other parseable segment (preserves two-sidedness).
+ * Unparsable segments are left unchanged. Empty/absent values become a single angle.
+ */
+export function utilRetargetDirectionDegreesValue(
+    value: string | undefined,
+    targetDegrees: number
+): string {
+    const target = Math.round(utilNormalizeAzimuthDegrees(targetDegrees));
+
+    if (value === undefined || value === '') {
+        return target.toString();
+    }
+
+    const segments = value.split(';');
+    const parsed = segments.map(segment => utilParseDirectionDegreesSegment(segment));
+    const firstIndex = parsed.findIndex(degrees => degrees !== null);
+
+    if (firstIndex === -1) {
+        return value;
+    }
+
+    const delta = target - (parsed[firstIndex] as number);
+
+    return segments.map((segment, index) => {
+        const degrees = parsed[index];
+        if (degrees === null) return segment;
+
+        return Math.round(utilNormalizeAzimuthDegrees(degrees + delta)).toString();
+    }).join(';');
+}

--- a/modules/util/direction_field.ts
+++ b/modules/util/direction_field.ts
@@ -1,0 +1,88 @@
+import type { coreGraph } from '../core';
+import type { EntityId, OsmEntity } from '../osm';
+import { presetManager } from '../presets';
+
+
+/**
+ * True for `direction` and `*:direction` tag keys.
+ */
+export function utilIsDirectionKey(key: string | undefined): key is TagKey {
+    return !!key && (key === 'direction' || key.endsWith(':direction'));
+}
+
+
+/**
+ * Find a direction field on the entity's preset.
+ * @param numeric when true, match angle fields (`type: number`);
+ *   when false, match relative fields used by reverse (`forward`/`backward`).
+ * @returns false or the direction tag key
+ */
+export function utilDirectionFieldKey(
+    node: OsmEntity,
+    graph: coreGraph,
+    numeric: boolean
+): false | TagKey {
+    // @ts-expect-error -- will be fixed in a different PR
+    const preset = presetManager.match(node, graph);
+    const loc = node.extent(graph).center();
+    const geometry = node.geometry(graph);
+
+    const fields = [...preset.fields(loc), ...preset.moreFields(loc)];
+
+    const maybeDirectionField = fields.find(field => {
+        if (!utilIsDirectionKey(field.key)) return false;
+
+        // Numeric angle fields vs relative forward/backward fields.
+        const isNumericField = field.type === 'number';
+        if (numeric !== isNumericField) return false;
+
+        // the field's geometry might be restricted to a subset of the preset's geometry
+        const isGeometryValid = !field.geometry || field.geometry.includes(geometry);
+
+        return isGeometryValid;
+    });
+
+    return maybeDirectionField?.key || false;
+}
+
+
+/**
+ * Resolve which direction tag key rotate should use for a node.
+ * Prefers an existing numeric `*:direction` / `direction` tag, otherwise a
+ * numeric direction field on the preset (so R can set an absent tag).
+ */
+export function utilRotatePointDirectionKey(
+    node: OsmEntity,
+    graph: coreGraph
+): false | TagKey {
+    let plainDirectionKey: TagKey | false = false;
+
+    for (const key of Object.keys(node.tags)) {
+        if (!utilIsDirectionKey(key)) continue;
+        if (!isFinite(Number(node.tags[key]))) continue;
+        // Prefer prefixed keys (e.g. camera:direction) over plain direction.
+        if (key !== 'direction') return key;
+        plainDirectionKey = key;
+    }
+
+    if (plainDirectionKey) return plainDirectionKey;
+
+    return utilDirectionFieldKey(node, graph, true);
+}
+
+
+/**
+ * Like {@link utilRotatePointDirectionKey}, but for a selection: only a single
+ * selected node is eligible for point-direction rotate.
+ */
+export function utilSelectedRotatePointDirectionKey(
+    entityIDs: readonly EntityId[],
+    graph: coreGraph
+): false | TagKey {
+    if (entityIDs.length !== 1) return false;
+
+    const entity = graph.hasEntity(entityIDs[0]);
+    if (!entity || entity.type !== 'node') return false;
+
+    return utilRotatePointDirectionKey(entity, graph);
+}

--- a/modules/util/direction_field.ts
+++ b/modules/util/direction_field.ts
@@ -1,6 +1,7 @@
 import type { coreGraph } from '../core';
 import type { EntityId, OsmEntity } from '../osm';
 import { presetManager } from '../presets';
+import { utilHasDirectionDegrees } from './direction_degrees';
 
 
 /**
@@ -13,7 +14,7 @@ export function utilIsDirectionKey(key: string | undefined): key is TagKey {
 
 /**
  * Whether the tag-reference UI should mention Rotate (R).
- * Preset fields pass `fieldType`; raw tags fall back to a numeric value check.
+ * Preset fields pass `fieldType`; raw tags fall back to a degrees/cardinal check.
  */
 export function utilShowsDirectionRotateHint(what: {
     key?: string;
@@ -22,7 +23,7 @@ export function utilShowsDirectionRotateHint(what: {
 }): boolean {
     if (!utilIsDirectionKey(what.key)) return false;
     if (what.fieldType) return what.fieldType === 'number';
-    return what.value !== undefined && what.value !== '' && isFinite(Number(what.value));
+    return utilHasDirectionDegrees(what.value);
 }
 
 
@@ -63,8 +64,9 @@ export function utilDirectionFieldKey(
 
 /**
  * Resolve which direction tag key rotate should use for a node.
- * Prefers an existing numeric `*:direction` / `direction` tag, otherwise a
- * numeric direction field on the preset (so R can set an absent tag).
+ * Prefers an existing degrees/cardinal `*:direction` / `direction` tag (including
+ * multi-value), otherwise a numeric direction field on the preset (so R can set
+ * an absent tag).
  */
 export function utilRotatePointDirectionKey(
     node: OsmEntity,
@@ -74,7 +76,7 @@ export function utilRotatePointDirectionKey(
 
     for (const key of Object.keys(node.tags)) {
         if (!utilIsDirectionKey(key)) continue;
-        if (!isFinite(Number(node.tags[key]))) continue;
+        if (!utilHasDirectionDegrees(node.tags[key])) continue;
         // Prefer prefixed keys (e.g. camera:direction) over plain direction.
         if (key !== 'direction') return key;
         plainDirectionKey = key;

--- a/modules/util/direction_field.ts
+++ b/modules/util/direction_field.ts
@@ -12,6 +12,21 @@ export function utilIsDirectionKey(key: string | undefined): key is TagKey {
 
 
 /**
+ * Whether the tag-reference UI should mention Rotate (R).
+ * Preset fields pass `fieldType`; raw tags fall back to a numeric value check.
+ */
+export function utilShowsDirectionRotateHint(what: {
+    key?: string;
+    value?: string;
+    fieldType?: string;
+}): boolean {
+    if (!utilIsDirectionKey(what.key)) return false;
+    if (what.fieldType) return what.fieldType === 'number';
+    return what.value !== undefined && what.value !== '' && isFinite(Number(what.value));
+}
+
+
+/**
  * Find a direction field on the entity's preset.
  * @param numeric when true, match angle fields (`type: number`);
  *   when false, match relative fields used by reverse (`forward`/`backward`).

--- a/modules/util/index.ts
+++ b/modules/util/index.ts
@@ -45,7 +45,7 @@ export { utilUniqueDomId } from './util';
 export { utilWrap } from './util';
 export { utilCleanOsmString } from './util';
 
-export { utilDirectionFieldKey, utilIsDirectionKey, utilRotatePointDirectionKey, utilSelectedRotatePointDirectionKey } from './direction_field';
+export { utilDirectionFieldKey, utilIsDirectionKey, utilShowsDirectionRotateHint, utilRotatePointDirectionKey, utilSelectedRotatePointDirectionKey } from './direction_field';
 
 
 export { dmsCoordinatePair } from './units';

--- a/modules/util/index.ts
+++ b/modules/util/index.ts
@@ -45,5 +45,8 @@ export { utilUniqueDomId } from './util';
 export { utilWrap } from './util';
 export { utilCleanOsmString } from './util';
 
+export { utilDirectionFieldKey, utilIsDirectionKey, utilRotatePointDirectionKey, utilSelectedRotatePointDirectionKey } from './direction_field';
+
+
 export { dmsCoordinatePair } from './units';
 export { dmsMatcher } from './units';

--- a/modules/util/index.ts
+++ b/modules/util/index.ts
@@ -45,6 +45,12 @@ export { utilUniqueDomId } from './util';
 export { utilWrap } from './util';
 export { utilCleanOsmString } from './util';
 
+export {
+    utilHasDirectionDegrees,
+    utilNormalizeAzimuthDegrees,
+    utilParseDirectionDegreesSegment,
+    utilRetargetDirectionDegreesValue
+} from './direction_degrees';
 export { utilDirectionFieldKey, utilIsDirectionKey, utilShowsDirectionRotateHint, utilRotatePointDirectionKey, utilSelectedRotatePointDirectionKey } from './direction_field';
 
 

--- a/test/spec/actions/rotate_point_direction.ts
+++ b/test/spec/actions/rotate_point_direction.ts
@@ -1,0 +1,37 @@
+describe('iD.actionRotatePointDirection', () => {
+    it('rotates a numeric direction clockwise', () => {
+        const node = new iD.osmNode({ tags: { direction: '350' } });
+        const graph = iD.actionRotatePointDirection(node.id, 20)(
+            new iD.coreGraph().replace(node)
+        );
+
+        expect(graph.entity(node.id).tags.direction).toEqual('10');
+    });
+
+    it('rotates a numeric direction counterclockwise', () => {
+        const node = new iD.osmNode({ tags: { direction: '5' } });
+        const graph = iD.actionRotatePointDirection(node.id, -15)(
+            new iD.coreGraph().replace(node)
+        );
+
+        expect(graph.entity(node.id).tags.direction).toEqual('350');
+    });
+
+    it('does nothing for non-numeric directions', () => {
+        const node = new iD.osmNode({ tags: { direction: 'forward' } });
+        const graph = iD.actionRotatePointDirection(node.id, 45)(
+            new iD.coreGraph().replace(node)
+        );
+
+        expect(graph.entity(node.id).tags.direction).toEqual('forward');
+    });
+
+    it('rounds rotated direction to whole degrees', () => {
+        const node = new iD.osmNode({ tags: { direction: '10' } });
+        const graph = iD.actionRotatePointDirection(node.id, 0.123456)(
+            new iD.coreGraph().replace(node)
+        );
+
+        expect(graph.entity(node.id).tags.direction).toEqual('10');
+    });
+});

--- a/test/spec/actions/rotate_point_direction.ts
+++ b/test/spec/actions/rotate_point_direction.ts
@@ -53,4 +53,40 @@ describe('iD.actionRotatePointDirection', () => {
 
         expect(graph.entity(node.id).tags.direction).toEqual('10');
     });
+
+    it('preserves two-sided offsets with a shared delta', () => {
+        const node = new iD.osmNode({ tags: { direction: '120;300' } });
+        const graph = iD.actionRotatePointDirection(node.id, 90)(
+            new iD.coreGraph().replace(node)
+        );
+
+        expect(graph.entity(node.id).tags.direction).toEqual('90;270');
+    });
+
+    it('converts cardinals to numeric degrees', () => {
+        const node = new iD.osmNode({ tags: { direction: 'N' } });
+        const graph = iD.actionRotatePointDirection(node.id, 45)(
+            new iD.coreGraph().replace(node)
+        );
+
+        expect(graph.entity(node.id).tags.direction).toEqual('45');
+    });
+
+    it('converts lowercase intercardinals to numeric degrees', () => {
+        const node = new iD.osmNode({ tags: { direction: 'ne' } });
+        const graph = iD.actionRotatePointDirection(node.id, 90)(
+            new iD.coreGraph().replace(node)
+        );
+
+        expect(graph.entity(node.id).tags.direction).toEqual('90');
+    });
+
+    it('preserves junk segments while retargeting parseable ones', () => {
+        const node = new iD.osmNode({ tags: { direction: '120;error;300' } });
+        const graph = iD.actionRotatePointDirection(node.id, 90)(
+            new iD.coreGraph().replace(node)
+        );
+
+        expect(graph.entity(node.id).tags.direction).toEqual('90;error;270');
+    });
 });

--- a/test/spec/actions/rotate_point_direction.ts
+++ b/test/spec/actions/rotate_point_direction.ts
@@ -1,23 +1,42 @@
 describe('iD.actionRotatePointDirection', () => {
-    it('rotates a numeric direction clockwise', () => {
+    it('sets a numeric direction to the given absolute degrees', () => {
         const node = new iD.osmNode({ tags: { direction: '350' } });
         const graph = iD.actionRotatePointDirection(node.id, 20)(
             new iD.coreGraph().replace(node)
         );
 
-        expect(graph.entity(node.id).tags.direction).toEqual('10');
+        expect(graph.entity(node.id).tags.direction).toEqual('20');
     });
 
-    it('rotates a numeric direction counterclockwise', () => {
+    it('wraps absolute degrees into [0, 360)', () => {
         const node = new iD.osmNode({ tags: { direction: '5' } });
         const graph = iD.actionRotatePointDirection(node.id, -15)(
             new iD.coreGraph().replace(node)
         );
 
-        expect(graph.entity(node.id).tags.direction).toEqual('350');
+        expect(graph.entity(node.id).tags.direction).toEqual('345');
     });
 
-    it('does nothing for non-numeric directions', () => {
+    it('sets a prefixed numeric direction key', () => {
+        const node = new iD.osmNode({ tags: { 'camera:direction': '10' } });
+        const graph = iD.actionRotatePointDirection(node.id, 90, 'camera:direction')(
+            new iD.coreGraph().replace(node)
+        );
+
+        expect(graph.entity(node.id).tags['camera:direction']).toEqual('90');
+        expect(graph.entity(node.id).tags.direction).toBeUndefined();
+    });
+
+    it('sets a direction when the tag was previously absent', () => {
+        const node = new iD.osmNode({ tags: { amenity: 'bench' } });
+        const graph = iD.actionRotatePointDirection(node.id, 123.4, 'direction')(
+            new iD.coreGraph().replace(node)
+        );
+
+        expect(graph.entity(node.id).tags.direction).toEqual('123');
+    });
+
+    it('does nothing for non-numeric directions without an explicit key', () => {
         const node = new iD.osmNode({ tags: { direction: 'forward' } });
         const graph = iD.actionRotatePointDirection(node.id, 45)(
             new iD.coreGraph().replace(node)
@@ -26,9 +45,9 @@ describe('iD.actionRotatePointDirection', () => {
         expect(graph.entity(node.id).tags.direction).toEqual('forward');
     });
 
-    it('rounds rotated direction to whole degrees', () => {
+    it('rounds direction to whole degrees', () => {
         const node = new iD.osmNode({ tags: { direction: '10' } });
-        const graph = iD.actionRotatePointDirection(node.id, 0.123456)(
+        const graph = iD.actionRotatePointDirection(node.id, 10.123456)(
             new iD.coreGraph().replace(node)
         );
 

--- a/test/spec/operations/rotate.ts
+++ b/test/spec/operations/rotate.ts
@@ -13,6 +13,32 @@ describe('iD.operationRotate', () => {
         enter: () => {}
     };
 
+    beforeEach(() => {
+        const cached: any = iD.fileFetcher.cache();
+        cached.preset_fields = {
+            direction: { key: 'direction', type: 'number' },
+            'camera/direction': { key: 'camera:direction', type: 'number' },
+            direction_relative: { key: 'direction', type: 'combo' }
+        };
+        cached.preset_presets = {
+            'Surveillance Camera': {
+                tags: { 'man_made': 'surveillance' },
+                geometry: ['point', 'vertex'],
+                fields: ['camera/direction']
+            },
+            Bench: {
+                tags: { amenity: 'bench' },
+                geometry: ['point', 'vertex'],
+                fields: ['direction']
+            },
+            'Give Way Sign': {
+                tags: { highway: 'give_way' },
+                geometry: ['point', 'vertex'],
+                fields: ['direction_relative']
+            }
+        };
+    });
+
     it('is available for points with numeric direction tags', () => {
         const node = new iD.osmNode({ id: 'n1', tags: { direction: '45' } });
         graph = new iD.coreGraph().replace(node);
@@ -20,8 +46,36 @@ describe('iD.operationRotate', () => {
         expect(iD.operationRotate(fakeContext, [node.id]).available()).toBeTruthy();
     });
 
-    it('is not available for points with non-numeric direction tags', () => {
-        const node = new iD.osmNode({ id: 'n1', tags: { direction: 'forward' } });
+    it('is available for points with numeric camera:direction tags', () => {
+        const node = new iD.osmNode({ id: 'n1', tags: { 'camera:direction': '90' } });
+        graph = new iD.coreGraph().replace(node);
+
+        expect(iD.operationRotate(fakeContext, [node.id]).available()).toBeTruthy();
+    });
+
+    it('is available for vertices with numeric direction tags', () => {
+        const node = new iD.osmNode({ id: 'n1', loc: [0, 0], tags: { direction: '45' } });
+        const node2 = new iD.osmNode({ id: 'n2', loc: [1, 0] });
+        const way = new iD.osmWay({ id: 'w1', nodes: [node.id, node2.id] });
+        graph = new iD.coreGraph()
+            .replace(node)
+            .replace(node2)
+            .replace(way);
+
+        expect(iD.operationRotate(fakeContext, [node.id]).available()).toBeTruthy();
+    });
+
+    it('is available when the tag is absent but the preset has a numeric direction field', async () => {
+        await (iD.presetManager as any).ensureLoaded(true);
+        const node = new iD.osmNode({ id: 'n1', tags: { amenity: 'bench' } });
+        graph = new iD.coreGraph().replace(node);
+
+        expect(iD.operationRotate(fakeContext, [node.id]).available()).toBeTruthy();
+    });
+
+    it('is not available for points with non-numeric direction tags', async () => {
+        await (iD.presetManager as any).ensureLoaded(true);
+        const node = new iD.osmNode({ id: 'n1', tags: { highway: 'give_way', direction: 'forward' } });
         graph = new iD.coreGraph().replace(node);
 
         expect(iD.operationRotate(fakeContext, [node.id]).available()).toBeFalsy();

--- a/test/spec/operations/rotate.ts
+++ b/test/spec/operations/rotate.ts
@@ -1,0 +1,41 @@
+describe('iD.operationRotate', () => {
+    let graph: iD.Graph;
+
+    const fakeContext = {
+        graph: () => graph,
+        map: () => ({
+            extent: () => iD.geoExtent()
+        }),
+        inIntro: () => false,
+        connection: () => null,
+        hasHiddenConnections: () => false,
+        entity: (id: iD.OsmEntity['id']) => graph.entity(id),
+        enter: () => {}
+    };
+
+    it('is available for points with numeric direction tags', () => {
+        const node = new iD.osmNode({ id: 'n1', tags: { direction: '45' } });
+        graph = new iD.coreGraph().replace(node);
+
+        expect(iD.operationRotate(fakeContext, [node.id]).available()).toBeTruthy();
+    });
+
+    it('is not available for points with non-numeric direction tags', () => {
+        const node = new iD.osmNode({ id: 'n1', tags: { direction: 'forward' } });
+        graph = new iD.coreGraph().replace(node);
+
+        expect(iD.operationRotate(fakeContext, [node.id]).available()).toBeFalsy();
+    });
+
+    it('is available for multi-node geometries', () => {
+        const node1 = new iD.osmNode({ id: 'n1', loc: [0, 0] });
+        const node2 = new iD.osmNode({ id: 'n2', loc: [1, 0] });
+        const way = new iD.osmWay({ id: 'w1', nodes: [node1.id, node2.id] });
+        graph = new iD.coreGraph()
+            .replace(node1)
+            .replace(node2)
+            .replace(way);
+
+        expect(iD.operationRotate(fakeContext, [way.id]).available()).toBeTruthy();
+    });
+});

--- a/test/spec/operations/rotate.ts
+++ b/test/spec/operations/rotate.ts
@@ -46,6 +46,20 @@ describe('iD.operationRotate', () => {
         expect(iD.operationRotate(fakeContext, [node.id]).available()).toBeTruthy();
     });
 
+    it('is available for points with multi-value direction tags', () => {
+        const node = new iD.osmNode({ id: 'n1', tags: { direction: '120;300' } });
+        graph = new iD.coreGraph().replace(node);
+
+        expect(iD.operationRotate(fakeContext, [node.id]).available()).toBeTruthy();
+    });
+
+    it('is available for points with cardinal direction tags', () => {
+        const node = new iD.osmNode({ id: 'n1', tags: { direction: 'N' } });
+        graph = new iD.coreGraph().replace(node);
+
+        expect(iD.operationRotate(fakeContext, [node.id]).available()).toBeTruthy();
+    });
+
     it('is available for points with numeric camera:direction tags', () => {
         const node = new iD.osmNode({ id: 'n1', tags: { 'camera:direction': '90' } });
         graph = new iD.coreGraph().replace(node);

--- a/test/spec/util/direction_degrees.ts
+++ b/test/spec/util/direction_degrees.ts
@@ -1,0 +1,61 @@
+describe('iD.util direction degrees helpers', () => {
+    describe('utilNormalizeAzimuthDegrees', () => {
+        it('wraps into [0, 360)', () => {
+            expect(iD.utilNormalizeAzimuthDegrees(0)).toEqual(0);
+            expect(iD.utilNormalizeAzimuthDegrees(360)).toEqual(0);
+            expect(iD.utilNormalizeAzimuthDegrees(-15)).toEqual(345);
+            expect(iD.utilNormalizeAzimuthDegrees(370)).toEqual(10);
+        });
+    });
+
+    describe('utilParseDirectionDegreesSegment', () => {
+        it('parses numbers and cardinals', () => {
+            expect(iD.utilParseDirectionDegreesSegment('90')).toEqual(90);
+            expect(iD.utilParseDirectionDegreesSegment('N')).toEqual(0);
+            expect(iD.utilParseDirectionDegreesSegment('ne')).toEqual(45);
+            expect(iD.utilParseDirectionDegreesSegment(' 270 ')).toEqual(270);
+        });
+
+        it('rejects empty and relative/junk values', () => {
+            expect(iD.utilParseDirectionDegreesSegment('')).toBeNull();
+            expect(iD.utilParseDirectionDegreesSegment('forward')).toBeNull();
+            expect(iD.utilParseDirectionDegreesSegment('error')).toBeNull();
+        });
+    });
+
+    describe('utilHasDirectionDegrees', () => {
+        it('detects any parseable semicolon segment', () => {
+            expect(iD.utilHasDirectionDegrees('120;300')).toBeTruthy();
+            expect(iD.utilHasDirectionDegrees('N')).toBeTruthy();
+            expect(iD.utilHasDirectionDegrees('forward;90')).toBeTruthy();
+            expect(iD.utilHasDirectionDegrees('forward')).toBeFalsy();
+            expect(iD.utilHasDirectionDegrees(undefined)).toBeFalsy();
+            expect(iD.utilHasDirectionDegrees('')).toBeFalsy();
+        });
+    });
+
+    describe('utilRetargetDirectionDegreesValue', () => {
+        it('sets an absent or empty value to the target', () => {
+            expect(iD.utilRetargetDirectionDegreesValue(undefined, 123.4)).toEqual('123');
+            expect(iD.utilRetargetDirectionDegreesValue('', 90)).toEqual('90');
+        });
+
+        it('applies a shared delta across multi-value tags', () => {
+            expect(iD.utilRetargetDirectionDegreesValue('120;300', 90)).toEqual('90;270');
+            expect(iD.utilRetargetDirectionDegreesValue('N;90', 45)).toEqual('45;135');
+        });
+
+        it('preserves unparsable segments', () => {
+            expect(iD.utilRetargetDirectionDegreesValue('120;error;300', 90)).toEqual('90;error;270');
+        });
+
+        it('leaves all-junk values unchanged', () => {
+            expect(iD.utilRetargetDirectionDegreesValue('forward', 45)).toEqual('forward');
+        });
+
+        it('converts cardinals to numeric degrees', () => {
+            expect(iD.utilRetargetDirectionDegreesValue('N', 45)).toEqual('45');
+            expect(iD.utilRetargetDirectionDegreesValue('ne', 90)).toEqual('90');
+        });
+    });
+});

--- a/test/spec/util/direction_field.ts
+++ b/test/spec/util/direction_field.ts
@@ -32,10 +32,12 @@ describe('iD.utilDirectionFieldKey / iD.utilRotatePointDirectionKey', () => {
         expect(iD.utilIsDirectionKey(undefined)).toBeFalsy();
     });
 
-    it('shows the rotate hint only for numeric direction fields or values', () => {
+    it('shows the rotate hint only for numeric direction fields or degrees values', () => {
         expect(iD.utilShowsDirectionRotateHint({ key: 'direction', fieldType: 'number' })).toBeTruthy();
         expect(iD.utilShowsDirectionRotateHint({ key: 'direction', fieldType: 'combo' })).toBeFalsy();
         expect(iD.utilShowsDirectionRotateHint({ key: 'direction', value: '90' })).toBeTruthy();
+        expect(iD.utilShowsDirectionRotateHint({ key: 'direction', value: '120;300' })).toBeTruthy();
+        expect(iD.utilShowsDirectionRotateHint({ key: 'direction', value: 'N' })).toBeTruthy();
         expect(iD.utilShowsDirectionRotateHint({ key: 'direction', value: 'forward' })).toBeFalsy();
         expect(iD.utilShowsDirectionRotateHint({ key: 'direction' })).toBeFalsy();
     });
@@ -66,6 +68,15 @@ describe('iD.utilDirectionFieldKey / iD.utilRotatePointDirectionKey', () => {
         const graph = new iD.coreGraph().replace(node);
 
         expect(iD.utilRotatePointDirectionKey(node, graph)).toEqual('camera:direction');
+    });
+
+    it('recognizes multi-value and cardinal direction tags', async () => {
+        await (iD.presetManager as any).ensureLoaded(true);
+        const multi = new iD.osmNode({ tags: { direction: '120;300' } });
+        const cardinal = new iD.osmNode({ tags: { direction: 'N' } });
+
+        expect(iD.utilRotatePointDirectionKey(multi, new iD.coreGraph().replace(multi))).toEqual('direction');
+        expect(iD.utilRotatePointDirectionKey(cardinal, new iD.coreGraph().replace(cardinal))).toEqual('direction');
     });
 
     it('falls back to a numeric preset field when the tag is absent', async () => {

--- a/test/spec/util/direction_field.ts
+++ b/test/spec/util/direction_field.ts
@@ -32,6 +32,14 @@ describe('iD.utilDirectionFieldKey / iD.utilRotatePointDirectionKey', () => {
         expect(iD.utilIsDirectionKey(undefined)).toBeFalsy();
     });
 
+    it('shows the rotate hint only for numeric direction fields or values', () => {
+        expect(iD.utilShowsDirectionRotateHint({ key: 'direction', fieldType: 'number' })).toBeTruthy();
+        expect(iD.utilShowsDirectionRotateHint({ key: 'direction', fieldType: 'combo' })).toBeFalsy();
+        expect(iD.utilShowsDirectionRotateHint({ key: 'direction', value: '90' })).toBeTruthy();
+        expect(iD.utilShowsDirectionRotateHint({ key: 'direction', value: 'forward' })).toBeFalsy();
+        expect(iD.utilShowsDirectionRotateHint({ key: 'direction' })).toBeFalsy();
+    });
+
     it('finds a numeric direction field on the preset', async () => {
         await (iD.presetManager as any).ensureLoaded(true);
         const node = new iD.osmNode({ tags: { amenity: 'bench' } });

--- a/test/spec/util/direction_field.ts
+++ b/test/spec/util/direction_field.ts
@@ -1,0 +1,80 @@
+describe('iD.utilDirectionFieldKey / iD.utilRotatePointDirectionKey', () => {
+    beforeEach(() => {
+        const cached: any = iD.fileFetcher.cache();
+        cached.preset_fields = {
+            direction: { key: 'direction', type: 'number' },
+            'camera/direction': { key: 'camera:direction', type: 'number' },
+            direction_relative: { key: 'direction', type: 'combo' }
+        };
+        cached.preset_presets = {
+            Bench: {
+                tags: { amenity: 'bench' },
+                geometry: ['point', 'vertex'],
+                fields: ['direction']
+            },
+            'Surveillance Camera': {
+                tags: { 'man_made': 'surveillance' },
+                geometry: ['point', 'vertex'],
+                fields: ['camera/direction']
+            },
+            'Give Way Sign': {
+                tags: { highway: 'give_way' },
+                geometry: ['point', 'vertex'],
+                fields: ['direction_relative']
+            }
+        };
+    });
+
+    it('recognizes direction and *:direction keys', () => {
+        expect(iD.utilIsDirectionKey('direction')).toBeTruthy();
+        expect(iD.utilIsDirectionKey('camera:direction')).toBeTruthy();
+        expect(iD.utilIsDirectionKey('highway')).toBeFalsy();
+        expect(iD.utilIsDirectionKey(undefined)).toBeFalsy();
+    });
+
+    it('finds a numeric direction field on the preset', async () => {
+        await (iD.presetManager as any).ensureLoaded(true);
+        const node = new iD.osmNode({ tags: { amenity: 'bench' } });
+        const graph = new iD.coreGraph().replace(node);
+
+        expect(iD.utilDirectionFieldKey(node, graph, true)).toEqual('direction');
+        expect(iD.utilDirectionFieldKey(node, graph, false)).toBeFalsy();
+    });
+
+    it('finds a relative direction field on the preset', async () => {
+        await (iD.presetManager as any).ensureLoaded(true);
+        const node = new iD.osmNode({ tags: { highway: 'give_way' } });
+        const graph = new iD.coreGraph().replace(node);
+
+        expect(iD.utilDirectionFieldKey(node, graph, false)).toEqual('direction');
+        expect(iD.utilDirectionFieldKey(node, graph, true)).toBeFalsy();
+    });
+
+    it('prefers an existing prefixed numeric direction tag', async () => {
+        await (iD.presetManager as any).ensureLoaded(true);
+        const node = new iD.osmNode({
+            tags: { 'man_made': 'surveillance', 'camera:direction': '45', direction: '10' }
+        });
+        const graph = new iD.coreGraph().replace(node);
+
+        expect(iD.utilRotatePointDirectionKey(node, graph)).toEqual('camera:direction');
+    });
+
+    it('falls back to a numeric preset field when the tag is absent', async () => {
+        await (iD.presetManager as any).ensureLoaded(true);
+        const node = new iD.osmNode({ tags: { 'man_made': 'surveillance' } });
+        const graph = new iD.coreGraph().replace(node);
+
+        expect(iD.utilRotatePointDirectionKey(node, graph)).toEqual('camera:direction');
+    });
+
+    it('resolves a selected node for point-direction rotate', async () => {
+        await (iD.presetManager as any).ensureLoaded(true);
+        const node = new iD.osmNode({ id: 'n1', tags: { direction: '45' } });
+        const graph = new iD.coreGraph().replace(node);
+
+        expect(iD.utilSelectedRotatePointDirectionKey([node.id], graph)).toEqual('direction');
+        expect(iD.utilSelectedRotatePointDirectionKey([node.id, 'n2'], graph)).toBeFalsy();
+    });
+
+});


### PR DESCRIPTION

**Testing:** 
* standalone (bench) https://pr-12673--ideditor.netlify.app/#disable_features=boundaries&map=21.85/52.47409/13.44556&background=Bing&id=n12518261743
* vertex (camera) https://pr-12673--ideditor.netlify.app/#disable_features=boundaries&map=21.96/52.47427/13.44495&background=Bing&id=n877058722

---

This is a subset of https://github.com/openstreetmap/iD/pull/12104.
The PR only add the `R` Shortcut that we explored over there, plus some context.

The idea is: This change is a lot simpler than https://github.com/openstreetmap/iD/pull/12104 but it bringt us a long way to improve the UX for editing node `direction`s.

Changes:
- Add the `R` for nodes with `direction` tag
- Help text on the Info-i of the field
- Some other help texts modified
- During rotate, the sidebar stays on the feature (and does not switch to "Search features") – this ist IMO a UX bug we had before but we did not really notice because when rotating lines and areas I look at the map, not the sidebar. But for nodes, I want to see the direction number change during rotate, so the feature needs to stay active.

Closes https://github.com/openstreetmap/iD/issues/12341

---

Aside: This idea was also adopted to GoMap where it works great, IMO

---

🤖  the changes are build with Cursor Models and reviewed by me.