### PR TITLE
increase the colour contrast of `--link-color`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 # Unreleased (2.43.0-dev)
 
 #### :sparkles: Usability & Accessibility
+* Increase the colour contrast of the blue text used for links and preset fields ([#12724], thanks [@k-yle])
 * Render diameter and radius tags when a node is selected ([#9732], thanks [@k-yle])
 #### :scissors: Operations
 #### :camera: Street-Level
@@ -52,6 +53,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 
 [#9732]: https://github.com/openstreetmap/iD/pull/9732
 [#12679]: https://github.com/openstreetmap/iD/pull/12679
+[#12724]: https://github.com/openstreetmap/iD/pull/12724
 
 
 # 2.42.1

--- a/css/10_colors.css
+++ b/css/10_colors.css
@@ -12,8 +12,8 @@
     --outset-color: #fcfcfc; /* brighter than --border-color with white */
     --shadow-color: #bbb; /* mix 91.5% of --border-color with black */
     --text-color: #333;
-    --link-color: #7092ff;
-    --link-focus-color: #597be7;
+    --link-color: #516fd9;
+    --link-focus-color: #3f6ae0;
     --muted-text-color: #aaa;
     --transparent-text-color: #2223;
     --transparent-text-emphasis-color: #0007;


### PR DESCRIPTION
as mentioned in https://github.com/openstreetmap/iD/discussions/12714#discussioncomment-17969751, in light mode `--link-color` doesn't meet the [WCAG AA colour constrast guidelines](https://en.wikipedia.org/wiki/Web_Content_Accessibility_Guidelines).

Before:
- Light Mode: `#7092ff` $`{\color{#7092ff} \blacksquare}`$ on $`{\color{#ffffff} \blacksquare}`$ `#ffffff` [fail](https://webaim.org/resources/contrastchecker/?fcolor=7092ff&bcolor=FFFFFF)
- Dark Mode: `#7b92db` $`{\color{#7b92db} \blacksquare}`$ on $`{\color{#212529} \blacksquare}`$ `#212529` [pass](https://webaim.org/resources/contrastchecker/?fcolor=7b92db&bcolor=212529)


After:
- Light Mode: `#516fd9` $`{\color{#516fd9} \blacksquare}`$ on $`{\color{#ffffff} \blacksquare}`$ `#ffffff` [pass](https://webaim.org/resources/contrastchecker/?fcolor=516fd9&bcolor=FFFFFF)
- Dark Mode: _unchanged_


<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td><img width="318" height="352" alt="image" src="https://github.com/user-attachments/assets/a5b61379-b7f1-4a25-9428-5a9925c97981" />
 <td><img width="337" height="344" alt="image" src="https://github.com/user-attachments/assets/417a329e-ca96-45db-8ab6-8db3e9845ece" />


</table>

apart from personal preference, one minor disadvantage is that it no longer matches the light blue text used on parts of the main osm website:

<img width="175" height="47" alt="image" src="https://github.com/user-attachments/assets/ca1410f0-2cfc-4c56-8b5f-29e9cddbb240" />

cc @hlfan for feedback since you worked on dark mode and the osm website