### PR TITLE
fix console error when using some disabled operations

### DIFF
--- a/modules/behavior/operation.js
+++ b/modules/behavior/operation.js
@@ -15,8 +15,6 @@ export function behaviorOperation(context) {
 
         d3_event.preventDefault();
 
-        const disabled = _operation.disabled();
-
         if (!_operation.available()) {
             context.ui().flash
                 .duration(4000)
@@ -25,7 +23,12 @@ export function behaviorOperation(context) {
                 .label(t.append('operations._unavailable', {
                     operation: t.append(`operations.${_operation.id}.title`) || _operation.id
                 }))();
-        } else if (disabled) {
+            return;
+        }
+
+        const disabled = _operation.disabled();
+
+        if (disabled) {
             const interrupt = _operation.interrupts?.[disabled];
             if (interrupt) {
                 interrupt();


### PR DESCRIPTION
caused by [#10615](https://github.com/openstreetmap/iD/pull/10615) 

`_operation.disabled()` can only be called after `_operation.available()` returns true.

otherwise you'll get a console error when trying to use an operation which is `available` but `disabled`. For example, straightening a rectangular building area via the keyboard shortcut. 