### PR TITLE
tweak osmPavedTags and osmSemipavedTags

### DIFF
--- a/modules/osm/tags.ts
+++ b/modules/osm/tags.ts
@@ -234,7 +234,7 @@ export const osmOneWayTags = merge(
     osmOneWayBiDirectionalTags,
 );
 
-// solid and smooth surfaces akin to the assumed default road surface in OSM
+// solid and smooth surfaces akin to the assumed default road or path surface
 export const osmPavedTags: TagDictionary<boolean> = {
     'surface': {
         'paved': true,
@@ -243,6 +243,7 @@ export const osmPavedTags: TagDictionary<boolean> = {
         'chipseal': true,
         'concrete:lanes': true,
         'concrete:plates': true,
+        'metal': true,
         'tiles': true
     },
     'tracktype': {
@@ -250,7 +251,7 @@ export const osmPavedTags: TagDictionary<boolean> = {
     }
 };
 
-// solid, if somewhat uncommon surfaces with a high range of smoothness
+// solid, if somewhat uncommon surfaces with a high range of smoothness used on roads or paths
 export const osmSemipavedTags: TagDictionary<boolean> = {
     'surface': {
         'bricks': true,
@@ -259,7 +260,6 @@ export const osmSemipavedTags: TagDictionary<boolean> = {
         'sett': true,
         'paving_stones': true,
         'grass_paver': true,
-        'metal': true,
         'metal_grid': true,
         'fibre_reinforced_polymer_grate': true,
         'wood': true


### PR DESCRIPTION
better description - drop obvious "in osm", move surface=metal to expected smooth surface, restrict also semipaved to paths/roads, extend paved to paths...

(alternative would be listing also carpet, tartan and probably artificial_turf)

done in preparation of possible move of this info into iD tagging schema (see https://github.com/openstreetmap/id-tagging-schema/issues/2673 and https://github.com/openstreetmap/id-tagging-schema/issues/2623) as some changes in meaning were tempting - and I thought it would be better to be sure these are fine on iD side