### PR TITLE
fix `imagery_used` set to None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :camera: Street-Level
 #### :white_check_mark: Validation
 #### :bug: Bugfixes
+* fix `imagery_used` set to None ([#12721], thanks [@k-yle])
 #### :earth_asia: Localization
 #### :hourglass: Performance
 #### :mortar_board: Walkthrough / Help
@@ -50,6 +51,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Drop code previously responsible for _maprules_ integration (which has been defunct for a while now) ([#12679])
 
 [#12679]: https://github.com/openstreetmap/iD/pull/12679
+[#12721]: https://github.com/openstreetmap/iD/pull/12721
 
 # 2.42.0
 ##### 2026-Aug-10

--- a/modules/ui/sections/background_list.js
+++ b/modules/ui/sections/background_list.js
@@ -184,20 +184,16 @@ export function uiSectionBackgroundList(context) {
                         s.prefix === prefix && s.suffix === suffix);
                     if (main) {
                         main.variants.push({ variant, source });
+                        return;
                     } else {
-                        sources.push({
-                            ...source,
-                            prefix,
-                            suffix,
-                            variants: [{ variant, source }]
-                        });
+                        source.prefix = prefix;
+                        source.suffix = suffix;
+                        source.variants = [{ variant, source }];
                     }
                 } else {
-                    sources.push({
-                        ...source,
-                        variants: [{ source }]
-                    });
+                    source.variants = [{ source }];
                 }
+                sources.push(source);
             });
         sources.forEach(source => {
                 source.variants = sortBy(source.variants, [


### PR DESCRIPTION
Closes #12717

fixes a regression from #12561, currently the imagery-source object is being [spread](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax), which creates a new object while rendering.

and that breaks existing code which [relies on reference-equality](https://github.com/openstreetmap/iD/blob/524d01baf65bd136c3d60098831222e2299fc088/modules/renderer/background.js#L110).

typescript would prevent this, since it bans spreading class instances (as discussed in https://github.com/openstreetmap/iD/pull/12641#discussion_r3673806034). but there are a lot of blockers before this file can be converted to TS