### PR TITLE
migrate wiki{base,data,pedia} to typescript

### DIFF
--- a/modules/services/osm_wikibase.ts
+++ b/modules/services/osm_wikibase.ts
@@ -1,28 +1,41 @@
+/* eslint-disable @typescript-eslint/no-this-alias */
 import { debounce } from 'es-toolkit';
-
+import type { Claim, Item, PropertyId, ItemId, MonolingualTextSnakDataValue, Site, SnakWithValue, WikibaseItemSnakDataValue } from 'wikibase-sdk';
 import { json as d3_json } from 'd3-fetch';
-
+import type { WikibaseApiResponse, WikibaseResult } from './wikidata';
 import { localizer } from '../core/localizer';
 import { utilQsString } from '../util';
 
 
 var apibase = 'https://wiki.openstreetmap.org/w/api.php';
-var _inflight = {};
-var _wikibaseCache = {};
-var _localeIDs = { en: false };
+var _inflight: { [url: string]: AbortController } = {};
+var _wikibaseCache: { [sitelink: string]: Item } = {};
+var _localeIDs: { [locale: string]: false | ItemId } = { en: false };
 
+interface ItemResult {
+    rtype?: Item;
+    key?: Item;
+    tag?: Item;
+}
 
-var debouncedRequest = debounce(request, 500, { edges: [ 'trailing' ] });
+interface Params {
+    key: string;
+    value?: string;
+    langCodes: string[];
+    debounce?: boolean;
+}
 
-function request(url, callback) {
+var debouncedRequest = debounce(request, 500, { edges: [ 'trailing' ] }) as typeof request;
+
+function request<T>(url: string, callback: Callback<T>) {
     if (_inflight[url]) return;
     var controller = new AbortController();
     _inflight[url] = controller;
 
-    d3_json(url, { signal: controller.signal })
+    d3_json<T>(url, { signal: controller.signal })
         .then(function(result) {
             delete _inflight[url];
-            if (callback) callback(null, result);
+            if (callback) callback(null, result!);
         })
         .catch(function(err) {
             delete _inflight[url];
@@ -53,10 +66,11 @@ export default {
      * @param property string e.g. 'P4' for image
      * @param langCode string e.g. 'fr' for French
      */
-    claimToValue: function(entity, property, langCode) {
-        if (!entity.claims[property]) return undefined;
+    claimToValue: function(entity: Item, property: PropertyId, langCode: string) {
+        if (!entity.claims?.[property]) return undefined;
         var locale = _localeIDs[langCode];
-        var preferredPick, localePick;
+        let preferredPick: Claim | undefined;
+        let localePick: Claim | undefined;
 
         entity.claims[property].forEach(function(stmt) {
             // If exists, use value limited to the needed language (has a qualifier P26 = locale)
@@ -65,7 +79,7 @@ export default {
                 preferredPick = stmt;
             }
             if (locale && stmt.qualifiers && stmt.qualifiers.P26 &&
-                stmt.qualifiers.P26[0].datavalue.value.id === locale
+                (<WikibaseItemSnakDataValue>(<SnakWithValue>stmt.qualifiers.P26[0]).datavalue).value.id === locale
             ) {
                 localePick = stmt;
             }
@@ -73,7 +87,7 @@ export default {
 
         var result = localePick || preferredPick;
         if (result) {
-            var datavalue = result.mainsnak.datavalue;
+            var datavalue = (<SnakWithValue>result.mainsnak).datavalue;
             return datavalue.type === 'wikibase-entityid' ? datavalue.value.id : datavalue.value;
         } else {
             return undefined;
@@ -86,18 +100,18 @@ export default {
      * @param entity object from wikibase
      * @param property string e.g. 'P31' for monolingual wiki page title
      */
-    monolingualClaimToValueObj: function(entity, property) {
-        if (!entity || !entity.claims[property]) return undefined;
+    monolingualClaimToValueObj: function(entity: Item | undefined, property: PropertyId) {
+        if (!entity || !entity.claims?.[property]) return undefined;
 
-        return entity.claims[property].reduce(function(acc, obj) {
-            var value = obj.mainsnak.datavalue.value;
+        return entity.claims[property].reduce<{ [lang: string]: string }>(function(acc, obj) {
+            var value = (<MonolingualTextSnakDataValue>(<SnakWithValue>obj.mainsnak).datavalue).value;
             acc[value.language] = value.text;
             return acc;
         }, {});
     },
 
 
-    toSitelink: function(key, value) {
+    toSitelink: function(key: string, value?: string) {
         var result = value ? ('Tag:' + key + '=' + value) : 'Key:' + key;
         return result.replace(/_/g, ' ').trim();
     },
@@ -105,10 +119,9 @@ export default {
     /**
      * Converts text like `tag:...=...` into clickable links
      *
-     * @param {string} unsafeText - unsanitized text
+     * @param unsafeText - unsanitized text
      */
-    linkifyWikiText(unsafeText) {
-        /** @param {import('d3').Selection} selection */
+    linkifyWikiText(unsafeText: string): d3.Selector {
         return (selection) => {
             const segments = unsafeText.split(/(key|tag):([\w-]+)(=([\w-]+))?/g);
 
@@ -143,11 +156,11 @@ export default {
     //   langCode: 'string'
     // }
     //
-    getEntity: function(params, callback) {
+    getEntity: function(params: Params, callback: Callback<ItemResult>) {
         var doRequest = params.debounce ? debouncedRequest : request;
         var that = this;
         var titles = [];
-        var result = {};
+        var result: ItemResult = {};
         var rtypeSitelink = (params.key === 'type' && params.value) ? ('Relation:' + params.value).replace(/_/g, ' ').trim() : false;
         var keySitelink = params.key ? this.toSitelink(params.key) : false;
         var tagSitelink = (params.key && params.value) ? this.toSitelink(params.key, params.value) : false;
@@ -216,17 +229,18 @@ export default {
         };
 
         var url = apibase + '?' + utilQsString(obj);
-        doRequest(url, function(err, d) {
-            if (err) {
-                callback(err);
+        doRequest<WikibaseApiResponse>(url, function(err, d) {
+            if (err || !d) {
+                callback(err || new Error('no result'));
             } else if (!d.success || d.error) {
-                const errorMessage = d.error?.messages.map(v => v.html['*']).join('<br />') || 'Unknown Error';
+                const errorMessage = d.error?.info || 'Unknown Error';
                 callback(new Error(errorMessage));
             } else {
                 Object.values(d.entities).forEach(function(res) {
+                    // @ts-expect-error -- this should be impossible, keep it just in case
                     if (res.missing !== '') {
 
-                        var title = res.sitelinks.wiki.title;
+                        var title = res.sitelinks?.[<Site>'wiki']?.title;
                         if (title === rtypeSitelink) {
                             _wikibaseCache[rtypeSitelink] = res;
                             result.rtype = res;
@@ -236,7 +250,7 @@ export default {
                         } else if (title === tagSitelink) {
                             _wikibaseCache[tagSitelink] = res;
                             result.tag = res;
-                        } else if (title.startsWith('Locale:')) {
+                        } else if (title?.startsWith('Locale:')) {
                             const langCode = title.replace(/ /g, '_').replace(/^Locale:/, '');
                             that.addLocale(langCode, res.id);
                         } else {
@@ -251,13 +265,6 @@ export default {
     },
 
 
-    //
-    // Pass params object of the form:
-    // {
-    //   key: 'string',     // required
-    //   value: 'string'    // optional
-    // }
-    //
     // Get an result object used to display tag documentation
     // {
     //   title:        'string',
@@ -267,7 +274,7 @@ export default {
     //   wiki:         { title: 'string', text: 'string', url: 'string' }
     // }
     //
-    getDocs: function(params, callback) {
+    getDocs: function(params: Params, callback: Callback<WikibaseResult>) {
         var that = this;
         var langCodes = localizer.localeCodes().map(function(code) {
             return code.toLowerCase();
@@ -280,8 +287,8 @@ export default {
                 return;
             }
 
-            var entity = data.rtype || data.tag || data.key;
-            if (!entity) {
+            var entity = data?.rtype || data?.tag || data?.key;
+            if (!entity || !data) {
                 callback(new Error('No entity'));
                 return;
             }
@@ -290,16 +297,16 @@ export default {
             var description;
             for (i in langCodes) {
                 let code = langCodes[i];
-                if (entity.descriptions[code] && entity.descriptions[code].language === code) {
+                if (entity.descriptions?.[code]?.language === code) {
                     description = entity.descriptions[code];
                     break;
                 }
             }
-            if (!description && Object.values(entity.descriptions).length) description = Object.values(entity.descriptions)[0];
+            if (!description && entity.descriptions && Object.values(entity.descriptions).length) description = Object.values(entity.descriptions)[0];
 
             // prepare result
-            var result = {
-                title: entity.title,
+            var result: WikibaseResult = {
+                title: entity.title!,
                 description: that.linkifyWikiText(description?.value || ''),
                 descriptionLocaleCode: description ? description.language : '',
                 editURL: 'https://wiki.openstreetmap.org/wiki/' + entity.title
@@ -351,7 +358,7 @@ export default {
 
 
             // Helper method to get wiki info if a given language exists
-            function getWikiInfo(wiki, langCode, tKey) {
+            function getWikiInfo(wiki: Record<string, string> | undefined, langCode: string, tKey: string) {
                 if (wiki && wiki[langCode]) {
                     return {
                         title: wiki[langCode],
@@ -366,13 +373,13 @@ export default {
     getLocaleIDs: () => _localeIDs,
 
 
-    addLocale: function(langCode, qid) {
+    addLocale: function(langCode: string, qid: ItemId | false) {
         // Makes it easier to unit test
         _localeIDs[langCode] = qid;
     },
 
 
-    apibase: function(val) {
+    apibase: function(val: string) {
         if (!arguments.length) return apibase;
         apibase = val;
         return this;

--- a/modules/services/wikidata.ts
+++ b/modules/services/wikidata.ts
@@ -1,11 +1,33 @@
 import { json as d3_json } from 'd3-fetch';
+import type { Entities, Item, ItemId, PropertyId, SearchResponse, SearchResult, Site, SnakWithValue, Term, WbGetEntitiesResponse } from 'wikibase-sdk';
 
 import { utilQsString } from '../util';
 import { localizer } from '../core/localizer';
 
 var apibase = 'https://www.wikidata.org/w/api.php?';
-var _wikidataCache = {};
+var _wikidataCache: { [qId: ItemId]: Item } = {};
 
+export interface WikibaseApiResponse {
+    success: 0 | 1;
+    error: WbGetEntitiesResponse['error'];
+    entities: {
+        [qId: ItemId]: Item;
+    };
+}
+
+
+export interface WikibaseResult {
+    title: string;
+    description: d3.Selector;
+    descriptionLocaleCode: string;
+    editURL: string;
+    imageURL?: string;
+    wiki?: {
+        title: string;
+        text: string;
+        url: string;
+    };
+}
 
 export default {
 
@@ -17,7 +39,7 @@ export default {
 
 
     // Search for Wikidata items matching the query
-    itemsForSearchQuery: function(query, callback, language) {
+    itemsForSearchQuery: function(query: string, callback: Callback<SearchResult[]>, language?: string) {
         if (!query) {
             if (callback) callback(new Error('No query'));
             return;
@@ -40,7 +62,8 @@ export default {
         });
 
         d3_json(url)
-            .then(result => {
+            .then(_result => {
+                const result = _result as SearchResponse;
                 if (result && result.error) {
                     if (result.error.code === 'badvalue' &&
                         result.error.info.includes(lang) &&
@@ -49,7 +72,7 @@ export default {
                         this.itemsForSearchQuery(query, callback, lang.split('-')[0]);
                         return;
                     } else {
-                        throw new Error(result.error);
+                        throw new Error(JSON.stringify(result.error));
                     }
                 }
                 if (callback) callback(null, result.search || {});
@@ -62,7 +85,7 @@ export default {
 
     // Given a Wikipedia language and article title,
     // return an array of corresponding Wikidata entities.
-    itemsByTitle: function(lang, title, callback) {
+    itemsByTitle: function(lang?: string, title?: string, callback?: Callback<Entities>) {
         if (!title) {
             if (callback) callback(new Error('No title'));
             return;
@@ -80,9 +103,10 @@ export default {
         });
 
         d3_json(url)
-            .then(function(result) {
+            .then(function(_result) {
+                const result = _result as WikibaseApiResponse;
                 if (result && result.error) {
-                    throw new Error(result.error);
+                    throw new Error(JSON.stringify(result.error));
                 }
                 if (callback) callback(null, result.entities || {});
             })
@@ -103,7 +127,7 @@ export default {
     },
 
 
-    entityByQID: function(qid, callback) {
+    entityByQID: function(qid: ItemId, callback: Callback<Item>) {
         if (!qid) {
             callback(new Error('No qid'));
             return;
@@ -127,9 +151,10 @@ export default {
         });
 
         d3_json(url)
-            .then(function(result) {
+            .then(function(_result) {
+                const result = _result as WikibaseApiResponse;
                 if (result && result.error) {
-                    throw new Error(result.error);
+                    throw new Error(JSON.stringify(result.error));
                 }
                 if (callback) callback(null, result.entities[qid] || {});
             })
@@ -153,7 +178,7 @@ export default {
     //   wiki:         { title: 'string', text: 'string', url: 'string' }
     // }
     //
-    getDocs: function(params, callback) {
+    getDocs: function(params: { qid: ItemId }, callback: Callback<WikibaseResult>) {
         var langs = this.languagesToQuery();
         this.entityByQID(params.qid, function(err, entity) {
             if (err || !entity) {
@@ -162,18 +187,18 @@ export default {
             }
 
             var i;
-            var description;
+            let description: Term | undefined;
             for (i in langs) {
                 let code = langs[i];
-                if (entity.descriptions[code] && entity.descriptions[code].language === code) {
+                if (entity.descriptions?.[code]?.language === code) {
                     description = entity.descriptions[code];
                     break;
                 }
             }
-            if (!description && Object.values(entity.descriptions).length) description = Object.values(entity.descriptions)[0];
+            if (!description && Object.values(entity.descriptions || {}).length) description = Object.values(entity.descriptions || {})[0];
 
             // prepare result
-            var result = {
+            const result: WikibaseResult = {
                 title: entity.id,
                 description: selection => selection.text(description ? description.value : ''),
                 descriptionLocaleCode: description ? description.language : '',
@@ -183,12 +208,12 @@ export default {
             // add image
             if (entity.claims) {
                 var imageroot = 'https://commons.wikimedia.org/w/index.php';
-                var props = ['P154','P18'];  // logo image, image
+                const props: PropertyId[] = ['P154', 'P18'];  // logo image, image
                 var prop, image;
                 for (i = 0; i < props.length; i++) {
                     prop = entity.claims[props[i]];
                     if (prop && Object.keys(prop).length > 0) {
-                        image = prop[Object.keys(prop)[0]].mainsnak.datavalue.value;
+                        image = (Object.values(prop)[0].mainsnak as SnakWithValue).datavalue.value;
                         if (image) {
                             result.imageURL = imageroot + '?' + utilQsString({
                                 title: 'Special:Redirect/file/' + image,
@@ -205,9 +230,9 @@ export default {
 
                 // must be one of these that we requested..
                 for (i = 0; i < langs.length; i++) {   // check each, in order of preference
-                    var w = langs[i] + 'wiki';
+                    var w = langs[i] + 'wiki' as Site;
                     if (entity.sitelinks[w]) {
-                        var title = entity.sitelinks[w].title;
+                        var title = entity.sitelinks[w]!.title;
                         var tKey = 'inspector.wiki_reference';
                         if (!englishLocale && langs[i] === 'en') {   // user's locale isn't English but
                             tKey = 'inspector.wiki_en_reference';    // we are sending them to enwiki anyway..

--- a/modules/services/wikipedia.ts
+++ b/modules/services/wikipedia.ts
@@ -5,13 +5,24 @@ import { utilQsString } from '../util';
 
 var endpoint = 'https://en.wikipedia.org/w/api.php?';
 
+interface Article {
+    title: string;
+    snippet: string;
+}
+
+interface ApiError {
+    code: string;
+    info: string;
+    '*': string;
+}
+
 export default {
 
     init: function() {},
     reset: function() {},
 
 
-    search: function(lang, query, callback) {
+    search: function(lang: string, query: string, callback: Callback<string[]>) {
         if (!query) {
             if (callback) callback(new Error('No Query'));
             return;
@@ -30,9 +41,10 @@ export default {
             });
 
         d3_json(url)
-            .then(function(result) {
+            .then(function(_result) {
+                const result = _result as { error?: ApiError; query?: { search: Article[] }; };
                 if (result && result.error) {
-                    throw new Error(result.error);
+                    throw new Error(JSON.stringify(result.error));
                 } else if (!result || !result.query || !result.query.search) {
                     throw new Error('No Results');
                 }
@@ -47,7 +59,7 @@ export default {
     },
 
 
-    suggestions: function(lang, query, callback) {
+    suggestions: function(lang: string, query: string, callback: Callback<string[]>) {
         if (!query) {
             if (callback) callback(new Error('No Query'));
             return;
@@ -65,9 +77,10 @@ export default {
             });
 
         d3_json(url)
-            .then(function(result) {
+            .then(function(_result) {
+                const result = _result as [query: string, titles: string[]] & { error?: ApiError };
                 if (result && result.error) {
-                    throw new Error(result.error);
+                    throw new Error(JSON.stringify(result.error));
                 } else if (!result || result.length < 2) {
                     throw new Error('No Results');
                 }

--- a/modules/util/util.ts
+++ b/modules/util/util.ts
@@ -480,8 +480,8 @@ export function utilStringQs(str: string): {[k: string]: string} {
 }
 
 
-export function utilQsString(obj: {[k: string]: string}, softEncode: boolean) {
-    let str = new URLSearchParams(obj).toString();
+export function utilQsString(obj: { [k: string]: string | number | boolean }, softEncode?: boolean) {
+    let str = new URLSearchParams(obj as Record<string, string>).toString();
     if (softEncode) {
         // for better readability of URL hashes: optionally
         // leave some special characters unescaped

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,7 +88,8 @@
         "typescript": "npm:@typescript/typescript6@^6.0.2",
         "typescript-eslint": "^8.56.0",
         "vite": "^8.0.1",
-        "vitest": "^4.1.0"
+        "vitest": "^4.1.0",
+        "wikibase-sdk": "^11.1.1"
       },
       "engines": {
         "node": ">=22"
@@ -10092,6 +10093,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
@@ -10715,6 +10729,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/wikibase-sdk": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/wikibase-sdk/-/wikibase-sdk-11.1.1.tgz",
+      "integrity": "sha512-ql7tJmQUeFZYBk9a1hAvveVlF/DpFOfjo31+SX1NW0VZYQQwV47UemBzJ1A+TsXjTNFkLkW/pwhiBNXmbkE0wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^4.41.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/winston": {

--- a/package.json
+++ b/package.json
@@ -131,7 +131,8 @@
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "typescript-eslint": "^8.56.0",
     "vite": "^8.0.1",
-    "vitest": "^4.1.0"
+    "vitest": "^4.1.0",
+    "wikibase-sdk": "^11.1.1"
   },
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
for this PR, we import the defintions from a library called [`wikibase-sdk`](https://npm.im/wikibase-sdk), instead of [a `@types/*` package](https://github.com/DefinitelyTyped/DefinitelyTyped). 

We only use this library for type-definitions, not for runtime code. Therefore we can use the [`import type` syntax](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export) to ensure that the library is not bundled into our runtime code.