### PR TITLE
Add direction dial for numeric `*:direction` fields (stacked branch experiment)

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -1504,43 +1504,27 @@ button.preset-reset .label.flash-bg {
 }
 
 .form-field-has-direction-dial {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
-    grid-template-areas:
-        "label dial"
-        "input dial";
-    align-items: stretch;
-    column-gap: 0;
-}
-
-.form-field-has-direction-dial > .field-label {
-    grid-area: label;
-    border-radius: 4px 0 0 0;
-}
-
-.form-field-has-direction-dial > .form-field-input-wrap {
-    grid-area: input;
-    border-radius: 0 0 0 4px;
+    /* Keep hook class for direction fields; layout is handled in input row. */
 }
 
 .form-field-has-direction-dial .direction-dial-wrap {
-    grid-area: dial;
     display: flex;
     flex-flow: row nowrap;
     flex: 0 0 auto;
-    width: min-content;
+    width: 32px;
     border: 1px solid var(--border-color);
     border-left: 0;
-    border-radius: 0 4px 4px 0;
-    background: var(--bg-color-2);
+    border-top-width: 0;
+    border-radius: 0;
+    background: var(--bg-color);
     justify-content: center;
     align-items: center;
-    padding: 3px;
+    padding: 2px;
 }
 
 .direction-dial {
-    width: 55px;
-    height: 55px;
+    width: 28px;
+    height: 28px;
     cursor: crosshair;
     outline: none;
 }
@@ -1553,7 +1537,8 @@ button.preset-reset .label.flash-bg {
 }
 
 @media (hover: hover) {
-    .direction-dial:not(.disabled):hover .direction-dial-ring {
+    .direction-dial:not(.disabled):hover .direction-dial-ring,
+    .direction-dial:not(.disabled).dragging .direction-dial-ring {
         stroke: var(--border-color);
     }
 }
@@ -1562,13 +1547,12 @@ button.preset-reset .label.flash-bg {
     stroke: var(--border-color);
 }
 
-.form-field-has-direction-dial .field-label .tag-reference-button {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
+.form-field-has-direction-dial .form-field-input-wrap > button:last-of-type {
+    border-bottom-right-radius: 4px;
 }
 
-.form-field-has-direction-dial .form-field-input-wrap > button.increment:last-of-type {
-    border-bottom-right-radius: 0;
+.form-field-has-direction-dial .form-field-input-wrap > .form-field-button {
+    padding: 0;
 }
 
 .direction-dial-inner {
@@ -1581,7 +1565,8 @@ button.preset-reset .label.flash-bg {
 }
 
 @media (hover: hover) {
-    .direction-dial:not(.disabled):hover .direction-dial-center-dot {
+    .direction-dial:not(.disabled):hover .direction-dial-center-dot,
+    .direction-dial:not(.disabled).dragging .direction-dial-center-dot {
         fill-opacity: 1;
     }
 }
@@ -1599,7 +1584,8 @@ button.preset-reset .label.flash-bg {
 }
 
 @media (hover: hover) {
-    .direction-dial:not(.disabled):hover .direction-dial-line {
+    .direction-dial:not(.disabled):hover .direction-dial-line,
+    .direction-dial:not(.disabled).dragging .direction-dial-line {
         stroke-opacity: 1;
     }
 }

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -1548,7 +1548,7 @@ button.preset-reset .label.flash-bg {
 .direction-dial-ring {
     fill: none;
     stroke: transparent;
-    stroke-width: 2;
+    stroke-width: 1;
     pointer-events: none;
 }
 
@@ -1558,7 +1558,6 @@ button.preset-reset .label.flash-bg {
     }
 }
 
-.direction-dial:not(.disabled):focus .direction-dial-ring,
 .direction-dial:not(.disabled):focus-visible .direction-dial-ring {
     stroke: var(--border-color);
 }
@@ -1578,12 +1577,36 @@ button.preset-reset .label.flash-bg {
 
 .direction-dial-center-dot {
     fill: var(--text-color);
+    fill-opacity: 0.5;
+}
+
+@media (hover: hover) {
+    .direction-dial:not(.disabled):hover .direction-dial-center-dot {
+        fill-opacity: 1;
+    }
+}
+
+.direction-dial:not(.disabled):focus .direction-dial-center-dot,
+.direction-dial:not(.disabled):focus-visible .direction-dial-center-dot {
+    fill-opacity: 1;
 }
 
 .direction-dial-line {
     stroke: var(--text-color);
+    stroke-opacity: 0.5;
     stroke-width: 2;
     stroke-linecap: round;
+}
+
+@media (hover: hover) {
+    .direction-dial:not(.disabled):hover .direction-dial-line {
+        stroke-opacity: 1;
+    }
+}
+
+.direction-dial:not(.disabled):focus .direction-dial-line,
+.direction-dial:not(.disabled):focus-visible .direction-dial-line {
+    stroke-opacity: 1;
 }
 
 .direction-dial-line.hidden {

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -1511,8 +1511,8 @@ button.preset-reset .label.flash-bg {
     display: flex;
     flex-flow: row nowrap;
     flex: 0 0 auto;
-    width: 30px;
-    height: 30px;
+    width: 32px;
+    height: 31px;
     border: 1px solid var(--border-color);
     border-left: 0;
     border-top-width: 0;
@@ -1528,6 +1528,10 @@ button.preset-reset .label.flash-bg {
 .direction-dial {
     width: 28px;
     height: 28px;
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
     overflow: visible;
     cursor: crosshair;
     outline: none;
@@ -1535,10 +1539,6 @@ button.preset-reset .label.flash-bg {
 }
 
 .direction-dial.dragging {
-    position: absolute;
-    left: 50%;
-    top: 50%;
-    transform: translate(-50%, -50%);
     z-index: 3;
 }
 
@@ -1615,6 +1615,19 @@ button.preset-reset .label.flash-bg {
 }
 
 .direction-dial-line.hidden {
+    display: none;
+}
+
+.direction-dial-range {
+    fill: none;
+    stroke: var(--link-color);
+    stroke-opacity: 0.8;
+    stroke-width: 3;
+    pointer-events: none;
+    vector-effect: non-scaling-stroke;
+}
+
+.direction-dial-range.hidden {
     display: none;
 }
 

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -1511,7 +1511,8 @@ button.preset-reset .label.flash-bg {
     display: flex;
     flex-flow: row nowrap;
     flex: 0 0 auto;
-    width: 32px;
+    width: 30px;
+    height: 30px;
     border: 1px solid var(--border-color);
     border-left: 0;
     border-top-width: 0;
@@ -1519,14 +1520,30 @@ button.preset-reset .label.flash-bg {
     background: var(--bg-color);
     justify-content: center;
     align-items: center;
-    padding: 2px;
+    padding: 1px;
+    position: relative;
+    z-index: 2;
 }
 
 .direction-dial {
     width: 28px;
     height: 28px;
+    overflow: visible;
     cursor: crosshair;
     outline: none;
+    transition: width 120ms ease-out, height 120ms ease-out, filter 120ms ease-out;
+}
+
+.direction-dial.dragging {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 3;
+}
+
+.direction-dial.dragging.expanded {
+    filter: drop-shadow(0 8px 16px rgba(0, 0, 0, 0.35));
 }
 
 .direction-dial-ring {
@@ -1534,6 +1551,7 @@ button.preset-reset .label.flash-bg {
     stroke: transparent;
     stroke-width: 1;
     pointer-events: none;
+    vector-effect: non-scaling-stroke;
 }
 
 @media (hover: hover) {
@@ -1581,6 +1599,7 @@ button.preset-reset .label.flash-bg {
     stroke-opacity: 0.5;
     stroke-width: 2;
     stroke-linecap: round;
+    vector-effect: non-scaling-stroke;
 }
 
 @media (hover: hover) {
@@ -1603,6 +1622,7 @@ button.preset-reset .label.flash-bg {
     stroke: var(--border-color);
     stroke-width: 1;
     pointer-events: none;
+    vector-effect: non-scaling-stroke;
 }
 
 .direction-dial.disabled {

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -1618,19 +1618,6 @@ button.preset-reset .label.flash-bg {
     display: none;
 }
 
-.direction-dial-range {
-    fill: none;
-    stroke: var(--link-color);
-    stroke-opacity: 0.8;
-    stroke-width: 3;
-    pointer-events: none;
-    vector-effect: non-scaling-stroke;
-}
-
-.direction-dial-range.hidden {
-    display: none;
-}
-
 .direction-dial-tick {
     stroke: var(--border-color);
     stroke-width: 1;

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -1503,6 +1503,104 @@ button.preset-reset .label.flash-bg {
     border-radius: 0;
 }
 
+.form-field-has-direction-dial {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-areas:
+        "label dial"
+        "input dial";
+    align-items: stretch;
+    column-gap: 0;
+}
+
+.form-field-has-direction-dial > .field-label {
+    grid-area: label;
+    border-radius: 4px 0 0 0;
+}
+
+.form-field-has-direction-dial > .form-field-input-wrap {
+    grid-area: input;
+    border-radius: 0 0 0 4px;
+}
+
+.form-field-has-direction-dial .direction-dial-wrap {
+    grid-area: dial;
+    display: flex;
+    flex-flow: row nowrap;
+    flex: 0 0 auto;
+    width: min-content;
+    border: 1px solid var(--border-color);
+    border-left: 0;
+    border-radius: 0 4px 4px 0;
+    background: var(--bg-color-2);
+    justify-content: center;
+    align-items: center;
+    padding: 3px;
+}
+
+.direction-dial {
+    width: 55px;
+    height: 55px;
+    cursor: crosshair;
+    outline: none;
+}
+
+.direction-dial-ring {
+    fill: none;
+    stroke: transparent;
+    stroke-width: 2;
+    pointer-events: none;
+}
+
+@media (hover: hover) {
+    .direction-dial:not(.disabled):hover .direction-dial-ring {
+        stroke: var(--border-color);
+    }
+}
+
+.direction-dial:not(.disabled):focus .direction-dial-ring,
+.direction-dial:not(.disabled):focus-visible .direction-dial-ring {
+    stroke: var(--border-color);
+}
+
+.form-field-has-direction-dial .field-label .tag-reference-button {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+}
+
+.form-field-has-direction-dial .form-field-input-wrap > button.increment:last-of-type {
+    border-bottom-right-radius: 0;
+}
+
+.direction-dial-inner {
+    fill: var(--bg-color);
+}
+
+.direction-dial-center-dot {
+    fill: var(--text-color);
+}
+
+.direction-dial-line {
+    stroke: var(--text-color);
+    stroke-width: 2;
+    stroke-linecap: round;
+}
+
+.direction-dial-line.hidden {
+    display: none;
+}
+
+.direction-dial-tick {
+    stroke: var(--border-color);
+    stroke-width: 1;
+    pointer-events: none;
+}
+
+.direction-dial.disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+}
+
 
 .form-field-input-wrap > input,
 .form-field-input-wrap > label,

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -3056,6 +3056,13 @@ button.raw-tag-option svg.icon {
 .tag-reference-link {
     display: block;
 }
+.tag-reference-separator {
+    border-top: 1px solid var(--border-color);
+    margin: 8px 0;
+}
+.tag-reference-direction-help {
+    margin: 0;
+}
 .tag-reference-link .icon:first-child {
     margin-left: 0;
 }

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -734,7 +734,8 @@ en:
     edit_reference: "edit/translate documentation"
     wiki_reference: View documentation
     wiki_en_reference: View documentation in English
-    direction_rotate_help: "Press {key} to adjust this value on the map."
+direction_rotate_help: "Press {key} to adjust this value on the map."
+    direction_dial_help: "You can use the dial to change direction. Use {shift} for 5° steps. Use {command} to set a range."
     key_value: "key=value"
     empty: (empty)
     multiple_values: Multiple Values

--- a/modules/ui/direction_dial.ts
+++ b/modules/ui/direction_dial.ts
@@ -182,6 +182,7 @@ export function uiDirectionDial(): DirectionDial {
 
         dialMerge
             .classed('disabled', _disabled)
+            .classed('dragging', _isDragging)
             .attr('tabindex', _disabled ? null : 0);
 
         const dragBehavior = d3_drag<SVGSVGElement, DialSvgDatum>()

--- a/modules/ui/direction_dial.ts
+++ b/modules/ui/direction_dial.ts
@@ -263,9 +263,18 @@ export function uiDirectionDial(): DirectionDial {
             .classed('disabled', _disabled)
             .classed('dragging', _isDragging)
             .classed('expanded', _isDragging && _isExpandedDrag)
-            .style('width', _isDragging ? `${_dragDialDiameter}px` : null)
-            .style('height', _isDragging ? `${_dragDialDiameter}px` : null)
             .attr('tabindex', _disabled ? null : 0);
+
+        if (_isDragging) {
+            const dragDialSize = `${_dragDialDiameter}px`;
+            dialMerge
+                .style('width', dragDialSize)
+                .style('height', dragDialSize);
+        } else {
+            dialMerge
+                .style('width', null)
+                .style('height', null);
+        }
 
         const dragBehavior = d3_drag<SVGSVGElement, DialSvgDatum>()
             .on('start', function(this: SVGSVGElement, event: DialSvgDragEvent) {

--- a/modules/ui/direction_dial.ts
+++ b/modules/ui/direction_dial.ts
@@ -3,9 +3,7 @@ import { drag as d3_drag, type D3DragEvent } from 'd3-drag';
 import { utilNormalizeAzimuthDegrees } from '../util/direction_degrees';
 
 
-type DialRange = { start: number; end: number };
-type DirectionDialValue = number | DialRange;
-type DirectionDialCallback = (value: DirectionDialValue) => void;
+type DirectionDialCallback = (degrees: number) => void;
 
 type DialWrapperSelection = d3.Selection<HTMLDivElement>;
 
@@ -16,7 +14,6 @@ type DialSvgDragEvent = D3DragEvent<SVGSVGElement, DialSvgDatum, DialSvgDatum>;
 interface DirectionDial {
     (selection: DialWrapperSelection): void;
     value: (val: number | null) => DirectionDial;
-    range: (val: DialRange | null) => DirectionDial;
     disabled: (val: boolean) => DirectionDial;
     /** Degrees between absolute snap positions (preset `increment`, e.g. 5 → 0, 5, 10, …). */
     step: (val: number) => DirectionDial;
@@ -96,7 +93,6 @@ function dragPointerDistanceFromCenterPx(
 /** Direction dial UI for `*:direction` numeric fields. */
 export function uiDirectionDial(): DirectionDial {
     let _value: number | null = null;
-    let _range: DialRange | null = null;
     let _disabled = false;
     let _step = 1;
     let _shiftHeld = false;
@@ -112,8 +108,6 @@ export function uiDirectionDial(): DirectionDial {
     let _dragDialDiameter = DIAL_BASE_RENDER_SIZE;
     let _dragCenterClientX: number | null = null;
     let _dragCenterClientY: number | null = null;
-    let _rangeSpan = 0;
-    let _rangeAnchor: number | null = null;
 
     function attachWrapShiftListeners() {
         if (_shiftWindowListenersAttached || typeof window === 'undefined') return;
@@ -147,14 +141,6 @@ export function uiDirectionDial(): DirectionDial {
         return false;
     }
 
-    function rangeModifierFromDragEvent(event: DialSvgDragEvent): boolean {
-        const source = event.sourceEvent;
-        if (!source || typeof source !== 'object') return false;
-        if (source instanceof MouseEvent) return source.metaKey || source.ctrlKey;
-        if (source instanceof KeyboardEvent) return source.metaKey || source.ctrlKey;
-        return false;
-    }
-
     function pointerStateFromEvent(
         event: DialSvgDragEvent,
         node: SVGSVGElement
@@ -166,35 +152,6 @@ export function uiDirectionDial(): DirectionDial {
             angle: utilNormalizeAzimuthDegrees(radians * (180 / Math.PI)),
             distanceFromCenter: state.distanceFromCenter
         };
-    }
-
-    function rangeSpan(start: number, end: number): number {
-        return utilNormalizeAzimuthDegrees(end - start);
-    }
-
-    function rangeCenter(start: number, end: number): number {
-        return utilNormalizeAzimuthDegrees(start + (rangeSpan(start, end) / 2));
-    }
-
-    function rangeFromCenterSpan(center: number, span: number): DialRange {
-        const half = span / 2;
-        return {
-            start: utilNormalizeAzimuthDegrees(center - half),
-            end: utilNormalizeAzimuthDegrees(center + half)
-        };
-    }
-
-    function rangeArcPath(start: number, end: number): string {
-        const span = rangeSpan(start, end);
-        if (span <= 0) return '';
-        const startRad = start * (Math.PI / 180);
-        const endRad = end * (Math.PI / 180);
-        const x1 = DIAL_CENTER + (Math.sin(startRad) * DIAL_RADIUS);
-        const y1 = DIAL_CENTER - (Math.cos(startRad) * DIAL_RADIUS);
-        const x2 = DIAL_CENTER + (Math.sin(endRad) * DIAL_RADIUS);
-        const y2 = DIAL_CENTER - (Math.cos(endRad) * DIAL_RADIUS);
-        const largeArc = span > 180 ? 1 : 0;
-        return `M ${x1} ${y1} A ${DIAL_RADIUS} ${DIAL_RADIUS} 0 ${largeArc} 1 ${x2} ${y2}`;
     }
 
     function renderDial(selection: DialWrapperSelection) {
@@ -248,10 +205,6 @@ export function uiDirectionDial(): DirectionDial {
             .attr('y1', DIAL_CENTER);
 
         dialEnter
-            .append('path')
-            .attr('class', 'direction-dial-range');
-
-        dialEnter
             .append('circle')
             .attr('class', 'direction-dial-center-dot')
             .attr('cx', DIAL_CENTER)
@@ -296,19 +249,11 @@ export function uiDirectionDial(): DirectionDial {
                 // Jump needle to click angle; drag continues from this pointer direction.
                 _lastPointerAngle = pointerState.angle;
                 _dragValue = pointerState.angle;
-                _rangeAnchor = _dragValue;
-                if (!_range && shiftFromDragEvent(event)) {
+                if (shiftFromDragEvent(event)) {
                     _dragValue = snapAbsolute(_dragValue, _step);
                 }
-
-                if (_range) {
-                    _rangeSpan = rangeSpan(_range.start, _range.end);
-                    _value = rangeCenter(_range.start, _range.end);
-                    _onInput({ start: _range.start, end: _range.end });
-                } else {
-                    _value = _dragValue;
-                    _onInput(Math.round(_dragValue));
-                }
+                _value = _dragValue;
+                _onInput(Math.round(_dragValue));
                 renderDial(selection);
             })
             .on('drag', function(this: SVGSVGElement, event: DialSvgDragEvent) {
@@ -333,60 +278,21 @@ export function uiDirectionDial(): DirectionDial {
                     }
                 }
 
-                const pointerAngleRaw = pointerState.angle;
-                const wantsSnap = shiftFromDragEvent(event);
-                const wantsRangeAdjust = rangeModifierFromDragEvent(event);
-                const pointerAngle = wantsSnap ? snapAbsolute(pointerAngleRaw, _step) : pointerAngleRaw;
-                if (_range) {
-                    if (wantsRangeAdjust && _rangeAnchor !== null) {
-                        const delta = shortestAngleDelta(_rangeAnchor, pointerAngle);
-                        if (delta >= 0) {
-                            _range = { start: _rangeAnchor, end: pointerAngle };
-                        } else {
-                            _range = { start: pointerAngle, end: _rangeAnchor };
-                        }
-                        _rangeSpan = rangeSpan(_range.start, _range.end);
-                    } else {
-                        const span = _rangeSpan || rangeSpan(_range.start, _range.end);
-                        _range = rangeFromCenterSpan(pointerAngle, span);
-                    }
-                    _dragValue = rangeCenter(_range.start, _range.end);
-                    _value = _dragValue;
+                const pointerAngle = pointerState.angle;
+                if (_isExpandedDrag) {
+                    // In expanded mode, keep indicator directly under cursor angle.
+                    _dragValue = pointerAngle;
                 } else {
-                    if (wantsRangeAdjust) {
-                        if (_rangeAnchor === null) {
-                            _rangeAnchor = _dragValue;
-                        }
-                        const delta = shortestAngleDelta(_rangeAnchor, pointerAngle);
-                        if (Math.abs(delta) > 0) {
-                            if (delta >= 0) {
-                                _range = { start: _rangeAnchor, end: pointerAngle };
-                            } else {
-                                _range = { start: pointerAngle, end: _rangeAnchor };
-                            }
-                            _rangeSpan = rangeSpan(_range.start, _range.end);
-                            _dragValue = rangeCenter(_range.start, _range.end);
-                            _value = _dragValue;
-                        }
-                    } else {
-                        _rangeAnchor = null;
-                        if (_isExpandedDrag) {
-                            _dragValue = pointerAngle;
-                        } else {
-                            const delta = shortestAngleDelta(_lastPointerAngle, pointerAngle);
-                            const gain = precisionGain(pointerState.distanceFromCenter);
-                            _dragValue = utilNormalizeAzimuthDegrees(_dragValue + (delta * gain));
-                        }
-                        _value = _dragValue;
-                    }
+                    const delta = shortestAngleDelta(_lastPointerAngle, pointerAngle);
+                    const gain = precisionGain(pointerState.distanceFromCenter);
+                    _dragValue = utilNormalizeAzimuthDegrees(_dragValue + (delta * gain));
                 }
                 _lastPointerAngle = pointerAngle;
-                if (_range) {
-                    _onInput({ start: _range.start, end: _range.end });
-                } else {
-                    _onInput(Math.round(_dragValue));
+                if (shiftFromDragEvent(event)) {
+                    _dragValue = snapAbsolute(_dragValue, _step);
                 }
-
+                _value = _dragValue;
+                _onInput(Math.round(_dragValue));
                 renderDial(selection);
             })
             .on('end', function(this: SVGSVGElement, event: DialSvgDragEvent) {
@@ -396,16 +302,11 @@ export function uiDirectionDial(): DirectionDial {
                 _dragDialDiameter = DIAL_BASE_RENDER_SIZE;
                 _dragCenterClientX = null;
                 _dragCenterClientY = null;
-                _rangeAnchor = null;
-                if (!_range && shiftFromDragEvent(event)) {
+                if (shiftFromDragEvent(event)) {
                     _dragValue = snapAbsolute(_dragValue, _step);
                 }
                 _value = _dragValue;
-                if (_range) {
-                    _onCommit({ start: _range.start, end: _range.end });
-                } else {
-                    _onCommit(Math.round(_dragValue));
-                }
+                _onCommit(Math.round(_dragValue));
                 _shiftHeld = false;
                 detachWrapShiftListeners();
                 renderDial(selection);
@@ -447,21 +348,10 @@ export function uiDirectionDial(): DirectionDial {
             .attr('y2', (d: number) => DIAL_CENTER - Math.cos(d * (Math.PI / 180)) * rOuter);
 
         const line = dialMerge.select<SVGLineElement>('line.direction-dial-line');
-        const rangePath = dialMerge.select<SVGPathElement>('path.direction-dial-range');
         const angle = (_value === null) ? null : utilNormalizeAzimuthDegrees(_value);
         const displayAngle = angle === null
             ? null
             : (_shiftHeld ? snapAbsolute(angle, _step) : angle);
-
-        if (_range) {
-            rangePath
-                .classed('hidden', false)
-                .attr('d', rangeArcPath(_range.start, _range.end));
-        } else {
-            rangePath
-                .classed('hidden', true)
-                .attr('d', '');
-        }
 
         if (displayAngle === null) {
             line.classed('hidden', true);
@@ -482,23 +372,6 @@ export function uiDirectionDial(): DirectionDial {
 
     directionDial.value = function(val: number | null) {
         _value = (val === null || !isFinite(val)) ? null : utilNormalizeAzimuthDegrees(val);
-        if (_value !== null) {
-            _range = null;
-        }
-        return directionDial;
-    };
-
-    directionDial.range = function(val: DialRange | null) {
-        if (!val) {
-            _range = null;
-            _rangeSpan = 0;
-            return directionDial;
-        }
-        const start = utilNormalizeAzimuthDegrees(val.start);
-        const end = utilNormalizeAzimuthDegrees(val.end);
-        _range = { start, end };
-        _rangeSpan = rangeSpan(start, end);
-        _value = rangeCenter(start, end);
         return directionDial;
     };
 

--- a/modules/ui/direction_dial.ts
+++ b/modules/ui/direction_dial.ts
@@ -1,0 +1,328 @@
+import { drag as d3_drag, type D3DragEvent } from 'd3-drag';
+import { pointer as d3_pointer } from 'd3-selection';
+
+import { utilNormalizeAzimuthDegrees } from '../util/direction_degrees';
+
+
+type DirectionDialCallback = (degrees: number) => void;
+
+type DialWrapperSelection = d3.Selection<HTMLDivElement>;
+
+type DialSvgDatum = number;
+
+type DialSvgDragEvent = D3DragEvent<SVGSVGElement, DialSvgDatum, DialSvgDatum>;
+
+interface DirectionDial {
+    (selection: DialWrapperSelection): void;
+    value: (val: number | null) => DirectionDial;
+    disabled: (val: boolean) => DirectionDial;
+    /** Degrees between absolute snap positions (preset `increment`, e.g. 5 → 0, 5, 10, …). */
+    step: (val: number) => DirectionDial;
+    onInput: (callback: DirectionDialCallback) => DirectionDial;
+    onCommit: (callback: DirectionDialCallback) => DirectionDial;
+}
+
+
+const DIAL_SIZE = 92;
+const DIAL_CENTER = DIAL_SIZE / 2;
+const DIAL_RADIUS = 34;
+/** White disk to the dial edge (no ring stroke). */
+const DIAL_WHITE_RADIUS = DIAL_RADIUS;
+const DIAL_VIEWBOX_EXTENT = DIAL_RADIUS + 1;
+const DIAL_VIEWBOX_MIN = DIAL_CENTER - DIAL_VIEWBOX_EXTENT;
+const DIAL_VIEWBOX_SIZE = DIAL_VIEWBOX_EXTENT * 2;
+
+
+/** Snap to absolute multiples of `step` on the circle (e.g. step 5 → …, 355, 0, 5, 10, …). */
+function snapAbsolute(degrees: number, step: number): number {
+    if (!step || step <= 0 || !isFinite(step)) return utilNormalizeAzimuthDegrees(degrees);
+    const d = utilNormalizeAzimuthDegrees(degrees);
+    const snapped = Math.round(d / step) * step;
+    return utilNormalizeAzimuthDegrees(snapped);
+}
+
+
+function shortestAngleDelta(previousDegrees: number, nextDegrees: number): number {
+    let delta = nextDegrees - previousDegrees;
+    if (delta > 180) delta -= 360;
+    if (delta < -180) delta += 360;
+    return delta;
+}
+
+
+function precisionGain(distanceFromCenter: number): number {
+    if (distanceFromCenter <= DIAL_RADIUS) return 1;
+    return Math.max(0.2, DIAL_RADIUS / distanceFromCenter);
+}
+
+
+function angleFromPointer(
+    event: DialSvgDragEvent,
+    node: SVGSVGElement
+): { angle: number; distanceFromCenter: number } | null {
+    const sourceEvent = event.sourceEvent as MouseEvent | TouchEvent | undefined;
+    if (!sourceEvent) return null;
+
+    const [x, y] = d3_pointer(sourceEvent, node);
+    const dx = x - DIAL_CENTER;
+    const dy = y - DIAL_CENTER;
+    const distanceFromCenter = Math.hypot(dx, dy);
+    if (!isFinite(distanceFromCenter)) return null;
+
+    const radians = Math.atan2(dx, -dy);
+    const angle = utilNormalizeAzimuthDegrees(radians * (180 / Math.PI));
+    return { angle, distanceFromCenter };
+}
+
+
+/** Direction dial UI for `*:direction` numeric fields. */
+export function uiDirectionDial(): DirectionDial {
+    let _value: number | null = null;
+    let _disabled = false;
+    let _step = 1;
+    let _shiftHeld = false;
+    let _shiftWindowListenersAttached = false;
+    let _onShiftKeyChange: ((e: KeyboardEvent) => void) | undefined;
+    let _selectionRef: DialWrapperSelection | null = null;
+    let _onInput: DirectionDialCallback = function() {};
+    let _onCommit: DirectionDialCallback = function() {};
+    let _isDragging = false;
+    let _dragValue = 0;
+    let _lastPointerAngle = 0;
+
+    function attachWrapShiftListeners() {
+        if (_shiftWindowListenersAttached || typeof window === 'undefined') return;
+        _shiftWindowListenersAttached = true;
+
+        _onShiftKeyChange = function(e: KeyboardEvent) {
+            const next = e.shiftKey;
+            if (next !== _shiftHeld) {
+                _shiftHeld = next;
+                if (_selectionRef) renderDial(_selectionRef);
+            }
+        };
+
+        window.addEventListener('keydown', _onShiftKeyChange, true);
+        window.addEventListener('keyup', _onShiftKeyChange, true);
+    }
+
+    function detachWrapShiftListeners() {
+        if (!_shiftWindowListenersAttached || !_onShiftKeyChange) return;
+        window.removeEventListener('keydown', _onShiftKeyChange, true);
+        window.removeEventListener('keyup', _onShiftKeyChange, true);
+        _shiftWindowListenersAttached = false;
+        _onShiftKeyChange = undefined;
+    }
+
+    function shiftFromDragEvent(event: DialSvgDragEvent): boolean {
+        const source = event.sourceEvent;
+        if (!source || typeof source !== 'object') return false;
+        if (source instanceof MouseEvent) return source.shiftKey;
+        if (source instanceof KeyboardEvent) return source.shiftKey;
+        return false;
+    }
+
+    function renderDial(selection: DialWrapperSelection) {
+        _selectionRef = selection;
+
+        selection
+            .on('mouseenter.directionDialShift', function(event: MouseEvent) {
+                if (_disabled) return;
+                _shiftHeld = !!event.shiftKey;
+                attachWrapShiftListeners();
+                renderDial(selection);
+            })
+            .on('mouseleave.directionDialShift', function() {
+                _shiftHeld = false;
+                detachWrapShiftListeners();
+                renderDial(selection);
+            });
+
+        const dialSVG = selection.selectAll<SVGSVGElement, DialSvgDatum>('svg.direction-dial')
+            .data([0]);
+
+        const dialEnter = dialSVG.enter()
+            .append('svg')
+            .attr('class', 'direction-dial')
+            .attr('viewBox', `${DIAL_VIEWBOX_MIN} ${DIAL_VIEWBOX_MIN} ${DIAL_VIEWBOX_SIZE} ${DIAL_VIEWBOX_SIZE}`)
+            .attr('aria-hidden', 'true');
+
+        dialEnter
+            .append('circle')
+            .attr('class', 'direction-dial-inner')
+            .attr('cx', DIAL_CENTER)
+            .attr('cy', DIAL_CENTER)
+            .attr('r', DIAL_WHITE_RADIUS);
+
+        dialEnter
+            .append('g')
+            .attr('class', 'direction-dial-ticks');
+
+        dialEnter
+            .append('circle')
+            .attr('class', 'direction-dial-ring')
+            .attr('cx', DIAL_CENTER)
+            .attr('cy', DIAL_CENTER)
+            .attr('r', DIAL_RADIUS);
+
+        dialEnter
+            .append('line')
+            .attr('class', 'direction-dial-line')
+            .attr('x1', DIAL_CENTER)
+            .attr('y1', DIAL_CENTER);
+
+        dialEnter
+            .append('circle')
+            .attr('class', 'direction-dial-center-dot')
+            .attr('cx', DIAL_CENTER)
+            .attr('cy', DIAL_CENTER)
+            .attr('r', 3);
+
+        const dialMerge = dialEnter.merge(dialSVG);
+
+        dialMerge
+            .classed('disabled', _disabled)
+            .attr('tabindex', _disabled ? null : 0);
+
+        const dragBehavior = d3_drag<SVGSVGElement, DialSvgDatum>()
+            .on('start', function(this: SVGSVGElement, event: DialSvgDragEvent) {
+                if (_disabled) return;
+                _isDragging = true;
+
+                const pointerState = angleFromPointer(event, this);
+                if (!pointerState) {
+                    _isDragging = false;
+                    return;
+                }
+
+                // Jump needle to click angle; drag continues from this pointer direction.
+                _lastPointerAngle = pointerState.angle;
+                _dragValue = pointerState.angle;
+                if (shiftFromDragEvent(event)) {
+                    _dragValue = snapAbsolute(_dragValue, _step);
+                }
+
+                _value = _dragValue;
+                _onInput(Math.round(_dragValue));
+                renderDial(selection);
+            })
+            .on('drag', function(this: SVGSVGElement, event: DialSvgDragEvent) {
+                if (_disabled || !_isDragging) return;
+
+                const pointerState = angleFromPointer(event, this);
+                if (!pointerState) return;
+
+                const pointerAngle = pointerState.angle;
+                const delta = shortestAngleDelta(_lastPointerAngle, pointerAngle);
+                _lastPointerAngle = pointerAngle;
+
+                const gain = precisionGain(pointerState.distanceFromCenter);
+                _dragValue = utilNormalizeAzimuthDegrees(_dragValue + (delta * gain));
+                if (shiftFromDragEvent(event)) {
+                    _dragValue = snapAbsolute(_dragValue, _step);
+                }
+                _value = _dragValue;
+                _onInput(Math.round(_dragValue));
+
+                renderDial(selection);
+            })
+            .on('end', function(this: SVGSVGElement, event: DialSvgDragEvent) {
+                if (_disabled || !_isDragging) return;
+                _isDragging = false;
+                if (shiftFromDragEvent(event)) {
+                    _dragValue = snapAbsolute(_dragValue, _step);
+                }
+                _value = _dragValue;
+                _onCommit(Math.round(_dragValue));
+                renderDial(selection);
+            });
+
+        dialMerge.call(dragBehavior);
+
+        const showTicks = _shiftHeld && _step > 0 && !_disabled;
+        const tickAngles: number[] = [];
+        if (showTicks && 360 / _step <= 80) {
+            for (let a = 0; a < 360; a += _step) {
+                tickAngles.push(a);
+            }
+        }
+
+        const tickLen = 5;
+        const rOuter = DIAL_RADIUS + 1;
+        const rInner = DIAL_RADIUS - tickLen;
+
+        const tickGroup = dialMerge.select<SVGGElement>('g.direction-dial-ticks')
+            .style('display', function displayTicks() {
+                return showTicks && tickAngles.length ? null : 'none';
+            });
+
+        const tickLines = tickGroup.selectAll<SVGLineElement, number>('line.direction-dial-tick')
+            .data(tickAngles);
+
+        tickLines.exit()
+            .remove();
+
+        const tickEnter = tickLines.enter()
+            .append('line')
+            .attr('class', 'direction-dial-tick');
+
+        tickEnter.merge(tickLines)
+            .attr('x1', (d: number) => DIAL_CENTER + Math.sin(d * (Math.PI / 180)) * rInner)
+            .attr('y1', (d: number) => DIAL_CENTER - Math.cos(d * (Math.PI / 180)) * rInner)
+            .attr('x2', (d: number) => DIAL_CENTER + Math.sin(d * (Math.PI / 180)) * rOuter)
+            .attr('y2', (d: number) => DIAL_CENTER - Math.cos(d * (Math.PI / 180)) * rOuter);
+
+        const line = dialMerge.select<SVGLineElement>('line.direction-dial-line');
+        const angle = (_value === null) ? null : utilNormalizeAzimuthDegrees(_value);
+        const displayAngle = angle === null
+            ? null
+            : (_shiftHeld ? snapAbsolute(angle, _step) : angle);
+
+        if (displayAngle === null) {
+            line.classed('hidden', true);
+            return;
+        }
+
+        const radians = displayAngle * (Math.PI / 180);
+        const lineEndX = DIAL_CENTER + (Math.sin(radians) * DIAL_RADIUS);
+        const lineEndY = DIAL_CENTER - (Math.cos(radians) * DIAL_RADIUS);
+
+        line
+            .classed('hidden', false)
+            .attr('x2', lineEndX)
+            .attr('y2', lineEndY);
+    }
+
+    const directionDial = renderDial as DirectionDial;
+
+    directionDial.value = function(val: number | null) {
+        _value = (val === null || !isFinite(val)) ? null : utilNormalizeAzimuthDegrees(val);
+        return directionDial;
+    };
+
+    directionDial.disabled = function(val: boolean) {
+        _disabled = !!val;
+        if (_disabled) {
+            _shiftHeld = false;
+            detachWrapShiftListeners();
+        }
+        return directionDial;
+    };
+
+    directionDial.step = function(val: number) {
+        _step = (val && isFinite(val) && val > 0) ? val : 1;
+        return directionDial;
+    };
+
+    directionDial.onInput = function(callback: DirectionDialCallback) {
+        _onInput = callback;
+        return directionDial;
+    };
+
+    directionDial.onCommit = function(callback: DirectionDialCallback) {
+        _onCommit = callback;
+        return directionDial;
+    };
+
+    return directionDial;
+}

--- a/modules/ui/direction_dial.ts
+++ b/modules/ui/direction_dial.ts
@@ -29,7 +29,7 @@ const DIAL_SIZE = 92;
 const DIAL_CENTER = DIAL_SIZE / 2;
 const DIAL_RADIUS = 34;
 const DIAL_BASE_RENDER_SIZE = 28;
-const DIAL_MAX_DRAG_DIAMETER = 180;
+const DIAL_MAX_DRAG_DIAMETER = DIAL_BASE_RENDER_SIZE + 30;
 const DIAL_BASE_RADIUS_PX = DIAL_BASE_RENDER_SIZE / 2;
 const DIAL_MAX_RADIUS_PX = DIAL_MAX_DRAG_DIAMETER / 2;
 /** White disk to the dial edge (no ring stroke). */

--- a/modules/ui/direction_dial.ts
+++ b/modules/ui/direction_dial.ts
@@ -3,7 +3,9 @@ import { drag as d3_drag, type D3DragEvent } from 'd3-drag';
 import { utilNormalizeAzimuthDegrees } from '../util/direction_degrees';
 
 
-type DirectionDialCallback = (degrees: number) => void;
+type DialRange = { start: number; end: number };
+type DirectionDialValue = number | DialRange;
+type DirectionDialCallback = (value: DirectionDialValue) => void;
 
 type DialWrapperSelection = d3.Selection<HTMLDivElement>;
 
@@ -14,6 +16,7 @@ type DialSvgDragEvent = D3DragEvent<SVGSVGElement, DialSvgDatum, DialSvgDatum>;
 interface DirectionDial {
     (selection: DialWrapperSelection): void;
     value: (val: number | null) => DirectionDial;
+    range: (val: DialRange | null) => DirectionDial;
     disabled: (val: boolean) => DirectionDial;
     /** Degrees between absolute snap positions (preset `increment`, e.g. 5 → 0, 5, 10, …). */
     step: (val: number) => DirectionDial;
@@ -93,6 +96,7 @@ function dragPointerDistanceFromCenterPx(
 /** Direction dial UI for `*:direction` numeric fields. */
 export function uiDirectionDial(): DirectionDial {
     let _value: number | null = null;
+    let _range: DialRange | null = null;
     let _disabled = false;
     let _step = 1;
     let _shiftHeld = false;
@@ -108,6 +112,8 @@ export function uiDirectionDial(): DirectionDial {
     let _dragDialDiameter = DIAL_BASE_RENDER_SIZE;
     let _dragCenterClientX: number | null = null;
     let _dragCenterClientY: number | null = null;
+    let _rangeSpan = 0;
+    let _rangeAnchor: number | null = null;
 
     function attachWrapShiftListeners() {
         if (_shiftWindowListenersAttached || typeof window === 'undefined') return;
@@ -141,6 +147,14 @@ export function uiDirectionDial(): DirectionDial {
         return false;
     }
 
+    function rangeModifierFromDragEvent(event: DialSvgDragEvent): boolean {
+        const source = event.sourceEvent;
+        if (!source || typeof source !== 'object') return false;
+        if (source instanceof MouseEvent) return source.metaKey || source.ctrlKey;
+        if (source instanceof KeyboardEvent) return source.metaKey || source.ctrlKey;
+        return false;
+    }
+
     function pointerStateFromEvent(
         event: DialSvgDragEvent,
         node: SVGSVGElement
@@ -152,6 +166,35 @@ export function uiDirectionDial(): DirectionDial {
             angle: utilNormalizeAzimuthDegrees(radians * (180 / Math.PI)),
             distanceFromCenter: state.distanceFromCenter
         };
+    }
+
+    function rangeSpan(start: number, end: number): number {
+        return utilNormalizeAzimuthDegrees(end - start);
+    }
+
+    function rangeCenter(start: number, end: number): number {
+        return utilNormalizeAzimuthDegrees(start + (rangeSpan(start, end) / 2));
+    }
+
+    function rangeFromCenterSpan(center: number, span: number): DialRange {
+        const half = span / 2;
+        return {
+            start: utilNormalizeAzimuthDegrees(center - half),
+            end: utilNormalizeAzimuthDegrees(center + half)
+        };
+    }
+
+    function rangeArcPath(start: number, end: number): string {
+        const span = rangeSpan(start, end);
+        if (span <= 0) return '';
+        const startRad = start * (Math.PI / 180);
+        const endRad = end * (Math.PI / 180);
+        const x1 = DIAL_CENTER + (Math.sin(startRad) * DIAL_RADIUS);
+        const y1 = DIAL_CENTER - (Math.cos(startRad) * DIAL_RADIUS);
+        const x2 = DIAL_CENTER + (Math.sin(endRad) * DIAL_RADIUS);
+        const y2 = DIAL_CENTER - (Math.cos(endRad) * DIAL_RADIUS);
+        const largeArc = span > 180 ? 1 : 0;
+        return `M ${x1} ${y1} A ${DIAL_RADIUS} ${DIAL_RADIUS} 0 ${largeArc} 1 ${x2} ${y2}`;
     }
 
     function renderDial(selection: DialWrapperSelection) {
@@ -205,6 +248,10 @@ export function uiDirectionDial(): DirectionDial {
             .attr('y1', DIAL_CENTER);
 
         dialEnter
+            .append('path')
+            .attr('class', 'direction-dial-range');
+
+        dialEnter
             .append('circle')
             .attr('class', 'direction-dial-center-dot')
             .attr('cx', DIAL_CENTER)
@@ -240,12 +287,19 @@ export function uiDirectionDial(): DirectionDial {
                 // Jump needle to click angle; drag continues from this pointer direction.
                 _lastPointerAngle = pointerState.angle;
                 _dragValue = pointerState.angle;
-                if (shiftFromDragEvent(event)) {
+                _rangeAnchor = _dragValue;
+                if (!_range && shiftFromDragEvent(event)) {
                     _dragValue = snapAbsolute(_dragValue, _step);
                 }
 
-                _value = _dragValue;
-                _onInput(Math.round(_dragValue));
+                if (_range) {
+                    _rangeSpan = rangeSpan(_range.start, _range.end);
+                    _value = rangeCenter(_range.start, _range.end);
+                    _onInput({ start: _range.start, end: _range.end });
+                } else {
+                    _value = _dragValue;
+                    _onInput(Math.round(_dragValue));
+                }
                 renderDial(selection);
             })
             .on('drag', function(this: SVGSVGElement, event: DialSvgDragEvent) {
@@ -270,21 +324,59 @@ export function uiDirectionDial(): DirectionDial {
                     }
                 }
 
-                const pointerAngle = pointerState.angle;
-                if (_isExpandedDrag) {
-                    // In expanded mode, keep indicator directly under cursor angle.
-                    _dragValue = pointerAngle;
+                const pointerAngleRaw = pointerState.angle;
+                const wantsSnap = shiftFromDragEvent(event);
+                const wantsRangeAdjust = rangeModifierFromDragEvent(event);
+                const pointerAngle = wantsSnap ? snapAbsolute(pointerAngleRaw, _step) : pointerAngleRaw;
+                if (_range) {
+                    if (wantsRangeAdjust && _rangeAnchor !== null) {
+                        const delta = shortestAngleDelta(_rangeAnchor, pointerAngle);
+                        if (delta >= 0) {
+                            _range = { start: _rangeAnchor, end: pointerAngle };
+                        } else {
+                            _range = { start: pointerAngle, end: _rangeAnchor };
+                        }
+                        _rangeSpan = rangeSpan(_range.start, _range.end);
+                    } else {
+                        const span = _rangeSpan || rangeSpan(_range.start, _range.end);
+                        _range = rangeFromCenterSpan(pointerAngle, span);
+                    }
+                    _dragValue = rangeCenter(_range.start, _range.end);
+                    _value = _dragValue;
                 } else {
-                    const delta = shortestAngleDelta(_lastPointerAngle, pointerAngle);
-                    const gain = precisionGain(pointerState.distanceFromCenter);
-                    _dragValue = utilNormalizeAzimuthDegrees(_dragValue + (delta * gain));
+                    if (wantsRangeAdjust) {
+                        if (_rangeAnchor === null) {
+                            _rangeAnchor = _dragValue;
+                        }
+                        const delta = shortestAngleDelta(_rangeAnchor, pointerAngle);
+                        if (Math.abs(delta) > 0) {
+                            if (delta >= 0) {
+                                _range = { start: _rangeAnchor, end: pointerAngle };
+                            } else {
+                                _range = { start: pointerAngle, end: _rangeAnchor };
+                            }
+                            _rangeSpan = rangeSpan(_range.start, _range.end);
+                            _dragValue = rangeCenter(_range.start, _range.end);
+                            _value = _dragValue;
+                        }
+                    } else {
+                        _rangeAnchor = null;
+                        if (_isExpandedDrag) {
+                            _dragValue = pointerAngle;
+                        } else {
+                            const delta = shortestAngleDelta(_lastPointerAngle, pointerAngle);
+                            const gain = precisionGain(pointerState.distanceFromCenter);
+                            _dragValue = utilNormalizeAzimuthDegrees(_dragValue + (delta * gain));
+                        }
+                        _value = _dragValue;
+                    }
                 }
                 _lastPointerAngle = pointerAngle;
-                if (shiftFromDragEvent(event)) {
-                    _dragValue = snapAbsolute(_dragValue, _step);
+                if (_range) {
+                    _onInput({ start: _range.start, end: _range.end });
+                } else {
+                    _onInput(Math.round(_dragValue));
                 }
-                _value = _dragValue;
-                _onInput(Math.round(_dragValue));
 
                 renderDial(selection);
             })
@@ -295,11 +387,16 @@ export function uiDirectionDial(): DirectionDial {
                 _dragDialDiameter = DIAL_BASE_RENDER_SIZE;
                 _dragCenterClientX = null;
                 _dragCenterClientY = null;
-                if (shiftFromDragEvent(event)) {
+                _rangeAnchor = null;
+                if (!_range && shiftFromDragEvent(event)) {
                     _dragValue = snapAbsolute(_dragValue, _step);
                 }
                 _value = _dragValue;
-                _onCommit(Math.round(_dragValue));
+                if (_range) {
+                    _onCommit({ start: _range.start, end: _range.end });
+                } else {
+                    _onCommit(Math.round(_dragValue));
+                }
                 _shiftHeld = false;
                 detachWrapShiftListeners();
                 renderDial(selection);
@@ -341,10 +438,21 @@ export function uiDirectionDial(): DirectionDial {
             .attr('y2', (d: number) => DIAL_CENTER - Math.cos(d * (Math.PI / 180)) * rOuter);
 
         const line = dialMerge.select<SVGLineElement>('line.direction-dial-line');
+        const rangePath = dialMerge.select<SVGPathElement>('path.direction-dial-range');
         const angle = (_value === null) ? null : utilNormalizeAzimuthDegrees(_value);
         const displayAngle = angle === null
             ? null
             : (_shiftHeld ? snapAbsolute(angle, _step) : angle);
+
+        if (_range) {
+            rangePath
+                .classed('hidden', false)
+                .attr('d', rangeArcPath(_range.start, _range.end));
+        } else {
+            rangePath
+                .classed('hidden', true)
+                .attr('d', '');
+        }
 
         if (displayAngle === null) {
             line.classed('hidden', true);
@@ -365,6 +473,23 @@ export function uiDirectionDial(): DirectionDial {
 
     directionDial.value = function(val: number | null) {
         _value = (val === null || !isFinite(val)) ? null : utilNormalizeAzimuthDegrees(val);
+        if (_value !== null) {
+            _range = null;
+        }
+        return directionDial;
+    };
+
+    directionDial.range = function(val: DialRange | null) {
+        if (!val) {
+            _range = null;
+            _rangeSpan = 0;
+            return directionDial;
+        }
+        const start = utilNormalizeAzimuthDegrees(val.start);
+        const end = utilNormalizeAzimuthDegrees(val.end);
+        _range = { start, end };
+        _rangeSpan = rangeSpan(start, end);
+        _value = rangeCenter(start, end);
         return directionDial;
     };
 

--- a/modules/ui/direction_dial.ts
+++ b/modules/ui/direction_dial.ts
@@ -59,12 +59,12 @@ function precisionGain(distanceFromCenter: number): number {
 }
 
 
-function dragPointerDistanceFromCenterPx(
+function dragPointerState(
     event: DialSvgDragEvent,
     node: SVGSVGElement,
     centerX?: number | null,
     centerY?: number | null
-): { dx: number; dy: number; distanceFromCenter: number } | null {
+): { angle: number; distanceFromCenter: number } | null {
     const sourceEvent = event.sourceEvent as MouseEvent | TouchEvent | undefined;
     if (!sourceEvent) return null;
 
@@ -86,7 +86,13 @@ function dragPointerDistanceFromCenterPx(
     const cy = (centerY !== null && centerY !== undefined) ? centerY : (rect.top + (rect.height / 2));
     const dx = clientX - cx;
     const dy = clientY - cy;
-    return { dx, dy, distanceFromCenter: Math.hypot(dx, dy) };
+    const distanceFromCenter = Math.hypot(dx, dy);
+    if (!isFinite(distanceFromCenter)) return null;
+    const radians = Math.atan2(dx, -dy);
+    return {
+        angle: utilNormalizeAzimuthDegrees(radians * (180 / Math.PI)),
+        distanceFromCenter
+    };
 }
 
 
@@ -139,19 +145,6 @@ export function uiDirectionDial(): DirectionDial {
         if (source instanceof MouseEvent) return source.shiftKey;
         if (source instanceof KeyboardEvent) return source.shiftKey;
         return false;
-    }
-
-    function pointerStateFromEvent(
-        event: DialSvgDragEvent,
-        node: SVGSVGElement
-    ): { angle: number; distanceFromCenter: number } | null {
-        const state = dragPointerDistanceFromCenterPx(event, node, _dragCenterClientX, _dragCenterClientY);
-        if (!state || !isFinite(state.distanceFromCenter)) return null;
-        const radians = Math.atan2(state.dx, -state.dy);
-        return {
-            angle: utilNormalizeAzimuthDegrees(radians * (180 / Math.PI)),
-            distanceFromCenter: state.distanceFromCenter
-        };
     }
 
     function renderDial(selection: DialWrapperSelection) {
@@ -240,7 +233,7 @@ export function uiDirectionDial(): DirectionDial {
                 _dragCenterClientX = rect.left + (rect.width / 2);
                 _dragCenterClientY = rect.top + (rect.height / 2);
 
-                const pointerState = pointerStateFromEvent(event, this);
+                const pointerState = dragPointerState(event, this, _dragCenterClientX, _dragCenterClientY);
                 if (!pointerState) {
                     _isDragging = false;
                     return;
@@ -259,23 +252,15 @@ export function uiDirectionDial(): DirectionDial {
             .on('drag', function(this: SVGSVGElement, event: DialSvgDragEvent) {
                 if (_disabled || !_isDragging) return;
 
-                const pointerState = pointerStateFromEvent(event, this);
+                const pointerState = dragPointerState(event, this, _dragCenterClientX, _dragCenterClientY);
                 if (!pointerState) return;
-                const pointerDistancePx = dragPointerDistanceFromCenterPx(
-                    event,
-                    this,
-                    _dragCenterClientX,
-                    _dragCenterClientY
-                );
-                if (pointerDistancePx) {
-                    if (!_isExpandedDrag && pointerDistancePx.distanceFromCenter > DIAL_BASE_RADIUS_PX) {
-                        _isExpandedDrag = true;
-                        _dragDialDiameter = DIAL_MAX_DRAG_DIAMETER;
-                        renderDial(selection);
-                    }
-                    if (_isExpandedDrag && pointerDistancePx.distanceFromCenter > DIAL_MAX_RADIUS_PX) {
-                        return;
-                    }
+                if (!_isExpandedDrag && pointerState.distanceFromCenter > DIAL_BASE_RADIUS_PX) {
+                    _isExpandedDrag = true;
+                    _dragDialDiameter = DIAL_MAX_DRAG_DIAMETER;
+                    renderDial(selection);
+                }
+                if (_isExpandedDrag && pointerState.distanceFromCenter > DIAL_MAX_RADIUS_PX) {
+                    return;
                 }
 
                 const pointerAngle = pointerState.angle;

--- a/modules/ui/direction_dial.ts
+++ b/modules/ui/direction_dial.ts
@@ -1,5 +1,4 @@
 import { drag as d3_drag, type D3DragEvent } from 'd3-drag';
-import { pointer as d3_pointer } from 'd3-selection';
 
 import { utilNormalizeAzimuthDegrees } from '../util/direction_degrees';
 
@@ -26,6 +25,10 @@ interface DirectionDial {
 const DIAL_SIZE = 92;
 const DIAL_CENTER = DIAL_SIZE / 2;
 const DIAL_RADIUS = 34;
+const DIAL_BASE_RENDER_SIZE = 28;
+const DIAL_MAX_DRAG_DIAMETER = 180;
+const DIAL_BASE_RADIUS_PX = DIAL_BASE_RENDER_SIZE / 2;
+const DIAL_MAX_RADIUS_PX = DIAL_MAX_DRAG_DIAMETER / 2;
 /** White disk to the dial edge (no ring stroke). */
 const DIAL_WHITE_RADIUS = DIAL_RADIUS;
 const DIAL_VIEWBOX_EXTENT = DIAL_RADIUS + 1;
@@ -56,22 +59,34 @@ function precisionGain(distanceFromCenter: number): number {
 }
 
 
-function angleFromPointer(
+function dragPointerDistanceFromCenterPx(
     event: DialSvgDragEvent,
-    node: SVGSVGElement
-): { angle: number; distanceFromCenter: number } | null {
+    node: SVGSVGElement,
+    centerX?: number | null,
+    centerY?: number | null
+): { dx: number; dy: number; distanceFromCenter: number } | null {
     const sourceEvent = event.sourceEvent as MouseEvent | TouchEvent | undefined;
     if (!sourceEvent) return null;
 
-    const [x, y] = d3_pointer(sourceEvent, node);
-    const dx = x - DIAL_CENTER;
-    const dy = y - DIAL_CENTER;
-    const distanceFromCenter = Math.hypot(dx, dy);
-    if (!isFinite(distanceFromCenter)) return null;
+    let clientX: number;
+    let clientY: number;
+    if (sourceEvent instanceof MouseEvent) {
+        clientX = sourceEvent.clientX;
+        clientY = sourceEvent.clientY;
+    } else {
+        const touch = (sourceEvent.touches && sourceEvent.touches[0]) ||
+            (sourceEvent.changedTouches && sourceEvent.changedTouches[0]);
+        if (!touch) return null;
+        clientX = touch.clientX;
+        clientY = touch.clientY;
+    }
 
-    const radians = Math.atan2(dx, -dy);
-    const angle = utilNormalizeAzimuthDegrees(radians * (180 / Math.PI));
-    return { angle, distanceFromCenter };
+    const rect = node.getBoundingClientRect();
+    const cx = (centerX !== null && centerX !== undefined) ? centerX : (rect.left + (rect.width / 2));
+    const cy = (centerY !== null && centerY !== undefined) ? centerY : (rect.top + (rect.height / 2));
+    const dx = clientX - cx;
+    const dy = clientY - cy;
+    return { dx, dy, distanceFromCenter: Math.hypot(dx, dy) };
 }
 
 
@@ -87,8 +102,12 @@ export function uiDirectionDial(): DirectionDial {
     let _onInput: DirectionDialCallback = function() {};
     let _onCommit: DirectionDialCallback = function() {};
     let _isDragging = false;
+    let _isExpandedDrag = false;
     let _dragValue = 0;
     let _lastPointerAngle = 0;
+    let _dragDialDiameter = DIAL_BASE_RENDER_SIZE;
+    let _dragCenterClientX: number | null = null;
+    let _dragCenterClientY: number | null = null;
 
     function attachWrapShiftListeners() {
         if (_shiftWindowListenersAttached || typeof window === 'undefined') return;
@@ -122,6 +141,19 @@ export function uiDirectionDial(): DirectionDial {
         return false;
     }
 
+    function pointerStateFromEvent(
+        event: DialSvgDragEvent,
+        node: SVGSVGElement
+    ): { angle: number; distanceFromCenter: number } | null {
+        const state = dragPointerDistanceFromCenterPx(event, node, _dragCenterClientX, _dragCenterClientY);
+        if (!state || !isFinite(state.distanceFromCenter)) return null;
+        const radians = Math.atan2(state.dx, -state.dy);
+        return {
+            angle: utilNormalizeAzimuthDegrees(radians * (180 / Math.PI)),
+            distanceFromCenter: state.distanceFromCenter
+        };
+    }
+
     function renderDial(selection: DialWrapperSelection) {
         _selectionRef = selection;
 
@@ -133,6 +165,7 @@ export function uiDirectionDial(): DirectionDial {
                 renderDial(selection);
             })
             .on('mouseleave.directionDialShift', function() {
+                if (_isDragging) return;
                 _shiftHeld = false;
                 detachWrapShiftListeners();
                 renderDial(selection);
@@ -179,18 +212,26 @@ export function uiDirectionDial(): DirectionDial {
             .attr('r', 3);
 
         const dialMerge = dialEnter.merge(dialSVG);
-
         dialMerge
             .classed('disabled', _disabled)
             .classed('dragging', _isDragging)
+            .classed('expanded', _isDragging && _isExpandedDrag)
+            .style('width', _isDragging ? `${_dragDialDiameter}px` : null)
+            .style('height', _isDragging ? `${_dragDialDiameter}px` : null)
             .attr('tabindex', _disabled ? null : 0);
 
         const dragBehavior = d3_drag<SVGSVGElement, DialSvgDatum>()
             .on('start', function(this: SVGSVGElement, event: DialSvgDragEvent) {
                 if (_disabled) return;
                 _isDragging = true;
+                _isExpandedDrag = false;
+                _dragDialDiameter = DIAL_BASE_RENDER_SIZE;
+                attachWrapShiftListeners();
+                const rect = this.getBoundingClientRect();
+                _dragCenterClientX = rect.left + (rect.width / 2);
+                _dragCenterClientY = rect.top + (rect.height / 2);
 
-                const pointerState = angleFromPointer(event, this);
+                const pointerState = pointerStateFromEvent(event, this);
                 if (!pointerState) {
                     _isDragging = false;
                     return;
@@ -210,15 +251,35 @@ export function uiDirectionDial(): DirectionDial {
             .on('drag', function(this: SVGSVGElement, event: DialSvgDragEvent) {
                 if (_disabled || !_isDragging) return;
 
-                const pointerState = angleFromPointer(event, this);
+                const pointerState = pointerStateFromEvent(event, this);
                 if (!pointerState) return;
+                const pointerDistancePx = dragPointerDistanceFromCenterPx(
+                    event,
+                    this,
+                    _dragCenterClientX,
+                    _dragCenterClientY
+                );
+                if (pointerDistancePx) {
+                    if (!_isExpandedDrag && pointerDistancePx.distanceFromCenter > DIAL_BASE_RADIUS_PX) {
+                        _isExpandedDrag = true;
+                        _dragDialDiameter = DIAL_MAX_DRAG_DIAMETER;
+                        renderDial(selection);
+                    }
+                    if (_isExpandedDrag && pointerDistancePx.distanceFromCenter > DIAL_MAX_RADIUS_PX) {
+                        return;
+                    }
+                }
 
                 const pointerAngle = pointerState.angle;
-                const delta = shortestAngleDelta(_lastPointerAngle, pointerAngle);
+                if (_isExpandedDrag) {
+                    // In expanded mode, keep indicator directly under cursor angle.
+                    _dragValue = pointerAngle;
+                } else {
+                    const delta = shortestAngleDelta(_lastPointerAngle, pointerAngle);
+                    const gain = precisionGain(pointerState.distanceFromCenter);
+                    _dragValue = utilNormalizeAzimuthDegrees(_dragValue + (delta * gain));
+                }
                 _lastPointerAngle = pointerAngle;
-
-                const gain = precisionGain(pointerState.distanceFromCenter);
-                _dragValue = utilNormalizeAzimuthDegrees(_dragValue + (delta * gain));
                 if (shiftFromDragEvent(event)) {
                     _dragValue = snapAbsolute(_dragValue, _step);
                 }
@@ -230,11 +291,17 @@ export function uiDirectionDial(): DirectionDial {
             .on('end', function(this: SVGSVGElement, event: DialSvgDragEvent) {
                 if (_disabled || !_isDragging) return;
                 _isDragging = false;
+                _isExpandedDrag = false;
+                _dragDialDiameter = DIAL_BASE_RENDER_SIZE;
+                _dragCenterClientX = null;
+                _dragCenterClientY = null;
                 if (shiftFromDragEvent(event)) {
                     _dragValue = snapAbsolute(_dragValue, _step);
                 }
                 _value = _dragValue;
                 _onCommit(Math.round(_dragValue));
+                _shiftHeld = false;
+                detachWrapShiftListeners();
                 renderDial(selection);
             });
 

--- a/modules/ui/direction_field_dial.ts
+++ b/modules/ui/direction_field_dial.ts
@@ -1,0 +1,107 @@
+import { select as d3_select } from 'd3-selection';
+import type { Selection } from 'd3-selection';
+
+import {
+    utilDirectionSegmentFractionDigits,
+    utilGetSetValue,
+    utilNormalizeAzimuthDegrees,
+    utilParseDirectionDegreesString
+} from '../util';
+import { uiDirectionDial } from './direction_dial';
+
+/**
+ * Preset field container passed to `uiFieldText`’s render function (the `.form-field` node).
+ */
+type FormFieldRootSelection = Selection<HTMLElement, unknown, HTMLElement | null, unknown>;
+
+type InputSelection = Selection<HTMLInputElement, unknown, HTMLElement | null, unknown>;
+
+interface DirectionFieldDialMountOptions {
+    /** Preset `increment` when sensible; dial falls back to 1 if invalid. */
+    step: number;
+    getInput: () => InputSelection;
+    notifyChange: (onInput: boolean) => void;
+    clampNumber: (n: number) => number;
+    formatFloat: (n: number, fractionDigits: number) => string;
+    countDecimalPlaces: (s: string) => number;
+    parseLocaleFloat: (s: string) => number;
+}
+
+type SyncDirectionDial = (isMixed: boolean, isLocked: boolean) => void;
+
+/**
+ * Returns a function called on each `i(selection)` pass: updates the dial shell for `fieldRoot`
+ * and returns `sync` to run after `i.tags(…)`.
+ */
+export function createDirectionFieldDialMount(
+    enabled: boolean,
+    options: DirectionFieldDialMountOptions
+): (fieldRoot: FormFieldRootSelection) => SyncDirectionDial {
+    if (!enabled) {
+        return function mountDisabled(fieldRoot: FormFieldRootSelection) {
+            fieldRoot.classed('form-field-has-direction-dial', false);
+            fieldRoot.selectAll('.direction-dial-wrap').remove();
+            return function syncNoOp() {
+                /* no dial */
+            };
+        };
+    }
+
+    let dialWrap = d3_select(null) as unknown as Selection<HTMLDivElement, unknown, HTMLElement | null, unknown>;
+
+    const dial = uiDirectionDial()
+        .step(options.step)
+        .onInput(function(degrees: number) {
+            applyDegreesToInput(degrees, true);
+        })
+        .onCommit(function(degrees: number) {
+            applyDegreesToInput(degrees, false);
+        });
+
+    function applyDegreesToInput(degrees: number, onInput: boolean) {
+        const inputSel = options.getInput();
+        if (inputSel.empty()) return;
+
+        const normalized = utilNormalizeAzimuthDegrees(degrees);
+        const currentValue = utilGetSetValue(inputSel);
+        const vals = currentValue ? currentValue.split(';') : [''];
+        const firstValue = (vals[0] || '').trim();
+        const fractionDigits = utilDirectionSegmentFractionDigits(
+            firstValue,
+            options.countDecimalPlaces
+        );
+
+        vals[0] = options.formatFloat(options.clampNumber(normalized), fractionDigits);
+        utilGetSetValue(inputSel, vals.join(';'));
+        options.notifyChange(onInput);
+    }
+
+    function syncDialFromInput(isMixed: boolean, isLocked: boolean) {
+        if (dialWrap.empty()) return;
+
+        const inputSel = options.getInput();
+        const rawValue = utilGetSetValue(inputSel);
+        const firstValue = (rawValue || '').split(';')[0];
+        const degrees = isMixed
+            ? null
+            : utilParseDirectionDegreesString(firstValue, options.parseLocaleFloat);
+
+        dial
+            .value(degrees)
+            .disabled(isMixed || isLocked);
+
+        dialWrap.call(dial);
+    }
+
+    return function mountFieldDirectionDial(fieldRoot: FormFieldRootSelection) {
+        fieldRoot.classed('form-field-has-direction-dial', true);
+        const wrapSel = fieldRoot.selectAll<HTMLDivElement, number>('.direction-dial-wrap').data([0]);
+        dialWrap = wrapSel
+            .enter()
+            .insert('div', '.form-field-input-wrap')
+            .attr('class', 'direction-dial-wrap')
+            .merge(wrapSel) as unknown as Selection<HTMLDivElement, unknown, HTMLElement | null, unknown>;
+
+        return syncDialFromInput;
+    };
+}

--- a/modules/ui/direction_field_dial.ts
+++ b/modules/ui/direction_field_dial.ts
@@ -1,6 +1,3 @@
-import { select as d3_select } from 'd3-selection';
-import type { Selection } from 'd3-selection';
-
 import {
     utilDirectionSegmentFractionDigits,
     utilGetSetValue,
@@ -9,12 +6,12 @@ import {
 } from '../util';
 import { uiDirectionDial } from './direction_dial';
 
-/**
- * Preset field container passed to `uiFieldText`’s render function (the `.form-field` node).
- */
-type FormFieldRootSelection = Selection<HTMLElement, unknown, HTMLElement | null, unknown>;
+/** Preset field container passed to `uiFieldText`’s render function (the `.form-field` node). */
+type FormFieldRootSelection = d3.Selection<HTMLElement>;
 
-type InputSelection = Selection<HTMLInputElement, unknown, HTMLElement | null, unknown>;
+type InputSelection = d3.Selection<HTMLInputElement>;
+
+type DialWrapSelection = d3.Selection<HTMLDivElement>;
 
 interface DirectionFieldDialMountOptions {
     /** Preset `increment` when sensible; dial falls back to 1 if invalid. */
@@ -47,7 +44,7 @@ export function createDirectionFieldDialMount(
         };
     }
 
-    let dialWrap = d3_select(null) as unknown as Selection<HTMLDivElement, unknown, HTMLElement | null, unknown>;
+    let dialWrap: DialWrapSelection | null = null;
 
     const dial = uiDirectionDial()
         .step(options.step)
@@ -77,7 +74,7 @@ export function createDirectionFieldDialMount(
     }
 
     function syncDialFromInput(isMixed: boolean, isLocked: boolean) {
-        if (dialWrap.empty()) return;
+        if (!dialWrap) return;
 
         const inputSel = options.getInput();
         const rawValue = utilGetSetValue(inputSel);
@@ -100,7 +97,7 @@ export function createDirectionFieldDialMount(
             .enter()
             .insert('div', '.form-field-input-wrap')
             .attr('class', 'direction-dial-wrap')
-            .merge(wrapSel) as unknown as Selection<HTMLDivElement, unknown, HTMLElement | null, unknown>;
+            .merge(wrapSel);
 
         return syncDialFromInput;
     };

--- a/modules/ui/direction_field_dial.ts
+++ b/modules/ui/direction_field_dial.ts
@@ -2,8 +2,7 @@ import {
     utilDirectionSegmentFractionDigits,
     utilGetSetValue,
     utilNormalizeAzimuthDegrees,
-    utilParseDirectionDegreesString,
-    utilParseDirectionRangeString
+    utilParseDirectionDegreesString
 } from '../util';
 import { uiDirectionDial } from './direction_dial';
 
@@ -26,7 +25,6 @@ interface DirectionFieldDialMountOptions {
 }
 
 type SyncDirectionDial = (isMixed: boolean, isLocked: boolean) => void;
-type DialValue = number | { start: number; end: number };
 
 /**
  * Returns a function called on each `i(selection)` pass: updates the dial shell for `fieldRoot`
@@ -50,17 +48,18 @@ export function createDirectionFieldDialMount(
 
     const dial = uiDirectionDial()
         .step(options.step)
-        .onInput(function(value: DialValue) {
-            applyDialValueToInput(value, true);
+        .onInput(function(degrees: number) {
+            applyDegreesToInput(degrees, true);
         })
-        .onCommit(function(value: DialValue) {
-            applyDialValueToInput(value, false);
+        .onCommit(function(degrees: number) {
+            applyDegreesToInput(degrees, false);
         });
 
-    function applyDialValueToInput(value: DialValue, onInput: boolean) {
+    function applyDegreesToInput(degrees: number, onInput: boolean) {
         const inputSel = options.getInput();
         if (inputSel.empty()) return;
 
+        const normalized = utilNormalizeAzimuthDegrees(degrees);
         const currentValue = utilGetSetValue(inputSel);
         const vals = currentValue ? currentValue.split(';') : [''];
         const firstValue = (vals[0] || '').trim();
@@ -69,14 +68,7 @@ export function createDirectionFieldDialMount(
             options.countDecimalPlaces
         );
 
-        if (typeof value === 'number') {
-            const normalized = utilNormalizeAzimuthDegrees(value);
-            vals[0] = options.formatFloat(options.clampNumber(normalized), fractionDigits);
-        } else {
-            const start = options.formatFloat(options.clampNumber(utilNormalizeAzimuthDegrees(value.start)), fractionDigits);
-            const end = options.formatFloat(options.clampNumber(utilNormalizeAzimuthDegrees(value.end)), fractionDigits);
-            vals[0] = `${start}-${end}`;
-        }
+        vals[0] = options.formatFloat(options.clampNumber(normalized), fractionDigits);
         utilGetSetValue(inputSel, vals.join(';'));
         options.notifyChange(onInput);
     }
@@ -87,18 +79,12 @@ export function createDirectionFieldDialMount(
         const inputSel = options.getInput();
         const rawValue = utilGetSetValue(inputSel);
         const firstValue = (rawValue || '').split(';')[0];
-        const range = isMixed
-            ? null
-            : utilParseDirectionRangeString(firstValue, options.parseLocaleFloat);
-        const degrees = range
-            ? null
-            : isMixed
+        const degrees = isMixed
             ? null
             : utilParseDirectionDegreesString(firstValue, options.parseLocaleFloat);
 
         dial
             .value(degrees)
-            .range(range)
             .disabled(isMixed || isLocked);
 
         dialWrap.call(dial);

--- a/modules/ui/direction_field_dial.ts
+++ b/modules/ui/direction_field_dial.ts
@@ -2,7 +2,8 @@ import {
     utilDirectionSegmentFractionDigits,
     utilGetSetValue,
     utilNormalizeAzimuthDegrees,
-    utilParseDirectionDegreesString
+    utilParseDirectionDegreesString,
+    utilParseDirectionRangeString
 } from '../util';
 import { uiDirectionDial } from './direction_dial';
 
@@ -25,6 +26,7 @@ interface DirectionFieldDialMountOptions {
 }
 
 type SyncDirectionDial = (isMixed: boolean, isLocked: boolean) => void;
+type DialValue = number | { start: number; end: number };
 
 /**
  * Returns a function called on each `i(selection)` pass: updates the dial shell for `fieldRoot`
@@ -48,18 +50,17 @@ export function createDirectionFieldDialMount(
 
     const dial = uiDirectionDial()
         .step(options.step)
-        .onInput(function(degrees: number) {
-            applyDegreesToInput(degrees, true);
+        .onInput(function(value: DialValue) {
+            applyDialValueToInput(value, true);
         })
-        .onCommit(function(degrees: number) {
-            applyDegreesToInput(degrees, false);
+        .onCommit(function(value: DialValue) {
+            applyDialValueToInput(value, false);
         });
 
-    function applyDegreesToInput(degrees: number, onInput: boolean) {
+    function applyDialValueToInput(value: DialValue, onInput: boolean) {
         const inputSel = options.getInput();
         if (inputSel.empty()) return;
 
-        const normalized = utilNormalizeAzimuthDegrees(degrees);
         const currentValue = utilGetSetValue(inputSel);
         const vals = currentValue ? currentValue.split(';') : [''];
         const firstValue = (vals[0] || '').trim();
@@ -68,7 +69,14 @@ export function createDirectionFieldDialMount(
             options.countDecimalPlaces
         );
 
-        vals[0] = options.formatFloat(options.clampNumber(normalized), fractionDigits);
+        if (typeof value === 'number') {
+            const normalized = utilNormalizeAzimuthDegrees(value);
+            vals[0] = options.formatFloat(options.clampNumber(normalized), fractionDigits);
+        } else {
+            const start = options.formatFloat(options.clampNumber(utilNormalizeAzimuthDegrees(value.start)), fractionDigits);
+            const end = options.formatFloat(options.clampNumber(utilNormalizeAzimuthDegrees(value.end)), fractionDigits);
+            vals[0] = `${start}-${end}`;
+        }
         utilGetSetValue(inputSel, vals.join(';'));
         options.notifyChange(onInput);
     }
@@ -79,12 +87,18 @@ export function createDirectionFieldDialMount(
         const inputSel = options.getInput();
         const rawValue = utilGetSetValue(inputSel);
         const firstValue = (rawValue || '').split(';')[0];
-        const degrees = isMixed
+        const range = isMixed
+            ? null
+            : utilParseDirectionRangeString(firstValue, options.parseLocaleFloat);
+        const degrees = range
+            ? null
+            : isMixed
             ? null
             : utilParseDirectionDegreesString(firstValue, options.parseLocaleFloat);
 
         dial
             .value(degrees)
+            .range(range)
             .disabled(isMixed || isLocked);
 
         dialWrap.call(dial);

--- a/modules/ui/direction_field_dial.ts
+++ b/modules/ui/direction_field_dial.ts
@@ -92,10 +92,17 @@ export function createDirectionFieldDialMount(
 
     return function mountFieldDirectionDial(fieldRoot: FormFieldRootSelection) {
         fieldRoot.classed('form-field-has-direction-dial', true);
-        const wrapSel = fieldRoot.selectAll<HTMLDivElement, number>('.direction-dial-wrap').data([0]);
+        const inputWrap = fieldRoot.select<HTMLElement>('.form-field-input-wrap');
+        if (inputWrap.empty()) {
+            fieldRoot.selectAll('.direction-dial-wrap').remove();
+            dialWrap = null;
+            return syncDialFromInput;
+        }
+
+        const wrapSel = inputWrap.selectAll<HTMLDivElement, number>('.direction-dial-wrap').data([0]);
         dialWrap = wrapSel
             .enter()
-            .insert('div', '.form-field-input-wrap')
+            .insert('div', '.form-field-button')
             .attr('class', 'direction-dial-wrap')
             .merge(wrapSel);
 

--- a/modules/ui/fields/input.js
+++ b/modules/ui/fields/input.js
@@ -7,11 +7,21 @@ import * as countryCoder from '@rapideditor/country-coder';
 import { presetManager } from '../../presets';
 import { fileFetcher } from '../../core/file_fetcher';
 import { t, localizer } from '../../core/localizer';
-import { utilDetect, utilGetSetValue, utilNoAuto, utilRebind, utilTotalExtent } from '../../util';
+import {
+    utilDetect,
+    utilDirectionSegmentFractionDigits,
+    utilGetSetValue,
+    utilNoAuto,
+    utilNormalizeAzimuthDegrees,
+    utilParseDirectionDegreesString,
+    utilRebind,
+    utilTotalExtent,
+    numberFieldRawRegex
+} from '../../util';
 import { svgIcon } from '../../svg/icon';
-import { cardinal } from '../../osm/node';
 import { isColorValid } from '../../osm/tags';
 import { uiLengthIndicator } from '..';
+import { createDirectionFieldDialMount } from '../direction_field_dial';
 import { uiTooltip } from '../tooltip';
 import { utilIsValidURL } from '../../util/util';
 
@@ -24,10 +34,9 @@ export {
     uiFieldText as uiFieldSchedule,
     uiFieldText as uiFieldTel,
     uiFieldText as uiFieldUrl,
-    likelyRawNumberFormat
+    numberFieldRawRegex as likelyRawNumberFormat, // Legacy export
 };
 
-const likelyRawNumberFormat = /^-?(0\.\d*|\d*\.\d{0,2}(\d{4,})?|\d{4,}\.\d{3})$/;
 const yoHoursURLFormat = 'https://projets.pavie.info/yohours/?oh={value}';
 
 export function uiFieldText(field, context) {
@@ -43,6 +52,7 @@ export function uiFieldText(field, context) {
     const formatFloat = localizer.floatFormatter(localizer.languageCode());
     const parseLocaleFloat = localizer.floatParser(localizer.languageCode());
     const countDecimalPlaces = localizer.decimalPlaceCounter(localizer.languageCode());
+    const isDirectionNumberField = isDirectionField && (field.type === 'number' || field.type === 'integer');
 
     if (field.type === 'tel') {
         fileFetcher.get('phone_formats')
@@ -110,6 +120,8 @@ export function uiFieldText(field, context) {
 
         wrap.call(_lengthIndicator);
 
+        syncDirectionDial = mountDirectionDial(selection);
+
         if (field.type === 'tel') {
             updatePhonePlaceholder();
 
@@ -145,30 +157,27 @@ export function uiFieldText(field, context) {
                     var vals = raw_vals.split(';');
                     vals = vals.map(function(v) {
                         v = v.trim();
-                        const isRawNumber = likelyRawNumberFormat.test(v);
-                        var num = isRawNumber ? parseFloat(v) : parseLocaleFloat(v);
+                        const isRawNumber = numberFieldRawRegex.test(v);
+                        let num;
                         if (isDirectionField) {
-                            const compassDir = cardinal[v.toLowerCase()];
-                            if (compassDir !== undefined) {
-                                num = compassDir;
-                            }
+                            num = utilParseDirectionDegreesString(v, parseLocaleFloat);
+                            if (num === null) return v;
+                        } else {
+                            num = isRawNumber ? parseFloat(v) : parseLocaleFloat(v);
+                            // do nothing if the value is not a number
+                            if (!isFinite(num)) return v;
+                            num = parseFloat(num);
+                            if (!isFinite(num)) return v;
                         }
-
-                        // do nothing if the value is neither a number, nor a cardinal direction
-                        if (!isFinite(num)) return v;
-                        num = parseFloat(num);
-                        if (!isFinite(num)) return v;
 
                         num += d;
                         // clamp to 0..359 degree range if it's a direction field
                         // https://github.com/openstreetmap/iD/issues/9386
                         if (isDirectionField) {
-                            num = ((num % 360) + 360) % 360;
+                            num = utilNormalizeAzimuthDegrees(num);
                         }
-                        // make sure no extra decimals are introduced
-                        return formatFloat(clamped(num), isRawNumber
-                            ? (v.includes('.') ? v.split('.')[1].length : 0)
-                            : countDecimalPlaces(v));
+                        const fractionDigits = utilDirectionSegmentFractionDigits(v, countDecimalPlaces);
+                        return formatFloat(clamped(num), fractionDigits);
                     });
                     input.node().value = vals.join(';');
                     change()();
@@ -247,7 +256,6 @@ export function uiFieldText(field, context) {
             updateDateField();
         }
     }
-
 
     function updateColourPreview() {
         wrap.selectAll('.colour-preview')
@@ -458,7 +466,7 @@ export function uiFieldText(field, context) {
             let displayVal = val;
             if ((field.type === 'number' || field.type === 'integer') && val) {
                 const numbers = val.split(';').map(v => {
-                    if (likelyRawNumberFormat.test(v)) {
+                    if (numberFieldRawRegex.test(v)) {
                         // input number likely in "raw" format
                         return {
                             v,
@@ -506,6 +514,18 @@ export function uiFieldText(field, context) {
         };
     }
 
+    const mountDirectionDial = createDirectionFieldDialMount(isDirectionNumberField, {
+        step: isDirectionNumberField && field.increment ? field.increment : 1,
+        getInput: function() { return input; },
+        notifyChange: function(onInput) {
+            change(onInput)();
+        },
+        clampNumber: clamped,
+        formatFloat: formatFloat,
+        countDecimalPlaces: countDecimalPlaces,
+        parseLocaleFloat: parseLocaleFloat
+    });
+    let syncDirectionDial = function directionDialSyncNoop() {};
 
     i.entityIDs = function(val) {
         if (!arguments.length) return _entityIDs;
@@ -540,7 +560,7 @@ export function uiFieldText(field, context) {
             // can and should update the content of the input element.
             shouldUpdate = (inputValue, setValue) => {
                 const inputNums = inputValue.split(';').map(val => {
-                    const parsedNum = likelyRawNumberFormat.test(val)
+                    const parsedNum = numberFieldRawRegex.test(val)
                         ? parseFloat(val)
                         : parseLocaleFloat(val);
                     if (!isFinite(parsedNum)) return val; // keep unparsable values as-is
@@ -568,11 +588,14 @@ export function uiFieldText(field, context) {
                 var raw_vals = tags[field.key] || '0';
                 const canIncDec = raw_vals.split(';').some((val) =>
                     isFinite(Number(val))
-                    || (isDirectionField && (val.trim().toLowerCase() in cardinal))
+                    || (isDirectionField
+                        && utilParseDirectionDegreesString(val, parseLocaleFloat) !== null)
                 );
                 buttons.attr('disabled', canIncDec ? null : 'disabled').classed('disabled', !canIncDec);
             }
         }
+
+        syncDirectionDial(isMixed, field.locked());
 
         if (field.type === 'tel') updatePhonePlaceholder();
 

--- a/modules/ui/tag_reference.js
+++ b/modules/ui/tag_reference.js
@@ -94,7 +94,8 @@ export function uiTagReference(what) {
               .call(t.append(docs.wiki.text));
         }
 
-        // Rotate (R) adjusts numeric direction=* on standalone points.
+// Rotate (R) adjusts numeric direction=* on standalone points.
+        // The dial provides an alternate UI for the same tag.
         if (what.key === 'direction') {
             _body
                 .append('div')
@@ -105,6 +106,14 @@ export function uiTagReference(what) {
                 .attr('class', 'shortcut-hint')
                 .call(t.append('inspector.direction_rotate_help', {
                     key: uiCmd.display(t('operations.rotate.key'))
+                }));
+
+            _body
+                .append('p')
+                .attr('class', 'tag-reference-direction-help')
+                .call(t.append('inspector.direction_dial_help', {
+                    shift: uiCmd.display('⇧'),
+                    command: uiCmd.display('⌘')
                 }));
         }
 

--- a/modules/util/direction_degrees.ts
+++ b/modules/util/direction_degrees.ts
@@ -35,44 +35,6 @@ export function utilParseDirectionDegreesString(
     return utilNormalizeAzimuthDegrees(parsed);
 }
 
-export interface DirectionRange {
-    start: number;
-    end: number;
-}
-
-/**
- * Parse a direction range from user-entered text (single semicolon segment).
- * Supports formats like `120-300` with optional whitespace.
- */
-export function utilParseDirectionRangeString(
-    value: string,
-    parseLocaleFloat: (s: string) => number,
-    rawNumberRe: RegExp = numberFieldRawRegex
-): DirectionRange | null {
-    const directionText = (value || '').trim();
-    if (!directionText) return null;
-
-    const match = directionText.match(/^(.+?)\s*-\s*(.+)$/);
-    if (!match) return null;
-
-    const parsePart = (s: string): number | null => {
-        const part = s.trim().toLowerCase();
-        if (!part) return null;
-        if (cardinal[part as keyof typeof cardinal] !== undefined) {
-            return cardinal[part as keyof typeof cardinal];
-        }
-        const isRawNumber = rawNumberRe.test(part);
-        const parsed = isRawNumber ? parseFloat(part) : parseLocaleFloat(part);
-        if (!isFinite(parsed)) return null;
-        return utilNormalizeAzimuthDegrees(parsed);
-    };
-
-    const start = parsePart(match[1]);
-    const end = parsePart(match[2]);
-    if (start === null || end === null) return null;
-    return { start, end };
-}
-
 /**
  * Fraction digits to use when re-formatting a direction segment, matching number-field behavior.
  * @param segment trimmed or untrimmed single value (e.g. first semicolon part)

--- a/modules/util/direction_degrees.ts
+++ b/modules/util/direction_degrees.ts
@@ -35,6 +35,44 @@ export function utilParseDirectionDegreesString(
     return utilNormalizeAzimuthDegrees(parsed);
 }
 
+export interface DirectionRange {
+    start: number;
+    end: number;
+}
+
+/**
+ * Parse a direction range from user-entered text (single semicolon segment).
+ * Supports formats like `120-300` with optional whitespace.
+ */
+export function utilParseDirectionRangeString(
+    value: string,
+    parseLocaleFloat: (s: string) => number,
+    rawNumberRe: RegExp = numberFieldRawRegex
+): DirectionRange | null {
+    const directionText = (value || '').trim();
+    if (!directionText) return null;
+
+    const match = directionText.match(/^(.+?)\s*-\s*(.+)$/);
+    if (!match) return null;
+
+    const parsePart = (s: string): number | null => {
+        const part = s.trim().toLowerCase();
+        if (!part) return null;
+        if (cardinal[part as keyof typeof cardinal] !== undefined) {
+            return cardinal[part as keyof typeof cardinal];
+        }
+        const isRawNumber = rawNumberRe.test(part);
+        const parsed = isRawNumber ? parseFloat(part) : parseLocaleFloat(part);
+        if (!isFinite(parsed)) return null;
+        return utilNormalizeAzimuthDegrees(parsed);
+    };
+
+    const start = parsePart(match[1]);
+    const end = parsePart(match[2]);
+    if (start === null || end === null) return null;
+    return { start, end };
+}
+
 /**
  * Fraction digits to use when re-formatting a direction segment, matching number-field behavior.
  * @param segment trimmed or untrimmed single value (e.g. first semicolon part)

--- a/modules/util/direction_degrees.ts
+++ b/modules/util/direction_degrees.ts
@@ -1,0 +1,59 @@
+import { cardinal } from '../osm/node';
+import { numberFieldRawRegex } from './number_field';
+
+/**
+ * Normalize an angle in degrees to the range [0, 360).
+ * @param degrees
+ */
+export function utilNormalizeAzimuthDegrees(degrees: number): number {
+    return ((degrees % 360) + 360) % 360;
+}
+
+/**
+ * Parse a direction value from user-entered text (single semicolon segment).
+ * Supports cardinal shortcuts and numeric values (raw or locale-parsed).
+ * @param value raw segment (e.g. from an input field)
+ * @param parseLocaleFloat localized number parser
+ * @param rawNumberRe defaults to {@link numberFieldRawRegex} (inspector `uiFieldText` rule)
+ */
+export function utilParseDirectionDegreesString(
+    value: string,
+    parseLocaleFloat: (s: string) => number,
+    rawNumberRe: RegExp = numberFieldRawRegex
+): number | null {
+    const directionText = (value || '').trim().toLowerCase();
+    if (!directionText) return null;
+
+    if (cardinal[directionText as keyof typeof cardinal] !== undefined) {
+        return cardinal[directionText as keyof typeof cardinal];
+    }
+
+    const isRawNumber = rawNumberRe.test(directionText);
+    const parsed = isRawNumber ? parseFloat(directionText) : parseLocaleFloat(directionText);
+    if (!isFinite(parsed)) return null;
+
+    return utilNormalizeAzimuthDegrees(parsed);
+}
+
+/**
+ * Fraction digits to use when re-formatting a direction segment, matching number-field behavior.
+ * @param segment trimmed or untrimmed single value (e.g. first semicolon part)
+ * @param countDecimalPlaces localized decimal-place counter for display strings
+ * @param rawNumberRe defaults to {@link numberFieldRawRegex}
+ */
+export function utilDirectionSegmentFractionDigits(
+    segment: string,
+    countDecimalPlaces: (s: string) => number,
+    rawNumberRe: RegExp = numberFieldRawRegex
+): number {
+    const s = (segment || '').trim();
+    const isRawNumber = rawNumberRe.test(s);
+    let fractionDigits = countDecimalPlaces(s);
+    if (isRawNumber) {
+        fractionDigits = s.includes('.') ? s.split('.')[1].length : 0;
+    }
+    if (!isFinite(fractionDigits)) {
+        fractionDigits = 0;
+    }
+    return fractionDigits;
+}

--- a/modules/util/index.ts
+++ b/modules/util/index.ts
@@ -5,6 +5,12 @@ export { utilCleanTags } from './clean_tags';
 export { utilCombinedTags } from './util';
 export { utilDeepMemberSelector } from './util';
 export { utilDetect } from './detect';
+export { numberFieldRawRegex } from './number_field';
+export {
+    utilNormalizeAzimuthDegrees,
+    utilParseDirectionDegreesString,
+    utilDirectionSegmentFractionDigits
+} from './direction_degrees';
 export { utilDisplayName } from './util';
 export { utilDisplayNameForPath } from './util';
 export { utilDisplayType } from './util';

--- a/modules/util/index.ts
+++ b/modules/util/index.ts
@@ -9,7 +9,6 @@ export { numberFieldRawRegex } from './number_field';
 export {
     utilNormalizeAzimuthDegrees,
     utilParseDirectionDegreesString,
-    utilParseDirectionRangeString,
     utilDirectionSegmentFractionDigits
 } from './direction_degrees';
 export { utilDisplayName } from './util';

--- a/modules/util/index.ts
+++ b/modules/util/index.ts
@@ -9,6 +9,7 @@ export { numberFieldRawRegex } from './number_field';
 export {
     utilNormalizeAzimuthDegrees,
     utilParseDirectionDegreesString,
+    utilParseDirectionRangeString,
     utilDirectionSegmentFractionDigits
 } from './direction_degrees';
 export { utilDisplayName } from './util';

--- a/modules/util/number_field.ts
+++ b/modules/util/number_field.ts
@@ -1,0 +1,2 @@
+/** Detects inspector number-field values in “raw” ASCII form vs localized formatting. */
+export const numberFieldRawRegex = /^-?(0\.\d*|\d*\.\d{0,2}(\d{4,})?|\d{4,}\.\d{3})$/;

--- a/test/spec/util/direction_degrees.ts
+++ b/test/spec/util/direction_degrees.ts
@@ -42,6 +42,31 @@ describe('iD.direction_degrees util', () => {
         });
     });
 
+    describe('utilParseDirectionRangeString', () => {
+        it('returns null for empty or non-range input', () => {
+            expect(iD.utilParseDirectionRangeString('', parseIdentity)).to.equal(null);
+            expect(iD.utilParseDirectionRangeString('90', parseIdentity)).to.equal(null);
+        });
+
+        it('parses numeric range strings and normalizes', () => {
+            expect(iD.utilParseDirectionRangeString('120-300', parseIdentity)).to.deep.equal({
+                start: 120,
+                end: 300
+            });
+            expect(iD.utilParseDirectionRangeString('-10-370', parseIdentity)).to.deep.equal({
+                start: 350,
+                end: 10
+            });
+        });
+
+        it('parses range strings with cardinal directions', () => {
+            expect(iD.utilParseDirectionRangeString('N-E', parseIdentity)).to.deep.equal({
+                start: 0,
+                end: 90
+            });
+        });
+    });
+
     describe('utilDirectionSegmentFractionDigits', () => {
         it('uses decimal places from raw dot notation', () => {
             expect(

--- a/test/spec/util/direction_degrees.ts
+++ b/test/spec/util/direction_degrees.ts
@@ -42,31 +42,6 @@ describe('iD.direction_degrees util', () => {
         });
     });
 
-    describe('utilParseDirectionRangeString', () => {
-        it('returns null for empty or non-range input', () => {
-            expect(iD.utilParseDirectionRangeString('', parseIdentity)).to.equal(null);
-            expect(iD.utilParseDirectionRangeString('90', parseIdentity)).to.equal(null);
-        });
-
-        it('parses numeric range strings and normalizes', () => {
-            expect(iD.utilParseDirectionRangeString('120-300', parseIdentity)).to.deep.equal({
-                start: 120,
-                end: 300
-            });
-            expect(iD.utilParseDirectionRangeString('-10-370', parseIdentity)).to.deep.equal({
-                start: 350,
-                end: 10
-            });
-        });
-
-        it('parses range strings with cardinal directions', () => {
-            expect(iD.utilParseDirectionRangeString('N-E', parseIdentity)).to.deep.equal({
-                start: 0,
-                end: 90
-            });
-        });
-    });
-
     describe('utilDirectionSegmentFractionDigits', () => {
         it('uses decimal places from raw dot notation', () => {
             expect(

--- a/test/spec/util/direction_degrees.ts
+++ b/test/spec/util/direction_degrees.ts
@@ -1,0 +1,64 @@
+describe('iD.direction_degrees util', () => {
+    function parseIdentity(s: string): number {
+        return parseFloat(s);
+    }
+
+    describe('utilNormalizeAzimuthDegrees', () => {
+        it('maps negative angles into [0, 360)', () => {
+            expect(iD.utilNormalizeAzimuthDegrees(-10)).to.equal(350);
+            expect(iD.utilNormalizeAzimuthDegrees(-360)).to.equal(0);
+        });
+
+        it('reduces angles >= 360', () => {
+            expect(iD.utilNormalizeAzimuthDegrees(360)).to.equal(0);
+            expect(iD.utilNormalizeAzimuthDegrees(370)).to.equal(10);
+        });
+
+        it('leaves canonical values unchanged', () => {
+            expect(iD.utilNormalizeAzimuthDegrees(0)).to.equal(0);
+            expect(iD.utilNormalizeAzimuthDegrees(90)).to.equal(90);
+        });
+    });
+
+    describe('utilParseDirectionDegreesString', () => {
+        it('returns null for empty input', () => {
+            expect(iD.utilParseDirectionDegreesString('', parseIdentity)).to.equal(null);
+            expect(iD.utilParseDirectionDegreesString('   ', parseIdentity)).to.equal(null);
+        });
+
+        it('parses cardinal shortcuts', () => {
+            expect(iD.utilParseDirectionDegreesString('n', parseIdentity)).to.equal(0);
+            expect(iD.utilParseDirectionDegreesString('E', parseIdentity)).to.equal(90);
+        });
+
+        it('parses numeric strings and normalizes', () => {
+            expect(iD.utilParseDirectionDegreesString('90', parseIdentity)).to.equal(90);
+            expect(iD.utilParseDirectionDegreesString('-10', parseIdentity)).to.equal(350);
+            expect(iD.utilParseDirectionDegreesString('370', parseIdentity)).to.equal(10);
+        });
+
+        it('returns null for non-direction text', () => {
+            expect(iD.utilParseDirectionDegreesString('foo', parseIdentity)).to.equal(null);
+        });
+    });
+
+    describe('utilDirectionSegmentFractionDigits', () => {
+        it('uses decimal places from raw dot notation', () => {
+            expect(
+                iD.utilDirectionSegmentFractionDigits('12.345678', () => 0)
+            ).to.equal(6);
+        });
+
+        it('falls back to countDecimalPlaces for non-raw strings', () => {
+            expect(
+                iD.utilDirectionSegmentFractionDigits('1,5', () => 1)
+            ).to.equal(1);
+        });
+
+        it('returns 0 when fraction digit count is not finite', () => {
+            expect(
+                iD.utilDirectionSegmentFractionDigits('x', () => NaN)
+            ).to.equal(0);
+        });
+    });
+});


### PR DESCRIPTION
Closes #5530
Ping #9733, https://github.com/openstreetmap/id-tagging-schema/pull/2081

**This PR adds a dial control to the numeric direction fields.**

Stacked on top of #12674 (rotate for points with `direction`).

_Features:_
- Users can drag the dial to change the value in steps of 1 (regardless of the specified [`increment` property](https://github.com/ideditor/schema-builder?tab=readme-ov-file#increment)
- Users can hold down shift to change values only based on the `increment`
- Clicking into the dial changes the value to where the user clicked
- The state is synced between map, fields, dial

Site note: The `increment` features works differently on the dial than on the `+/-` buttons. The buttons increase in +/- steps so 3 becomes 3+5=7. The dial jumps to either 5 or 10. — I think this inconsistency is OK. We keep the backward compatibility for the buttons and the dial works more natural like this IMO.

_Video:_

https://github.com/user-attachments/assets/c52a89dc-7eab-4326-a694-c7a179729e85

----

Replaces #12104 (rebased onto `rotate-point-direction` and recreated as a same-repo PR for GitHub stacked PRs).

This code is created using LLM tools. I reviewed it and iterated on it for a while to get into a shape that I find easy to understand and that has a clean split between the existing features and the new additions.