### PR TITLE
throw errors instead of strings

### DIFF
--- a/modules/core/file_fetcher.ts
+++ b/modules/core/file_fetcher.ts
@@ -128,7 +128,7 @@ export function coreFileFetcher() {
     const file = _fileMap[which];
     const url = file && _this.asset(file);
     if (!url) {
-      return Promise.reject(`Unknown data file for "${which}"`);
+      return Promise.reject(new Error(`Unknown data file for "${which}"`));
     }
 
     if (url.includes('{presets_version}')) {

--- a/modules/renderer/background_source.js
+++ b/modules/renderer/background_source.js
@@ -379,7 +379,7 @@ rendererBackgroundSource.Bing = function(data, dispatch) {
                 })
                 .catch(function (err) {
                     delete inflight[tileID];
-                    if (callback) callback(err.message);
+                    if (callback) callback(err);
                 });
         });
     };
@@ -518,7 +518,7 @@ rendererBackgroundSource.Esri = function(data) {
             })
             .catch(function(err) {
                 delete inflight[tileID];
-                if (callback) callback(err.message);
+                if (callback) callback(err);
             });
 
 

--- a/modules/services/nominatim.js
+++ b/modules/services/nominatim.js
@@ -34,7 +34,7 @@ export default {
             } else if (result.address) {
                 return callback(null, result.address.country_code);
             } else {
-                return callback('Unable to geocode', null);
+                return callback(new Error('Unable to geocode'));
             }
         });
     },
@@ -75,7 +75,7 @@ export default {
             .catch(function(err) {
                 delete _inflight[url];
                 if (err.name === 'AbortError') return;
-                if (callback) callback(err.message);
+                if (callback) callback(err);
             });
     },
 
@@ -108,7 +108,7 @@ export default {
             .catch(function(err) {
                 delete _inflight[url];
                 if (err.name === 'AbortError') return;
-                if (callback) callback(err.message);
+                if (callback) callback(err);
             });
     }
 

--- a/modules/services/osm_wikibase.js
+++ b/modules/services/osm_wikibase.js
@@ -27,7 +27,7 @@ function request(url, callback) {
         .catch(function(err) {
             delete _inflight[url];
             if (err.name === 'AbortError') return;
-            if (callback) callback(err.message);
+            if (callback) callback(err);
         });
 }
 
@@ -220,7 +220,8 @@ export default {
             if (err) {
                 callback(err);
             } else if (!d.success || d.error) {
-                callback(d.error.messages.map(function(v) { return v.html['*']; }).join('<br>'));
+                const errorMessage = d.error?.messages.map(v => v.html['*']).join('<br />') || 'Unknown Error';
+                callback(new Error(errorMessage));
             } else {
                 Object.values(d.entities).forEach(function(res) {
                     if (res.missing !== '') {
@@ -281,7 +282,7 @@ export default {
 
             var entity = data.rtype || data.tag || data.key;
             if (!entity) {
-                callback('No entity');
+                callback(new Error('No entity'));
                 return;
             }
 

--- a/modules/services/osmose.js
+++ b/modules/services/osmose.js
@@ -310,7 +310,7 @@ export default {
       .then(after)
       .catch(err => {
         delete _cache.inflightPost[issue.id];
-        if (callback) callback(err.message);
+        if (callback) callback(err);
       });
   },
 

--- a/modules/services/wikidata.js
+++ b/modules/services/wikidata.js
@@ -19,7 +19,7 @@ export default {
     // Search for Wikidata items matching the query
     itemsForSearchQuery: function(query, callback, language) {
         if (!query) {
-            if (callback) callback('No query', {});
+            if (callback) callback(new Error('No query'));
             return;
         }
 
@@ -55,7 +55,7 @@ export default {
                 if (callback) callback(null, result.search || {});
             })
             .catch(function(err) {
-                if (callback) callback(err.message, {});
+                if (callback) callback(err);
             });
     },
 
@@ -64,7 +64,7 @@ export default {
     // return an array of corresponding Wikidata entities.
     itemsByTitle: function(lang, title, callback) {
         if (!title) {
-            if (callback) callback('No title', {});
+            if (callback) callback(new Error('No title'));
             return;
         }
 
@@ -87,7 +87,7 @@ export default {
                 if (callback) callback(null, result.entities || {});
             })
             .catch(function(err) {
-                if (callback) callback(err.message, {});
+                if (callback) callback(err);
             });
     },
 
@@ -105,7 +105,7 @@ export default {
 
     entityByQID: function(qid, callback) {
         if (!qid) {
-            callback('No qid', {});
+            callback(new Error('No qid'));
             return;
         }
         if (_wikidataCache[qid]) {
@@ -134,7 +134,7 @@ export default {
                 if (callback) callback(null, result.entities[qid] || {});
             })
             .catch(function(err) {
-                if (callback) callback(err.message, {});
+                if (callback) callback(err);
             });
     },
 
@@ -157,7 +157,7 @@ export default {
         var langs = this.languagesToQuery();
         this.entityByQID(params.qid, function(err, entity) {
             if (err || !entity) {
-                callback(err || 'No entity');
+                callback(err || new Error('No entity'));
                 return;
             }
 

--- a/modules/services/wikipedia.js
+++ b/modules/services/wikipedia.js
@@ -13,7 +13,7 @@ export default {
 
     search: function(lang, query, callback) {
         if (!query) {
-            if (callback) callback('No Query', []);
+            if (callback) callback(new Error('No Query'));
             return;
         }
 
@@ -42,14 +42,14 @@ export default {
                 }
             })
             .catch(function(err) {
-                if (callback) callback(err, []);
+                if (callback) callback(err);
             });
     },
 
 
     suggestions: function(lang, query, callback) {
         if (!query) {
-            if (callback) callback('', []);
+            if (callback) callback(new Error('No Query'));
             return;
         }
 
@@ -74,7 +74,7 @@ export default {
                 if (callback) callback(null, result[1] || []);
             })
             .catch(function(err) {
-                if (callback) callback(err.message, []);
+                if (callback) callback(err);
             });
     },
 

--- a/modules/ui/fields/wikidata.js
+++ b/modules/ui/fields/wikidata.js
@@ -149,7 +149,7 @@ export function uiFieldWikidata(field, context) {
 
         wikidata.itemsForSearchQuery(q, function(err, data) {
             if (err) {
-                if (err !== 'No query') console.error(err); // eslint-disable-line
+                if (err.message !== 'No query') console.error(err); // eslint-disable-line no-console
                 return;
             }
 

--- a/modules/ui/fields/wikipedia.js
+++ b/modules/ui/fields/wikipedia.js
@@ -58,8 +58,8 @@ export function uiFieldWikipedia(field, context) {
         }
       }
       const searchfn = value.length > 7 ? wikipedia.search : wikipedia.suggestions;
-      searchfn(language()[2], value, (query, data) => {
-        callback( data.map(d => ({ value: d })) );
+      searchfn(language()[2], value, (error, data) => {
+        callback(error ? [] : data.map(d => ({ value: d })) );
       });
     });
 

--- a/test/spec/services/nominatim.js
+++ b/test/spec/services/nominatim.js
@@ -124,7 +124,7 @@ describe('iD.serviceNominatim', function() {
             expect(parseQueryString(fetchMock.calls()[0][0])).toEqual(
                 {zoom: '13', format: 'json', addressdetails: '1', lat: '1000', lon: '1000'}
             );
-            expect(callback).toHaveBeenCalledWith('Unable to geocode');
+            expect(callback).toHaveBeenCalledWith(new Error('Unable to geocode'));
         });
     });
 


### PR DESCRIPTION
similar to #12615. 

- we should never throw a string, or use it as an error, since it has no stracktrace
- callbacks should be called with a Error xor a result. but never with both. we need to fix this before callbacks can be converted to promises.
