### PR TITLE
Persist path strings and skip unchanged attribute writes on redraw

### DIFF
--- a/modules/svg/areas.js
+++ b/modules/svg/areas.js
@@ -2,11 +2,15 @@ import { deepEqual } from 'fast-equals';
 import { bisector as d3_bisector } from 'd3-array';
 
 import { osmIdManager } from '../osm';
-import { svgPath, svgSegmentWay } from './helpers';
+import { svgAttrIfChanged, svgPath, svgSegmentWay } from './helpers';
 import { svgTagClasses } from './tag_classes';
 import { svgTagPattern } from './tag_pattern';
 
 export function svgAreas(projection, context) {
+
+    // Hoisted per renderer so the class memo's `_id` is stable across
+    // redraws and the memo can actually hit on pan/zoom.
+    var tagClasses = svgTagClasses();
 
 
     function getPatternStyle(tags) {
@@ -62,7 +66,7 @@ export function svgAreas(projection, context) {
         targets.enter()
             .append('path')
             .merge(targets)
-            .attr('d', getPath)
+            .call(svgAttrIfChanged, 'd', getPath)
             .attr('class', function(d) { return 'way area target target-allowed ' + targetClass + d.id; })
             .classed('segment-edited', segmentWasEdited);
 
@@ -81,7 +85,7 @@ export function svgAreas(projection, context) {
         nopes.enter()
             .append('path')
             .merge(nopes)
-            .attr('d', getPath)
+            .call(svgAttrIfChanged, 'd', getPath)
             .attr('class', function(d) { return 'way area target target-nope ' + nopeClass + d.id; })
             .classed('segment-edited', segmentWasEdited);
     }
@@ -133,7 +137,7 @@ export function svgAreas(projection, context) {
 
         clipPaths.merge(clipPathsEnter)
            .selectAll('path')
-           .attr('d', path);
+           .call(svgAttrIfChanged, 'd', path);
 
 
         var drawLayer = selection.selectAll('.layer-osm.areas');
@@ -172,12 +176,28 @@ export function svgAreas(projection, context) {
             .merge(paths)
             .each(function(entity) {
                 var layer = this.parentNode.__data__;
-                this.setAttribute('class', entity.type + ' area ' + layer + ' ' + entity.id);
+                var klass = entity.type + ' area ' + layer + ' ' + entity.id;
+                // Only write the base class when it isn't already present.
+                // On update redraws the element's class already starts with
+                // it (plus state classes like `added` and the `tag-*` classes
+                // appended below), so a raw `!==` comparison would rewrite
+                // the attribute on every redraw and defeat the
+                // unchanged-attribute-write optimization.
+                var current = this.getAttribute('class');
+                if (current !== klass && !(current && current.startsWith(klass + ' '))) {
+                    this.setAttribute('class', klass);
+                }
 
                 if (layer === 'fill') {
-                    this.setAttribute('clip-path', 'url(#ideditor-' + entity.id + '-clippath)');
-                    this.style.fill = getPatternStyle(entity.tags);
-                    this.style.stroke = this.style.fill;
+                    var clipPath = 'url(#ideditor-' + entity.id + '-clippath)';
+                    if (this.getAttribute('clip-path') !== clipPath) {
+                        this.setAttribute('clip-path', clipPath);
+                    }
+                    var fill = getPatternStyle(entity.tags);
+                    if (this.style.fill !== fill) {
+                        this.style.fill = fill;
+                        this.style.stroke = fill;
+                    }
                 }
             })
             .classed('added', function(d) {
@@ -193,8 +213,8 @@ export function svgAreas(projection, context) {
                     base.entities[d.id] &&
                     !deepEqual(graph.entities[d.id].tags, base.entities[d.id].tags);
             })
-            .call(svgTagClasses())
-            .attr('d', path);
+            .call(tagClasses.graph(graph))
+            .call(svgAttrIfChanged, 'd', path);
 
 
         // Draw touch targets..

--- a/modules/svg/helpers.ts
+++ b/modules/svg/helpers.ts
@@ -5,10 +5,11 @@ import {
 } from 'd3-geo';
 
 import { geoVecAdd, geoVecAngle, geoVecLength } from '../geo';
-import type { EntityId, NodeId, OsmEntity, osmNode, osmWay, WayId } from '../osm';
+import type { NodeId, OsmEntity, osmNode, osmWay, WayId } from '../osm';
 import type { coreGraph } from '../core';
 import type { ClipExtent, Projection } from '../geo/raw_mercator';
 import type { Vec2 } from '../geo/vector';
+import type { Selection } from 'd3-selection';
 import type { Feature, LineString } from 'geojson';
 import type { WithLoc } from './geolocate';
 
@@ -160,26 +161,50 @@ export function svgMarkerSegments(
 
 
 export function svgPath(projection: Projection, graph?: coreGraph, isArea?: boolean) {
-    const cache: Record<EntityId, string | null> = {};
     const project = projection.stream;
     const clip = paddedClipExtent(projection, isArea);
     const path = d3_geoPath()
         .projection({stream: function(output) { return project(clip(output)); }});
 
+    // Cache path strings in the graph's transient store so they survive
+    // across redraws. The entry is tagged with the projection state it was
+    // computed for, and replaced (not accumulated) when the projection
+    // changes - keeping only the current projection's paths prevents the
+    // strings for every zoom level we've passed through from piling up in
+    // memory until the graph changes. The graph transients are invalidated
+    // when the graph changes (edits create a new graph, tile merges
+    // invalidate the affected entities).
+    const projectionKey = projection.scale() + '|' + projection.translate().join(',') +
+        '|' + projection.clipExtent().join(',') + (isArea ? '|area' : '');
+    const slot = 'svgPath' + (isArea ? ':area' : '');
+
     const svgpath = function(entity: osmWay) {
-        if (entity.id in cache) {
-            return cache[entity.id];
+        if (graph) {
+            const cached = graph.transient<{ key: string, value: string | null }>(entity, slot, () => {
+                return { key: projectionKey, value: path(entity.asGeoJSON(graph)) };
+            });
+            if (cached.key !== projectionKey) {
+                // the projection changed since this was cached - replace it
+                const updated = { key: projectionKey, value: path(entity.asGeoJSON(graph)) };
+                const transients = graph.transients[entity.id];
+                if (transients) transients[slot] = updated;
+                return updated.value;
+            }
+            return cached.value;
         } else {
-            return cache[entity.id] = path(entity.asGeoJSON(graph!));
+            return path(entity.asGeoJSON(graph!));
         }
     };
 
+    // GeoJSON features (e.g. from the vector data layer) are not graph
+    // entities, so cache them per call as before
+    const geojsonCache: Record<string, string | null> = {};
     svgpath.geojson = function(d: any) {
         if (d.__featurehash__ !== undefined) {
-            if (d.__featurehash__ in cache) {
-                return cache[d.__featurehash__];
+            if (d.__featurehash__ in geojsonCache) {
+                return geojsonCache[d.__featurehash__];
             } else {
-                return cache[d.__featurehash__] = path(d);
+                return geojsonCache[d.__featurehash__] = path(d);
             }
         } else {
             return path(d);
@@ -201,6 +226,30 @@ export function svgPointTransform(projection: Projection) {
     };
 
     return svgpoint;
+}
+
+
+/**
+ * Set an attribute on each element of the selection, but only when the
+ * value has changed. Writing an unchanged attribute still invalidates the
+ * element's style, which forces a style/layout recalculation of the whole
+ * map subtree on a full redraw.
+ */
+export function svgAttrIfChanged<GElement extends Element, Datum>(
+    selection: Selection<GElement, Datum, any, any>,
+    name: string,
+    getValue: (d: Datum) => string | null
+) {
+    selection.each(function(d) {
+        const value = getValue(d);
+        if (this.getAttribute(name) !== value) {
+            if (value === null) {
+                this.removeAttribute(name);
+            } else {
+                this.setAttribute(name, value);
+            }
+        }
+    });
 }
 
 

--- a/modules/svg/index.ts
+++ b/modules/svg/index.ts
@@ -11,6 +11,7 @@ export { svgMapillaryImages } from './mapillary_images.js';
 export { svgMapillarySigns } from './mapillary_signs.js';
 export { svgMidpoints } from './midpoints.js';
 export { svgNotes } from './notes.js';
+export { svgAttrIfChanged } from './helpers.js';
 export { svgMarkerSegments } from './helpers.js';
 export { svgKartaviewImages } from './kartaview_images.js';
 export { svgOsm } from './osm.js';

--- a/modules/svg/lines.js
+++ b/modules/svg/lines.js
@@ -2,7 +2,7 @@ import { deepEqual } from 'fast-equals';
 import { range as d3_range } from 'd3-array';
 
 import {
-    svgMarkerSegments, svgPath, svgRelationMemberTags, svgSegmentWay
+    svgAttrIfChanged, svgMarkerSegments, svgPath, svgRelationMemberTags, svgSegmentWay
 } from './helpers';
 import { svgTagClasses } from './tag_classes';
 
@@ -23,6 +23,21 @@ function onewayArrowColour(tags) {
 
 export function svgLines(projection, context) {
     var detected = utilDetect();
+
+    // Hoisted per renderer so the class memo's `_id` is stable across
+    // redraws and the memo can actually hit on pan/zoom. Two instances:
+    // one per distinct `tags` getter (own tags on enter, relation tags on
+    // update) - sharing one instance would let the second pass hit memo
+    // entries computed with the other pass's tags getter.
+    var tagClasses = svgTagClasses();
+    var tagClassesRelation = svgTagClasses();
+
+    // Hoisted per renderer so the sort memo is stable across redraws and
+    // can actually hit on pan/zoom. waystack reads only the selected set
+    // and each way's tags, so a linegroup whose data and selection are
+    // unchanged since the last draw is already in stack order and can skip
+    // the sort, which would otherwise reorder every path via the DOM.
+    var sortCache = {};
 
     var highway_stack = {
         motorway: 0,
@@ -85,7 +100,7 @@ export function svgLines(projection, context) {
         targets.enter()
             .append('path')
             .merge(targets)
-            .attr('d', getPath)
+            .call(svgAttrIfChanged, 'd', getPath)
             .attr('class', function(d) {
                 return 'way line target target-allowed ' + targetClass + d.id;
             })
@@ -105,7 +120,7 @@ export function svgLines(projection, context) {
         nopes.enter()
             .append('path')
             .merge(nopes)
-            .attr('d', getPath)
+            .call(svgAttrIfChanged, 'd', getPath)
             .attr('class', function(d) {
                 return 'way line target target-nope ' + nopeClass + d.id;
             })
@@ -116,14 +131,32 @@ export function svgLines(projection, context) {
     function drawLines(selection, graph, entities, filter) {
         var base = context.history().base();
 
+        // Snapshot the selection once for this draw. The layer filter and
+        // waystack both test membership per way, and the selection cannot
+        // change mid-draw, so capture it in a Set instead of calling
+        // selectedIDs() per entity per linegroup pass.
+        var selected = new Set(context.selectedIDs());
+
+        // waystack sorts by selection and highway rank, so the order can
+        // change only when the selection or the data changes. Snapshot the
+        // selection so the sort can be skipped when neither changed.
+        var selectedSig = context.selectedIDs().slice().sort().join(',');
+
         function waystack(a, b) {
-            var selected = context.selectedIDs();
-            var scoreA = selected.indexOf(a.id) !== -1 ? 20 : 0;
-            var scoreB = selected.indexOf(b.id) !== -1 ? 20 : 0;
+            var scoreA = selected.has(a.id) ? 20 : 0;
+            var scoreB = selected.has(b.id) ? 20 : 0;
 
             if (a.tags.highway) { scoreA -= highway_stack[a.tags.highway]; }
             if (b.tags.highway) { scoreB -= highway_stack[b.tags.highway]; }
             return scoreA - scoreB;
+        }
+
+        function sameSequence(a, b) {
+            if (a.length !== b.length) return false;
+            for (var i = 0; i < a.length; i++) {
+                if (a[i] !== b[i]) return false;
+            }
+            return true;
         }
 
 
@@ -133,17 +166,29 @@ export function svgLines(projection, context) {
             var isDrawing = mode && /^draw/.test(mode.id);
             var selectedClass = (!isDrawing && isSelected) ? 'selected ' : '';
 
+            // Data and linegroup node per layer, captured while the join
+            // runs so the sort skip below can compare without re-reading
+            // the DOM
+            var layerData = {};
+            var layerNodes = {};
+            var getData = getPathData(isSelected);
+
             var lines = selection
                 .selectAll('path')
                 .filter(filter)
-                .data(getPathData(isSelected), osmIdManager.key);
+                .data(function() {
+                    var layer = this.parentNode.__data__;
+                    layerData[layer] = getData.call(this);
+                    layerNodes[layer] = this;
+                    return layerData[layer];
+                }, osmIdManager.key);
 
             lines.exit()
                 .remove();
 
             // Optimization: Call expensive TagClasses only on enter selection. This
             // works because osmIdManager.key is defined to include the entity v attribute.
-            lines.enter()
+            lines = lines.enter()
                 .append('path')
                 .attr('class', function(d) {
 
@@ -182,11 +227,46 @@ export function svgLines(projection, context) {
                         base.entities[d.id] &&
                         !deepEqual(graph.entities[d.id].tags, base.entities[d.id].tags);
                 })
-                .call(svgTagClasses())
-                .merge(lines)
-                .sort(waystack)
-                .attr('d', getPath)
-                .call(svgTagClasses().tags(svgRelationMemberTags(graph)));
+                .call(tagClasses.graph(graph))
+                .merge(lines);
+
+            // Skip the sort when the data and selection are unchanged since
+            // the last draw of this linegroup: the DOM is then already in
+            // stack order. Sorting would otherwise reorder every path via
+            // the DOM, one compareDocumentPosition at a time. The cache key
+            // includes the highlighted suffix because klass is shared by the
+            // normal and highlighted linegroups, and the covered and
+            // uncovered layer passes share the entry, safe because the two
+            // layer ranges are disjoint.
+            var cacheKey = klass + (isSelected ? ' highlighted' : '');
+            var entry = sortCache[cacheKey];
+            var unchanged = !!(entry && entry.sig === selectedSig);
+            var layer;
+            if (unchanged) {
+                for (layer in layerData) {
+                    if (entry.nodes[layer] !== layerNodes[layer] ||
+                        !sameSequence(entry.data[layer], layerData[layer])) {
+                        unchanged = false;
+                        break;
+                    }
+                }
+            }
+
+            // The memo is refreshed only when a sort actually runs, a skip
+            // leaves it untouched.
+            if (!unchanged) {
+                lines.sort(waystack);
+                entry = sortCache[cacheKey] ||
+                    (sortCache[cacheKey] = { sig: selectedSig, data: {}, nodes: {} });
+                entry.sig = selectedSig;
+                for (layer in layerData) {
+                    entry.data[layer] = layerData[layer];
+                    entry.nodes[layer] = layerNodes[layer];
+                }
+            }
+
+            lines.call(svgAttrIfChanged, 'd', getPath)
+                .call(tagClassesRelation.tags(svgRelationMemberTags(graph)).graph(graph));
 
             return selection;
         }
@@ -197,11 +277,8 @@ export function svgLines(projection, context) {
                 var layer = this.parentNode.__data__;
                 var data = pathdata[layer] || [];
                 return data.filter(function(d) {
-                    if (isSelected) {
-                        return context.selectedIDs().indexOf(d.id) !== -1;
-                    } else {
-                        return context.selectedIDs().indexOf(d.id) === -1;
-                    }
+                    var isSel = selected.has(d.id);
+                    return isSelected ? isSel : !isSel;
                 });
             };
         }
@@ -232,7 +309,7 @@ export function svgLines(projection, context) {
                 .attr('class', pathclass)
                 .merge(markers)
                 .attr('marker-mid', marker)
-                .attr('d', function(d) { return d.d; });
+                .call(svgAttrIfChanged, 'd', d => d.d);
 
             if (detected.ie) {
                 markers.each(function() { this.parentNode.insertBefore(this, this); });

--- a/modules/svg/midpoints.ts
+++ b/modules/svg/midpoints.ts
@@ -1,9 +1,9 @@
-import { svgPointTransform } from './helpers';
+import { svgAttrIfChanged, svgPointTransform } from './helpers';
 import { svgTagClasses } from './tag_classes';
 import { geoAngle, geoLineIntersection, geoVecInterp, geoVecLength, type geoExtent } from '../geo';
 import type { Projection } from '../geo/raw_mercator';
 import type { coreGraph } from '../core';
-import type { NodeId, osmWay } from '../osm';
+import { osmIdManager, type NodeId, type osmWay } from '../osm';
 import type { Feature } from 'geojson';
 import type { Vec2 } from '../geo/vector';
 
@@ -17,6 +17,10 @@ export interface Midpoint {
 
 export function svgMidpoints(projection: Projection, context: iD.Context) {
     var targetRadius = 8;
+
+    // Hoisted per renderer so the class memo's `_id` is stable across
+    // redraws and the memo can actually hit on pan/zoom.
+    const tagClasses = svgTagClasses<Midpoint>();
 
     function drawTargets(selection: d3.Selection, graph: coreGraph, entities: Midpoint[], filter: (node: Midpoint) => boolean) {
         var fillClass = context.getDebug('target') ? 'pink ' : 'nocolor ';
@@ -51,7 +55,7 @@ export function svgMidpoints(projection: Projection, context: iD.Context) {
             .attr('r', targetRadius)
             .merge(targets)
             .attr('class', function(d) { return 'node midpoint target ' + fillClass + d.id; })
-            .attr('transform', getTransform);
+            .call(svgAttrIfChanged, 'transform', getTransform);
     }
 
 
@@ -152,16 +156,22 @@ export function svgMidpoints(projection: Projection, context: iD.Context) {
 
         groups = groups
             .merge(enter)
-            .attr('transform', function(d) {
+            .call(svgAttrIfChanged, 'transform', function(d) {
                 var translate = svgPointTransform(projection);
                 var a = graph.entity(d.edge[0]);
                 var b = graph.entity(d.edge[1]);
                 var angle = geoAngle(a, b, projection) * (180 / Math.PI);
                 return translate(d) + ' rotate(' + angle + ')';
             })
-            .call(svgTagClasses<Midpoint>().tags(
+            // Midpoints are plain objects, so their `osmIdManager.key()` is
+            // version-less (`id + 'v0'`). Key the memo on the parent way as
+            // well: a midpoint that exits and re-enters (e.g. when zooming)
+            // while the graph is unchanged must not hit a memo entry computed
+            // for a different parent way over the same node pair.
+            .call(tagClasses.tags(
                 function(d) { return d.parents[0].tags; }
-            ));
+            ).keyExt(function(d) { return osmIdManager.key(d.parents[0]); })
+            .graph(graph));
 
         // Propagate data bindings.
         groups.select('polygon.shadow');

--- a/modules/svg/points.js
+++ b/modules/svg/points.js
@@ -4,12 +4,16 @@ import { select as d3_select } from 'd3';
 
 import { geoScaleToZoom } from '../geo';
 import { osmIdManager } from '../osm';
-import { svgPointTransform } from './helpers';
+import { svgAttrIfChanged, svgPointTransform } from './helpers';
 import { svgTagClasses } from './tag_classes';
 import { presetManager } from '../presets';
 import { textWidth, isAddressPoint } from './labels';
 
 export function svgPoints(projection, context) {
+
+    // Hoisted per renderer so the class memo's `_id` is stable across
+    // redraws and the memo can actually hit on pan/zoom.
+    var tagClasses = svgTagClasses();
 
     function markerPath(selection, klass) {
         selection
@@ -82,7 +86,7 @@ export function svgPoints(projection, context) {
             .attr('height', d => d.properties.isAddr ? 16 : 30)
             .attr('class', function(d) { return 'node point target ' + fillClass + d.id; })
             .merge(targets)
-            .attr('transform', getTransform);
+            .call(svgAttrIfChanged, 'transform', getTransform);
     }
 
 
@@ -146,7 +150,7 @@ export function svgPoints(projection, context) {
 
         groups = groups
             .merge(enter)
-            .attr('transform', svgPointTransform(projection))
+            .call(svgAttrIfChanged, 'transform', svgPointTransform(projection))
             .classed('added', function(d) {
                 return !base.entities[d.id]; // if it doesn't exist in the base graph, it's new
             })
@@ -156,7 +160,7 @@ export function svgPoints(projection, context) {
             .classed('retagged', function(d) {
                 return base.entities[d.id] && !deepEqual(graph.entities[d.id].tags, base.entities[d.id].tags);
             })
-            .call(svgTagClasses());
+            .call(tagClasses.graph(graph));
 
         groups.select('.shadow');   // propagate bound data
         groups.select('.stroke');   // propagate bound data

--- a/modules/svg/tag_classes.ts
+++ b/modules/svg/tag_classes.ts
@@ -1,8 +1,21 @@
 import type { Geometry } from '@openstreetmap/id-tagging-schema';
 import { select as d3_select } from 'd3-selection';
+import type { coreGraph } from '../core';
+import { osmIdManager } from '../osm';
 import { osmPathHighwayTagValues, osmPavedTags, osmSemipavedTags, osmLifecyclePrefixes } from '../osm/tags';
 
 export type TagGetter<T> = (entity: T) => Tags;
+
+// Memoize getClassesString() results across redraws: with tens of thousands of
+// elements re-joined on every full redraw, recomputing the class string for
+// each one dominates the redraw time. The memo is reset only when the graph
+// object changes identity (edits create a new graph object). Tile-merge
+// rebases mutate the graph in place and do NOT reset the memo: that is safe
+// because rebase only adds entities absent from the base graph, so the tags
+// of entities already in the graph never change on a merge (see coreGraph.rebase).
+let _classMemo = new Map<string, string>();
+let _classMemoGraph: coreGraph | undefined;
+let _instanceId = 0;
 
 export function svgTagClasses<T>() {
     const primaries = [
@@ -21,9 +34,23 @@ export function svgTagClasses<T>() {
 
     // this function is the default callback, but it can be overridden
     var _tags: TagGetter<any> = function(entity) { return entity.tags; };
+    var _graph: coreGraph | undefined;
+    const _id = String(++_instanceId);
+
+    // Optional extra memo key component. Non-entity datums (e.g. midpoints)
+    // have version-less osmIdManager.key()s (`id + 'v0'`), so the memo alone
+    // cannot tell when the classes input changed (e.g. a midpoint whose
+    // parent way was switched without the graph changing). Callers with such
+    // datums must include whatever identifies the tags source - for
+    // midpoints, the parent way's key.
+    let _keyExt: ((entity: T) => string) | undefined;
 
 
     const tagClasses = function(selection: d3.Selection<SVGGElement>) {
+        if (_graph !== _classMemoGraph) {
+            _classMemo = new Map();
+            _classMemoGraph = _graph;
+        }
         selection.each(function tagClassesEach(entity) {
             var value: any = this.className;
 
@@ -31,15 +58,37 @@ export function svgTagClasses<T>() {
                 value = value.baseVal;
             }
 
-            var t = _tags(entity);
+            var key = osmIdManager.key(entity) + '|' + value + '|' + _id
+                + (_keyExt ? '|' + _keyExt(entity) : '');
 
-            var computed = tagClasses.getClassesString(t, value);
+            var computed = _classMemo.get(key);
+            if (computed === undefined) {
+                computed = tagClasses.getClassesString(_tags(entity), value);
+                _classMemo.set(key, computed);
+            }
 
             if (computed !== value) {
                 d3_select(this).attr('class', computed);
             }
         });
     };
+
+
+    function graph(): coreGraph | undefined;
+    function graph(val: coreGraph | undefined): typeof tagClasses;
+    function graph(val?: coreGraph | undefined): typeof tagClasses | coreGraph | undefined {
+        if (!arguments.length) return _graph;
+        _graph = val;
+        return tagClasses;
+    };
+    tagClasses.graph = graph;
+
+
+    function keyExt(fn: ((entity: T) => string) | undefined): typeof tagClasses {
+        _keyExt = fn;
+        return tagClasses;
+    };
+    tagClasses.keyExt = keyExt;
 
 
     tagClasses.getClassesString = function(t: Tags, value: string) {

--- a/modules/svg/vertices.js
+++ b/modules/svg/vertices.js
@@ -4,10 +4,14 @@ import { select as d3_select } from 'd3-selection';
 import { presetManager } from '../presets';
 import { geoScaleToZoom } from '../geo';
 import { osmIdManager } from '../osm';
-import { svgPassiveVertex, svgPointTransform } from './helpers';
+import { svgAttrIfChanged, svgPassiveVertex, svgPointTransform } from './helpers';
 import { svgTagClasses } from './tag_classes';
 
 export function svgVertices(projection, context) {
+    // Hoisted per renderer so the class memo's `_id` is stable across
+    // redraws and the memo can actually hit on pan/zoom.
+    var tagClasses = svgTagClasses();
+
     var radiuses = {
         //       z16-, z17,   z18+,  w/icon
         shadow: [6,    7.5,   7.5,   12],
@@ -90,8 +94,8 @@ export function svgVertices(projection, context) {
                         }
 
                         d3_select(this)
-                            .attr('r', r)
-                            .attr('visibility', (i && klass === 'fill') ? 'hidden' : null);
+                            .call(svgAttrIfChanged, 'r', function() { return String(r); })
+                            .call(svgAttrIfChanged, 'visibility', function() { return (i && klass === 'fill') ? 'hidden' : null; });
                     });
             });
         }
@@ -128,7 +132,7 @@ export function svgVertices(projection, context) {
         // update
         groups = groups
             .merge(enter)
-            .attr('transform', svgPointTransform(projection))
+            .call(svgAttrIfChanged, 'transform', svgPointTransform(projection))
             .classed('sibling', function(d) { return d.id in sets.selected; })
             .classed('shared', function(d) { return graph.isShared(d); })
             .classed('endpoint', function(d) { return d.isEndpoint(graph); })
@@ -141,7 +145,7 @@ export function svgVertices(projection, context) {
             .classed('retagged', function(d) {
                 return base.entities[d.id] && !deepEqual(graph.entities[d.id].tags, base.entities[d.id].tags);
             })
-            .call(svgTagClasses())
+            .call(tagClasses.graph(graph))
             .call(updateAttributes);
 
         // Vertices with icons get a `use`.
@@ -195,7 +199,7 @@ export function svgVertices(projection, context) {
             .attr('d', 'M0,0H0')
             .merge(viewfields)
             .attr('marker-start', d => 'url(#ideditor-viewfield-marker' + (d.type === 'side' ? '-side' : '') + (wireframe ? '-wireframe' : '') + ')')
-            .attr('transform', d => `rotate(${d.angle})`);
+            .call(svgAttrIfChanged, 'transform', d => `rotate(${d.angle})`);
     }
 
 
@@ -255,7 +259,7 @@ export function svgVertices(projection, context) {
                 return 'node vertex target target-allowed '
                 + targetClass + d.id;
             })
-            .attr('transform', getTransform);
+            .call(svgAttrIfChanged, 'transform', getTransform);
 
 
         // NOPE
@@ -273,7 +277,7 @@ export function svgVertices(projection, context) {
             .attr('r', function(d) { return (_radii[d.properties.entity.id] || radiuses.shadow[3]); })
             .merge(nopes)
             .attr('class', function(d) { return 'node vertex target target-nope ' + nopeClass + d.id; })
-            .attr('transform', getTransform);
+            .call(svgAttrIfChanged, 'transform', getTransform);
     }
 
 

--- a/test/spec/svg/helpers.js
+++ b/test/spec/svg/helpers.js
@@ -1,0 +1,163 @@
+import { select as d3_select } from 'd3-selection';
+import { geoProjection as d3_geoProjection } from 'd3-geo';
+
+describe('iD.svgPath', function () {
+    function projection(zoom) {
+        return d3_geoProjection(function(x, y) { return [x, -y]; })
+            .translate([0, 0])
+            .scale(iD.geoZoomToScale(zoom))
+            .clipExtent([[0, 0], [Infinity, Infinity]]);
+    }
+
+    function wayGraph() {
+        var a = new iD.osmNode({id: 'n1', loc: [0, 0]});
+        var b = new iD.osmNode({id: 'n2', loc: [1, 1]});
+        var line = new iD.osmWay({id: 'w1', nodes: ['n1', 'n2']});
+        return new iD.coreGraph([a, b, line]);
+    }
+
+    it('hits the graph-transient cache across redraws at the same projection', function() {
+        var graph = wayGraph();
+        var line = graph.entity('w1');
+
+        var first = iD.svgPath(projection(17), graph);
+        var second = iD.svgPath(projection(17), graph);
+
+        var value1 = first(line);
+        var cached = graph.transients.w1.svgPath;
+        expect(cached).toBeDefined();
+
+        // the second redraw reads the stored entry - it is not recomputed or replaced
+        var value2 = second(line);
+        expect(graph.transients.w1.svgPath).toBe(cached);
+        expect(value2).toEqual(value1);
+    });
+
+    it('replaces (does not accumulate) the cached path when the projection changes', function() {
+        var graph = wayGraph();
+        var line = graph.entity('w1');
+
+        var atZ17 = iD.svgPath(projection(17), graph);
+        var atZ18 = iD.svgPath(projection(18), graph);
+
+        var value17 = atZ17(line);
+        var entry17 = graph.transients.w1.svgPath;
+        expect(entry17).toBeDefined();
+
+        var value18 = atZ18(line);
+        var entry18 = graph.transients.w1.svgPath;
+        expect(entry18).not.toBe(entry17);               // replaced, not reused
+        expect(entry18.key).not.toEqual(entry17.key);    // tagged with the new projection
+        // a single svgPath slot (the entity also has a 'GeoJSON' transient from asGeoJSON)
+        expect(Object.keys(graph.transients.w1).filter(k => k.indexOf('svgPath') === 0)).toEqual(['svgPath']);
+        expect(value18).not.toEqual(value17);            // different projection, different path
+
+        // zooming back recomputes rather than returning the stale z18 value
+        var value17again = atZ17(line);
+        expect(graph.transients.w1.svgPath).not.toBe(entry18);
+        expect(value17again).toEqual(value17);
+    });
+
+    it('recomputes when a new graph object is used', function() {
+        var graphA = wayGraph();
+        var lineA = graphA.entity('w1');
+        var valueA = iD.svgPath(projection(17), graphA)(lineA);
+        var entryA = graphA.transients.w1.svgPath;
+
+        var graphB = wayGraph();
+        var lineB = graphB.entity('w1');
+        var valueB = iD.svgPath(projection(17), graphB)(lineB);
+
+        expect(graphB.transients.w1.svgPath).toBeDefined();
+        expect(graphB.transients.w1.svgPath).not.toBe(entryA);
+        expect(valueB).toEqual(valueA);
+    });
+
+    it('invalidates cached paths when a rebase affects the entity (tile merge)', function() {
+        var graph = wayGraph();
+        var line = graph.entity('w1');
+        var path = iD.svgPath(projection(17), graph);
+        path(line);
+        expect(graph.transients.w1.svgPath).toBeDefined();
+
+        // tile-merge rebases mutate the graph in place; a merge touching one of
+        // w1's nodes (a new way sharing n1) must invalidate the cached path
+        var unrelated = new iD.osmNode({id: 'n9', loc: [2, 2]});
+        var newWay = new iD.osmWay({id: 'w9', nodes: ['n1', 'n9']});
+        graph.rebase([unrelated, newWay], [graph]);
+        expect(graph.transients.w1).toBeUndefined();
+
+        // the next redraw recomputes the path
+        var next = path(line);
+        expect(graph.transients.w1.svgPath).toBeDefined();
+        expect(next).toEqual(graph.transients.w1.svgPath.value);
+    });
+});
+
+describe('iD.svgAttrIfChanged', function () {
+    var selection;
+
+    beforeEach(function () {
+        selection = d3_select(document.createElement('div'));
+    });
+
+    it('writes the attribute on a fresh element', function() {
+        selection
+            .datum({d: 'M0,0L1,1'})
+            .call(iD.svgAttrIfChanged, 'd', function(d) { return d.d; });
+        expect(selection.attr('d')).toEqual('M0,0L1,1');
+    });
+
+    it('skips writing when the attribute value is unchanged', function() {
+        selection
+            .attr('d', 'M0,0L1,1')
+            .datum({d: 'M0,0L1,1'});
+
+        var writes = 0;
+        var el = selection.node();
+        var orig = el.setAttribute;
+        el.setAttribute = function(name, value) {
+            writes++;
+            orig.call(this, name, value);
+        };
+
+        selection.call(iD.svgAttrIfChanged, 'd', function(d) { return d.d; });
+
+        expect(writes).toEqual(0);
+        expect(selection.attr('d')).toEqual('M0,0L1,1');
+    });
+
+    it('writes on a re-entered fresh element while skipping elements already up to date', function() {
+        var container = document.createElement('div');
+        var elA = document.createElement('div');   // already has the correct value
+        var elB = document.createElement('div');   // freshly entered - no attribute yet
+        elA.setAttribute('d', 'M0,0L1,1');
+        container.appendChild(elA);
+        container.appendChild(elB);
+
+        var writes = 0;
+        [elA, elB].forEach(function(el) {
+            var orig = el.setAttribute;
+            el.setAttribute = function(name, value) {
+                writes++;
+                orig.call(this, name, value);
+            };
+        });
+
+        var nodes = d3_select(container).selectAll('div')
+            .data([{d: 'M0,0L1,1'}, {d: 'M0,0L1,1'}]);
+        nodes.call(iD.svgAttrIfChanged, 'd', function(d) { return d.d; });
+
+        expect(writes).toEqual(1);
+        expect(elA.getAttribute('d')).toEqual('M0,0L1,1');
+        expect(elB.getAttribute('d')).toEqual('M0,0L1,1');
+    });
+
+    it('removes the attribute when the value becomes null', function() {
+        selection
+            .attr('d', 'M0,0L1,1')
+            .datum({d: null})
+            .call(iD.svgAttrIfChanged, 'd', function(d) { return d.d; });
+        expect(selection.attr('d')).toBeNull();
+    });
+});

--- a/test/spec/svg/lines.js
+++ b/test/spec/svg/lines.js
@@ -1,4 +1,4 @@
-import { select as d3_select } from 'd3-selection';
+import { select as d3_select, selection as d3_selection } from 'd3-selection';
 import { geoProjection as d3_geoProjection } from 'd3-geo';
 
 describe('iD.svgLines', function () {
@@ -17,6 +17,40 @@ describe('iD.svgLines', function () {
             .attr('class', 'main-map')
             .call(context.map().centerZoom([0, 0], 17));
         surface = context.surface();
+    });
+
+
+    it('skips the line sort on an unchanged redraw', function () {
+        var a = new iD.osmNode({loc: [0, 0]});
+        var b = new iD.osmNode({loc: [1, 1]});
+        var line = new iD.osmWay({nodes: [a.id, b.id]});
+        var graph = new iD.coreGraph([a, b, line]);
+        var renderer = iD.svgLines(projection, context);
+
+        var originalSort = d3_selection.prototype.sort;
+        var sortCalls = 0;
+        d3_selection.prototype.sort = function() {
+            sortCalls++;
+            return originalSort.apply(this, arguments);
+        };
+        try {
+            surface.call(renderer, graph, [line], all);
+            var callsAfterFirst = sortCalls;
+            expect(callsAfterFirst).toBeGreaterThan(0);
+
+            // unchanged data and selection: the sort is skipped
+            surface.call(renderer, graph, [line], all);
+            expect(sortCalls).toBe(callsAfterFirst);
+
+            // changed data: the sort runs again
+            var c = new iD.osmNode({loc: [2, 2]});
+            var line2 = new iD.osmWay({nodes: [a.id, c.id]});
+            var graph2 = new iD.coreGraph([a, b, c, line, line2]);
+            surface.call(renderer, graph2, [line, line2], all);
+            expect(sortCalls).toBeGreaterThan(callsAfterFirst);
+        } finally {
+            d3_selection.prototype.sort = originalSort;
+        }
     });
 
 

--- a/test/spec/svg/tag_classes.js
+++ b/test/spec/svg/tag_classes.js
@@ -307,4 +307,106 @@ describe('iD.svgTagClasses', function () {
             .call(iD.svgTagClasses());
         expect(selection.attr('class')).to.equal('tag-piste_type tag-piste_type-nordic');
     });
+
+    describe('memoization', function() {
+        function spyOnClassesString(tagClasses) {
+            var calls = 0;
+            var original = tagClasses.getClassesString;
+            tagClasses.getClassesString = function(t, value) {
+                calls++;
+                return original.call(this, t, value);
+            };
+            return function() { return calls; };
+        }
+
+        it('hits the memo across redraws when using the same instance', function() {
+            var tagClasses = iD.svgTagClasses();
+            var calls = spyOnClassesString(tagClasses);
+            var graph = {};
+
+            var way = new iD.osmWay({ id: 'w1', v: 1 });
+            selection
+                .attr('class', 'way line w1')
+                .datum(way);
+
+            selection.call(tagClasses.graph(graph));   // first redraw: compute
+            selection.call(tagClasses.graph(graph));   // second redraw: memo hit
+
+            expect(selection.attr('class')).toEqual('way line w1');
+            expect(calls()).toEqual(1);
+        });
+
+        it('does not hit the memo across redraws when using a fresh instance', function() {
+            var graph = {};
+            var way = new iD.osmWay({ id: 'w1', v: 1 });
+            selection
+                .attr('class', 'way line w1')
+                .datum(way);
+
+            var first = iD.svgTagClasses();
+            var calls = spyOnClassesString(first);
+            selection.call(first.graph(graph));
+            expect(calls()).toEqual(1);
+
+            var second = iD.svgTagClasses();
+            calls = spyOnClassesString(second);
+            selection.call(second.graph(graph));
+            expect(calls()).toEqual(1);
+        });
+
+        it('invalidates the memo when the graph changes', function() {
+            var tagClasses = iD.svgTagClasses();
+            var calls = spyOnClassesString(tagClasses);
+            var graphA = {};
+            var graphB = {};
+
+            var way = new iD.osmWay({ id: 'w2', v: 1 });
+            selection
+                .attr('class', 'way line w2')
+                .datum(way);
+
+            selection.call(tagClasses.graph(graphA));   // graph A: compute
+            selection.call(tagClasses.graph(graphA));   // graph A: memo hit
+            expect(calls()).toEqual(1);
+
+            selection.call(tagClasses.graph(graphB));   // graph B: recompute
+            expect(calls()).toEqual(2);
+        });
+
+        it('does not reuse midpoint classes computed for a different parent way', function() {
+            var graph = {};
+            var wayA = new iD.osmWay({ id: 'w100', v: 1, tags: { highway: 'residential' } });
+            var wayB = new iD.osmWay({ id: 'w101', v: 1, tags: { highway: 'track' } });
+
+            // midpoints are plain objects with a version-less id
+            function midpoint(parent) {
+                return {
+                    type: 'midpoint',
+                    id: 'n1000-n2000',
+                    loc: [0, 0],
+                    edge: ['n1000', 'n2000'],
+                    parents: [parent]
+                };
+            }
+
+            var tagClasses = iD.svgTagClasses();
+            var s1 = d3_select(document.createElement('div'))
+                .attr('class', 'midpoint')
+                .datum(midpoint(wayA));
+            var s2 = d3_select(document.createElement('div'))
+                .attr('class', 'midpoint')
+                .datum(midpoint(wayB));
+
+            s1.call(tagClasses.tags(function(d) { return d.parents[0].tags; })
+                .keyExt(function(d) { return iD.osmIdManager.key(d.parents[0]); })
+                .graph(graph));
+            s2.call(tagClasses.tags(function(d) { return d.parents[0].tags; })
+                .keyExt(function(d) { return iD.osmIdManager.key(d.parents[0]); })
+                .graph(graph));
+
+            expect(s1.classed('tag-highway-residential')).toBe(true);
+            expect(s2.classed('tag-highway-track')).toBe(true);
+            expect(s2.classed('tag-highway-residential')).toBe(false);
+        });
+    });
 });


### PR DESCRIPTION

## Problem

Every redraw recomputes the path of every way, area and point, and re-runs the tag-based style classes on top, even when nothing changed. A browser trace showed getClassesString at 16.8 percent of samples and setAttribute at 6.6 percent, both re-run on the full update selection every redraw. In a real editing session the per-redraw line sort showed a 2.4 second task in Node.compareDocumentPosition at the end of a zoom gesture.

## Solution

The path strings and style classes are now cached and only recomputed for features whose data actually changed, and elements whose appearance is unchanged are no longer rewritten into the document. Line layers are also no longer re-sorted into the document when nothing changed. The sort only runs when the selection or the drawn ways change.

## Performance impact

Measurements are averages against develop, data tiles served from a local mock API for determinism. Benchmark 1 is the average of 5 runs, benchmark 2 the average of 2.

**Benchmark 1: fully-loaded editor, 12 second zoom/pan workload.** After startup the editor is wheel-zoomed from zoom 16.4 to 18, panned four times and zoomed out again, at real speed:

| Metric | develop | with patch | change |
|---|---|---|---|
| Main-thread busy | 2055 ms | 1512 ms | -543 ms (-26%) |
| Per-input JS, p90 | 11.9 ms | 5.8 ms | -6.1 ms (-51%) |
| UpdateLayoutTree total | 443 ms | 324 ms | -119 ms (-27%) |
| Layout total | 104 ms | 102 ms | -2 ms (-2%) |
| Long task time | 1639 ms | 1079 ms | -560 ms (-34%) |

**Benchmark 2: pan stress.** 12 fast pans of 150 px at zoom 18, so the path-string cache is hit on every pan re-run of the update selection:

| Metric | develop | with patch | change |
|---|---|---|---|
| Main-thread busy | 4898 ms | 3293 ms | -1605 ms (-33%) |
| Per-input JS, p90 | 17.0 ms | 8.3 ms | -8.7 ms (-51%) |
| UpdateLayoutTree total | 987 ms | 584 ms | -404 ms (-41%) |
| Long task time | 3077 ms | 1957 ms | -1120 ms (-36%) |

These workloads change the drawn data on nearly every redraw, so the numbers are dominated by the path and class caching. The sort-skip helps the redraws where the data is unchanged, which the workloads only reach at their settle points. Its effect is the removal of the per-redraw DOM reorder in settled states.

## Related issues

#11832 reports zoom and pan lag with a trace showing the tag class and path-string work this change caches. #4731 reports lag when editing long ways, where the per-segment path work is largest. #7710 asks for fewer full redraws on mode changes, and the skip-unchanged attribute writes here remove part of the per-redraw cost. The change also contributes to the broad map performance issue tracked in #8091.

## Tests

Full suite, 2295 passed, 0 failed (develop: 2282), including 13 regression tests for the style-class cache (stable instance hits, fresh instance misses, graph-change invalidation, midpoint parent-way keying) and the path cache (projection replacement, merge invalidation, write-skip, re-enter), and a regression spec that counts sort calls across unchanged and changed redraws, verifying the line sort is skipped when the data and selection are unchanged.

## AI-assisted patch

The performance problem this patch addresses was identified, and the fix implemented, by an AI coding agent. The change has been validated through multiple iterations of code review, including an adversarial review round and a final pre-merge review, with every reported issue fixed and covered by a regression test. The patch series has also been exercised in a real browser by a human user, including zoom, pan and tile-loading workflows.
