### PR TITLE
Drop HTML attribution handling

### DIFF
--- a/API.md
+++ b/API.md
@@ -285,7 +285,6 @@ Optional properties:
 * `polygon` - Array of coordinate rings within which imagery is valid.  If omitted, imagery is assumed to be valid worldwide
 * `overzoom` - Can this imagery be scaled up when zooming in beyond the max zoom?  Defaults to `true`
 * `terms_url` - Url to link to when displaying the imagery terms
-* `terms_html` - HTML content to display in the imagery terms
 * `terms_text` - Text content to display in the imagery terms
 * `best` - If set to `true`, this imagery is considered "better than Bing" and may be chosen by default when iD starts.  Will display with a star in the background imagery list.  Defaults to `false`
 

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -4963,6 +4963,7 @@ img.tile-debug {
     border-radius: 4px;
     margin: 0 3px;
     padding: 3px 6px;
+    vertical-align: middle;
 }
 
 

--- a/data/imagery.json
+++ b/data/imagery.json
@@ -178007,9 +178007,8 @@
     "zoomExtent": [0, 20],
     "terms_url": "https://www.openstreetmap.org/copyright",
     "terms_text": "© OpenStreetMap contributors",
-    "terms_html": "<span style='display: inline-block; padding: 0 8px; background-color: rgba(0,0,0,0.5);'><span style='color: #eee;'>GPS Direction:</span> <span style='font-size: 15px; padding-left: 2px; font-weight: bold;'> <span style='color: #0ee;'>&larr;</span> <span style='color: #96f;'>&darr;</span> <span style='color: #6e0;'>&uarr;</span> <span style='color: #f63;'>&rarr;</span> </span></span> © <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap contributors</a>.",
     "description": "Public GPS traces uploaded to OpenStreetMap.",
-    "icon": "https://osmlab.github.io/editor-layer-index/sources/world/OpenStreetMap-GPS.png",
+    "icon": "https://osmlab.github.io/editor-layer-index/sources/world/OpenStreetMap-GPS.svg",
     "overlay": true
   },
   {

--- a/modules/ui/attribution.js
+++ b/modules/ui/attribution.js
@@ -41,7 +41,7 @@ export function uiAttribution(context) {
           { default: d.terms_text || (d.terms_url && d.name()) }
         );
 
-        if (d.icon && !d.overlay) {
+        if (d.icon) {
           attribution
             .append('img')
             .attr('class', 'source-image')

--- a/modules/ui/attribution.js
+++ b/modules/ui/attribution.js
@@ -29,11 +29,6 @@ export function uiAttribution(context) {
       .each((d, i, nodes) => {
         let attribution = d3_select(nodes[i]);
 
-        if (d.terms_html) {
-          attribution.html(d.terms_html);
-          return;
-        }
-
         if (d.terms_url) {
           attribution = attribution
             .append('a')

--- a/scripts/update_imagery.js
+++ b/scripts/update_imagery.js
@@ -171,9 +171,6 @@ sources.features.forEach(feature => {
   if (attribution.text) {
     im.terms_text = attribution.text;
   }
-  if (attribution.html) {
-    im.terms_html = attribution.html;
-  }
 
   ['best', 'default', 'description', 'encrypted', 'icon', 'overlay', 'tileSize'].forEach(prop => {
     if (source[prop]) {


### PR DESCRIPTION
With https://github.com/osmlab/editor-layer-index/pull/3032 in place, we can drop the now unused terms_html option and fix #11570:

Before (on osm.org):
<img src="https://github.com/user-attachments/assets/0f2f68a7-9684-4fc1-967e-4699c8854a64" />
After (same everywhere, with i18n):
<img src="https://github.com/user-attachments/assets/4594b6f3-cf1e-4527-8b2b-7cd07c43da84" />
<img src="https://github.com/user-attachments/assets/158e3084-d206-48b9-bdd4-76d2f80fbcdd" />
