### PR TITLE
fix auto-completion not working in the "Add field" dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :camera: Street-Level
 #### :white_check_mark: Validation
 #### :bug: Bugfixes
+* Fix auto-completion not working in the "Add field" dropdown ([#12735], thanks [@k-yle])
 #### :earth_asia: Localization
 #### :hourglass: Performance
 #### :mortar_board: Walkthrough / Help
@@ -50,6 +51,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Drop code previously responsible for _maprules_ integration (which has been defunct for a while now) ([#12679])
 
 [#12679]: https://github.com/openstreetmap/iD/pull/12679
+[#12735]: https://github.com/openstreetmap/iD/pull/12735
 
 # 2.42.0
 ##### 2026-Aug-10

--- a/modules/ui/combobox.js
+++ b/modules/ui/combobox.js
@@ -65,7 +65,7 @@ export function uiCombobox(context, klass) {
             .on('blur.combo-input', blur)
             .on('keydown.combo-input', keydown)
             .on('keyup.combo-input', keyup)
-            .on('input.combo-input', change)
+            .on('input.combo-input', d3_event => change(d3_event))
             .on('mousedown.combo-input', mousedown)
             .on('mouseup.combo-input', mouseup)
             .each(function() {
@@ -183,7 +183,7 @@ export function uiCombobox(context, klass) {
                     input.on('input.combo-input', function() {
                         var start = input.property('selectionStart');
                         input.node().setSelectionRange(start, start);
-                        input.on('input.combo-input', change); // reset event handler
+                        input.on('input.combo-input', d3_event => change(d3_event)); // reset event handler
                         change(undefined, false);
                     });
                     break;


### PR DESCRIPTION
Closes #12732 -  another bug that typescript would have caught, the second argument to `change()` should be an optional boolean, not a d3 datum. 

we never noticed this bug until #12565, because previously the first argument was sometimes a boolean, and sometimes a d3_event (which is always truthy)