### PR TITLE
include upcoming events from osmcal in communities list in after-upload message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 
 #### :sparkles: Usability & Accessibility
 * Render diameter and radius tags when a node is selected ([#9732], thanks [@k-yle])
+* Include event from osmcal.org in post-upload dialog ([#12678])
 #### :scissors: Operations
 #### :camera: Street-Level
 #### :white_check_mark: Validation
@@ -55,6 +56,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 
 [#8424]: https://github.com/openstreetmap/iD/issues/8424
 [#9732]: https://github.com/openstreetmap/iD/pull/9732
+[#12678]: https://github.com/openstreetmap/iD/pull/12678
 [#12679]: https://github.com/openstreetmap/iD/pull/12679
 [#12736]: https://github.com/openstreetmap/iD/pull/12736
 [#12800]: https://github.com/openstreetmap/iD/pull/12800

--- a/cspell.json
+++ b/cspell.json
@@ -11,7 +11,9 @@
     "dictionaries": [
         "custom-dictionary"
     ],
-    "words": [],
+    "words": [
+        "osmcal"
+    ],
     "ignoreWords": [],
     "import": []
 }

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1079,7 +1079,6 @@ en:
         details: "Any donation will go directly towards keeping OpenStreetMap running."
     like_osm: "Like OpenStreetMap? Connect with others:"
     more: More
-    events: Events
     languages: "Languages: {languages}"
     missing: "Is something missing from this list?"
     tell_us: "Tell us!"

--- a/modules/core/file_fetcher.ts
+++ b/modules/core/file_fetcher.ts
@@ -24,8 +24,28 @@ import type { AddressFormatsJSON } from '../ui/fields/address.js';
 import type { WmfSite } from '../ui/fields/wikipedia.js';
 import type { EntityId } from '../osm/id_manager.js';
 import type { OsmEntity } from '../osm/abstract-entity.js';
+import { type Vec2 } from '../geo/vector.js';
 import packageJSON from '../../package.json';
 
+
+interface OsmCalEvent {
+    name: string;
+    url: string;
+    date: {
+        start: string;
+        end?: string;
+        human: string;
+        human_short: string;
+        whole_day: boolean;
+    },
+    location?: {
+        short?: string;
+        detailed?: string;
+        coords: Vec2;
+        venue: string;
+    },
+    cancelled: boolean;
+}
 
 interface Definitions {
   address_formats: AddressFormatsJSON;
@@ -40,6 +60,8 @@ interface Definitions {
   oci_defaults: unknown;
   oci_features: unknown;
   oci_resources: unknown;
+
+  osmcal_events: OsmCalEvent[];
 
   presets_package: typeof packageJSON;
   deprecated: Deprecated;
@@ -103,6 +125,7 @@ export function coreFileFetcher() {
     'oci_defaults': ociCdnUrl.replace('{version}', ociVersion) + 'dist/json/defaults.min.json',
     'oci_features': ociCdnUrl.replace('{version}', ociVersion) + 'dist/json/featureCollection.min.json',
     'oci_resources': ociCdnUrl.replace('{version}', ociVersion) + 'dist/json/resources.min.json',
+    'osmcal_events': 'https://osmcal.org/api/v2/events/',
     'presets_package': presetsCdnUrl.replace('{presets_version}', presetsVersion) + 'package.json',
     'deprecated': presetsCdnUrl + 'dist/deprecated.min.json',
     'discarded': presetsCdnUrl + 'dist/discarded.min.json',

--- a/modules/core/file_fetcher.ts
+++ b/modules/core/file_fetcher.ts
@@ -24,28 +24,9 @@ import type { AddressFormatsJSON } from '../ui/fields/address.js';
 import type { WmfSite } from '../ui/fields/wikipedia.js';
 import type { EntityId } from '../osm/id_manager.js';
 import type { OsmEntity } from '../osm/abstract-entity.js';
-import { type Vec2 } from '../geo/vector.js';
 import packageJSON from '../../package.json';
 
 
-interface OsmCalEvent {
-    name: string;
-    url: string;
-    date: {
-        start: string;
-        end?: string;
-        human: string;
-        human_short: string;
-        whole_day: boolean;
-    },
-    location?: {
-        short?: string;
-        detailed?: string;
-        coords: Vec2;
-        venue: string;
-    },
-    cancelled: boolean;
-}
 
 interface Definitions {
   address_formats: AddressFormatsJSON;
@@ -60,8 +41,6 @@ interface Definitions {
   oci_defaults: unknown;
   oci_features: unknown;
   oci_resources: unknown;
-
-  osmcal_events: OsmCalEvent[];
 
   presets_package: typeof packageJSON;
   deprecated: Deprecated;
@@ -125,7 +104,6 @@ export function coreFileFetcher() {
     'oci_defaults': ociCdnUrl.replace('{version}', ociVersion) + 'dist/json/defaults.min.json',
     'oci_features': ociCdnUrl.replace('{version}', ociVersion) + 'dist/json/featureCollection.min.json',
     'oci_resources': ociCdnUrl.replace('{version}', ociVersion) + 'dist/json/resources.min.json',
-    'osmcal_events': 'https://osmcal.org/api/v2/events/',
     'presets_package': presetsCdnUrl.replace('{presets_version}', presetsVersion) + 'package.json',
     'deprecated': presetsCdnUrl + 'dist/deprecated.min.json',
     'discarded': presetsCdnUrl + 'dist/discarded.min.json',

--- a/modules/services/osmcal.ts
+++ b/modules/services/osmcal.ts
@@ -22,7 +22,11 @@ export interface OsmCalEvent {
 
 const apibase = 'https://osmcal.org/api/v2/events/';
 
+const _cache: Record<string, OsmCalEvent[]> = {};
+
 export async function getOsmCalEvents(center: Vec2): Promise<OsmCalEvent[]> {
+    const cacheIdx = `${center[0]},${center[1]}`;
+    if (_cache[cacheIdx]) return _cache[cacheIdx];
     const url = new URL(apibase);
     const lon = roundToDecimal(center[0], 2);
     const lat = roundToDecimal(center[1], 2);
@@ -37,5 +41,6 @@ export async function getOsmCalEvents(center: Vec2): Promise<OsmCalEvent[]> {
             return [];
         }) as OsmCalEvent[])
         .filter(event => !event.cancelled);
+    _cache[cacheIdx] = events; // eslint-disable-line require-atomic-updates
     return events;
 }

--- a/modules/services/osmcal.ts
+++ b/modules/services/osmcal.ts
@@ -1,0 +1,41 @@
+import { type Vec2 } from '../geo/vector.js';
+import { roundToDecimal } from '../util/units.js';
+
+export interface OsmCalEvent {
+    name: string;
+    url: string;
+    date: {
+        start: string;
+        end?: string;
+        human: string;
+        human_short: string;
+        whole_day: boolean;
+    },
+    location?: {
+        short?: string;
+        detailed?: string;
+        coords: Vec2;
+        venue: string;
+    },
+    cancelled?: boolean;
+}
+
+const apibase = 'https://osmcal.org/api/v2/events/';
+
+export async function getOsmCalEvents(center: Vec2): Promise<OsmCalEvent[]> {
+    const url = new URL(apibase);
+    const lon = roundToDecimal(center[0], 2);
+    const lat = roundToDecimal(center[1], 2);
+    url.searchParams.append('around', `${lat},${lon}`);
+    url.searchParams.append('radius', '100'); // max 100km away
+    url.searchParams.append('days', '30'); // next 30 days
+    url.searchParams.append('client-app', 'iD');
+    const events = (await fetch(url, { signal: AbortSignal.timeout(2000) })
+        .then(r => r.json())
+        .catch(err => {
+            console.error(err); // eslint-disable-line no-console
+            return [];
+        }) as OsmCalEvent[])
+        .filter(event => !event.cancelled);
+    return events;
+}

--- a/modules/ui/success.js
+++ b/modules/ui/success.js
@@ -12,16 +12,21 @@ import { t, localizer } from '../core/localizer';
 import { svgIcon } from '../svg/icon';
 import { uiDisclosure } from '../ui/disclosure';
 import { utilRebind } from '../util/rebind';
+import { geoSphericalDistance } from '../geo/geo.js';
+import { escape } from 'es-toolkit';
 
 
 let _oci = null;
+/** @type OsmCalEvent[] */
+let _osmCalEvents = null;
 
 export function uiSuccess(context) {
-  const MAXEVENTS = 2;
+  const MAXEVENTS = 4;
   const dispatch = d3_dispatch('cancel');
   let _changeset;
   let _location;
   ensureOSMCommunityIndex();   // start fetching the data
+  ensureOSMCal();
 
 
   function ensureOSMCommunityIndex() {
@@ -58,20 +63,14 @@ export function uiSuccess(context) {
       });
   }
 
+  function ensureOSMCal() {
+    return fileFetcher
+        .get('osmcal_events')
+        .then(events => {
+            if (!_osmCalEvents) _osmCalEvents = events;
 
-  // string-to-date parsing in JavaScript is weird
-  function parseEventDate(when) {
-    if (!when) return;
-
-    let raw = when.trim();
-    if (!raw) return;
-
-    if (!/Z$/.test(raw)) {   // if no trailing 'Z', add one
-      raw += 'Z';            // this forces date to be parsed as a UTC date
-    }
-
-    const parsed = new Date(raw);
-    return new Date(parsed.toUTCString().slice(0, 25));  // convert to local timezone
+            return _osmCalEvents;
+        });
   }
 
 
@@ -210,7 +209,7 @@ export function uiSuccess(context) {
     }
 
     // Get OSM community index features intersecting the map..
-    ensureOSMCommunityIndex()
+    const fetchCommunitiesData = ensureOSMCommunityIndex()
       .then(oci => {
         const loc = context.map().center();
         const validHere = locationManager.locationSetsAt(loc);
@@ -234,14 +233,74 @@ export function uiSuccess(context) {
 
         // sort communities by feature area ascending, community order descending
         communities.sort((a, b) => a.area - b.area || b.order - a.order);
-
-        body
-          .call(showCommunityLinks, communities.map(c => c.resource));
+        return communities
+          .map(c => c.resource)
+          .map(resource => ({
+            id: resource.id,
+            url: resource.resolved.url,
+            icon: `#community-${resource.type}`,
+            name: resource.resolved.name,
+            description: resource.resolved.description,
+            extendedDescription: resource.resolved.extendedDescription,
+            languageCodes: resource.languageCodes,
+          }));
       });
+    const fetchEventsData = ensureOSMCal()
+      .then(osmCalData => {
+        const nearbyEvents = [];
+        for (const event of osmCalData) {
+          if (event.cancelled) {
+            // cancelled event
+            continue;
+          }
+          const eventLoc = event.location?.coords;
+          if (!eventLoc) {
+            // global event
+            continue;
+          }
+          const loc = context.map().center();
+          const distance = geoSphericalDistance(eventLoc, loc);
+          if (distance > 100_000) {
+            // more than 100km away
+            continue;
+          }
+          const date = new Date(event.date.start);
+          const now = new Date();
+          if (date - now > 1000 * 60 * 60 * 24 * 30) {
+            // more than 30 days in the future
+            continue;
+          }
+          nearbyEvents.push(event);
+        }
+
+        nearbyEvents.sort((a, b) => {
+          // sort by date ascending
+          return a.date.start < b.date.start ? -1 : a.date.start > b.date.start ? 1 : 0;
+        });
+
+        return nearbyEvents
+          .slice(0, MAXEVENTS) // limit number of events shown
+          .map((event, idx) => ({
+            id: `osmcal-${idx}`,
+            url: event.url,
+            icon: '#pinhead-calendar',
+            name: selection => selection.text(event.name),
+            description: selection => selection.text(`${escape(event.date.human_short)}, ${escape(event.location.short)}`),
+            extendedDescription: selection => selection.text(`${escape(event.date.human)}, ${escape(event.location.venue)}`),
+          }));
+      });
+
+    Promise.all([fetchCommunitiesData, fetchEventsData])
+        .then(([communities, events]) => {
+            body.call(showEngagementLinks, [
+                ...events,
+                ...communities
+            ]);
+        });
   }
 
 
-  function showCommunityLinks(selection, resources) {
+  function showEngagementLinks(selection, resources) {
     let communityLinks = selection
       .append('div')
       .attr('class', 'save-communityLinks');
@@ -266,11 +325,11 @@ export function uiSuccess(context) {
       .attr('class', 'cell-icon community-icon')
       .append('a')
       .attr('target', '_blank')
-      .attr('href', d => d.resolved.url)
+      .attr('href', d => d.url)
       .append('svg')
       .attr('class', 'logo-small')
       .append('use')
-      .attr('xlink:href', d => `#community-${d.type}`);
+      .attr('xlink:href', d => d.icon);
 
     let communityDetail = rowEnter
       .append('td')
@@ -299,54 +358,39 @@ export function uiSuccess(context) {
 
     selection
       .append('div')
-      .attr('class', 'community-name')
-      .html(d.resolved.nameHTML);
+      .classed('community-name', true)
+      .append('a')
+      .attr('target', '_blank')
+      .attr('href', d => d.url)
+      .each(function(d) {
+        if (typeof d.name === 'string') {
+          d3_select(this).html(d.name);
+        } else {
+          d3_select(this).call(d.name);
+        }
+      });
 
     selection
       .append('div')
       .attr('class', 'community-description')
-      .html(d.resolved.descriptionHTML);
+      .each(function(d) {
+        if (typeof d.description === 'string') {
+          d3_select(this).html(d.description);
+        } else {
+          d3_select(this).call(d.description);
+        }
+      });
 
     // Create an expanding section if any of these are present..
-    if (d.resolved.extendedDescriptionHTML || (d.languageCodes && d.languageCodes.length)) {
+    if (d.extendedDescription || (d.languageCodes && d.languageCodes.length)) {
       selection
         .append('div')
-        .call(uiDisclosure(context, `community-more-${d.id}`, false)
+        .call(uiDisclosure(context, `community-more-${communityID}`, false)
           .expanded(false)
           .updatePreference(false)
           .label(() => t.append('success.more'))
           .content(showMore)
         );
-    }
-
-    let nextEvents = (d.events || [])
-      .map(event => {
-        event.date = parseEventDate(event.when);
-        return event;
-      })
-      .filter(event => {      // date is valid and future (or today)
-        const t = event.date.getTime();
-        const now = (new Date()).setHours(0,0,0,0);
-        return !isNaN(t) && t >= now;
-      })
-      .sort((a, b) => {       // sort by date ascending
-        return a.date < b.date ? -1 : a.date > b.date ? 1 : 0;
-      })
-      .slice(0, MAXEVENTS);   // limit number of events shown
-
-    if (nextEvents.length) {
-      selection
-        .append('div')
-        .call(uiDisclosure(context, `community-events-${d.id}`, false)
-          .expanded(false)
-          .updatePreference(false)
-          .label(t.append('success.events'))
-          .content(showNextEvents)
-        )
-        .select('.hide-toggle')
-        .append('span')
-        .attr('class', 'badge-text')
-        .text(nextEvents.length);
     }
 
 
@@ -358,11 +402,17 @@ export function uiSuccess(context) {
         .append('div')
         .attr('class', 'community-more');
 
-      if (d.resolved.extendedDescriptionHTML) {
+      if (d.extendedDescription) {
         moreEnter
           .append('div')
           .attr('class', 'community-extended-description')
-          .html(d.resolved.extendedDescriptionHTML);
+          .each(function(d) {
+            if (typeof d.extendedDescription === 'string') {
+              d3_select(this).html(d.extendedDescription);
+            } else {
+              d3_select(this).call(d.extendedDescription);
+            }
+          });
       }
 
       if (d.languageCodes && d.languageCodes.length) {
@@ -375,68 +425,6 @@ export function uiSuccess(context) {
           .attr('class', 'community-languages')
           .call(t.append('success.languages', { languages: languageList }));
       }
-    }
-
-
-    function showNextEvents(selection) {
-      let events = selection
-        .append('div')
-        .attr('class', 'community-events');
-
-      let item = events.selectAll('.community-event')
-        .data(nextEvents);
-
-      let itemEnter = item.enter()
-        .append('div')
-        .attr('class', 'community-event');
-
-      itemEnter
-        .append('div')
-        .attr('class', 'community-event-name')
-        .append('a')
-        .attr('target', '_blank')
-        .attr('href', d => d.url)
-        .text(d => {
-          let name = d.name;
-          if (d.i18n && d.id) {
-            name = t(`community.${communityID}.events.${d.id}.name`, { default: name });
-          }
-          return name;
-        });
-
-      itemEnter
-        .append('div')
-        .attr('class', 'community-event-when')
-        .text(d => {
-          let options = { weekday: 'short', day: 'numeric', month: 'short', year: 'numeric' };
-          if (d.date.getHours() || d.date.getMinutes()) {   // include time if it has one
-            options.hour = 'numeric';
-            options.minute = 'numeric';
-          }
-          return d.date.toLocaleString(localizer.localeCode(), options);
-        });
-
-      itemEnter
-        .append('div')
-        .attr('class', 'community-event-where')
-        .text(d => {
-          let where = d.where;
-          if (d.i18n && d.id) {
-            where = t(`community.${communityID}.events.${d.id}.where`, { default: where });
-          }
-          return where;
-        });
-
-      itemEnter
-        .append('div')
-        .attr('class', 'community-event-description')
-        .text(d => {
-          let description = d.description;
-          if (d.i18n && d.id) {
-            description = t(`community.${communityID}.events.${d.id}.description`, { default: description });
-          }
-          return description;
-        });
     }
   }
 

--- a/modules/ui/success.js
+++ b/modules/ui/success.js
@@ -12,8 +12,7 @@ import { t, localizer } from '../core/localizer';
 import { svgIcon } from '../svg/icon';
 import { uiDisclosure } from '../ui/disclosure';
 import { utilRebind } from '../util/rebind';
-import { geoSphericalDistance } from '../geo/geo.js';
-import { escape } from 'es-toolkit';
+import { getOsmCalEvents } from '../services/osmcal.js';
 
 
 let _oci = null;
@@ -21,7 +20,7 @@ let _oci = null;
 let _osmCalEvents = null;
 
 export function uiSuccess(context) {
-  const MAXEVENTS = 4;
+  const MAX_EVENTS = 4;
   const dispatch = d3_dispatch('cancel');
   let _changeset;
   let _location;
@@ -245,48 +244,23 @@ export function uiSuccess(context) {
             languageCodes: resource.languageCodes,
           }));
       });
-    const fetchEventsData = ensureOSMCal()
-      .then(osmCalData => {
-        const nearbyEvents = [];
-        for (const event of osmCalData) {
-          if (event.cancelled) {
-            // cancelled event
-            continue;
-          }
-          const eventLoc = event.location?.coords;
-          if (!eventLoc) {
-            // global event
-            continue;
-          }
-          const loc = context.map().center();
-          const distance = geoSphericalDistance(eventLoc, loc);
-          if (distance > 100_000) {
-            // more than 100km away
-            continue;
-          }
-          const date = new Date(event.date.start);
-          const now = new Date();
-          if (date - now > 1000 * 60 * 60 * 24 * 30) {
-            // more than 30 days in the future
-            continue;
-          }
-          nearbyEvents.push(event);
-        }
-
+    const loc = context.map().center();
+    const fetchEventsData = getOsmCalEvents(loc)
+      .then(nearbyEvents => {
         nearbyEvents.sort((a, b) => {
           // sort by date ascending
           return a.date.start < b.date.start ? -1 : a.date.start > b.date.start ? 1 : 0;
         });
 
         return nearbyEvents
-          .slice(0, MAXEVENTS) // limit number of events shown
+          .slice(0, MAX_EVENTS) // limit number of events shown
           .map((event, idx) => ({
             id: `osmcal-${idx}`,
             url: event.url,
             icon: '#pinhead-calendar',
             name: selection => selection.text(event.name),
-            description: selection => selection.text(`${escape(event.date.human_short)}, ${escape(event.location.short)}`),
-            extendedDescription: selection => selection.text(`${escape(event.date.human)}, ${escape(event.location.venue)}`),
+            description: selection => selection.text(`${event.date.human_short}, ${event.location.short}`),
+            extendedDescription: selection => selection.text(`${event.date.human}, ${event.location.venue}`),
           }));
       });
 
@@ -406,7 +380,7 @@ export function uiSuccess(context) {
         moreEnter
           .append('div')
           .attr('class', 'community-extended-description')
-          .each(function(d) {
+          .each(function() {
             if (typeof d.extendedDescription === 'string') {
               d3_select(this).html(d.extendedDescription);
             } else {

--- a/modules/util/units.ts
+++ b/modules/util/units.ts
@@ -106,7 +106,7 @@ function wrap(x: number, min: number, max: number) {
     return ((x - min) % d + d) % d + min;
 }
 
-function roundToDecimal (target: number, decimalPlace: number) {
+export function roundToDecimal (target: number, decimalPlace: number) {
     target = Number(target);
     decimalPlace = Number(decimalPlace);
     const factor = Math.pow(10, decimalPlace);


### PR DESCRIPTION
<img width="300" src="https://github.com/user-attachments/assets/9118063f-6dda-497c-9879-c7737eef6279" />

currently shows upcoming events that are:
* max 100km away
* max 30 days in the future
* max 4 entries

to decide:
* [ ] should we sort by recency or by distance (currently it's done by date)?

PS: this also removes some essentially unused code that was rendering events stored alongside OCI's communities, which was AFAIK never really used.