### PR TITLE
Fix check field crash when the field has no options list

### DIFF
--- a/modules/ui/fields/check.ts
+++ b/modules/ui/fields/check.ts
@@ -226,7 +226,7 @@ export function uiFieldCheck(field: any, context: iD.Context) {
                     ? (selection: d3.Selection) => selection.text(textForValue)
                     : textForValue)
             .classed('mixed', isMixed)
-            .classed('raw-value', !options.includes(tag))
+            .classed('raw-value', !values.some(value => value === tag))
             .attr('title', function() {
                 if (isMixed) return t('inspector.unshared_value_tooltip');
                 if (!_value) return null;


### PR DESCRIPTION


## Summary 🤖 (Cursor)
- Fixes a crash in `uiFieldCheck` when `field.options` is undefined (common for check fields without an explicit options list, e.g. `backrest` on benches).
- Regression from https://github.com/openstreetmap/iD/commit/58b22fd20: `options.includes(tag)` threw during entity editor render, which aborted `modeSelect.enter()` before the `mode-select` class was applied.
- Symptoms: selecting such features left the map without select cursors (stuck on the pan hand) and the Tags section still showing the previously selected feature.

## Test plan (@tordans)
1. Open https://ideditor.netlify.app/#map=20.80/52.47409/13.44559&background=Berlin-2024&locale=en&disable_features=boundaries
2. Try selecting 
   > <img width="343" height="208" alt="image" src="https://github.com/user-attachments/assets/02587435-ad3c-4807-898f-df20640194e3" />
   
Vs. 
1. Open https://pr-12685--ideditor.netlify.app/#map=20.80/52.47408/13.44560&background=Berlin-2024&locale=en&disable_features=boundaries
2. Try selecting the same objects



Made with [Cursor](https://cursor.com)