### PR TITLE
tidy & deduplicate geometry code

### DIFF
--- a/modules/actions/reflect.ts
+++ b/modules/actions/reflect.ts
@@ -1,22 +1,25 @@
-import type { Vec2 } from '@rapideditor/location-conflation';
 import type { coreGraph } from '../core';
 import type { Action } from '../core/history';
-import { geoGetSmallestSurroundingRectangle, geoVecInterp, geoVecLength } from '../geo';
+import { geoGetAxis, geoVecInterp, type Vec2 } from '../geo';
 import type { Projection } from '../geo/raw_mercator';
 import { utilGetAllNodes } from '../util';
 import type { EntityId } from '../osm';
 
+export interface ActionReflect extends Action {
+    useLongAxis: GetSet<this, boolean>;
+    getReflectAxis(graph: coreGraph): [Vec2, Vec2] | undefined;
+}
 
 /* Reflect the given area around its axis of symmetry */
-export function actionReflect(reflectIds: EntityId[], projection: Projection) {
+export function actionReflect(reflectIds: EntityId[], projection: Projection): ActionReflect {
     var _useLongAxis = true;
 
 
-    var action: Action = function(graph, t) {
+    const action: ActionReflect = function(graph, t) {
         if (t === null || t === undefined || !isFinite(t)) t = 1;
         t = Math.min(Math.max(+t, 0), 1);
 
-        const [p, q] = getReflectAxis(graph);
+        const [p, q] = getReflectAxis(graph)!;
 
         // reflect c across pq
         // http://math.stackexchange.com/questions/65503/point-reflection-over-a-line
@@ -40,32 +43,20 @@ export function actionReflect(reflectIds: EntityId[], projection: Projection) {
     };
 
 
-    action.useLongAxis = function(val) {
-        if (!arguments.length) return _useLongAxis;
-        _useLongAxis = val;
+    function useLongAxis(): boolean;
+    function useLongAxis(newValue: boolean): ActionReflect;
+    function useLongAxis(...args: [] | [boolean]) {
+        if (!args.length) return _useLongAxis;
+        _useLongAxis = args[0];
         return action;
-    } as GetSet<Action, boolean>;
+    };
+    action.useLongAxis = useLongAxis;
 
 
     function getReflectAxis(graph: coreGraph) {
         const nodes = utilGetAllNodes(reflectIds, graph);
         const points = nodes.map(function(n) { return projection(n.loc); });
-        const ssr = geoGetSmallestSurroundingRectangle(points);
-
-        // Choose line pq = axis of symmetry.
-        // The shape's surrounding rectangle has 2 axes of symmetry.
-        // Reflect across the longer axis by default.
-        const p1: Vec2 = [(ssr.poly[0][0] + ssr.poly[1][0]) / 2, (ssr.poly[0][1] + ssr.poly[1][1]) / 2 ];
-        const q1: Vec2 = [(ssr.poly[2][0] + ssr.poly[3][0]) / 2, (ssr.poly[2][1] + ssr.poly[3][1]) / 2 ];
-        const p2: Vec2 = [(ssr.poly[3][0] + ssr.poly[4][0]) / 2, (ssr.poly[3][1] + ssr.poly[4][1]) / 2 ];
-        const q2: Vec2 = [(ssr.poly[1][0] + ssr.poly[2][0]) / 2, (ssr.poly[1][1] + ssr.poly[2][1]) / 2 ];
-
-        const isLong = (geoVecLength(p1, q1) > geoVecLength(p2, q2));
-        if ((_useLongAxis && isLong) || (!_useLongAxis && !isLong)) {
-            return [p1, q1];
-        } else {
-            return [p2, q2];
-        }
+        return geoGetAxis(points, _useLongAxis);
     };
     action.getReflectAxis = getReflectAxis;
 

--- a/modules/actions/straighten_nodes.ts
+++ b/modules/actions/straighten_nodes.ts
@@ -1,36 +1,11 @@
 import type { Action } from '../core/history';
-import { geoGetSmallestSurroundingRectangle, geoVecDot, geoVecLength, geoVecInterp } from '../geo';
+import { geoGetAxis, geoVecLength, geoVecInterp, geoVecPositionAlongWay as positionAlongWay } from '../geo';
 import type { Projection } from '../geo/raw_mercator';
-import type { Vec2 } from '../geo/vector';
 import type { NodeId } from '../osm';
 
 
 /* Align nodes along their common axis */
 export function actionStraightenNodes(nodeIDs: NodeId[], projection: Projection): Action {
-
-    function positionAlongWay(a: Vec2, o: Vec2, b: Vec2) {
-        return geoVecDot(a, b, o) / geoVecDot(b, b, o);
-    }
-
-    // returns the endpoints of the long axis of symmetry of the `points` bounding rect
-    function getEndpoints(points: Vec2[]) {
-        var ssr = geoGetSmallestSurroundingRectangle(points);
-
-        // Choose line pq = axis of symmetry.
-        // The shape's surrounding rectangle has 2 axes of symmetry.
-        // Snap points to the long axis
-        var p1: Vec2 = [(ssr.poly[0][0] + ssr.poly[1][0]) / 2, (ssr.poly[0][1] + ssr.poly[1][1]) / 2 ];
-        var q1: Vec2 = [(ssr.poly[2][0] + ssr.poly[3][0]) / 2, (ssr.poly[2][1] + ssr.poly[3][1]) / 2 ];
-        var p2: Vec2 = [(ssr.poly[3][0] + ssr.poly[4][0]) / 2, (ssr.poly[3][1] + ssr.poly[4][1]) / 2 ];
-        var q2: Vec2 = [(ssr.poly[1][0] + ssr.poly[2][0]) / 2, (ssr.poly[1][1] + ssr.poly[2][1]) / 2 ];
-
-        var isLong = (geoVecLength(p1, q1) > geoVecLength(p2, q2));
-        if (isLong) {
-            return [p1, q1];
-        }
-        return [p2, q2];
-    }
-
 
     const action: Action = function(graph, t) {
         if (t === null || t === undefined || !isFinite(t)) t = 1;
@@ -38,7 +13,7 @@ export function actionStraightenNodes(nodeIDs: NodeId[], projection: Projection)
 
         var nodes = nodeIDs.map(function(id) { return graph.entity(id); });
         var points = nodes.map(function(n) { return projection(n.loc); });
-        var endpoints = getEndpoints(points);
+        var endpoints = geoGetAxis(points)!;
         var startPoint = endpoints[0];
         var endPoint = endpoints[1];
 
@@ -60,7 +35,7 @@ export function actionStraightenNodes(nodeIDs: NodeId[], projection: Projection)
 
         var nodes = nodeIDs.map(function(id) { return graph.entity(id); });
         var points = nodes.map(function(n) { return projection(n.loc); });
-        var endpoints = getEndpoints(points);
+        var endpoints = geoGetAxis(points)!;
         var startPoint = endpoints[0];
         var endPoint = endpoints[1];
 

--- a/modules/core/graph.ts
+++ b/modules/core/graph.ts
@@ -1,4 +1,4 @@
-import { debug, type EntityId } from '../index';
+import { debug, type EntityId, type OsmEntity } from '../index';
 import type { NodeId, RelationId, WayId } from '../osm/id_manager';
 import type { osmNode } from '../osm/node';
 import type { osmRelation } from '../osm/relation';
@@ -13,7 +13,7 @@ export class coreGraph {
     _childNodes: { [id: EntityId]: osmNode[] };
     frozen: boolean;
 
-  constructor(other?: coreGraph, mutable?: boolean) {
+  constructor(other?: coreGraph | OsmEntity[], mutable?: boolean) {
     if (other instanceof coreGraph) {
         var base = other.base();
         this.entities = Object.assign(Object.create(base.entities), other.entities);

--- a/modules/core/history.js
+++ b/modules/core/history.js
@@ -28,8 +28,6 @@ import { osmIdManager } from '../osm';
     transitionable?: boolean;
 
     copies?(): Record<string, OsmEntity>;
-    useLongAxis?: GetSet<this, boolean>;
-    getReflectAxis?(graph: coreGraph): Vec2[];
  }} Action */
 
 /** @typedef {{

--- a/modules/geo/geom.ts
+++ b/modules/geo/geom.ts
@@ -280,10 +280,14 @@ export function geoPolygonIntersectsPolygon(outer: Vec2[], inner: Vec2[], checkS
 }
 
 
+/** can return `undefined` if there are <3 points, or if all points form a straight line */
 // http://gis.stackexchange.com/questions/22895/finding-minimum-area-rectangle-for-given-points
 // http://gis.stackexchange.com/questions/3739/generalisation-strategies-for-building-outlines/3756#3756
 export function geoGetSmallestSurroundingRectangle(points: Vec2[]) {
-    var hull = d3_polygonHull(points)!;
+    var hull = d3_polygonHull(points);
+
+    if (!hull || hull.length < 3) return undefined;
+
     var centroid = d3_polygonCentroid(hull);
     var minArea = Infinity;
     var ssrExtent!: geoExtent;
@@ -311,6 +315,37 @@ export function geoGetSmallestSurroundingRectangle(points: Vec2[]) {
         poly: geoRotate(ssrExtent.polygon(), ssrAngle, centroid),
         angle: ssrAngle
     };
+}
+
+
+/**
+ * returns the endpoints of an axis of symmetry of the `points` bounding rect.
+ * By default this is the long axis, unless `useLongAxis` is false.
+ */
+export function geoGetAxis(points: Vec2[], useLongAxis = true): [Vec2, Vec2] | undefined {
+    const ssr = geoGetSmallestSurroundingRectangle(points);
+    if (!ssr) {
+        // if there are exactly 2 or 3 points, then use the outermost points
+        const hull = d3_polygonHull(points) || points;
+        if (hull.length === 2) return [hull[0], hull[1]];
+
+        // if there are exactly 0 or 1 points, then there is no axis
+        return undefined;
+    }
+
+    // Choose line pq = axis of symmetry.
+    // The shape's surrounding rectangle has 2 axes of symmetry.
+    // Snap points to the long axis
+    const p1: Vec2 = [(ssr.poly[0][0] + ssr.poly[1][0]) / 2, (ssr.poly[0][1] + ssr.poly[1][1]) / 2 ];
+    const q1: Vec2 = [(ssr.poly[2][0] + ssr.poly[3][0]) / 2, (ssr.poly[2][1] + ssr.poly[3][1]) / 2 ];
+    const p2: Vec2 = [(ssr.poly[3][0] + ssr.poly[4][0]) / 2, (ssr.poly[3][1] + ssr.poly[4][1]) / 2 ];
+    const q2: Vec2 = [(ssr.poly[1][0] + ssr.poly[2][0]) / 2, (ssr.poly[1][1] + ssr.poly[2][1]) / 2 ];
+
+    const isLong = (geoVecLength(p1, q1) > geoVecLength(p2, q2));
+    if (isLong === useLongAxis) {
+        return [p1, q1];
+    }
+    return [p2, q2];
 }
 
 

--- a/modules/geo/index.ts
+++ b/modules/geo/index.ts
@@ -10,40 +10,9 @@ export { geoScaleToZoom } from './geo.js';
 export { geoSphericalClosestNode } from './geo.js';
 export { geoSphericalDistance } from './geo.js';
 export { geoZoomToScale } from './geo.js';
-
-export { geoAngle } from './geom.js';
-export { geoChooseEdge } from './geom.js';
-export { geoEdgeEqual } from './geom.js';
-export { geoGetSmallestSurroundingRectangle } from './geom.js';
-export { geoHasLineIntersections } from './geom.js';
-export { geoHasSelfIntersections } from './geom.js';
-export { geoRotate } from './geom.js';
-export { geoLineIntersection } from './geom.js';
-export { geoPathHasIntersections } from './geom.js';
-export { geoPathIntersections } from './geom.js';
-export { geoPathLength } from './geom.js';
-export { geoPointInPolygon } from './geom.js';
-export { geoPolygonContainsPolygon } from './geom.js';
-export { geoPolygonIntersectsPolygon } from './geom.js';
-export { geoViewportEdge } from './geom.js';
-
+export * from './geom.js';
 export { geoRawMercator } from './raw_mercator.js';
-
-export { geoVecAdd } from './vector.js';
-export { geoVecAngle } from './vector.js';
-export { geoVecCross } from './vector.js';
-export { geoVecDot } from './vector.js';
-export { geoVecEqual } from './vector.js';
-export { geoVecFloor } from './vector.js';
-export { geoVecInterp } from './vector.js';
-export { geoVecLength } from './vector.js';
-export { geoVecLengthSquare } from './vector.js';
-export { geoVecNormalize } from './vector.js';
-export { geoVecNormalizedDot } from './vector.js';
-export { geoVecProject } from './vector.js';
-export { geoVecSubtract } from './vector.js';
-export { geoVecScale } from './vector.js';
-
+export * from './vector.js';
 export { geoOrthoCalcScore } from './ortho.js';
 export { geoOrthoMaxOffsetAngle } from './ortho.js';
 export { geoOrthoCanOrthogonalize } from './ortho.js';

--- a/modules/geo/vector.ts
+++ b/modules/geo/vector.ts
@@ -93,6 +93,16 @@ export function geoVecCross(a: Vec2, b: Vec2, origin?: Vec2) {
 }
 
 
+/**
+ * given a line between `o` and `b`, this function determines how far along
+ * this line point `a` is, as a percentage (0-1 unless outside the range of
+ * `o`...`b`)
+ */
+export function geoVecPositionAlongWay(a: Vec2, o: Vec2, b: Vec2) {
+    return geoVecDot(a, b, o) / geoVecDot(b, b, o);
+}
+
+
 // find closest orthogonal projection of point onto points array
 export function geoVecProject(a: Vec2, points: Vec2[]) {
     var min = Infinity;

--- a/test/spec/geo/geom.js
+++ b/test/spec/geo/geom.js
@@ -457,6 +457,16 @@ describe('iD.geo - geometry', function() {
             expect(ssr.angle).toEqual(0);
         });
 
+        it('returns undefined when given less than 3 points', () => {
+            expect(iD.geoGetSmallestSurroundingRectangle([])).toBeUndefined();
+            expect(iD.geoGetSmallestSurroundingRectangle([[1, 1]])).toBeUndefined();
+            expect(iD.geoGetSmallestSurroundingRectangle([[1, 1], [2, 2]])).toBeUndefined();
+        });
+
+        it('returns undefined when all points are collinear', () => {
+            expect(iD.geoGetSmallestSurroundingRectangle([[0, 1], [0, 2], [0, 4]])).toBeUndefined();
+            expect(iD.geoGetSmallestSurroundingRectangle([[1, 1], [2, 2], [3, 3]])).toBeUndefined();
+        });
     });
 
     describe('geoPathLength', function() {
@@ -507,4 +517,54 @@ describe('iD.geo - geometry', function() {
         });
     });
 
+
+    describe('iD.geoGetAxis', () => {
+        it('can calculate the diameter of a set', () => {
+            // https://desmos.com/calculator/rstdsrvfkb
+            const points = [
+                [-1, 2],
+                [-3, 5],
+                [-2, -2],
+                [1, 1],
+                [4, -2],
+                [3, 0],
+            ];
+            expect(iD.geoGetAxis(points)).toStrictEqual([
+                [-4.516393442622951, 3.1803278688524594],
+                [3.057377049180328, -3.1311475409836067],
+            ]);
+        });
+
+        it('can calculate the short axis of a set', () => {
+            const points = [
+                [-1, 2],
+                [-3, 5],
+                [-2, -2],
+                [1, 1],
+                [4, -2],
+                [3, 0],
+            ];
+            expect(iD.geoGetAxis(points, false)).toStrictEqual([
+                [-2.245901639344262, -1.7950819672131142],
+                [0.78688524590164, 1.844262295081967],
+            ]);
+        });
+
+        it('returns undefined if only 1 or 0 points are selected', () => {
+            expect(iD.geoGetAxis([])).toBeUndefined();
+            expect(iD.geoGetAxis([[1, 1]])).toBeUndefined();
+        });
+
+        it('returns the input set if there are exactly two points', () => {
+            const points = [[-1, 2], [-3, 5]];
+            expect(iD.geoGetAxis(points)).toStrictEqual(points);
+            expect(iD.geoGetAxis(points, false)).toStrictEqual(points);
+        });
+
+        it('returns the two extremities if all points are collinear', () => {
+            const points = [[0, 1], [0, 2], [0, 4], [0, 6], [0, 10]];
+            expect(iD.geoGetAxis(points)).toStrictEqual([[0, 10], [0, 1]]);
+            expect(iD.geoGetAxis(points, false)).toStrictEqual([[0, 10], [0, 1]]);
+        });
+    });
 });


### PR DESCRIPTION
1. deduplicating some code from [#11774](https://github.com/openstreetmap/iD/pull/11774) which i want to re-use in [#12728](https://github.com/openstreetmap/iD/pull/12728), but i'm not going to copy-paste it for the 3rd time...
2. tidying some changes from [#12613](https://github.com/openstreetmap/iD/pull/12613): `getReflectAxis` and `useLongAxis` are specific to the reflect action, they're not re-used anywhere else.