### PR TITLE
fix: validate noexit on through-road nodes 🤖🤖🤖

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1610,6 +1610,9 @@ en:
           one: "{highway} is disconnected from other roads and paths"
           other: "{count} routable features are connected only to each other"
         reference: "All roads, paths, and ferry routes should connect to form a single routing network. This feature (or small collection of features) is either disconnected from the routing network or only connected to it via a feature that few applications consider routable."
+      invalid_noexit:
+        message: '{feature} is tagged "noexit=yes" but is not at the end of a road'
+        reference: 'The "noexit=yes" tag should only be used on nodes with one incident road segment.'
     fixme_tag:
       message: '{feature} has a "Fix Me" request'
       reference: 'A "fixme" tag indicates that a mapper has requested help with a feature.'

--- a/modules/validations/disconnected_way.js
+++ b/modules/validations/disconnected_way.js
@@ -1,4 +1,5 @@
 import { t, localizer } from '../core/localizer';
+import { actionChangeTags } from '../actions/change_tags';
 import { modeDrawLine } from '../modes/draw_line';
 import { operationDelete } from '../operations/delete';
 import { utilDisplayLabel } from '../util/utilDisplayLabel';
@@ -14,7 +15,58 @@ export function validationDisconnectedWay() {
     }
 
     var validation = function checkDisconnectedWay(entity, graph) {
+        if (entity.type === 'node' && entity.tags.noexit === 'yes') {
+            var segmentCount = 0;
+            graph.parentWays(entity).forEach(function(way) {
+                if (!isTaggedAsHighway(way)) return;
+                way.nodes.forEach(function(nodeID, index) {
+                    if (nodeID !== entity.id) return;
+                    if (index > 0 && graph.hasEntity(way.nodes[index - 1])) segmentCount++;
+                    if (index < way.nodes.length - 1 && graph.hasEntity(way.nodes[index + 1])) segmentCount++;
+                });
+            });
 
+            if (segmentCount !== 1) {
+                return [new validationIssue({
+                    type: type,
+                    subtype: 'invalid_noexit',
+                    severity: 'warning',
+                    message: function(context) {
+                        var node = context.hasEntity(this.entityIds[0]);
+                        var label = node && utilDisplayLabel(node, context.graph());
+                        return t.append('issues.disconnected_way.invalid_noexit.message', { feature: label });
+                    },
+                    reference: function(selection) {
+                        selection.selectAll('.issue-reference')
+                            .data([0])
+                            .enter()
+                            .append('div')
+                            .attr('class', 'issue-reference')
+                            .call(t.append('issues.disconnected_way.invalid_noexit.reference'));
+                    },
+                    entityIds: [entity.id],
+                    loc: entity.loc,
+                    dynamicFixes: function() {
+                        return [new validationIssueFix({
+                            icon: 'iD-operation-delete',
+                            title: t.append('issues.fix.remove_named_tag.title', { tag: 'noexit' }),
+                            onClick: function(context) {
+                                var entityId = this.issue.entityIds[0];
+                                var node = context.hasEntity(entityId);
+                                if (!node) return;
+
+                                var tags = Object.assign({}, node.tags);
+                                delete tags.noexit;
+                                context.perform(
+                                    actionChangeTags(entityId, tags),
+                                    t('issues.fix.remove_named_tag.annotation', { tag: 'noexit' })
+                                );
+                            }
+                        })];
+                    }
+                })];
+            }
+        }
         var routingIslandWays = routingIslandForEntity(entity);
         if (!routingIslandWays) return [];
 

--- a/test/spec/core/validator.js
+++ b/test/spec/core/validator.js
@@ -165,4 +165,28 @@ describe('iD.coreValidator', function() {
         issues = validator.getIssues();
         expect(issues).toHaveLength(1);
     });
+
+    it('reports invalid noexit through the validator lifecycle', async () => {
+        var n1 = new iD.osmNode({ id: 'n-1', loc: [4, 4], tags: { entrance: 'yes' } });
+        var n2 = new iD.osmNode({ id: 'n-2', loc: [4, 5], tags: { noexit: 'yes' } });
+        var n3 = new iD.osmNode({ id: 'n-3', loc: [4, 6], tags: { entrance: 'yes' } });
+        var w1 = new iD.osmWay({ id: 'w-1', nodes: ['n-1', 'n-2'], tags: { highway: 'residential' } });
+        var w2 = new iD.osmWay({ id: 'w-2', nodes: ['n-2', 'n-3'], tags: { highway: 'residential' } });
+        context.perform(
+            iD.actionAddEntity(n1),
+            iD.actionAddEntity(n2),
+            iD.actionAddEntity(n3),
+            iD.actionAddEntity(w1),
+            iD.actionAddEntity(w2)
+        );
+        var validator = new iD.coreValidator(context);
+        validator.init();
+        await validator.validate();
+
+        var issues = validator.getEntityIssues(n2.id);
+        expect(issues).toHaveLength(1);
+        expect(issues[0].type).toEqual('disconnected_way');
+        expect(issues[0].subtype).toEqual('invalid_noexit');
+        expect(issues[0].entityIds).toEqual([n2.id]);
+    });
 });

--- a/test/spec/validations/disconnected_way.js
+++ b/test/spec/validations/disconnected_way.js
@@ -33,6 +33,27 @@ describe('iD.validations.disconnected_way', function() {
         );
     }
 
+    function createNoExitWays(wayNodes, nodeTags, wayTags) {
+        var nodes = [
+            new iD.osmNode({ id: 'n-1', loc: [4, 4], tags: { entrance: 'yes' } }),
+            new iD.osmNode({ id: 'n-2', loc: [4, 5], tags: nodeTags }),
+            new iD.osmNode({ id: 'n-3', loc: [4, 6], tags: { entrance: 'yes' } })
+        ];
+        var ways = wayNodes.map(function(nodeIDs, index) {
+            return new iD.osmWay({ id: 'w-' + (index + 1), nodes: nodeIDs,
+                tags: wayTags && wayTags[index] || { highway: 'residential' } });
+        });
+
+        context.perform(
+            ...nodes.map(function(node) { return iD.actionAddEntity(node); }),
+            ...ways.map(function(way) { return iD.actionAddEntity(way); })
+        );
+
+        return nodes[1];
+    }
+
+    function validateEntity(entity) { return iD.validationDisconnectedWay(context)(entity, context.graph()); }
+
     function validate() {
         var validator = iD.validationDisconnectedWay(context);
         var changes = context.history().changes();
@@ -167,5 +188,55 @@ describe('iD.validations.disconnected_way', function() {
         );
 
         expect(validate()).toHaveLength(0);
+    });
+
+    it('allows noexit at the endpoint of one highway', function() {
+        var node = createNoExitWays([['n-1', 'n-2']], { noexit: 'yes' });
+        expect(validateEntity(node)).toHaveLength(0);
+    });
+
+    it('flags noexit at a node joining two highways', function() {
+        var node = createNoExitWays([
+            ['n-1', 'n-2'],
+            ['n-2', 'n-3']
+        ], { noexit: 'yes' });
+        expect(validateEntity(node)).toEqual([expect.objectContaining({ type: 'disconnected_way', subtype: 'invalid_noexit', severity: 'warning', entityIds: ['n-2'] })]);
+    });
+    it('flags noexit at an interior node', function() {
+        var node = createNoExitWays([['n-1', 'n-2', 'n-3']], { noexit: 'yes' });
+        expect(validateEntity(node)).toEqual([expect.objectContaining({ type: 'disconnected_way', subtype: 'invalid_noexit', severity: 'warning', entityIds: ['n-2'] })]);
+    });
+    it('flags noexit in closed and repeated topology', function() {
+        var node = createNoExitWays([['n-2', 'n-1', 'n-3', 'n-2', 'n-1', 'n-2']], { noexit: 'yes' });
+        expect(validateEntity(node)).toEqual([expect.objectContaining({ type: 'disconnected_way', subtype: 'invalid_noexit', severity: 'warning', entityIds: ['n-2'] })]);
+    });
+    it('ignores way-tagged noexit', function() {
+        var node = createNoExitWays([['n-1', 'n-2']], {}, [{ highway: 'residential', noexit: 'yes' }]);
+        expect(validateEntity(node)).toHaveLength(0);
+    });
+    it('ignores non-yes noexit values', function() {
+        var node = createNoExitWays([['n-1', 'n-2']], { noexit: 'no' });
+        expect(validateEntity(node)).toHaveLength(0);
+    });
+
+    it('removes noexit without losing other current tags', function() {
+        var node = createNoExitWays([['n-1', 'n-2'], ['n-2', 'n-3']], {
+            noexit: 'yes',
+            source: 'survey'
+        });
+        var issue = validateEntity(node)[0];
+
+        context.perform(iD.actionChangeTags(node.id, {
+            noexit: 'yes',
+            source: 'survey',
+            surface: 'asphalt'
+        }));
+
+        var fix = issue.fixes(context)[0];
+        fix.onClick(context);
+        expect(context.entity(node.id).tags).toEqual({
+            source: 'survey',
+            surface: 'asphalt'
+        });
     });
 });


### PR DESCRIPTION
## Summary

- flag `noexit=yes` nodes that are not endpoints of their connected highway network
- count routable segments across all parent highway ways
- offer a fix that removes only the invalid `noexit` tag

## Testing

- `npm run lint`
- `npm run typecheck`
- 24 focused `disconnected_way` and `almost_junction` validation tests
- `npm run build` with the frozen offline data inputs
- `npm run test:once` (2290 passed, 11 skipped, 6 todo)

Closes #8557
