### PR TITLE
Update CHANGELOG.md - Update tagging v7 migration guide link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 ##### 2026-Aug-10
 
 #### :newspaper: News
-* Update id-tagging-schema to [version 7](https://github.com/ideditor/schema-builder/blob/main/MIGRATION_GUIDE.md#v7-migration-guide), allowing to add more detailed information to be defined for presets and fields, adding [_pinhead_](https://pinhead.ink/) icon set, and unlocking additional functionality to be implemented for presets in the future ([#12358])
+* Update id-tagging-schema to [version 7](https://github.com/openstreetmap/id-tagging-schema/blob/main/MIGRATION_GUIDE.md#v7-migration-guide), allowing to add more detailed information to be defined for presets and fields, adding [_pinhead_](https://pinhead.ink/) icon set, and unlocking additional functionality to be implemented for presets in the future ([#12358])
 #### :sparkles: Usability & Accessibility
 * Display radio field options in a two-column layout if there is insufficient space for them in a single line ([#12455])
 * Render `highway=track` using different styles depending on the `tracktype` ([#12392], thanks [@RudyTheDev])


### PR DESCRIPTION
Update migration guide link to reflect merged repositories as of [7.1.0](https://github.com/openstreetmap/id-tagging-schema/blob/main/CHANGELOG.md#710)

though [7.0.0](https://github.com/openstreetmap/id-tagging-schema/blob/main/CHANGELOG.md#700) used both links. :/