### PR TITLE
Add rotate action for points with `direction`  (stacked branch experiment)

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -2919,6 +2919,13 @@ button.raw-tag-option svg.icon {
 .tag-reference-link .icon:first-child {
     margin-left: 0;
 }
+.tag-reference-separator {
+    border-top: 1px solid var(--border-color);
+    margin: 8px 0;
+}
+.shortcut-hint {
+    margin: 0;
+}
 
 img.tag-reference-wiki-image {
     float: right;

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -733,6 +733,7 @@ en:
     edit_reference: "edit/translate documentation"
     wiki_reference: View documentation
     wiki_en_reference: View documentation in English
+    direction_rotate_help: "Press {key} to adjust this value on the map."
     key_value: "key=value"
     empty: (empty)
     multiple_values: Multiple Values

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -410,6 +410,7 @@ en:
         multiple: Rotate these features around their center point.
       key: R
       annotation:
+        point: Rotated a point.
         line: Rotated a line.
         area: Rotated an area.
         relation: Rotated a relation.

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -406,6 +406,7 @@ en:
     rotate:
       title: Rotate
       description:
+        point: Adjust this point's numeric direction tag.
         single: Rotate this feature around its center point.
         multiple: Rotate these features around their center point.
       key: R
@@ -1405,7 +1406,7 @@ en:
       orthogonalize: "{orthogonalize_icon} **{orthogonalize}** snaps the corners of areas and lines to 90°. You can square individual corners or entire features."
       circularize: "{circularize_icon} **{circularize}** turns areas and closed lines into circles."
       move: "{move_icon} **{move}** lets you drag features around the map."
-      rotate: "{rotate_icon} **{rotate}** lets you swivel features around their center points."
+      rotate: "{rotate_icon} **{rotate}** lets you swivel features around their center points. For a point with a numeric direction tag, it adjusts that direction instead."
       reflect: "{reflect_short_icon} **{reflect_short}** and {reflect_long_icon} **{reflect_long}** reflect features over their short and long axes."
       continue: "{continue_icon} **{continue}** lets you extend existing lines from their endpoints."
       reverse: "{reverse_icon} **{reverse}** changes the direction of features. The direction matters for things like one-way roads, traffic signs, waterways, and cliffs."
@@ -2255,7 +2256,7 @@ en:
         nudge_more: "Nudge selected features by a lot"
         scale: "Scale selected features"
         scale_more: "Scale selected features by a lot"
-        rotate: "Rotate selected features"
+        rotate: "Rotate selected features, or adjust a point's numeric direction"
         orthogonalize: "Square corners of a line or area"
         straighten: "Straighten a line or points"
         circularize: "Circularize a closed line or area"

--- a/modules/actions/index.ts
+++ b/modules/actions/index.ts
@@ -30,6 +30,7 @@ export { actionRestrictTurn } from './restrict_turn';
 export { actionReverse } from './reverse';
 export { actionRevert } from './revert';
 export { actionRotate } from './rotate';
+export { actionRotatePointDirection } from './rotate_point_direction';
 export { actionScale } from './scale';
 export { actionSplit } from './split';
 export { actionStraightenNodes } from './straighten_nodes';

--- a/modules/actions/rotate_point_direction.ts
+++ b/modules/actions/rotate_point_direction.ts
@@ -1,0 +1,21 @@
+import type { Action } from '../core/history';
+import type { EntityId } from '../osm';
+import { utilWrap } from '../util';
+
+
+export function actionRotatePointDirection(entityID: EntityId, deltaDegrees: number): Action {
+    return function(graph) {
+        const entity = graph.hasEntity(entityID);
+        if (!entity || entity.type !== 'node') return graph;
+
+        const direction = Number(entity.tags.direction);
+        if (!isFinite(direction)) return graph;
+
+        // Keep values aligned with iD direction tagging (whole degrees, [0, 360)).
+        const nextDirection = Math.round(utilWrap(direction + deltaDegrees, 360)).toString();
+        if (nextDirection === entity.tags.direction) return graph;
+
+        const tags = Object.assign({}, entity.tags, { direction: nextDirection });
+        return graph.replace(entity.update({ tags: tags }));
+    };
+}

--- a/modules/core/context.js
+++ b/modules/core/context.js
@@ -325,7 +325,7 @@ export function coreContext() {
   context.mode = () => _mode;
   context.enter = (newMode) => {
     if (_mode) {
-      _mode.exit();
+      _mode.exit(newMode);
       dispatch.call('exit', this, _mode);
     }
 

--- a/modules/modes/rotate.js
+++ b/modules/modes/rotate.js
@@ -9,6 +9,7 @@ import {
 
 import { t } from '../core/localizer';
 import { actionRotate } from '../actions/rotate';
+import { actionRotatePointDirection } from '../actions/rotate_point_direction';
 import { actionNoop } from '../actions/noop';
 import { behaviorEdit } from '../behavior/edit';
 import { geoVecInterp, geoVecLength } from '../geo/vector';
@@ -27,15 +28,15 @@ import { utilFastMouse, utilGetAllNodes } from '../util/util';
 
 export function modeRotate(context, entityIDs) {
 
-    var _tolerancePx = 4; // see also behaviorDrag, behaviorSelect, modeMove
+    const _tolerancePx = 4; // see also behaviorDrag, behaviorSelect, modeMove
 
-    var mode = {
+    const mode = {
         id: 'rotate',
         button: 'browse'
     };
 
-    var keybinding = utilKeybinding('rotate');
-    var behaviors = [
+    const keybinding = utilKeybinding('rotate');
+    const behaviors = [
         behaviorEdit(context),
         operationCircularize(context, entityIDs).behavior,
         operationDelete(context, entityIDs).behavior,
@@ -44,49 +45,50 @@ export function modeRotate(context, entityIDs) {
         operationReflectLong(context, entityIDs).behavior,
         operationReflectShort(context, entityIDs).behavior
     ];
-    var annotation = entityIDs.length === 1 ?
+    const annotation = entityIDs.length === 1 ?
         t('operations.rotate.annotation.' + context.graph().geometry(entityIDs[0])) :
         t('operations.rotate.annotation.feature', { n: entityIDs.length });
 
-    var _prevGraph;
-    var _prevAngle;
-    var _prevTransform;
-    var _pivot;
+    let _prevGraph;
+    let _prevAngle;
+    let _prevTransform;
+    let _pivot;
+    let _pointDirectionRotate = false;
 
     // use pointer events on supported platforms; fallback to mouse events
-    var _pointerPrefix = 'PointerEvent' in window ? 'pointer' : 'mouse';
+    const _pointerPrefix = 'PointerEvent' in window ? 'pointer' : 'mouse';
 
 
     function doRotate(d3_event) {
-        var fn;
-        if (context.graph() !== _prevGraph) {
-            fn = context.perform;
-        } else {
-            fn = context.replace;
-        }
+        const fn = (context.graph() !== _prevGraph) ? context.perform : context.replace;
 
         // projection changed, recalculate _pivot
-        var projection = context.projection;
-        var currTransform = projection.transform();
+        const projection = context.projection;
+        const currTransform = projection.transform();
         if (!_prevTransform ||
             currTransform.k !== _prevTransform.k ||
             currTransform.x !== _prevTransform.x ||
             currTransform.y !== _prevTransform.y) {
 
-            var nodes = utilGetAllNodes(entityIDs, context.graph());
-            var points = nodes.map(function(n) { return projection(n.loc); });
+            const nodes = utilGetAllNodes(entityIDs, context.graph());
+            const points = nodes.map(function(n) { return projection(n.loc); });
             _pivot = getPivot(points);
             _prevAngle = undefined;
         }
 
 
-        var currMouse = context.map().mouse(d3_event);
-        var currAngle = Math.atan2(currMouse[1] - _pivot[1], currMouse[0] - _pivot[0]);
+        const currMouse = context.map().mouse(d3_event);
+        const currAngle = Math.atan2(currMouse[1] - _pivot[1], currMouse[0] - _pivot[0]);
 
         if (typeof _prevAngle === 'undefined') _prevAngle = currAngle;
-        var delta = currAngle - _prevAngle;
+        const delta = currAngle - _prevAngle;
 
-        fn(actionRotate(entityIDs, _pivot, delta, projection));
+        if (_pointDirectionRotate) {
+            const deltaDegrees = delta * (180 / Math.PI);
+            fn(actionRotatePointDirection(entityIDs[0], deltaDegrees));
+        } else {
+            fn(actionRotate(entityIDs, _pivot, delta, projection));
+        }
 
         _prevTransform = currTransform;
         _prevAngle = currAngle;
@@ -94,20 +96,31 @@ export function modeRotate(context, entityIDs) {
     }
 
     function getPivot(points) {
-        var _pivot;
         if (points.length === 1) {
-            _pivot = points[0];
-        } else if (points.length === 2) {
-            _pivot = geoVecInterp(points[0], points[1], 0.5);
-        } else {
-            var polygonHull = d3_polygonHull(points);
-            if (polygonHull.length === 2) {
-                _pivot = geoVecInterp(points[0], points[1], 0.5);
-            } else {
-                _pivot = d3_polygonCentroid(d3_polygonHull(points));
-            }
+            return points[0];
         }
-        return _pivot;
+        if (points.length === 2) {
+            return geoVecInterp(points[0], points[1], 0.5);
+        }
+
+        const polygonHull = d3_polygonHull(points);
+        if (!polygonHull || polygonHull.length <= 2) {
+            return geoVecInterp(points[0], points[1], 0.5);
+        }
+
+        return d3_polygonCentroid(polygonHull);
+    }
+
+
+    function isPointDirectionRotate(graph) {
+        if (entityIDs.length !== 1) return false;
+
+        const entity = graph.hasEntity(entityIDs[0]);
+        if (!entity || entity.type !== 'node') return false;
+        if (graph.geometry(entity.id) !== 'point') return false;
+
+        const direction = Number(entity.tags.direction);
+        return isFinite(direction);
     }
 
 
@@ -131,11 +144,12 @@ export function modeRotate(context, entityIDs) {
 
     mode.enter = function() {
         _prevGraph = null;
+        _pointDirectionRotate = isPointDirectionRotate(context.graph());
         context.features().forceVisible(entityIDs);
 
         behaviors.forEach(context.install);
 
-        var downEvent;
+        let downEvent;
 
         context.surface()
             .on(_pointerPrefix + 'down.modeRotate', function(d3_event) {
@@ -146,11 +160,11 @@ export function modeRotate(context, entityIDs) {
             .on(_pointerPrefix + 'move.modeRotate', doRotate, true)
             .on(_pointerPrefix + 'up.modeRotate', function(d3_event) {
                 if (!downEvent) return;
-                var mapNode = context.container().select('.main-map').node();
-                var pointGetter = utilFastMouse(mapNode);
-                var p1 = pointGetter(downEvent);
-                var p2 = pointGetter(d3_event);
-                var dist = geoVecLength(p1, p2);
+                const mapNode = context.container().select('.main-map').node();
+                const pointGetter = utilFastMouse(mapNode);
+                const p1 = pointGetter(downEvent);
+                const p2 = pointGetter(d3_event);
+                const dist = geoVecLength(p1, p2);
 
                 if (dist <= _tolerancePx) finish(d3_event);
                 downEvent = null;

--- a/modules/modes/rotate.js
+++ b/modules/modes/rotate.js
@@ -182,7 +182,7 @@ export function modeRotate(context, entityIDs) {
     };
 
 
-    mode.exit = function() {
+    mode.exit = function(nextMode) {
         behaviors.forEach(context.uninstall);
 
         context.surface()
@@ -198,6 +198,11 @@ export function modeRotate(context, entityIDs) {
         d3_select(document)
             .call(keybinding.unbind);
 
+        // select.enter will refresh the editor; hide only when leaving selection
+        // entirely (e.g. undo → browse).
+        if (!nextMode || nextMode.id !== 'select') {
+            context.ui().sidebar.hide();
+        }
         context.features().forceVisible([]);
     };
 

--- a/modules/modes/select.js
+++ b/modules/modes/select.js
@@ -645,7 +645,7 @@ export function modeSelect(context, selectedIDs) {
     };
 
 
-    mode.exit = function() {
+    mode.exit = function(nextMode) {
 
         // we could enter the mode multiple times but it's only new the first time
         _newFeature = false;
@@ -690,7 +690,10 @@ export function modeSelect(context, selectedIDs) {
             .classed('related', false);
 
         context.map().on('drawn.select', null);
-        context.ui().sidebar.hide();
+        // Keep the feature editor open when entering rotate (same selection).
+        if (!nextMode || nextMode.id !== 'rotate') {
+            context.ui().sidebar.hide();
+        }
         context.features().forceVisible([]);
 
         var entity = singular();

--- a/modules/operations/rotate.js
+++ b/modules/operations/rotate.js
@@ -70,9 +70,13 @@ export function operationRotate(context, selectedIDs) {
 
     operation.tooltip = function() {
         const disable = operation.disabled();
-        return disable ?
-            t.append('operations.rotate.' + disable + '.' + multi) :
-            t.append('operations.rotate.description.' + multi);
+        if (disable) {
+            return t.append('operations.rotate.' + disable + '.' + multi);
+        }
+        if (isPointDirectionRotate()) {
+            return t.append('operations.rotate.description.point');
+        }
+        return t.append('operations.rotate.description.' + multi);
     };
 
 

--- a/modules/operations/rotate.js
+++ b/modules/operations/rotate.js
@@ -5,19 +5,31 @@ import { utilGetAllNodes, utilTotalExtent } from '../util/util';
 
 
 export function operationRotate(context, selectedIDs) {
-    var multi = (selectedIDs.length === 1 ? 'single' : 'multiple');
-    var nodes = utilGetAllNodes(selectedIDs, context.graph());
-    var coords = nodes.map(function(n) { return n.loc; });
-    var extent = utilTotalExtent(selectedIDs, context.graph());
+    const multi = (selectedIDs.length === 1 ? 'single' : 'multiple');
+    const graph = context.graph();
+    const nodes = utilGetAllNodes(selectedIDs, graph);
+    const coords = nodes.map(function(n) { return n.loc; });
+    const extent = utilTotalExtent(selectedIDs, graph);
+
+    function isPointDirectionRotate() {
+        if (selectedIDs.length !== 1) return false;
+
+        const entity = graph.hasEntity(selectedIDs[0]);
+        if (!entity || entity.type !== 'node') return false;
+        if (graph.geometry(entity.id) !== 'point') return false;
+
+        const direction = Number(entity.tags.direction);
+        return isFinite(direction);
+    }
 
 
-    var operation = function() {
+    const operation = function() {
         context.enter(modeRotate(context, selectedIDs));
     };
 
 
     operation.available = function() {
-        return nodes.length >= 2;
+        return nodes.length >= 2 || isPointDirectionRotate();
     };
 
 
@@ -38,9 +50,9 @@ export function operationRotate(context, selectedIDs) {
 
         function someMissing() {
             if (context.inIntro()) return false;
-            var osm = context.connection();
+            const osm = context.connection();
             if (osm) {
-                var missing = coords.filter(function(loc) { return !osm.isDataLoaded(loc); });
+                const missing = coords.filter(function(loc) { return !osm.isDataLoaded(loc); });
                 if (missing.length) {
                     missing.forEach(function(loc) { context.loadTileAtLoc(loc); });
                     return true;
@@ -50,14 +62,14 @@ export function operationRotate(context, selectedIDs) {
         }
 
         function incompleteRelation(id) {
-            var entity = context.entity(id);
-            return entity.type === 'relation' && !entity.isComplete(context.graph());
+            const entity = context.entity(id);
+            return entity.type === 'relation' && !entity.isComplete(graph);
         }
     };
 
 
     operation.tooltip = function() {
-        var disable = operation.disabled();
+        const disable = operation.disabled();
         return disable ?
             t.append('operations.rotate.' + disable + '.' + multi) :
             t.append('operations.rotate.description.' + multi);

--- a/modules/ui/tag_reference.js
+++ b/modules/ui/tag_reference.js
@@ -5,6 +5,7 @@ import {
 import { t } from '../core/localizer';
 import { services } from '../services';
 import { svgIcon } from '../svg/icon';
+import { uiCmd } from './cmd';
 
 
 // Pass `what` object of the form:
@@ -91,6 +92,20 @@ export function uiTagReference(what) {
               .call(svgIcon('#iD-icon-out-link', 'inline'))
               .append('span')
               .call(t.append(docs.wiki.text));
+        }
+
+        // Rotate (R) adjusts numeric direction=* on standalone points.
+        if (what.key === 'direction') {
+            _body
+                .append('div')
+                .attr('class', 'tag-reference-separator');
+
+            _body
+                .append('p')
+                .attr('class', 'shortcut-hint')
+                .call(t.append('inspector.direction_rotate_help', {
+                    key: uiCmd.display(t('operations.rotate.key'))
+                }));
         }
 
         // Add link to info about "good changeset comments" - #2923

--- a/test/spec/actions/rotate_point_direction.ts
+++ b/test/spec/actions/rotate_point_direction.ts
@@ -1,0 +1,37 @@
+describe('iD.actionRotatePointDirection', () => {
+    it('rotates a numeric direction clockwise', () => {
+        const node = new iD.osmNode({ tags: { direction: '350' } });
+        const graph = iD.actionRotatePointDirection(node.id, 20)(
+            new iD.coreGraph().replace(node)
+        );
+
+        expect(graph.entity(node.id).tags.direction).toEqual('10');
+    });
+
+    it('rotates a numeric direction counterclockwise', () => {
+        const node = new iD.osmNode({ tags: { direction: '5' } });
+        const graph = iD.actionRotatePointDirection(node.id, -15)(
+            new iD.coreGraph().replace(node)
+        );
+
+        expect(graph.entity(node.id).tags.direction).toEqual('350');
+    });
+
+    it('does nothing for non-numeric directions', () => {
+        const node = new iD.osmNode({ tags: { direction: 'forward' } });
+        const graph = iD.actionRotatePointDirection(node.id, 45)(
+            new iD.coreGraph().replace(node)
+        );
+
+        expect(graph.entity(node.id).tags.direction).toEqual('forward');
+    });
+
+    it('rounds rotated direction to whole degrees', () => {
+        const node = new iD.osmNode({ tags: { direction: '10' } });
+        const graph = iD.actionRotatePointDirection(node.id, 0.123456)(
+            new iD.coreGraph().replace(node)
+        );
+
+        expect(graph.entity(node.id).tags.direction).toEqual('10');
+    });
+});

--- a/test/spec/operations/rotate.ts
+++ b/test/spec/operations/rotate.ts
@@ -1,0 +1,41 @@
+describe('iD.operationRotate', () => {
+    let graph: iD.Graph;
+
+    const fakeContext = {
+        graph: () => graph,
+        map: () => ({
+            extent: () => iD.geoExtent()
+        }),
+        inIntro: () => false,
+        connection: () => null,
+        hasHiddenConnections: () => false,
+        entity: (id: iD.OsmEntity['id']) => graph.entity(id),
+        enter: () => {}
+    };
+
+    it('is available for points with numeric direction tags', () => {
+        const node = new iD.osmNode({ id: 'n1', tags: { direction: '45' } });
+        graph = new iD.coreGraph().replace(node);
+
+        expect(iD.operationRotate(fakeContext, [node.id]).available()).toBeTruthy();
+    });
+
+    it('is not available for points with non-numeric direction tags', () => {
+        const node = new iD.osmNode({ id: 'n1', tags: { direction: 'forward' } });
+        graph = new iD.coreGraph().replace(node);
+
+        expect(iD.operationRotate(fakeContext, [node.id]).available()).toBeFalsy();
+    });
+
+    it('is available for multi-node geometries', () => {
+        const node1 = new iD.osmNode({ id: 'n1', loc: [0, 0] });
+        const node2 = new iD.osmNode({ id: 'n2', loc: [1, 0] });
+        const way = new iD.osmWay({ id: 'w1', nodes: [node1.id, node2.id] });
+        graph = new iD.coreGraph()
+            .replace(node1)
+            .replace(node2)
+            .replace(way);
+
+        expect(iD.operationRotate(fakeContext, [way.id]).available()).toBeTruthy();
+    });
+});


### PR DESCRIPTION
**Testing:** https://pr-12674--ideditor.netlify.app/#disable_features=boundaries&map=21.85/52.47409/13.44556&background=Bing&id=n12518261743

---

This is a subset of #12675 (formerly #12104).
The PR only adds the `R` shortcut that we explored over there, plus some context.

The idea is: This change is a lot simpler than the dial PR but it brings us a long way to improve the UX for editing node `direction`s.

Changes:
- Add the `R` for nodes with `direction` tag
- Help text on the Info-i of the field
- Some other help texts modified
- During rotate, the sidebar stays on the feature (and does not switch to "Search features") – this is IMO a UX bug we had before but we did not really notice because when rotating lines and areas I look at the map, not the sidebar. But for nodes, I want to see the direction number change during rotate, so the feature needs to stay active.

Closes #12341

🤖 the changes are build with Cursor Models and reviewed by me.

---

Aside: This idea was also adopted to GoMap where it works great, IMO

---

Replaces #12673 (recreated as a same-repo PR so it can use GitHub stacked PRs). Sorry for the noise, wanted to try out the new stacked branch feature.

---

## Screenshots
* regular node 
   <img width="374" height="352" alt="point regular" src="https://github.com/user-attachments/assets/cd83b258-185e-4119-807c-9d6976029a92" />
* node with rotate
   <img width="758" height="516" alt="point rotate" src="https://github.com/user-attachments/assets/6c89c0bc-444f-46aa-86be-d297c5710ce7" />
* rotating in progress with info line bottom and sidebar still visible
   <img width="680" height="536" alt="in progress" src="https://github.com/user-attachments/assets/f3f42d00-562c-49a1-85c0-848130df0390" />
* help on info-`i`
   <img width="590" height="392" alt="help inline" src="https://github.com/user-attachments/assets/52286bd3-61a9-4e61-83e8-3526f0577edc" />
* help panel 
   <img width="1074" height="234" alt="help panel" src="https://github.com/user-attachments/assets/d287338b-f2a3-4b4d-9aeb-cbe6f1ce81e7" />


