### PR TITLE
use translated labels for relation roles

### DIFF
--- a/config/id.js
+++ b/config/id.js
@@ -2,7 +2,7 @@
 
 // cdns for external data packages
 const presetsCdnUrl = ENV__ID_PRESETS_CDN_URL
-  || 'https://cdn.jsdelivr.net/npm/@openstreetmap/id-tagging-schema@{presets_version}/';
+  || 'https://pr-1538--ideditor-presets-preview.netlify.app/'; // temporary, until the iDTS PR is merged
 const ociCdnUrl = ENV__ID_OCI_CDN_URL
   || 'https://cdn.jsdelivr.net/npm/osm-community-index@{version}/';
 const wmfSitematrixCdnUrl = ENV__ID_WMF_SITEMATRIX_CDN_URL

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -1701,12 +1701,14 @@ input.date-selector {
 
 .form-field-input-combo input.raw-value,
 .form-field-input-semicombo input.raw-value,
-.form-field-input-multicombo input.raw-value {
+.form-field-input-multicombo input.raw-value,
+input.member-role.raw-value {
     font-family: monospace;
 }
 .form-field-input-combo input.known-value,
 .form-field-input-semicombo input.known-value,
-.form-field-input-multicombo input.known-value {
+.form-field-input-multicombo input.known-value,
+input.member-role.known-value {
     color: var(--link-color);
 }
 

--- a/modules/osm/deprecated.ts
+++ b/modules/osm/deprecated.ts
@@ -1,4 +1,5 @@
 import type { Deprecated as DataDeprecated } from '@openstreetmap/id-tagging-schema';
+import { osmMatchTags } from './tags';
 
 export function getDeprecatedTags(tags: Tags, dataDeprecated: DataDeprecated): DataDeprecated {
   // if there are no tags, none can be deprecated
@@ -21,31 +22,7 @@ export function getDeprecatedTags(tags: Tags, dataDeprecated: DataDeprecated): D
       if (hasExistingValues) return;
     }
 
-    var matchesDeprecatedTags = oldKeys.every((oldKey) => {
-      if (!tags[oldKey]) return false;
-      if (d.old[oldKey] === '*') return true;
-      if (d.old[oldKey] === tags[oldKey]) return true;
-
-      var vals = tags[oldKey].split(';').filter(Boolean);
-      if (vals.length === 0) {
-        return false;
-      } else if (vals.length > 1) {
-        return vals.indexOf(d.old[oldKey]) !== -1;
-      } else {
-        if (tags[oldKey] === d.old[oldKey]) {
-          if (d.replace && d.old[oldKey] === d.replace[oldKey]) {
-            var replaceKeys = Object.keys(d.replace);
-            return !replaceKeys.every((replaceKey) => {
-              return tags[replaceKey] === d.replace![replaceKey];
-            });
-          } else {
-            return true;
-          }
-        }
-      }
-
-      return false;
-    });
+    const matchesDeprecatedTags = osmMatchTags([d.old], tags);
 
     if (matchesDeprecatedTags) {
       deprecated.push(d);

--- a/modules/osm/index.ts
+++ b/modules/osm/index.ts
@@ -18,21 +18,4 @@ export {
     osmJoinWays
 } from './multipolygon';
 
-export {
-    osmAreaKeys,
-    osmSetAreaKeys,
-    osmTagSuggestingArea,
-    osmPointTags,
-    osmSetPointTags,
-    osmVertexTags,
-    osmSetVertexTags,
-    osmNodeGeometriesForTags,
-    osmPavedTags,
-    osmIsInterestingTag,
-    osmLifecyclePrefixes,
-    osmRemoveLifecyclePrefix,
-    osmRoutableHighwayTagValues,
-    osmFlowingWaterwayTagValues,
-    osmRailwayTrackTagValues,
-    osmWayOnlyTags
-} from './tags';
+export * from './tags';

--- a/modules/osm/tags.ts
+++ b/modules/osm/tags.ts
@@ -450,3 +450,22 @@ export const osmUrlKeys: Set<TagKey> = new Set([
     'website:menu',
     'post_office:website',
 ]);
+
+/** returns true if `tags` matches any of the criteria in `matchers` */
+export function osmMatchTags(matchers: Tags[], tags: Tags) {
+  for (const matcher of matchers) {
+    const isMatching = Object.keys(matcher).every((key) => {
+      const expectedValue = matcher[key];
+      const actualValue = tags[key];
+
+      if (!actualValue) return false;
+      if (expectedValue === '*') return true;
+      if (expectedValue === actualValue) return true;
+      if (actualValue.includes(';') && actualValue.split(';').filter(Boolean).includes(expectedValue)) return true;
+
+      return false;
+    });
+    if (isMatching) return true;
+  }
+  return false;
+}

--- a/modules/presets/field.ts
+++ b/modules/presets/field.ts
@@ -9,7 +9,7 @@ export interface presetField extends Omit<Field, 'label' | 'terms' | 'placeholde
   matchGeometry(geom: Geometry): boolean;
   matchAllGeometry(geometries: Geometry[]): boolean;
   t: {
-    (scope: string, options: ReplacementsSimple): string;
+    (scope: string, options?: ReplacementsSimple): string;
     append: typeof t.append;
   };
   t_all: typeof localizer.t_all;

--- a/modules/presets/preset.ts
+++ b/modules/presets/preset.ts
@@ -7,6 +7,15 @@ import { locationManager } from '../core/location_manager';
 import type { presetField } from './field';
 import type { Vec2 } from '../geo/vector';
 
+type PresetRelationMember = NonNullable<Preset['relation']>['members'][number];
+
+export interface PresetRoleDefinitions {
+  [role: string]: {
+    label: string;
+    member: PresetRelationMember;
+  }
+}
+
 export interface presetPreset extends Omit<Preset,
   | 'fields'
   | 'moreFields'
@@ -32,6 +41,7 @@ export interface presetPreset extends Omit<Preset,
   locationSetID?: string;
   matchGeometry(geometry: Geometry): boolean;
   matchAllGeometry(geometries: Geometry[]): boolean;
+  relationSchema(): PresetRoleDefinitions | undefined;
   matchScore(entityTags: Tags): number;
   setTags(tags: Tags, geometry: Geometry, skipFieldDefaults?: boolean, loc?: Vec2): Tags;
   unsetTags(tags: Tags, geometry: Geometry, ignoringKeys?: string[], skipFieldDefaults?: boolean, loc?: Vec2): Tags;
@@ -109,6 +119,19 @@ export function presetPreset(
   _this.matchGeometry = (geom) => _this.geometry.indexOf(geom) >= 0;
 
   _this.matchAllGeometry = (geoms) => geoms.every(_this.matchGeometry);
+
+  _this.relationSchema = () => {
+    if (!_this.relation) return undefined;
+
+    const labels: PresetRoleDefinitions = {};
+    for (const member of _this.relation.members) {
+      labels[member.role] = {
+        label: _this.t(`relation.role_labels.${member.role}`),
+        member,
+      };
+    }
+    return labels;
+  };
 
   _this.matchScore = (entityTags) => {
     const tags = _this.tags;

--- a/modules/ui/combobox.js
+++ b/modules/ui/combobox.js
@@ -23,7 +23,7 @@ export function fuzzyMatch(search, string) {
 }
 
 export function uiCombobox(context, klass) {
-    var dispatch = d3_dispatch('accept', 'cancel', 'update');
+    var dispatch = d3_dispatch('accept', 'cancel', 'update', 'render');
     var container = context.container();
 
     var _suggestions = [];
@@ -59,6 +59,9 @@ export function uiCombobox(context, klass) {
     var combobox = function(input, attachTo) {
         if (!input || input.empty()) return;
 
+        /** @type {MouseEvent | undefined} */
+        let _lastPointerUpEvent;
+
         input
             .classed('combobox-input', true)
             .on('focus.combo-input', focus)
@@ -67,7 +70,8 @@ export function uiCombobox(context, klass) {
             .on('keyup.combo-input', keyup)
             .on('input.combo-input', change)
             .on('mousedown.combo-input', mousedown)
-            .on('mouseup.combo-input', mouseup)
+            .on('mouseup.combo-input', toggle)
+            .on('click.combo-input', toggle)
             .each(function() {
                 var parent = this.parentNode;
                 var sibling = this.nextSibling;
@@ -133,6 +137,13 @@ export function uiCombobox(context, klass) {
             } else {
                 hide();
             }
+        }
+
+        /** @param {MouseEvent} d3_event */
+        function toggle(d3_event) {
+            if (_lastPointerUpEvent && (d3_event.timeStamp - _lastPointerUpEvent.timeStamp < 100)) return;
+            _lastPointerUpEvent = d3_event;
+            mouseup(d3_event);
         }
 
 
@@ -439,6 +450,8 @@ export function uiCombobox(context, klass) {
                 .style('left', (rect.left + 5 - containerRect.left) + 'px')
                 .style('width', (rect.width - 10) + 'px')
                 .style('top', (rect.height + rect.top - containerRect.top) + 'px');
+
+            dispatch.call('render');
         }
 
 
@@ -562,6 +575,7 @@ uiCombobox.off = function(input, context) {
         .on('input.combo-input', null)
         .on('mousedown.combo-input', null)
         .on('mouseup.combo-input', null)
+        .on('click.combo-input', null)
         .on('mousedown.combo-caret', null)
         .on('mouseup.combo-caret', null);
 

--- a/modules/ui/sections/raw_member_editor.js
+++ b/modules/ui/sections/raw_member_editor.js
@@ -11,7 +11,7 @@ import { actionMoveMember } from '../../actions/move_member';
 import { modeBrowse } from '../../modes/browse';
 import { modeSelect } from '../../modes/select';
 import { osmIdManager } from '../../osm';
-import { getRelationColor } from '../../osm/tags';
+import { getRelationColor, osmMatchTags } from '../../osm/tags';
 import { svgIcon } from '../../svg/icon';
 import { services } from '../../services';
 import { uiCombobox } from '../combobox';
@@ -19,6 +19,38 @@ import { uiSection } from '../section';
 import { utilDisplayName, utilDisplayType, utilHighlightEntities, utilNoAuto, utilUniqueDomId } from '../../util';
 import { prefs } from '../../core';
 
+/** @type {WeakMap<import('../../osm').OsmEntity, import('../../presets/preset').PresetRoleDefinitions>} */
+const relationRoleLabelsCache = new WeakMap();
+
+/**
+ * @param {iD.Context} context
+ * @param {import('../../osm').OsmEntity} relation
+ * @param {import('@openstreetmap/id-tagging-schema').Geometry} [memberGeom]
+ * @param {Tags} [memberTags]
+ */
+export function getRelationRoleLabels(context, relation, memberGeom, memberTags) {
+    if (!relationRoleLabelsCache.has(relation)) {
+        const preset = presetManager.match(relation, context.graph());
+        const basePreset = presetManager.matchTags({ type: relation.tags.type }, 'relation');
+        const result = preset.relationSchema() || basePreset.relationSchema() || {};
+        relationRoleLabelsCache.set(relation, result);
+    }
+    const cached = relationRoleLabelsCache.get(relation);
+    if (!cached) return {};
+
+    /** @type {Record<string, import('../../core/localizer').LocalizedTextRenderer>} */
+    const labels = {};
+    for (const role in cached) {
+        const def = cached[role];
+        // if there's a geometry filter, check that it passes
+        if (memberGeom && def.member.geometry && !def.member.geometry.includes(memberGeom)) continue;
+        // if there's a tags filter, check that it passes
+        if (memberTags && def.member.matchTags && !osmMatchTags(def.member.matchTags, memberTags)) continue;
+
+        labels[role] = def.label;
+    }
+    return labels;
+}
 
 export function uiSectionRawMemberEditor(context) {
 
@@ -81,9 +113,27 @@ export function uiSectionRawMemberEditor(context) {
     }
 
 
+    /** @param {import('../../osm').OsmEntity} relation */
+    function displayRole(relation, role) {
+        return getRelationRoleLabels(context, relation)[role] || role;
+    }
+
     function changeRole(d3_event, d) {
+        const input = d3_select(this);
+        // this could be the raw role, or the label
+        let rawValue = input.property('value');
+
+        for (const [role, label] of Object.entries(getRelationRoleLabels(context, d.relation))) {
+            if (rawValue === label) {
+                rawValue = role;
+            }
+        }
+
         var oldRole = d.role;
-        var newRole = context.cleanRelationRole(d3_select(this).property('value'));
+        var newRole = context.cleanRelationRole(rawValue);
+
+        // if the raw role was typed in, replace it with the label
+        input.property('value', displayRole(d.relation, newRole));
 
         if (oldRole !== newRole) {
             var member = { id: d.id, type: d.type, role: newRole };
@@ -301,7 +351,8 @@ export function uiSectionRawMemberEditor(context) {
             .order();
 
         items.select('input.member-role')
-            .property('value', function(d) { return d.role; })
+            // use the label from the schema if possible
+            .property('value', (d) => displayRole(d.relation, d.role))
             .on('blur', changeRole)
             .on('change', changeRole);
 
@@ -382,6 +433,14 @@ export function uiSectionRawMemberEditor(context) {
             var role = row.selectAll('input.member-role');
             var origValue = role.property('value');
 
+            const graph = context.graph();
+            const memberGeometry = d.member?.geometry(graph);
+            const rolesFromSchema = getRelationRoleLabels(context, d.relation, memberGeometry);
+
+            const suggestionsFromSchema = Object.entries(rolesFromSchema)
+                .filter(([, label]) => label) // skip roles with no labels
+                .map(([role, label]) => ({ key: role, value: label, title: role }));
+
             function sort(value, data) {
                 var sameletter = [];
                 var other = [];
@@ -395,8 +454,20 @@ export function uiSectionRawMemberEditor(context) {
                 return sameletter.concat(other);
             }
 
-            role.call(uiCombobox(context, 'member-role')
+            const isKnown = value => (
+                Object.values(rolesFromSchema).includes(value)
+                || Object.keys(rolesFromSchema).includes(value)
+            );
+
+            const combo = uiCombobox(context, 'member-role')
+                .minItems(1)
+                .on('render', () => {
+                    role.classed('known-value', isKnown(role.node().value));
+                    role.classed('raw-value', role.node().value && !isKnown(role.node().value));
+                })
+                .data(suggestionsFromSchema)
                 .fetcher(function(role, callback) {
+                    callback(suggestionsFromSchema);
                     // The `geometry` param is used in the `taginfo.js` interface for
                     // filtering results, as a key into the `tag_members_fractions`
                     // object.  If we don't know the geometry because the member is
@@ -418,14 +489,25 @@ export function uiSectionRawMemberEditor(context) {
                         rtype: rtype || '',
                         geometry: geometry,
                         query: role
-                    }, function(err, data) {
+                    }, (err, suggestionsFromTaginfo) => {
+                        const data = [
+                            ...suggestionsFromSchema,
+                            ...suggestionsFromTaginfo
+                                .filter(item => !rolesFromSchema[item.value]) // skip known values
+                                .map(item => ({...item, klass: 'raw-option'}))
+                        ];
+
                         if (!err) callback(sort(role, data));
                     });
                 })
                 .on('cancel', function() {
                     role.property('value', origValue);
-                })
-            );
+                });
+
+            role
+                .classed('known-value', d => isKnown(d.role))
+                .classed('raw-value', d => d.role && !isKnown(d.role))
+                .call(combo);
         }
 
 

--- a/modules/ui/sections/raw_membership_editor.js
+++ b/modules/ui/sections/raw_membership_editor.js
@@ -20,6 +20,7 @@ import { utilArrayGroupBy, utilArrayIntersection } from '../../util/array';
 import { utilDisplayName, utilNoAuto, utilHighlightEntities, utilUniqueDomId } from '../../util';
 import { prefs } from '../../core';
 import { idMatch } from '../feature_list';
+import { getRelationRoleLabels } from './raw_member_editor';
 
 
 export function uiSectionRawMembershipEditor(context) {
@@ -198,14 +199,31 @@ export function uiSectionRawMembershipEditor(context) {
         utilHighlightEntities([d.relation.id], true, context);
     }
 
+    /** @param {import('../../osm').OsmEntity} relation */
+    function displayRole(relation, role) {
+        return getRelationRoleLabels(context, relation)[role] || role;
+    }
 
     function changeRole(d3_event, d) {
         if (d === 0) return;    // called on newrow (shouldn't happen)
         if (_inChange) return;  // avoid accidental recursive call #5731
 
-        var newRole = context.cleanRelationRole(d3_select(this).property('value'));
+        const input = d3_select(this);
+        // this could be the raw role, or the label
+        let rawValue = input.property('value');
+
+        for (const [role, label] of Object.entries(getRelationRoleLabels(context, d.relation))) {
+            if (rawValue === label) {
+                rawValue = role;
+            }
+        }
+
+        var newRole = context.cleanRelationRole(rawValue);
 
         if (!newRole.trim() && typeof d.role !== 'string') return;
+
+        // if the raw role was typed in, replace it with the label.
+        input.property('value', displayRole(d.relation, newRole));
 
         var membersToUpdate = d.members.filter(function(member) {
             return member.role !== newRole;
@@ -552,7 +570,10 @@ export function uiSectionRawMembershipEditor(context) {
             })
             .property('type', 'text')
             .property('value', function(d) {
-                return typeof d.role === 'string' ? d.role : '';
+                // use the label from the schema if possible
+                return typeof d.role === 'string'
+                    ? displayRole(d.relation, d.role)
+                    : '';
             })
             .attr('title', function(d) {
                 return Array.isArray(d.role) ? d.role.filter(Boolean).join('\n') : d.role;
@@ -699,6 +720,18 @@ export function uiSectionRawMembershipEditor(context) {
             var role = row.selectAll('input.member-role');
             var origValue = role.property('value');
 
+            const graph = context.graph();
+            // when multiple features are selected, they may have different
+            // geometries, so we can't filter the roles by geometry.
+            const memberGeometry = _entityIDs.length === 1 ? graph.geometry(_entityIDs[0]) : undefined;
+            const rolesFromSchema = getRelationRoleLabels(context, d.relation, memberGeometry);
+
+            // like the combo field, `key` is the raw role and `value` is the label,
+            // so that typing either one autocompletes to the label.
+            const suggestionsFromSchema = Object.entries(rolesFromSchema)
+                .filter(([, label]) => label) // skip roles with no labels
+                .map(([role, label]) => ({ key: role, value: label, title: role }));
+
             function sort(value, data) {
                 var sameletter = [];
                 var other = [];
@@ -712,22 +745,45 @@ export function uiSectionRawMembershipEditor(context) {
                 return sameletter.concat(other);
             }
 
-            role.call(uiCombobox(context, 'member-role')
+            const isKnown = value => (
+                Object.values(rolesFromSchema).includes(value)
+                || Object.keys(rolesFromSchema).includes(value)
+            );
+
+            const combo = uiCombobox(context, 'member-role')
+                .minItems(1)
+                .on('render', () => {
+                    role.classed('known-value', isKnown(role.node().value));
+                    role.classed('raw-value', role.node().value && !isKnown(role.node().value));
+                })
+                .data(suggestionsFromSchema)
                 .fetcher(function(role, callback) {
+                    callback(suggestionsFromSchema);
                     var rtype = d.relation.tags.type;
                     taginfo.roles({
                         debounce: true,
                         rtype: rtype || '',
                         geometry: context.graph().geometry(_entityIDs[0]),
                         query: role
-                    }, function(err, data) {
+                    }, (err, suggestionsFromTaginfo) => {
+                        const data = [
+                            ...suggestionsFromSchema,
+                            ...suggestionsFromTaginfo
+                                .filter(item => !rolesFromSchema[item.value]) // skip known values
+                                .map(item => ({...item, klass: 'raw-option'}))
+                        ];
+
                         if (!err) callback(sort(role, data));
                     });
                 })
                 .on('cancel', function() {
                     role.property('value', origValue);
-                })
-            );
+                });
+
+            role
+                .classed('known-value', d => isKnown(d.role))
+                .classed('raw-value', d => d.role && !isKnown(d.role))
+                .call(combo);
         }
 
 

--- a/test/spec/osm/tags.js
+++ b/test/spec/osm/tags.js
@@ -21,3 +21,28 @@ describe('osmTagSuggestingArea', function () {
         expect(iD.osmTagSuggestingArea({ 'ex:leisure': 'stadium' })).toBeNull();
     });
 });
+
+describe('osmMatchTags', () => {
+  it.each`
+    matcher                             | tags                    | isMatching
+    ${[{ a: '*' }]}                     | ${{}}                   | ${false}
+    ${[{ a: '*' }]}                     | ${{ a: '' }}            | ${false}
+    ${[{ a: '*' }]}                     | ${{ a: '1' }}           | ${true}
+    ${[{ a: '1' }]}                     | ${{}}                   | ${false}
+    ${[{ a: '1' }]}                     | ${{ a: '' }}            | ${false}
+    ${[{ a: '1' }]}                     | ${{ a: '1' }}           | ${true}
+    ${[{ a: '1' }]}                     | ${{ a: '2' }}           | ${false}
+    ${[{ a: '1' }, { a: '2' }]}         | ${{ a: '1' }}           | ${true}
+    ${[{ a: '1' }, { a: '2' }]}         | ${{ a: '2' }}           | ${true}
+    ${[{ a: '1' }, { a: '2' }]}         | ${{ a: '3' }}           | ${false}
+    ${[] /* this means none */}         | ${{ a: '1' }}           | ${false}
+    ${[] /* this means none */}         | ${{}}                   | ${false}
+    ${[{}] /* this means any */}        | ${{}}                   | ${true}
+    ${[{ a: '1', b: '1' }, { b: '2' }]} | ${{ a: '1' }}           | ${false}
+    ${[{ a: '1', b: '1' }, { b: '2' }]} | ${{ a: '1', b: '1' }}   | ${true}
+    ${[{ a: '1', b: '1' }, { b: '2' }]} | ${{ b: '2' }}           | ${true}
+    ${[{ a: '1', b: '1' }, { b: '2' }]} | ${{ b: '1' }}           | ${false}
+  `('returns $isMatching when comparing $tags against $matcher', ({ matcher, tags, isMatching }) => {
+    expect(iD.osmMatchTags(matcher, tags)).toBe(isMatching);
+  });
+});


### PR DESCRIPTION
this is not ready for a code review, it's blocked by several other PRs. 

i'm just creating this PR to make it easier to review https://github.com/openstreetmap/id-tagging-schema/pull/1538

---

relation roles are now translated if the geometry and tags match:

<img width="513" height="155" alt="image" src="https://github.com/user-attachments/assets/93eeee62-0b1e-4558-a798-7bf81c18f14c" />

in this case, `stop` is not translated, since it's only valid for `vertex`, not valid for `point`:

<img width="516" height="322" alt="image" src="https://github.com/user-attachments/assets/41b02b6b-c42e-4f88-996b-0a2c557967ac" />


