### PR TITLE
NSI: only remove existing wikidata/wikipedia tags if they match the NSI suggestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :scissors: Operations
 #### :camera: Street-Level
 #### :white_check_mark: Validation
+* Only suggest deleting `wikidata`/`wikipedia` tags if they have the same value as the suggested `*:wikidata` tags from NSI ([#12758], thanks [@k-yle])
 #### :bug: Bugfixes
 #### :earth_asia: Localization
 #### :hourglass: Performance
@@ -52,6 +53,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 
 [#9732]: https://github.com/openstreetmap/iD/pull/9732
 [#12679]: https://github.com/openstreetmap/iD/pull/12679
+[#12758]: https://github.com/openstreetmap/iD/pull/12758
 
 
 # 2.42.1

--- a/modules/services/nsi.js
+++ b/modules/services/nsi.js
@@ -566,7 +566,7 @@ function _upgradeTags(tags, loc) {
     });
 
     // Replace mistagged `wikidata`/`wikipedia` with e.g. `brand:wikidata`/`brand:wikipedia`
-    if (foundQID) {
+    if (foundQID && foundQID === item.tags[item.mainTag]) {
       delete newTags.wikipedia;
       delete newTags.wikidata;
     }


### PR DESCRIPTION
Closes #12756

PR is draft because this should probably be discussed with the NSI maintainers, and we should start writing unit tests for NSI.

---

The bug is caused because:
1. "Mendocino National Forest" [is an _operator_ in NSI](https://nsi.guide/index.html?t=*&k=amenity&v=toilets&tt=mendocino%20national%20forest), but it's also a physical place. so `wikidata=Q6816692` and `operator:wikidata=Q6816692` are both valid.
2. also, [`r2067891`](https://osm.org/relation/2067891) matches a _different_ NSI preset. 

I can't think of any examples from my local area where this is valid, so maybe it's an NSI data issue? are the toilets really operated by the forest? the toilets are certainly not cleaned by the forest, i assume it's staff from the  _United States Forest Service_ who clean the toilets. Therefore, shouldn't the toilets use `operator=United States Forest Service` instead of `operator=Mendocino National Forest`?


--- 

this PR does not fix the even weider case of
```ini
building=office
wikidata=Q7660181
name=Sydney Trains HQ
```

which causes this suggestion:

<img width="375" height="569" alt="image" src="https://github.com/user-attachments/assets/25c186b4-982b-4eb2-bce7-4f6ef6f2d90c" />

because I'd like to get some unit tests written before we start fixing more of these issues