### PR TITLE
fix the outdated_tags validator raising erroneous tag upgrade suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :scissors: Operations
 #### :camera: Street-Level
 #### :white_check_mark: Validation
+* fix the outdated_tags validator raising erroneous errors ([#12736], thanks [@k-yle])
 #### :bug: Bugfixes
 #### :earth_asia: Localization
 #### :hourglass: Performance
@@ -50,6 +51,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Drop code previously responsible for _maprules_ integration (which has been defunct for a while now) ([#12679])
 
 [#12679]: https://github.com/openstreetmap/iD/pull/12679
+[#12736]: https://github.com/openstreetmap/iD/pull/12736
 
 # 2.42.0
 ##### 2026-Aug-10

--- a/modules/validations/outdated_tags.js
+++ b/modules/validations/outdated_tags.js
@@ -101,7 +101,7 @@ export function validationOutdatedTags() {
     let issues = [];
     issues.provisional = (_waitingForDeprecated || waitingForNsi);
 
-    if (deprecationDiff.length) {
+    if (deprecationDiff.some(d => d.type !== '~')) {
       const isOnlyAddingTags = !deprecationDiff.some(d => d.type === '-');
       const prefix = isOnlyAddingTags ? 'incomplete.' : '';
 

--- a/test/spec/validations/outdated_tags.js
+++ b/test/spec/validations/outdated_tags.js
@@ -249,6 +249,13 @@ describe('iD.validations.outdated_tags', function () {
         expect(tagReference.some(ref => ref.type === '~' && ref.key === 'building')).toBeTruthy();
     });
 
+    it('does not raise an error in valid situations', async () => {
+        createWay({ building: 'roof', layer: '1' });
+        const validator = iD.validationOutdatedTags(context);
+        await setTimeout(20);
+        expect(validate(validator)).toHaveLength(0);
+    });
+
     it('generates 2 separate issues for incomplete tags and NSI suggestions', async () => {
         createWay({ building: 'roof', amenity: 'fast_food', brand: 'Fish Bowl' });
         const validator = iD.validationOutdatedTags(context);


### PR DESCRIPTION
Closes #12733

caused by 88f106ebd92bd1596f27aa21dc119ecba0180355, now the diff includes unchanged rows which are identified by `type="~"`