### PR TITLE
Prevent area merges that introduce repeated interior nodes

### DIFF
--- a/modules/actions/connect.ts
+++ b/modules/actions/connect.ts
@@ -6,6 +6,37 @@ import type { EntityId, osmNode, osmRelation, osmWay, NodeId } from '../osm';
 import type { RelationMember } from '../osm/relation';
 
 
+function wouldIntroduceRepeatedAreaNode(way: osmWay, nodeIDs: NodeId[], survivorID: NodeId) {
+    if (!way.isArea()) return false;
+
+    var result = way;
+    for (const nodeID of nodeIDs) {
+        if (nodeID !== survivorID) {
+            result = result.replaceNode(nodeID, survivorID);
+        }
+    }
+
+    var originalNodes = way.isClosed() ? way.nodes.slice(0, -1) : way.nodes;
+    var originalCounts = new Map<NodeId, number>();
+    for (const nodeID of originalNodes) {
+        originalCounts.set(nodeID, (originalCounts.get(nodeID) ?? 0) + 1);
+    }
+
+    var resultNodes = result.isClosed() ? result.nodes.slice(0, -1) : result.nodes;
+    var resultCounts = new Map<NodeId, number>();
+    for (const nodeID of resultNodes) {
+        resultCounts.set(nodeID, (resultCounts.get(nodeID) ?? 0) + 1);
+    }
+
+    for (const [nodeID, count] of resultCounts) {
+        if (count > 1 && count > (originalCounts.get(nodeID) ?? 0)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+
 // Connect the ways at the given nodes.
 //
 // First choose a node to be the survivor, with preference given
@@ -99,17 +130,7 @@ export function actionConnect(nodeIDs: NodeId[]): Action {
         }
         for (const parentWayID of parentWayIDs) {
             way = graph.entity<osmWay>(parentWayID);
-            if (!way.isArea()) continue;
-
-            var result = way;
-            for (i = 0; i < nodeIDs.length; i++) {
-                if (nodeIDs[i] !== survivor.id) {
-                    result = result.replaceNode(nodeIDs[i], survivor.id);
-                }
-            }
-
-            var interiorNodes = result.isClosed() ? result.nodes.slice(0, -1) : result.nodes;
-            if (new Set(interiorNodes).size !== interiorNodes.length) {
+            if (wouldIntroduceRepeatedAreaNode(way, nodeIDs, survivor.id)) {
                 return 'paths_intersect';
             }
         }

--- a/modules/actions/connect.ts
+++ b/modules/actions/connect.ts
@@ -90,6 +90,30 @@ export function actionConnect(nodeIDs: NodeId[]): Action {
         // Select the node with the oldest ID as the survivor.
         survivor = graph.entity(utilOldestID(nodeIDs)!);
 
+        // Disable if connecting these nodes would create a repeated interior
+        // vertex in an area.
+        var parentWayIDs = new Set<EntityId>();
+        for (i = 0; i < nodeIDs.length; i++) {
+            node = graph.entity(nodeIDs[i]);
+            graph.parentWays(node).forEach(parent => parentWayIDs.add(parent.id));
+        }
+        for (const parentWayID of parentWayIDs) {
+            way = graph.entity<osmWay>(parentWayID);
+            if (!way.isArea()) continue;
+
+            var result = way;
+            for (i = 0; i < nodeIDs.length; i++) {
+                if (nodeIDs[i] !== survivor.id) {
+                    result = result.replaceNode(nodeIDs[i], survivor.id);
+                }
+            }
+
+            var interiorNodes = result.isClosed() ? result.nodes.slice(0, -1) : result.nodes;
+            if (new Set(interiorNodes).size !== interiorNodes.length) {
+                return 'paths_intersect';
+            }
+        }
+
         // 1. disable if the nodes being connected have conflicting relation roles
         for (i = 0; i < nodeIDs.length; i++) {
             node = graph.entity(nodeIDs[i]);

--- a/modules/actions/connect.ts
+++ b/modules/actions/connect.ts
@@ -6,7 +6,8 @@ import type { EntityId, osmNode, osmRelation, osmWay, NodeId } from '../osm';
 import type { RelationMember } from '../osm/relation';
 
 
-function wouldIntroduceRepeatedAreaNode(way: osmWay, nodeIDs: NodeId[], survivorID: NodeId) {
+// Count each ring without its closing node: the first/last node repetition is valid.
+function wouldIntroduceRepeatedInteriorAreaNode(way: osmWay, nodeIDs: NodeId[], survivorID: NodeId) {
     if (!way.isArea()) return false;
 
     var result = way;
@@ -130,7 +131,7 @@ export function actionConnect(nodeIDs: NodeId[]): Action {
         }
         for (const parentWayID of parentWayIDs) {
             way = graph.entity<osmWay>(parentWayID);
-            if (wouldIntroduceRepeatedAreaNode(way, nodeIDs, survivor.id)) {
+            if (wouldIntroduceRepeatedInteriorAreaNode(way, nodeIDs, survivor.id)) {
                 return 'paths_intersect';
             }
         }

--- a/test/spec/actions/merge_nodes.js
+++ b/test/spec/actions/merge_nodes.js
@@ -60,14 +60,27 @@ describe('iD.actionMergeNodes', function () {
             expect(iD.actionMergeNodes(['b', 'c', 'd']).disabled(graph)).toBeFalsy();
         });
 
-        it('allows repeated interior nodes in linear ways', function() {
+        it('allows merging nonadjacent nodes of a linear way', function() {
             var graph = new iD.coreGraph([
                 new iD.osmNode({ id: 'a', loc: [0, 0] }),
                 new iD.osmNode({ id: 'b', loc: [1, 0] }),
                 new iD.osmNode({ id: 'c', loc: [2, 0] }),
                 new iD.osmNode({ id: 'd', loc: [3, 0] }),
                 new iD.osmNode({ id: 'e', loc: [4, 0] }),
-                new iD.osmWay({ id: '-', nodes: ['a', 'b', 'c', 'b', 'd', 'e'] })
+                new iD.osmWay({ id: '-', nodes: ['a', 'b', 'c', 'd', 'e'] })
+            ]);
+
+            expect(iD.actionMergeNodes(['b', 'd']).disabled(graph)).toBeFalsy();
+        });
+
+        it('allows a merge that does not worsen an invalid area', function() {
+            var graph = new iD.coreGraph([
+                new iD.osmNode({ id: 'a', loc: [0, 0] }),
+                new iD.osmNode({ id: 'b', loc: [2, 0] }),
+                new iD.osmNode({ id: 'c', loc: [1, 1] }),
+                new iD.osmNode({ id: 'd', loc: [0, 2] }),
+                new iD.osmNode({ id: 'e', loc: [2, 2] }),
+                new iD.osmWay({ id: '-', nodes: ['a', 'b', 'c', 'b', 'd', 'a'], tags: { area: 'yes' } })
             ]);
 
             expect(iD.actionMergeNodes(['d', 'e']).disabled(graph)).toBeFalsy();

--- a/test/spec/actions/merge_nodes.js
+++ b/test/spec/actions/merge_nodes.js
@@ -21,6 +21,57 @@ describe('iD.actionMergeNodes', function () {
 
             expect(iD.actionMergeNodes(['b', 'e']).disabled(graph)).toBeFalsy();
         });
+
+        it('returns paths_intersect when merging nonadjacent nodes of an area', function() {
+            var graph = new iD.coreGraph([
+                new iD.osmNode({ id: 'a', loc: [0, 0] }),
+                new iD.osmNode({ id: 'b', loc: [2, 0] }),
+                new iD.osmNode({ id: 'c', loc: [1, 1] }),
+                new iD.osmNode({ id: 'd', loc: [2, 2] }),
+                new iD.osmNode({ id: 'e', loc: [0, 2] }),
+                new iD.osmWay({ id: '-', nodes: ['a', 'b', 'c', 'd', 'e', 'a'], tags: { area: 'yes' } })
+            ]);
+
+            expect(iD.actionMergeNodes(['b', 'd']).disabled(graph)).toEqual('paths_intersect');
+        });
+
+        it('allows merging adjacent nodes of an area', function() {
+            var graph = new iD.coreGraph([
+                new iD.osmNode({ id: 'a', loc: [0, 0] }),
+                new iD.osmNode({ id: 'b', loc: [2, 0] }),
+                new iD.osmNode({ id: 'c', loc: [2, 2] }),
+                new iD.osmNode({ id: 'd', loc: [0, 2] }),
+                new iD.osmWay({ id: '-', nodes: ['a', 'b', 'c', 'd', 'a'], tags: { area: 'yes' } })
+            ]);
+
+            expect(iD.actionMergeNodes(['b', 'c']).disabled(graph)).toBeFalsy();
+        });
+
+        it('allows merging three consecutive nodes of an area', function() {
+            var graph = new iD.coreGraph([
+                new iD.osmNode({ id: 'a', loc: [0, 0] }),
+                new iD.osmNode({ id: 'b', loc: [2, 0] }),
+                new iD.osmNode({ id: 'c', loc: [3, 1] }),
+                new iD.osmNode({ id: 'd', loc: [2, 2] }),
+                new iD.osmNode({ id: 'e', loc: [0, 2] }),
+                new iD.osmWay({ id: '-', nodes: ['a', 'b', 'c', 'd', 'e', 'a'], tags: { area: 'yes' } })
+            ]);
+
+            expect(iD.actionMergeNodes(['b', 'c', 'd']).disabled(graph)).toBeFalsy();
+        });
+
+        it('allows repeated interior nodes in linear ways', function() {
+            var graph = new iD.coreGraph([
+                new iD.osmNode({ id: 'a', loc: [0, 0] }),
+                new iD.osmNode({ id: 'b', loc: [1, 0] }),
+                new iD.osmNode({ id: 'c', loc: [2, 0] }),
+                new iD.osmNode({ id: 'd', loc: [3, 0] }),
+                new iD.osmNode({ id: 'e', loc: [4, 0] }),
+                new iD.osmWay({ id: '-', nodes: ['a', 'b', 'c', 'b', 'd', 'e'] })
+            ]);
+
+            expect(iD.actionMergeNodes(['d', 'e']).disabled(graph)).toBeFalsy();
+        });
     });
 
 

--- a/test/spec/actions/merge_nodes.js
+++ b/test/spec/actions/merge_nodes.js
@@ -47,6 +47,34 @@ describe('iD.actionMergeNodes', function () {
             expect(iD.actionMergeNodes(['b', 'c']).disabled(graph)).toBeFalsy();
         });
 
+        it('allows merging adjacent nodes across the closing node of an area', function() {
+            var graph = new iD.coreGraph([
+                new iD.osmNode({ id: 'a', loc: [0, 0] }),
+                new iD.osmNode({ id: 'b', loc: [2, 0] }),
+                new iD.osmNode({ id: 'c', loc: [2, 2] }),
+                new iD.osmNode({ id: 'd', loc: [0, 2] }),
+                new iD.osmWay({ id: '-', nodes: ['a', 'b', 'c', 'd', 'a'], tags: { area: 'yes' } })
+            ]);
+            var action = iD.actionMergeNodes(['d', 'a']);
+
+            expect(action.disabled(graph)).toBeFalsy();
+            var way = action(graph).entity('-');
+            expect(way.isClosed()).toBe(true);
+            expect(way.nodes).toEqual(['a', 'b', 'c', 'a']);
+        });
+
+        it('blocks a new interior repetition of the closing node of an area', function() {
+            var graph = new iD.coreGraph([
+                new iD.osmNode({ id: 'a', loc: [0, 0] }),
+                new iD.osmNode({ id: 'b', loc: [2, 0] }),
+                new iD.osmNode({ id: 'c', loc: [2, 2] }),
+                new iD.osmNode({ id: 'd', loc: [0, 2] }),
+                new iD.osmWay({ id: '-', nodes: ['a', 'b', 'c', 'd', 'a'], tags: { area: 'yes' } })
+            ]);
+
+            expect(iD.actionMergeNodes(['c', 'a']).disabled(graph)).toEqual('paths_intersect');
+        });
+
         it('allows merging three consecutive nodes of an area', function() {
             var graph = new iD.coreGraph([
                 new iD.osmNode({ id: 'a', loc: [0, 0] }),


### PR DESCRIPTION
**AI disclosure:** This PR contains AI-generated code and tests. This review update was prepared with OpenAI Codex: it read #9328 and the review comments, inspected the merge implementation, clarified the helper name and comments, added regression tests, ran the checks below, and exercised the local editor to capture the demonstration. These checks were performed by the agent; they are not a claim of independent human review.

## What changed

Prevent area-node merges that introduce or increase a repeated interior vertex. The normal repetition of the first node at the end of a closed way is explicitly excluded from the check.

- Preserve valid merges of adjacent or consecutive area nodes, including across the ring closure.
- Keep repeated interior nodes supported for linear ways.
- Allow merges that do not worsen an already-invalid area's repeated nodes.

The connect action simulates node replacements in affected parent areas and disables the merge with the existing `paths_intersect` reason when it would introduce or increase an interior repetition.

Closes #9328.

## Demonstration

Recorded from the local iD build at `5246475`, using synthetic geometry matching #9328. The extra “Load example area” button only supplies the fixture; selection and merging use the normal editor UI. OSM loading and saving were disabled using the walkthrough controls.

1. Select the nonadjacent top-right and bottom-right nodes and press **C**: the intersection warning appears and the area stays unchanged.
2. Reload the example, select the adjacent top-left and bottom-left nodes (across the ring closure), and press **C**: the merge succeeds.

![Recorded demonstration of the blocked invalid merge and allowed adjacent merge](https://raw.githubusercontent.com/seanwessmith/iD/57fe7478d3e007ff84519efba71fb9c9d7331ce2/area-node-merges.gif)

[MP4 recording](https://github.com/seanwessmith/iD/raw/57fe7478d3e007ff84519efba71fb9c9d7331ce2/area-node-merges.mp4). Pauses between steps were shortened.

## Validation

- Focused connect/merge-node tests: 41 passed.
- Full unit suite: 2,268 passed, 9 skipped, 6 todo.
- Build, distribution build, and TypeScript checks passed.
- Changed-file ESLint passed without warnings. Full lint completed with one existing `no-console` warning in `test/spec/core/difference.js:371`.
- `git diff --check` passed.
