### PR TITLE
create a 'distribute' operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :sparkles: Usability & Accessibility
 * Render diameter and radius tags when a node is selected ([#9732], thanks [@k-yle])
 #### :scissors: Operations
+* Create a 'distribute' operation ([#12728], thanks [@k-yle])
 #### :camera: Street-Level
 #### :white_check_mark: Validation
 #### :bug: Bugfixes
@@ -52,6 +53,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 
 [#9732]: https://github.com/openstreetmap/iD/pull/9732
 [#12679]: https://github.com/openstreetmap/iD/pull/12679
+[#12728]: https://github.com/openstreetmap/iD/pull/12728
 
 
 # 2.42.1

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -172,6 +172,16 @@ en:
       not_downloaded:
         single: This can't be made square because parts of it have not yet been downloaded.
         multiple: These can't be made square because parts of them have not yet been downloaded.
+    distribute:
+      title: Distribute Evenly
+      description: Spread out these points evenly along a straight line.
+      annotation: Distributed {n} points.
+      disabled:
+        too_few: Distributing requires at least 3 points.
+        already_distributed: These points can't be made distributed any more evenly than they already are.
+        too_large: These points can't be distributed because not enough of them are currently visible.
+        not_downloaded: These points can't be distributed because parts of them have not yet been downloaded.
+        connected_to_hidden: These points can't be distributed because some are connected to hidden features.
     straighten:
       title: Straighten
       description:
@@ -2256,6 +2266,7 @@ en:
         rotate: "Rotate selected features"
         orthogonalize: "Square corners of a line or area"
         straighten: "Straighten a line or points"
+        distribute: "Distribute points evenly along a line"
         circularize: "Circularize a closed line or area"
         reflect_long: "Flip features across the longer axis"
         reflect_short: "Flip features across the shorter axis"

--- a/data/shortcuts.json
+++ b/data/shortcuts.json
@@ -330,6 +330,11 @@
             "text": "shortcuts.editing.operations.straighten"
           },
           {
+            "modifiers": ["⇧"],
+            "shortcuts": ["operations.straighten.key"],
+            "text": "shortcuts.editing.operations.distribute"
+          },
+          {
             "shortcuts": ["operations.circularize.key"],
             "text": "shortcuts.editing.operations.circularize"
           },

--- a/modules/actions/distribute.ts
+++ b/modules/actions/distribute.ts
@@ -1,0 +1,60 @@
+import type { coreGraph } from '../core';
+import type { Action } from '../core/history';
+import { geoGetAxis, geoVecEqual, geoVecInterp, geoVecPositionAlongWay } from '../geo';
+import type { Projection } from '../geo/raw_mercator';
+import type { NodeId } from '../osm';
+import { actionMoveNode } from './move_node';
+
+/**
+ * distributes nodes evenly spaced along a line between the furthest two points.
+ * Involves running {@link actionStraightenNodes}.
+ */
+export function actionDistribute(nodeIds: NodeId[], projection: Projection): Action {
+
+    function distribute(graph: coreGraph) {
+        const nodes = nodeIds.map(id => graph.entity(id));
+        const locs = nodes.map(node => projection(node.loc));
+        const [first, last] = geoGetAxis(locs)!;
+
+        // the user might not have used the straighten operation yet, so the
+        // nodes might be scattered. therefore, sort every node based on the
+        // order if the straighten operation was already applied (i.e. the
+        // projected position).
+        const ordered = nodes
+            .map((node, i) => ({
+                node,
+                projected: geoVecPositionAlongWay(locs[i], first, last),
+            }))
+            .sort((a, b) => a.projected - b.projected);
+
+        return ordered.map(({ node }, i) => ({
+            node,
+            newLoc: projection.invert(
+                geoVecInterp(first, last, i / (ordered.length - 1))
+            )
+        }));
+    }
+
+    const action: Action = function(graph, t) {
+        for (const { node, newLoc } of distribute(graph)) {
+            graph = actionMoveNode(node.id, newLoc)(graph, t);
+        }
+        return graph;
+    };
+
+
+    action.disabled = function(graph) {
+        if (nodeIds.length <= 2) return 'too_few';
+
+        const isNoop = distribute(graph)
+            .every(({ node, newLoc }) => geoVecEqual(node.loc, newLoc, 1e-6));
+
+        if (isNoop) return 'already_distributed';
+    };
+
+
+    action.transitionable = true;
+
+
+    return action;
+}

--- a/modules/actions/index.ts
+++ b/modules/actions/index.ts
@@ -15,6 +15,7 @@ export { actionDeleteRelation } from './delete_relation';
 export { actionDeleteWay } from './delete_way';
 export { actionDiscardTags } from './discard_tags';
 export { actionDisconnect } from './disconnect';
+export { actionDistribute } from './distribute';
 export { actionExtract } from './extract';
 export { actionJoin } from './join';
 export { actionMerge } from './merge';

--- a/modules/operations/distribute.ts
+++ b/modules/operations/distribute.ts
@@ -1,0 +1,93 @@
+import { t } from '../core/localizer';
+import { behaviorOperation } from '../behavior/operation';
+import { uiCmd } from '../ui/cmd';
+import { utilGetAllNodes, utilTotalExtent } from '../util/index';
+import { actionDistribute } from '../actions';
+import type { CreateOperation, Operation } from '../core/history';
+import { svgPath } from '../svg';
+
+
+export const operationDistribute: CreateOperation = (context, selectedIDs) => {
+    const nodes = utilGetAllNodes(selectedIDs, context.graph());
+    const coords = nodes.map(n => n.loc);
+    const extent = utilTotalExtent(selectedIDs, context.graph());
+    const action = actionDistribute(nodes.map(n => n.id), context.projection);
+
+    const operation: Operation = () => {
+        context.perform(action, operation.annotation());
+
+        window.setTimeout(() => {
+            context.validator().validate();
+        }, 300);  // after any transition
+    };
+
+    operation.available = () => {
+        return nodes.length > 2 && selectedIDs.every(id => id[0] === 'n');
+    };
+
+    operation.disabled = () => {
+        var reason = action.disabled?.(context.graph());
+        if (reason) {
+            return reason;
+        } else if (extent.percentContainedIn(context.map().extent()) < 0.8) {
+            return 'too_large';
+        } else if (someMissing()) {
+            return 'not_downloaded';
+        } else if (selectedIDs.some(context.hasHiddenConnections)) {
+            return 'connected_to_hidden';
+        }
+
+        return false;
+
+
+        function someMissing() {
+            if (context.inIntro()) return false;
+            const osm = context.connection();
+            if (osm) {
+                const missing = coords.filter((loc) => !osm.isDataLoaded(loc));
+                if (missing.length) {
+                    for (const loc of missing) context.loadTileAtLoc(loc);
+                    return true;
+                }
+            }
+            return false;
+        }
+    };
+
+    operation.getAuxiliaryGeometry = () => {
+        const graph = context.graph();
+        const previewGraph = action(graph);
+        const getPath = svgPath(context.projection, previewGraph, false);
+        return selectedIDs.map(entityId => {
+            const entity = previewGraph.hasEntity(entityId)!;
+            return {
+                id: entity.id,
+                path: getPath(entity)!,
+                klass: 'preview'
+            };
+        });
+    };
+
+    operation.tooltip = function() {
+        var disableReason = operation.disabled();
+        return disableReason ?
+            t.append('operations.distribute.disabled.' + disableReason) :
+            t.append('operations.distribute.description');
+    };
+
+
+    operation.annotation = function() {
+        return t('operations.distribute.annotation', { n: nodes.length });
+    };
+
+
+    operation.id = 'distribute';
+    operation.title = t.append('operations.distribute.title');
+    operation.behavior = behaviorOperation(context).which(operation);
+
+    // same key as straighten, but with the shift key. This can't be customised per locale,
+    // because it's supposed to feel like an extension of the straighten operation.
+    operation.keys = [uiCmd('⇧' + t('operations.straighten.key'))];
+
+    return operation;
+};

--- a/modules/operations/index.ts
+++ b/modules/operations/index.ts
@@ -3,6 +3,7 @@ export { operationContinue } from './continue';
 export { operationCopy } from './copy';
 export { operationDelete } from './delete';
 export { operationDisconnect } from './disconnect';
+export { operationDistribute } from './distribute';
 export { operationDowngrade } from './downgrade';
 export { operationExtract } from './extract';
 export { operationMerge } from './merge';

--- a/modules/svg/helpers.ts
+++ b/modules/svg/helpers.ts
@@ -166,7 +166,7 @@ export function svgPath(projection: Projection, graph?: coreGraph, isArea?: bool
     const path = d3_geoPath()
         .projection({stream: function(output) { return project(clip(output)); }});
 
-    const svgpath = function(entity: osmWay) {
+    const svgpath = function(entity: OsmEntity) {
         if (entity.id in cache) {
             return cache[entity.id];
         } else {

--- a/svg/iD-sprite/operations/operation-distribute.svg
+++ b/svg/iD-sprite/operations/operation-distribute.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0" y="0" width="20" height="20" viewBox="0 0 20 20">
+    <path d="M5 9H7v2H5zm8 2h2V9H13zM9 9h2v2H9Z" fill="currentColor"/>
+    <path d="M2 8C.895 8 0 8.895 0 10s.895 2 2 2 2-.895 2-2-.895-2-2-2zM18 8c1.105 0 2 .895 2 2s-.895 2-2 2-2-.895-2-2 .895-2 2-2z" fill="inherit"/>
+</svg>

--- a/test/spec/actions/distribute.ts
+++ b/test/spec/actions/distribute.ts
@@ -1,0 +1,123 @@
+import type { NodeId, Vec2 } from '../../../modules';
+import type { Projection } from '../../../modules/geo/raw_mercator';
+
+describe('iD.actionDistribute', () => {
+    const projection = ((x: Vec2) => x) as Projection;
+    projection.invert = projection;
+
+
+    it('distributes nodes that are already in a straight line', () => {
+        const nodes = [
+            new iD.osmNode({ id: 'n1', loc: [0, 1] }),
+            new iD.osmNode({ id: 'n2', loc: [0, 2] }),
+            new iD.osmNode({ id: 'n3', loc: [0, 4] }),
+            new iD.osmNode({ id: 'n4', loc: [0, 6] }),
+            new iD.osmNode({ id: 'n5', loc: [0, 9] }),
+        ];
+        let graph = new iD.coreGraph(nodes);
+
+        // the selection order is irrelevant
+        graph = iD.actionDistribute(['n2', 'n1', 'n5', 'n3', 'n4'], projection)(graph);
+
+        expect(nodes.map(n => graph.entity(n.id).loc)).toStrictEqual([
+            [0, 1],
+            [0, 3],
+            [0, 5],
+            [0, 7],
+            [0, 9],
+        ]);
+    });
+
+    it('straightens nodes first, then distributes them', () => {
+        let graph = new iD.coreGraph([
+            new iD.osmNode({ id: 'n1', loc: [0, 1] }),
+            new iD.osmNode({ id: 'n2', loc: [1, 2] }),
+            new iD.osmNode({ id: 'n3', loc: [0, 4] }),
+            new iD.osmNode({ id: 'n4', loc: [1, 6] }),
+            new iD.osmNode({ id: 'n5', loc: [0, 9] }),
+        ]);
+
+        const nodes: NodeId[] = ['n1', 'n2', 'n3', 'n4', 'n5'];
+
+        graph = iD.actionDistribute(nodes, projection)(graph);
+        expect(nodes.map(n => graph.entity(n).loc)).toStrictEqual([
+            [expect.closeTo(0.5), 1],
+            [expect.closeTo(0.5), 3],
+            [expect.closeTo(0.5), 5],
+            [expect.closeTo(0.5), 7],
+            [expect.closeTo(0.5), 9],
+        ]);
+    });
+
+    it('works on any axis (e.g. a diagonal line)', () => {
+        let graph = new iD.coreGraph([
+            new iD.osmNode({ id: 'n1', loc: [0, 0] }),
+            new iD.osmNode({ id: 'n2', loc: [1, 1] }),
+            new iD.osmNode({ id: 'n3', loc: [4, 4] }),
+            new iD.osmNode({ id: 'n4', loc: [9, 9] }),
+        ]);
+
+        const nodes: NodeId[] = ['n1', 'n2', 'n3', 'n4'];
+
+        graph = iD.actionDistribute(nodes, projection)(graph);
+        expect(nodes.map(n => graph.entity(n).loc)).toStrictEqual([
+            [expect.closeTo(0), expect.closeTo(0)],
+            [expect.closeTo(3), expect.closeTo(3)],
+            [expect.closeTo(6), expect.closeTo(6)],
+            [expect.closeTo(9), expect.closeTo(9)],
+        ]);
+    });
+
+    it.each`
+        t      | out
+        ${0}   | ${[[0, 1], [0, 2  ], [0, 4  ], [0, 6  ], [0, 9]]}
+        ${0.5} | ${[[0, 1], [0, 2.5], [0, 4.5], [0, 6.5], [0, 9]]}
+        ${1}   | ${[[0, 1], [0, 3  ], [0, 5  ], [0, 7  ], [0, 9]]}
+    `('is transitionable at t=$t', ({ t, out }) => {
+        const nodes = [
+            new iD.osmNode({ id: 'n1', loc: [0, 1] }),
+            new iD.osmNode({ id: 'n2', loc: [0, 2] }),
+            new iD.osmNode({ id: 'n3', loc: [0, 4] }),
+            new iD.osmNode({ id: 'n4', loc: [0, 6] }),
+            new iD.osmNode({ id: 'n5', loc: [0, 9] }),
+        ];
+        let graph = new iD.coreGraph(nodes);
+
+        const action = iD.actionDistribute(nodes.map(n => n.id), projection);
+        expect(action.transitionable).toBe(true);
+        graph = action(graph, t);
+        expect(nodes.map(n => graph.entity(n.id).loc)).toStrictEqual(out);
+    });
+
+    describe('#disabled', () => {
+        it('is disabled if there are less than 3 nodes', () => {
+            const graph = new iD.coreGraph([
+                new iD.osmNode({ id: 'n1', loc: [0, 1] }),
+                new iD.osmNode({ id: 'n2', loc: [0, 2] }),
+            ]);
+
+            expect(iD.actionDistribute(['n1', 'n2'], projection).disabled!(graph)).toBe('too_few');
+            expect(iD.actionDistribute(['n1'], projection).disabled!(graph)).toBe('too_few');
+        });
+
+        it('is disabled if the nodes are already evenly distributed', () => {
+            const graph = new iD.coreGraph([
+                new iD.osmNode({ id: 'n1', loc: [0, 1] }),
+                new iD.osmNode({ id: 'n2', loc: [0, 2] }),
+                new iD.osmNode({ id: 'n3', loc: [0, 3] }),
+            ]);
+
+            expect(iD.actionDistribute(['n1', 'n2', 'n3'], projection).disabled!(graph)).toBe('already_distributed');
+        });
+
+        it('is disabled if every node is in the exact same location', () => {
+            const action = iD.actionDistribute(['n1', 'n2', 'n3'], projection);
+            const graph = new iD.coreGraph([
+                new iD.osmNode({ id: 'n1', loc: [1, 1] }),
+                new iD.osmNode({ id: 'n2', loc: [1, 1] }),
+                new iD.osmNode({ id: 'n3', loc: [1, 1] }),
+            ]);
+            expect(action.disabled!(graph)).toBe('already_distributed');
+        });
+    });
+});


### PR DESCRIPTION
Closes #12669

we already have #9020 for evenly dividing **areas**. This PR is a similar idea, but for evenly distributing **nodes**:

<img height="300" alt="20260811224736_rec_-convert" src="https://github.com/user-attachments/assets/dde026b7-9322-4b12-b082-7db16a7e044f" />

The keyboard shortcut is the same as the straighten operation, but with <kbd>⇧ Shift</kbd>. In english, that would be <kbd>⇧ Shift</kbd> <kbd>S</kbd>. Mostly because i see this as an extension of the straighten operation, since distributing involves first straightening the nodes. 

use cases:
 - indoor shops
 - any vertices like a loading dock, which you surveyed by counting, but can't see the exact location on aerial imagery
 
~~to do~~:
- [x] ~~unit tests~~