### PR TITLE
allow tags like `not:*:wikidata` to have multiple values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :camera: Street-Level
 #### :white_check_mark: Validation
 #### :bug: Bugfixes
+* Allow tags like `not:*:wikidata` to have multiple values ([#12736], thanks [@k-yle])
 #### :earth_asia: Localization
 #### :hourglass: Performance
 #### :mortar_board: Walkthrough / Help
@@ -50,6 +51,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 * Drop code previously responsible for _maprules_ integration (which has been defunct for a while now) ([#12679])
 
 [#12679]: https://github.com/openstreetmap/iD/pull/12679
+[#12736]: https://github.com/openstreetmap/iD/pull/12736
 
 # 2.42.0
 ##### 2026-Aug-10

--- a/modules/services/nsi.js
+++ b/modules/services/nsi.js
@@ -7,6 +7,7 @@ import { nsiCdnUrl } from '../../config/id.js';
 // Make very sure this resolves to iD's `package.json`
 // If you mess up the `../`s, the resolver may import another random package.json from somewhere else.
 import packageJSON from '../../package.json';
+import { utilSplitAtSemicolon } from '../util/util';
 
 
 // This service contains all the code related to the **name-suggestion-index** (aka NSI)
@@ -516,10 +517,10 @@ function _upgradeTags(tags, loc) {
       if (!item) continue;
       const mainTag = item.mainTag;               // e.g. `brand:wikidata`
       const itemQID = item.tags[mainTag];         // e.g. `brand:wikidata` qid
-      const notQID = newTags[`not:${mainTag}`];   // e.g. `not:brand:wikidata` qid
+      const notQIDs = utilSplitAtSemicolon(newTags[`not:${mainTag}`]); // e.g. `not:brand:wikidata` qid
 
       if (                                        // Exceptions, skip this hit
-        (!itemQID || itemQID === notQID) ||       // No `*:wikidata` or matched a `not:*:wikidata`
+        (!itemQID || notQIDs?.includes(itemQID)) ||// No `*:wikidata` or matched a `not:*:wikidata`
         (newTags.office && !item.tags.office)     // feature may be a corporate office for a brand? - #6416
       ) {
         item = null;

--- a/modules/ui/fields/combo.js
+++ b/modules/ui/fields/combo.js
@@ -15,6 +15,7 @@ import { uiLengthIndicator } from '../length_indicator';
 import { deprecatedTagValuesByKey } from '../../osm/deprecated';
 import { osmIsoCountryKeys } from '../../osm/tags';
 import { formatTag } from './tag_title';
+import { utilSplitAtSemicolon as splitAtSemicolon } from '../../util/util';
 
 export {
     uiFieldCombo as uiFieldManyCombo,
@@ -63,9 +64,6 @@ export function uiFieldCombo(field, context) {
         return s.replace(/\s+/g, '_');
     }
 
-    function splitAtSemicolon(s) {
-        return (s || '').split(';').map(s => s.trim()).filter(Boolean);
-    }
     function clean(s) {
         return splitAtSemicolon(s).join(';');
     }

--- a/modules/util/util.ts
+++ b/modules/util/util.ts
@@ -11,6 +11,10 @@ import type { osmNode as OsmNode } from '../osm/node';
 import type { EntityId as EntityID } from '../osm';
 
 
+export function utilSplitAtSemicolon(s: TagValue | undefined | null) {
+    return (s || '').split(';').map(s => s.trim()).filter(Boolean);
+}
+
 export function utilTagText(entity: iD.OsmEntity): string {
     const obj = (entity && entity.tags) || {};
     return Object.keys(obj)

--- a/modules/validations/outdated_tags.js
+++ b/modules/validations/outdated_tags.js
@@ -8,7 +8,8 @@ import { actionUpgradeTags } from '../actions/upgrade_tags';
 import { fileFetcher } from '../core';
 import { presetManager } from '../presets';
 import { services } from '../services';
-import {  utilHashcode, utilTagDiff } from '../util';
+import { utilArrayUniq, utilHashcode, utilTagDiff } from '../util';
+import { utilSplitAtSemicolon } from '../util/util';
 import { utilDisplayLabel } from '../util/utilDisplayLabel';
 import { validationIssue, validationIssueFix } from '../core/validation';
 import { getDeprecatedTags } from '../osm/deprecated';
@@ -214,7 +215,14 @@ export function validationOutdatedTags() {
       const wd = item.mainTag;     // e.g. `brand:wikidata`
       const notwd = `not:${wd}`;   // e.g. `not:brand:wikidata`
       const qid = item.tags[wd];
-      newTags[notwd] = qid;
+      if (newTags[notwd]) {
+        newTags[notwd] = utilArrayUniq([
+            ...utilSplitAtSemicolon(newTags[notwd]),
+            qid,
+        ]).join(';');
+      } else {
+        newTags[notwd] = qid;
+      }
 
       if (newTags[wd] === qid) {   // if `brand:wikidata` was set to that qid
         const wp = item.mainTag.replace('wikidata', 'wikipedia');

--- a/test/spec/validations/outdated_tags.js
+++ b/test/spec/validations/outdated_tags.js
@@ -20,7 +20,10 @@ describe('iD.validations.outdated_tags', function () {
                 const NSI = { 'Fish Bowl': 'Q110785465' };
                 if (tags.brand && NSI[tags.brand] && tags['brand:wikidata'] !== NSI[tags.brand]) {
                     return {
-                        matched: {},
+                        matched: {
+                            mainTag: 'brand:wikidata',
+                            tags: { 'brand:wikidata': NSI[tags.brand] },
+                        },
                         newTags: { ...tags, 'brand:wikidata': NSI[tags.brand] }
                     };
                 }
@@ -193,6 +196,44 @@ describe('iD.validations.outdated_tags', function () {
             amenity: 'fast_food',
             brand: 'Fish Bowl',
             'brand:wikidata': 'Q110785465', // added
+        });
+    });
+
+    it('adds a not:brand:wikidata tag if an NSI suggestion is rejected', async () => {
+        createWay({ amenity: 'fast_food', brand: 'Fish Bowl' });
+        const validator = iD.validationOutdatedTags(context);
+        await setTimeout(20);
+        const issues = validate(validator);
+
+        expect(issues).toHaveLength(1);
+
+        // click on "Tag as not the same as 'Fish Bowl'"
+        issues[0].dynamicFixes()[1].onClick(context);
+        expect(context.graph().entity('w-1').tags).toStrictEqual({
+            amenity: 'fast_food',
+            brand: 'Fish Bowl',
+            'not:brand:wikidata': 'Q110785465', // added
+        });
+    });
+
+    it('preserves existing values in the not:brand:wikidata tag if an NSI suggestion is rejected', async () => {
+        createWay({
+            amenity: 'fast_food',
+            brand: 'Fish Bowl',
+            'not:brand:wikidata': 'existing_value',
+        });
+        const validator = iD.validationOutdatedTags(context);
+        await setTimeout(20);
+        const issues = validate(validator);
+
+        expect(issues).toHaveLength(1);
+
+        // click on "Tag as not the same as 'Fish Bowl'"
+        issues[0].dynamicFixes()[1].onClick(context);
+        expect(context.graph().entity('w-1').tags).toStrictEqual({
+            amenity: 'fast_food',
+            brand: 'Fish Bowl',
+            'not:brand:wikidata': 'existing_value;Q110785465', // modified
         });
     });
 


### PR DESCRIPTION
 Closes #12691, Closes #12715

`not:brand:wikidata` can now be a semicolon-delimited list.

since https://github.com/osmlab/name-suggestion-index/issues/12496 and https://github.com/osmlab/name-suggestion-index/issues/12497 have already been fixed and released, this can't be tested with the original example.


but you can still test it by creating a node anywhere in the world tagged with:
```ini
amenity=fast_food
name=McDonald's
not:brand:wikidata=abc
```