### PR TITLE
Measure label text offscreen instead of on the visible map

### DIFF
--- a/modules/core/context.ts
+++ b/modules/core/context.ts
@@ -140,6 +140,7 @@ export interface coreContext extends Pick<Dispatch<object, EventMap>, 'on'> {
     surface(): d3.Selection;
     editableDataEnabled(): boolean;
     surfaceRect(): DOMRect;
+    invalidateSurfaceRect(): coreContext;
     editable(): boolean;
 
 
@@ -548,7 +549,46 @@ export function coreContext(this: object): coreContext {
   context.layers = () => _map.layers();
   context.surface = () => _map.surface;
   context.editableDataEnabled = () => _map.editableDataEnabled();
-  context.surfaceRect = () => _map.surface.node().getBoundingClientRect();
+  // Cache the surface rect for the current animation frame. getBoundingClientRect()
+  // on the surface (which contains the whole map DOM) forces layout, so it should
+  // not be called once per consumer per frame. The rect is cached per frame and
+  // self-corrects on the next frame: any change — including CSS-transform
+  // gestures, which move the rect mid-frame — is bounded to one frame, after
+  // which the cache is dropped and the next read measures fresh.
+  let _surfaceRect: DOMRect | undefined;
+  let _surfaceRectFrame = 0;
+  context.surfaceRect = () => {
+    // Without requestAnimationFrame there is no frame boundary to bound the
+    // cache to, so measure directly instead of caching.
+    if (typeof window.requestAnimationFrame !== 'function') {
+      return _map.surface.node().getBoundingClientRect();
+    }
+    if (_surfaceRectFrame === 0) {
+      _surfaceRect = _map.surface.node().getBoundingClientRect();
+      const frame = window.requestAnimationFrame(() => {
+        // Only reset if this is still the current frame, so that a stale
+        // callback from before an invalidateSurfaceRect() can't re-enable
+        // measurement early (which would cost an extra forced-layout read).
+        if (_surfaceRectFrame === frame) {
+          _surfaceRectFrame = 0;
+        }
+      });
+      _surfaceRectFrame = frame;
+    }
+    return _surfaceRect!;
+  };
+  // Drop the cached rect synchronously when the surface size changes.
+  // The resize/sidebar-toggle chain runs entirely inside the event task
+  // (window resize -> ui.onResize -> map.dimensions -> throttled redraw ->
+  // 'drawn' -> edit_menu repositioning), so a reset that waits for the
+  // next animation frame would leave those consumers reading the
+  // pre-resize rect. The rAF reset above still bounds repeated reads
+  // within a single animation frame after the next measurement.
+  context.invalidateSurfaceRect = () => {
+    _surfaceRect = undefined;
+    _surfaceRectFrame = 0;
+    return context;
+  };
   context.editable = () => {
     // don't allow editing during save
     const mode = context.mode();

--- a/modules/renderer/map.js
+++ b/modules/renderer/map.js
@@ -807,11 +807,23 @@ export function rendererMap(context) {
     map.dimensions = function(val) {
         if (!arguments.length) return _dimensions;
 
-        _dimensions = val;
-        drawLayers.dimensions(_dimensions);
-        context.background().dimensions(_dimensions);
-        projection.clipExtent([[0, 0], _dimensions]);
-        _getMouseCoords = utilFastMouse(supersurface.node());
+        // Early-out on no-op resizes: ui.onResize fires on every window
+        // resize event even when the map size is unchanged, and skipping the
+        // update (including invalidateSurfaceRect) keeps the cached surface
+        // rect alive across those.
+        if (val[0] !== _dimensions[0] || val[1] !== _dimensions[1]) {
+            _dimensions = val;
+            drawLayers.dimensions(_dimensions);
+            context.background().dimensions(_dimensions);
+            projection.clipExtent([[0, 0], _dimensions]);
+            _getMouseCoords = utilFastMouse(supersurface.node());
+
+            // The surface size changed synchronously inside this event task,
+            // so drop the cached surface rect now: consumers that read it
+            // before the next animation frame (e.g. the edit menu repositioning
+            // on 'drawn') must see the new geometry, not the pre-resize rect.
+            context.invalidateSurfaceRect();
+        }
 
         scheduleRedraw();
         return map;

--- a/modules/svg/labels.js
+++ b/modules/svg/labels.js
@@ -326,6 +326,11 @@ export function svgLabels(projection, context) {
             area: []
         };
 
+        // The label layer node is the same for every label, so look it up once.
+        // It is created once in svgOsm and never replaced, so it stays valid
+        // for the whole pass.
+        var labelLayerNode = selection.select('g.layer-osm.labels').node();
+
         // Try and find a valid label for labellable entities
         for (k = 0; k < labelable.length; k++) {
             var fontSize = labelStack[k][3];
@@ -337,7 +342,7 @@ export function svgLabels(projection, context) {
                 let name = geometry === 'line'
                     ? utilDisplayNameForPath(entity)
                     : utilDisplayName(entity, { isMapLabel: true });
-                var width = name && textWidth(name, fontSize, selection.select('g.layer-osm.labels').node());
+                var width = name && textWidth(name, fontSize, labelLayerNode);
                 var p = null;
 
                 if (geometry === 'point' || geometry === 'vertex') {
@@ -349,7 +354,7 @@ export function svgLabels(projection, context) {
                     let charsRemaining = utilUnicodeCharsCount(name) - 1;
                     while (renderAs.isAddr && width > 36) {
                         name = `${utilUnicodeCharsTruncated(name.replace(/…$/, ''), charsRemaining--)}…`;
-                        width = textWidth(name, fontSize, selection.select('g.layer-osm.labels').node());
+                        width = textWidth(name, fontSize, labelLayerNode);
                     }
 
                     p = getPointLabel(entity, width, fontSize, renderAs);
@@ -793,7 +798,41 @@ export function svgLabels(projection, context) {
 }
 
 
+// NOTE: `_textWidthCache` is shared by all three measurement paths — first-pass
+// widths measured on the offscreen canvas, widths that fell back to the
+// detached SVG element, and any that fell back to measuring attached. The
+// populations are identical today only because labels carry no font-family of
+// their own (every path measures with the body font stack, which is what
+// labels inherit). If a CSS font-family rule is ever added to
+// .arealabel/.linelabel/.pointlabel, the paths would silently produce
+// different widths for the same (size, text) key — key the cache by font then.
 const _textWidthCache = {};
+// Offscreen canvas for label text measurement — canvas 2D `measureText` is
+// substantially faster than SVG `getComputedTextLength` (the latter was ~14%
+// of JS busy time in the settled-editor zoom trace), and it never touches the
+// DOM or forces layout. Reused for every measurement; never attached.
+const _measureCtx = document.createElement('canvas').getContext('2d');
+// Detached SVG text element — kept only as the fallback measurement path
+// (e.g. when the canvas 2D context is unavailable or measures 0 width).
+const _measureTextElem = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+// Capture the label font lazily on the first textWidth() call, from the root
+// stack. Labels carry no font-family of their own, so they inherit the one on
+// <body>; measuring with it on the canvas/detached element below avoids
+// forcing a synchronous style/layout flush of the whole map on every cache
+// miss — including the very first label pass, when no real label exists in
+// the container yet to copy from. Capturing at module load would be fragile:
+// the bundle loads async and can execute before the stylesheets finish, so
+// the captured family could freeze in the UA default — and any future CSS
+// font-family on a label ancestor would never be seen. By the first
+// measurement the document is interactive and CSS is applied.
+let _labelFontFamily;
+function labelFontFamily() {
+    if (_labelFontFamily === undefined) {
+        _labelFontFamily = getComputedStyle(document.body).fontFamily;
+    }
+    return _labelFontFamily;
+}
+
 export function textWidth(text, size, container) {
     _textWidthCache[size] ||= {};
     let c = _textWidthCache[size];
@@ -801,14 +840,41 @@ export function textWidth(text, size, container) {
     if (c[text]) {
         return c[text];
     }
-    const elem = document.createElementNS('http://www.w3.org/2000/svg', 'text');
-    elem.style.fontSize = `${size}px`;
-    elem.style.fontWeight = 'bold';
-    elem.textContent = text;
-    container.appendChild(elem);
-    c[text] = elem.getComputedTextLength();
-    elem.remove();
-    return c[text];
+
+    const fontFamily = labelFontFamily();
+
+    let width;
+    if (_measureCtx && fontFamily) {
+        _measureCtx.font = `bold ${size}px ${fontFamily}`;
+        width = _measureCtx.measureText(text).width;
+    }
+
+    // Fall back to the detached SVG element if the canvas context was
+    // unavailable, or if the canvas measurement came back empty.
+    if (width === undefined || (width === 0 && text.length > 0)) {
+        if (fontFamily) {
+            _measureTextElem.style.fontSize = `${size}px`;
+            _measureTextElem.style.fontWeight = 'bold';
+            _measureTextElem.style.fontFamily = fontFamily;
+            _measureTextElem.textContent = text;
+            width = _measureTextElem.getComputedTextLength();
+        }
+
+        // Fall back to measuring attached if the computed body font was empty,
+        // or if the detached measurement came back empty.
+        if (width === undefined || (width === 0 && text.length > 0)) {
+            const elem = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+            elem.style.fontSize = `${size}px`;
+            elem.style.fontWeight = 'bold';
+            elem.textContent = text;
+            container.appendChild(elem);
+            width = elem.getComputedTextLength();
+            elem.remove();
+        }
+    }
+
+    c[text] = width;
+    return width;
 }
 
 

--- a/test/spec/core/surface_rect.js
+++ b/test/spec/core/surface_rect.js
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { select as d3_select } from 'd3-selection';
+
+
+// jsdom has no requestAnimationFrame; install a controllable stub so the
+// same-frame cache bound in context.surfaceRect() can be exercised.
+let _rAFQueue = [];
+const _origRAF = window.requestAnimationFrame;
+
+function runNextRAF() {
+    const cb = _rAFQueue.shift();
+    if (cb) cb(performance.now());
+}
+
+function rect(width, height) {
+    return {
+        x: 0, y: 0, top: 0, left: 0,
+        width, height,
+        right: width, bottom: height,
+        toJSON() { return {}; }
+    };
+}
+
+
+describe('iD.coreContext surfaceRect cache', function() {
+    var content, context, map, surfaceNode, measureCount;
+
+    beforeEach(function() {
+        _rAFQueue = [];
+        window.requestAnimationFrame = function(cb) {
+            _rAFQueue.push(cb);
+            return _rAFQueue.length;
+        };
+
+        content = d3_select('body').append('div');
+        context = iD.coreContext().assetPath('../dist/').init().container(content);
+        map = context.map();
+        content.call(map);
+        map.dimensions([1000, 1000]);
+
+        surfaceNode = context.surface().node();
+        measureCount = 0;
+        surfaceNode.getBoundingClientRect = function() {
+            measureCount++;
+            return rect(1000, 1000);
+        };
+    });
+
+    afterEach(function() {
+        content.remove();
+        window.requestAnimationFrame = _origRAF;
+    });
+
+    it('caches the rect for the current animation frame', function() {
+        var r1 = context.surfaceRect();
+        var r2 = context.surfaceRect();
+        expect(r1).toBe(r2);            // same cached object
+        expect(measureCount).toBe(1);   // measured only once
+    });
+
+    it('returns the new rect to a reader in the same frame as a resize', function() {
+        var before = context.surfaceRect();
+        expect(before.width).toBe(1000);
+        expect(measureCount).toBe(1);
+
+        // Simulate the synchronous resize chain: window resize / sidebar
+        // toggle -> ui.onResize -> map.dimensions -> scheduleRedraw, with
+        // the surfaceRect read (e.g. edit menu on 'drawn') landing before
+        // any animation frame has run.
+        surfaceNode.getBoundingClientRect = function() {
+            measureCount++;
+            return rect(700, 500);
+        };
+        map.dimensions([700, 500]);
+
+        var after = context.surfaceRect();
+        expect(after.width).toBe(700);
+        expect(after.height).toBe(500);
+
+        // Repeated reads in the same frame still reuse the cache.
+        expect(context.surfaceRect()).toBe(after);
+        expect(measureCount).toBe(2);
+    });
+
+    it('resets the same-frame bound on the next animation frame', function() {
+        context.surfaceRect();
+        expect(measureCount).toBe(1);
+        expect(_rAFQueue.length).toBe(1);
+
+        // The frame boundary passes without a resize: cache is dropped.
+        runNextRAF();
+        surfaceNode.getBoundingClientRect = function() {
+            measureCount++;
+            return rect(900, 900);
+        };
+        var r2 = context.surfaceRect();
+        expect(r2.width).toBe(900);
+        expect(measureCount).toBe(2);
+    });
+
+    it('does not let a stale rAF callback re-enable measurement early', function() {
+        context.surfaceRect();                       // measure (1), schedules R1
+        expect(measureCount).toBe(1);
+
+        surfaceNode.getBoundingClientRect = function() {
+            measureCount++;
+            return rect(600, 400);
+        };
+        map.dimensions([600, 400]);                  // invalidates the cache
+        context.surfaceRect();                       // re-measures (2), schedules R2
+        expect(measureCount).toBe(2);
+
+        // R1 (scheduled before the resize) fires first: with the stale-frame
+        // guard it must not drop the cache, so a read still reuses rect 2.
+        runNextRAF();
+        var cached = context.surfaceRect();
+        expect(cached.width).toBe(600);
+        expect(measureCount).toBe(2);
+
+        // R2 (the current frame) fires: bound resets for the next frame.
+        runNextRAF();
+        context.surfaceRect();
+        expect(measureCount).toBe(3);
+    });
+});

--- a/test/spec/svg/labels.js
+++ b/test/spec/svg/labels.js
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+
+// ============================================================================
+// Unit tests for the three-tier label text measurement chain in
+// modules/svg/labels.js (`textWidth`):
+//
+//   1. offscreen canvas 2D context (`measureText`)
+//   2. detached SVG <text> element (`getComputedTextLength`)
+//   3. SVG <text> attached to the caller's container (`getComputedTextLength`)
+//
+// jsdom quirks that shape this spec:
+//  * jsdom has no canvas implementation — `canvas.getContext('2d')` returns
+//    null (the optional `canvas` npm package is not installed). We stub
+//    `HTMLCanvasElement.prototype.getContext` with a scriptable fake 2D
+//    context whose `measureText` returns widths we control.
+//  * jsdom does not implement `SVGTextElement.getComputedTextLength` (it is
+//    undefined), so both SVG tiers would throw on it. We stub the prototype
+//    method and serve scriptable widths.
+//  * jsdom's `getComputedStyle(document.body).fontFamily` returns the literal
+//    string 'depends on user agent' (non-empty, but no real font), so the
+//    body-font gate in textWidth is satisfied by default; the stub is switched
+//    to '' to exercise the "no body font" fallback tier.
+//  * labels.js captures its body font lazily on the first textWidth() call and
+//    keeps a module-scope width cache, so each test imports a fresh module
+//    instance with the stubs installed first — otherwise the first test would
+//    freeze in one font/cache for the rest. `vi.resetModules()` is not usable
+//    here: re-evaluating the whole labels.js dependency graph from a different
+//    entry point trips an ESM class-inheritance cycle in modules/osm, so
+//    instead each test imports a unique query-suffixed URL
+//    (labels.js?fresh=N), which vite keys as a separate module whose
+//    dependencies are the already-evaluated originals.
+// ============================================================================
+
+var textWidth;
+var _freshId = 0;         // per-test import counter (see note above)
+var fakeCtx;              // scriptable fake 2D canvas context
+var measureTextCalls;     // count of measureText() calls on the fake context
+var computedLengths;      // queue of widths served by the getComputedTextLength stub
+var computedLengthCalls;  // count of getComputedTextLength() calls
+var lastMeasuredParent;   // parent of the SVG element measured (null = detached)
+var bodyFont;             // fontFamily the getComputedStyle stub reports
+
+// jsdom does not expose a global `SVGTextElement` constructor (its SVG <text>
+// elements are plain SVGElement instances), so reach the prototype through a
+// created element instead.
+var _svgTextProto = Object.getPrototypeOf(document.createElementNS('http://www.w3.org/2000/svg', 'text'));
+var _origGetContext = HTMLCanvasElement.prototype.getContext;
+var _origGetComputedStyle = window.getComputedStyle;
+
+beforeEach(async function() {
+    measureTextCalls = 0;
+    computedLengths = [];
+    computedLengthCalls = 0;
+    lastMeasuredParent = undefined;
+    bodyFont = 'test-font';
+
+    fakeCtx = {
+        font: undefined,
+        width: 0,
+        measureText: function() {
+            measureTextCalls++;
+            return { width: fakeCtx.width };
+        }
+    };
+    HTMLCanvasElement.prototype.getContext = function() { return fakeCtx; };
+    _svgTextProto.getComputedTextLength = function() {
+        computedLengthCalls++;
+        lastMeasuredParent = this.parentNode;
+        return computedLengths.shift() || 0;
+    };
+    window.getComputedStyle = function() { return { fontFamily: bodyFont }; };
+
+    // Fresh module instance: empty width cache, no captured body font, and
+    // the canvas context captured from the stubbed getContext above.
+    ({ textWidth } = await import('../../../modules/svg/labels.js?fresh=' + _freshId++));
+});
+
+afterEach(function() {
+    HTMLCanvasElement.prototype.getContext = _origGetContext;
+    delete _svgTextProto.getComputedTextLength;   // restore: jsdom has no such method
+    window.getComputedStyle = _origGetComputedStyle;
+});
+
+
+describe('iD.svgLabels textWidth measurement tiers', function() {
+    it('measures on the offscreen canvas without falling back', function() {
+        fakeCtx.width = 42;
+        expect(textWidth('hello', 12, document.body)).toBe(42);
+        expect(measureTextCalls).toBe(1);      // canvas tier only
+        expect(computedLengthCalls).toBe(0);   // no SVG fallback
+        expect(fakeCtx.font).toBe('bold 12px test-font');  // lazy body-font capture
+    });
+
+    it('falls back to the detached SVG tier when the canvas measures 0 for non-empty text', function() {
+        fakeCtx.width = 0;
+        computedLengths.push(17);
+        expect(textWidth('world', 12, document.body)).toBe(17);
+        expect(measureTextCalls).toBe(1);      // canvas consulted, came back 0
+        expect(computedLengthCalls).toBe(1);   // detached tier served the width
+        expect(lastMeasuredParent).toBe(null); // detached element is never attached
+    });
+
+    it('keeps width 0 for empty text without falling back', function() {
+        fakeCtx.width = 0;
+        computedLengths.push(99);
+        expect(textWidth('', 12, document.body)).toBe(0);
+        expect(measureTextCalls).toBe(1);
+        expect(computedLengthCalls).toBe(0);   // empty text does not fall back
+    });
+
+    it('falls back to measuring attached when the body font is missing', function() {
+        bodyFont = '';
+        fakeCtx.width = 42;                    // must not be consulted
+        computedLengths.push(23);
+        expect(textWidth('attached', 12, document.body)).toBe(23);
+        expect(measureTextCalls).toBe(0);      // canvas skipped (no body font)
+        expect(computedLengthCalls).toBe(1);   // attached tier served the width
+        expect(lastMeasuredParent).toBe(document.body);  // was attached, then removed
+    });
+
+    it('shares one cached width across measurement tiers', function() {
+        fakeCtx.width = 42;
+        expect(textWidth('mixed', 12, document.body)).toBe(42);  // canvas tier
+        expect(measureTextCalls).toBe(1);
+
+        // The next read of the same (size, text) would land on a different
+        // tier (canvas now 0, detached would report 99), but the shared cache
+        // serves the width measured by the first tier.
+        fakeCtx.width = 0;
+        computedLengths.push(99);
+        expect(textWidth('mixed', 12, document.body)).toBe(42);
+        expect(measureTextCalls).toBe(1);      // cache hit: no re-measure
+        expect(computedLengthCalls).toBe(0);   // no SVG tier consulted
+    });
+});


### PR DESCRIPTION

## Problem

Measuring label text on an element that is part of the visible map forces the browser to recalculate styles and layout for the entire map subtree on every redraw. A browser trace showed getComputedTextLength at 7.3 percent of samples and getBoundingClientRect at 4.8 percent, both called from the redraw path. In a real editing session a single redraw with many address labels spent 2.5 seconds in the per-label search for the label layer element at the end of a zoom gesture.

## Solution

Text is now measured on an offscreen canvas instead. The map's visible area is read once per animation frame instead of once per label, and the label layer element is found once per redraw instead of once per label. The cached visible-area rect is invalidated immediately when the map is resized, so the resize task never reads a stale rect. In environments without a canvas 2D context the measurement falls back to a detached SVG element and then to an attached one, returning the same widths as before in those environments.

## Performance impact

All measurements are average of 2 runs against develop, data tiles served from a local mock API for determinism.

**Benchmark 1: fully-loaded editor, 12 second zoom/pan workload.** After startup the editor is wheel-zoomed from zoom 16.4 to 18, panned four times and zoomed out again, at real speed:

| Metric | develop | with patch | change |
|---|---|---|---|
| Main-thread busy | 2410 ms | 1911 ms | -499 ms (-21%) |
| Text measurement time | 169 ms | 0 ms | -169 ms (-100%) |

Both patched runs (1709 and 2113 ms) stay below both develop runs (2409 and 2412 ms), so the reduction does not depend on a single favorable run.

**Benchmark 2: editor start-up.** Page load through the initial render and first validation pass:

| Metric | develop | with patch | change |
|---|---|---|---|
| Busy time | 4988 ms | 4822 ms | -166 ms (-3%) |
| Layout | 131 ms | 122 ms | -9 ms (-7%) (noise) |
| Long-task time | 1292 ms | 1007 ms | -285 ms (-22%) |

The measurement cost is gone from the profile entirely. The getComputedTextLength samples are zero in both patched runs. The start-up phase improves modestly. The detached measurement removes the forced layout flushes during the initial render, though the layout row is within run noise at this sample size, as the patched runs span 75 to 168 ms.

## Related issues

#11832 reports zoom and pan lag with a trace showing text-width calculation as a major cost while redrawing the map, the measurement this change moves off the main redraw path. The change also contributes to the broad map performance issue tracked in #8091.

## Tests

Full suite, 2291 passed, 0 failed (develop: 2282), including a five-test spec for the measurement tiers (canvas hit, zero-width fallback, empty text, missing font, cache mixing) and the surface rect regression spec. The single label layer lookup is covered by the label and renderer specs.

## AI-assisted patch

The performance problem this patch addresses was identified, and the fix implemented, by an AI coding agent. The change has been validated through multiple iterations of code review, including an adversarial review round and a final pre-merge review, with every reported issue fixed and covered by a regression test. The patch series has also been exercised in a real browser by a human user, including zoom, pan and tile-loading workflows.