### PR TITLE
fix broken mapillary features / traffic signs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :camera: Street-Level
 #### :white_check_mark: Validation
 #### :bug: Bugfixes
-* Fix mapillary broken ([#12722], thanks [@k-yle])
+* Fix Mapillary viewer not loading traffic signs and detected map features ([#12722], thanks [@k-yle])
 #### :earth_asia: Localization
 #### :hourglass: Performance
 #### :mortar_board: Walkthrough / Help

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :camera: Street-Level
 #### :white_check_mark: Validation
 #### :bug: Bugfixes
+* Fix mapillary broken ([#12722], thanks [@k-yle])
 #### :earth_asia: Localization
 #### :hourglass: Performance
 #### :mortar_board: Walkthrough / Help
@@ -50,6 +51,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Drop code previously responsible for _maprules_ integration (which has been defunct for a while now) ([#12679])
 
 [#12679]: https://github.com/openstreetmap/iD/pull/12679
+[#12722]: https://github.com/openstreetmap/iD/pull/12722
 
 # 2.42.0
 ##### 2026-Aug-10

--- a/modules/svg/mapillary_map_features.js
+++ b/modules/svg/mapillary_map_features.js
@@ -61,21 +61,21 @@ export function svgMapillaryMapFeatures(projection, context, dispatch) {
 
         context.map().centerEase(d.loc);
 
-        const selectedImageId = service.getActiveImage() && service.getActiveImage().id;
+        const selectedImage = service.getActiveImage();
 
         service.getDetections(d.id).then(detections => {
             if (detections.length) {
-                const imageId = detections[0].image.id;
-                if (imageId === selectedImageId) {
+                const { image } = detections[0];
+                if (selectedImage && image.id === selectedImage.id) {
                     service
                         .highlightDetection(detections[0])
-                        .selectImage(context, imageId);
+                        .selectImage(image);
                 } else {
                     service.ensureViewerLoaded(context)
                         .then(function() {
                             service
                                 .highlightDetection(detections[0])
-                                .selectImage(context, imageId)
+                                .selectImage(image)
                                 .showViewer(context);
                         });
                 }

--- a/modules/svg/mapillary_signs.js
+++ b/modules/svg/mapillary_signs.js
@@ -61,21 +61,21 @@ export function svgMapillarySigns(projection, context, dispatch) {
 
         context.map().centerEase(d.loc);
 
-        const selectedImageId = service.getActiveImage() && service.getActiveImage().id;
+        const selectedImage = service.getActiveImage();
 
         service.getDetections(d.id).then(detections => {
             if (detections.length) {
-                const imageId = detections[0].image.id;
-                if (imageId === selectedImageId) {
+                const { image } = detections[0];
+                if (selectedImage && image.id === selectedImage.id) {
                     service
                         .highlightDetection(detections[0])
-                        .selectImage(context, imageId);
+                        .selectImage(image);
                 } else {
                     service.ensureViewerLoaded(context)
                         .then(function() {
                             service
                                 .highlightDetection(detections[0])
-                                .selectImage(context, imageId)
+                                .selectImage(image)
                                 .showViewer(context);
                         });
                 }

--- a/test/spec/services/mapillary.js
+++ b/test/spec/services/mapillary.js
@@ -44,7 +44,7 @@ describe('iD.serviceMapillary', function() {
     describe('#reset', function() {
         it('resets cache', function() {
             mapillary.cache().foo = 'bar';
-            mapillary.selectImage(context, { key: 'baz', loc: [10,0] });
+            mapillary.selectImage({ key: 'baz', loc: [10,0] });
 
             mapillary.reset();
             expect(mapillary.cache()).not.toHaveProperty('foo');


### PR DESCRIPTION
Closes #12741

clicking on a traffic sign or "mapillary feature" currently results in a blank image:

<img width="411" height="282" alt="image" src="https://github.com/user-attachments/assets/b5f10a0b-a7f9-4e99-8ba8-4d89fd4c0def" />

seems to be caused by dc9d3cf5754cbf46a79cfc6a49bd7403132c7fb0 which changed the arguments (`context, imageId` -> `image`). typescript would prevent this, I opened a separate PR for that: #12725