### PR TITLE
Enable territory-aware address hints (with proper Hong Kong and Macao address formats)

### DIFF
--- a/data/address_formats.json
+++ b/data/address_formats.json
@@ -98,8 +98,8 @@
   {
     "countryCodes": ["mo"],
     "format": [
-      ["housenumber", "street"],
-      ["postcode", "city"]
+      ["street", "housenumber", "unit"],
+      ["floor"]
     ]
   },
   {

--- a/data/address_formats.json
+++ b/data/address_formats.json
@@ -72,6 +72,14 @@
     ]
   },
   {
+    "countryCodes": ["hk"],
+    "format": [
+      ["door", "floor"],
+      ["unit", "housename"],
+      ["housenumber", "street+place"]
+    ]
+  },
+  {
     "countryCodes": ["ma"],
     "format": [
       ["housename"],

--- a/modules/ui/fields/address.js
+++ b/modules/ui/fields/address.js
@@ -371,7 +371,8 @@ export function uiFieldAddress(field, context) {
                 countryCode = t('intro.graph.countrycode');
             } else {
                 var center = extent.center();
-                countryCode = countryCoder.iso1A2Code(center);
+                // even if we do not have data for this territory/country, the editor will generate a default format for us.
+                countryCode = countryCoder.iso1A2Code(center, { level: 'territory' });
             }
             if (countryCode) {
                 _countryCode = countryCode.toLowerCase();

--- a/modules/ui/fields/address.js
+++ b/modules/ui/fields/address.js
@@ -383,6 +383,8 @@ export function uiFieldAddress(field, context) {
                     countryCoder.iso1A2Code(center),
                 ];
             }
+            // country codes can be null (e.g. unclaimed ocean); we don't want that.
+            countryCodes = countryCodes.filter((item) => item !== null);
             if (countryCodes) {
                 _countryCodes = countryCodes.map((x) => x.toLowerCase());
                 updateForCountryCodes();

--- a/modules/ui/fields/address.js
+++ b/modules/ui/fields/address.js
@@ -383,8 +383,8 @@ export function uiFieldAddress(field, context) {
                     countryCoder.iso1A2Code(center),
                 ];
             }
-            // country codes can be null (e.g. unclaimed ocean); we don't want that.
-            countryCodes = countryCodes.filter((item) => item !== null);
+            // country codes can be null/undefined (e.g. unclaimed ocean); we don't want that.
+            countryCodes = countryCodes.filter((item) => !!item);
             if (countryCodes) {
                 _countryCodes = countryCodes.map((x) => x.toLowerCase());
                 updateForCountryCodes();

--- a/modules/ui/fields/address.js
+++ b/modules/ui/fields/address.js
@@ -23,7 +23,7 @@ export function uiFieldAddress(field, context) {
 
     var _entityIDs = [];
     var _tags;
-    var _countryCode;
+    var _countryCodes = []; // sometimes we want to check multiple address hints (e.g. HK vs CN, and CK vs NZ)
     var _addressFormats = [{
         format: [
             ['housenumber', 'street'],
@@ -196,18 +196,23 @@ export function uiFieldAddress(field, context) {
     }
 
 
-    function updateForCountryCode() {
+    function updateForCountryCodes() {
 
-        if (!_countryCode) return;
+        if (!_countryCodes) return;
 
+        // find the country with a usable format
         var addressFormat;
-        for (var i = 0; i < _addressFormats.length; i++) {
-            var format = _addressFormats[i];
-            if (!format.countryCodes) {
-                addressFormat = format;   // choose the default format, keep going
-            } else if (format.countryCodes.indexOf(_countryCode) !== -1) {
-                addressFormat = format;   // choose the country format, stop here
-                break;
+        for (var countryIter = 0; countryIter < _countryCodes.length && !addressFormat; countryIter++) {
+            var currentCountryCode = _countryCodes[countryIter];
+
+            for (var i = 0; i < _addressFormats.length; i++) {
+                var format = _addressFormats[i];
+                if (!format.countryCodes) {
+                    addressFormat = format;   // choose the default format, keep going
+                } else if (format.countryCodes.indexOf(currentCountryCode) !== -1) {
+                    addressFormat = format;   // choose the country format, stop here
+                    break;
+                }
             }
         }
 
@@ -365,18 +370,22 @@ export function uiFieldAddress(field, context) {
         var extent = combinedEntityExtent();
 
         if (extent) {
-            var countryCode;
+            var countryCodes = [];
             if (context.inIntro()) {
                 // localize the address format for the walkthrough
-                countryCode = t('intro.graph.countrycode');
+                countryCodes = [t('intro.graph.countrycode')];
             } else {
                 var center = extent.center();
-                // even if we do not have data for this territory/country, the editor will generate a default format for us.
-                countryCode = countryCoder.iso1A2Code(center, { level: 'territory' });
+                // we try to find the territory-level address format
+                // if we dn't have that, we fall back to (sovereign) country-level address format
+                countryCodes = [
+                    countryCoder.iso1A2Code(center, { level: 'territory' }),
+                    countryCoder.iso1A2Code(center),
+                ];
             }
-            if (countryCode) {
-                _countryCode = countryCode.toLowerCase();
-                updateForCountryCode();
+            if (countryCodes) {
+                _countryCodes = countryCodes.map((x) => x.toLowerCase());
+                updateForCountryCodes();
             }
         }
     }
@@ -429,8 +438,9 @@ export function uiFieldAddress(field, context) {
 
 
     function getLocalPlaceholder(key) {
-        if (_countryCode) {
-            var localkey = key + '!' + _countryCode;
+        if (_countryCodes) {
+            var firstCountryCode = _countryCodes[0];
+            var localkey = key + '!' + firstCountryCode;
             var tkey = addrField.hasTextForStringId('placeholders.' + localkey) ? localkey : key;
             return addrField.t('placeholders.' + tkey);
         }

--- a/modules/ui/fields/address.js
+++ b/modules/ui/fields/address.js
@@ -201,18 +201,14 @@ export function uiFieldAddress(field, context) {
         if (!_countryCodes) return;
 
         // find the country with a usable format
-        var addressFormat;
-        for (var countryIter = 0; countryIter < _countryCodes.length && !addressFormat; countryIter++) {
-            var currentCountryCode = _countryCodes[countryIter];
-
-            for (var i = 0; i < _addressFormats.length; i++) {
-                var format = _addressFormats[i];
-                if (!format.countryCodes) {
-                    addressFormat = format;   // choose the default format, keep going
-                } else if (format.countryCodes.indexOf(currentCountryCode) !== -1) {
-                    addressFormat = format;   // choose the country format, stop here
-                    break;
-                }
+        const defaultAddressFormat = _addressFormats.find((item) => !item.countryCodes);
+        console.assert(defaultAddressFormat !== undefined); // if undefined, then the config files are wrong.
+        let addressFormat = defaultAddressFormat;
+        for (const currentCountryCode of _countryCodes) {
+            const foundFormat = _addressFormats.find(format => (format.countryCodes?.includes(currentCountryCode)));
+            if (foundFormat) {
+                addressFormat = foundFormat;
+                break;
             }
         }
 

--- a/modules/ui/fields/address.js
+++ b/modules/ui/fields/address.js
@@ -198,7 +198,7 @@ export function uiFieldAddress(field, context) {
 
     function updateForCountryCodes() {
 
-        if (!_countryCodes) return;
+        if (!(_countryCodes?.length)) return;
 
         // find the country with a usable format
         const defaultAddressFormat = _addressFormats.find((item) => !item.countryCodes);
@@ -381,7 +381,7 @@ export function uiFieldAddress(field, context) {
             }
             // country codes can be null/undefined (e.g. unclaimed ocean); we don't want that.
             countryCodes = countryCodes.filter((item) => !!item);
-            if (countryCodes) {
+            if (countryCodes?.length) {
                 _countryCodes = countryCodes.map((x) => x.toLowerCase());
                 updateForCountryCodes();
             }


### PR DESCRIPTION
This supercedes the following PRs:

- Territory detection: #10914
- Format documentation: #10907

This fixes #10906.

-----------

While attempting to tackle #10906, I have previously attempted to "keep it fancy", which has been a grave mistake. the detection PR has nothing to confirm it is indeed working, and the format PR has no mechanism to demonstrate the updated formats. As such, both PRs could not be merged. I am deeply sorry about the undue progress blocking.

-----------

### Territory Detection (10914)

As guided by https://github.com/openstreetmap/iD/issues/10899#issuecomment-2745909687 , this PR enables the editor to look at the territory-level country code. It turns out the editor only looks at sovereign country codes to generate address format hints, which unfortunately means it omits the formats of Hong Kong and Macao, both non-sovereign and use their colonial address hint formats distinct from the suzerain PRC format.

### Format Documentation (10907)

While reading https://github.com/openstreetmap/iD/issues/10899#issuecomment-2745909687 , it is discovered that the editor does not currently know about Hong Kong's address format. Also, the Macao address format is inaccurate. Both should be documented/updated.

Address levels above "city" are removed because both are essentially city-states. Postcodes are omitted because both ([Hong Kong](https://en.wikipedia.org/wiki/Postal_codes_in_Hong_Kong), [Macao](https://www.travelchinaguide.com/essential/area_zip/macau.htm)) do not use them. Detailed indoor addresses are added owing to the dense urban development in both cities.

------------

Pinging past participants and interested parties: @Kovoschiz , @k-yle , @matkoniecz , @novolife, @tyrasd 