### PR TITLE
fix the crossing_ways validator not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :scissors: Operations
 #### :camera: Street-Level
 #### :white_check_mark: Validation
+* fix the crossing_ways validator not working ([#12734], thanks [@k-yle])
 #### :bug: Bugfixes
 #### :earth_asia: Localization
 #### :hourglass: Performance
@@ -50,6 +51,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Drop code previously responsible for _maprules_ integration (which has been defunct for a while now) ([#12679])
 
 [#12679]: https://github.com/openstreetmap/iD/pull/12679
+[#12734]: https://github.com/openstreetmap/iD/pull/12734
 
 # 2.42.0
 ##### 2026-Aug-10

--- a/modules/osm/way.ts
+++ b/modules/osm/way.ts
@@ -18,7 +18,7 @@ export interface Segment {
     wayId: WayId;
     index: number;
     nodes: NodeId[];
-    extent(graph: coreGraph): geoExtent | undefined;
+    extent(this: Segment, graph: coreGraph): geoExtent | undefined;
 }
 
 export class osmWay extends OsmAbstractEntity {
@@ -265,7 +265,7 @@ export class osmWay extends OsmAbstractEntity {
 
     // returns an array of objects representing the segments between the nodes in this way
     segments(graph: coreGraph) {
-        const segmentExtent = (graph: coreGraph) => {
+        function segmentExtent(this: Segment, graph: coreGraph) {
             var n1 = graph.hasEntity<osmNode>(this.nodes[0]);
             var n2 = graph.hasEntity<osmNode>(this.nodes[1]);
             return n1 && n2 && geoExtent([

--- a/test/spec/osm/way.js
+++ b/test/spec/osm/way.js
@@ -138,6 +138,42 @@ describe('iD.osmWay', function() {
         });
     });
 
+    describe('#segments', () => {
+        it('returns each way segment', () => {
+            const n1 = new iD.osmNode({ id: 'n1', loc: [1, 1] });
+            const n2 = new iD.osmNode({ id: 'n2', loc: [2, 2] });
+            const n3 = new iD.osmNode({ id: 'n3', loc: [3, 3] });
+            const w1 = new iD.osmWay({ id: 'w1', nodes: ['n1', 'n2', 'n3'] });
+            const graph = new iD.coreGraph([n1, n2, n3, w1]);
+
+            expect(w1.segments(graph)).toStrictEqual([
+                {
+                    id: 'w1-0',
+                    wayId: 'w1',
+                    index: 0,
+                    nodes: ['n1', 'n2'],
+                    extent: expect.any(Function),
+                },
+                {
+                    id: 'w1-1',
+                    wayId: 'w1',
+                    index: 1,
+                    nodes: ['n2', 'n3'],
+                    extent: expect.any(Function),
+                },
+            ]);
+
+            const extents = w1.segments(graph)
+                .map(segment => segment.extent(graph))
+                .map(extent => extent.toParam());
+
+            expect(extents).toStrictEqual([
+                '1,1,2,2', // segment w1-0
+                '2,2,3,3', // segment w1-1
+            ]);
+        });
+    });
+
     describe('#isClosed', function() {
         it('returns false when the way contains no nodes', function() {
             expect(new iD.osmWay().isClosed()).toBe(false);


### PR DESCRIPTION
Closes #12731

caused by #12425 😭 quite ironic because this is the exact type of bug that PR was supposed to prevent. i didn't notice it because both `osmWay` and `Segment`  have a property called `.nodes`.

this caused the validator to only use a single segment from the first to the last node, ignoring all other intermediate nodes.