### PR TITLE
Prefer specific recent default imagery 🤖🤖🤖

### DIFF
--- a/modules/renderer/background.js
+++ b/modules/renderer/background.js
@@ -18,6 +18,52 @@ import { patchHash } from '../behavior';
 
 let _imageryIndex = null;
 
+
+/**
+ * Choose the best default background for the current view.
+ * More-specific sources are preferred when they cover more than half the view.
+ * If equally specific sources all have dates, prefer the most recent one.
+ * Otherwise preserve the existing source order.
+ */
+export function rendererDefaultBackground(sources, extent) {
+  const viewArea = extent.area();
+  const candidates = [];
+
+  for (const source of sources) {
+    if (!source.best() || source.overlay) continue;
+
+    const bbox = turf_bbox(turf_bboxClip(
+      { type: 'MultiPolygon', coordinates: [ source.polygon || [extent.polygon()] ] },
+      extent.rectangle()
+    ));
+    const area = geoExtent(bbox.slice(0, 2), bbox.slice(2, 4)).area();
+    if (area / viewArea > 0.5) {
+      candidates.push({ source, area });
+    }
+  }
+
+  if (!candidates.length) return null;
+
+  const minArea = Math.min(...candidates.map(candidate => candidate.area));
+  const mostSpecific = candidates.filter(candidate => candidate.area === minArea);
+  if (mostSpecific.length === 1) return mostSpecific[0].source;
+
+  const dated = mostSpecific.map(candidate => {
+    const value = candidate.source.endDate || candidate.source.startDate;
+    const timestamp = value ? new Date(value).getTime() : NaN;
+    return { ...candidate, timestamp };
+  });
+
+  if (dated.every(candidate => Number.isFinite(candidate.timestamp))) {
+    return dated.reduce((newest, candidate) =>
+      candidate.timestamp > newest.timestamp ? candidate : newest
+    ).source;
+  }
+
+  // Source names are not reliable chronology, so don't guess when dates are incomplete.
+  return mostSpecific[0].source;
+}
+
 export function rendererBackground(context) {
   const dispatch = d3_dispatch('change');
   const baseLayer = rendererTileLayer(context).projection(context.projection);
@@ -457,15 +503,7 @@ export function rendererBackground(context) {
 
       let best;
       if (!requestedBackground && extent) {
-        const viewArea = extent.area();
-        best = validBackgrounds.find(s => {
-          if (!s.best() || s.overlay) return false;
-          let bbox = turf_bbox(turf_bboxClip(
-                { type: 'MultiPolygon', coordinates: [ s.polygon || [extent.polygon()] ] },
-                extent.rectangle()));
-          let area = geoExtent(bbox.slice(0,2), bbox.slice(2,4)).area();
-          return area / viewArea > 0.5; // min visible size: 50% of viewport area
-        });
+        best = rendererDefaultBackground(validBackgrounds, extent);
       }
 
       // Decide which background layer to display

--- a/test/spec/renderer/background.js
+++ b/test/spec/renderer/background.js
@@ -1,0 +1,80 @@
+import { geoExtent } from '../../../modules/geo';
+import { rendererDefaultBackground } from '../../../modules/renderer/background';
+
+
+describe('iD.rendererDefaultBackground', function() {
+    const extent = geoExtent([0, 0], [10, 10]);
+
+    function source(id, polygon, options = {}) {
+        return {
+            id,
+            polygon,
+            overlay: !!options.overlay,
+            startDate: options.startDate,
+            endDate: options.endDate,
+            best: () => options.best !== false
+        };
+    }
+
+    it('prefers the source with more-specific coverage', function() {
+        const broad = source('broad', [[[-5, -5], [-5, 15], [15, 15], [15, -5], [-5, -5]]]);
+        const specific = source('specific', [[[0, 0], [0, 10], [6, 10], [6, 0], [0, 0]]]);
+
+        expect(rendererDefaultBackground([broad, specific], extent)).toBe(specific);
+    });
+
+    it('prefers the most recent equally specific source when all have dates', function() {
+        const polygon = [extent.polygon()];
+        const older = source('older', polygon, { endDate: '2023-01-01T00:00:00.000Z' });
+        const newer = source('newer', polygon, { endDate: '2026-01-01T00:00:00.000Z' });
+
+        expect(rendererDefaultBackground([older, newer], extent)).toBe(newer);
+    });
+
+    it('uses start dates when end dates are unavailable', function() {
+        const polygon = [extent.polygon()];
+        const older = source('older', polygon, { startDate: '2023-01-01T00:00:00.000Z' });
+        const newer = source('newer', polygon, { startDate: '2026-01-01T00:00:00.000Z' });
+
+        expect(rendererDefaultBackground([older, newer], extent)).toBe(newer);
+    });
+
+    it('preserves the existing order when any equally specific source lacks a date', function() {
+        const polygon = [extent.polygon()];
+        const first = source('first', polygon);
+        const dated = source('dated', polygon, { endDate: '2026-01-01T00:00:00.000Z' });
+
+        expect(rendererDefaultBackground([first, dated], extent)).toBe(first);
+    });
+
+    it('preserves the existing order when any equally specific source has an invalid date', function() {
+        const polygon = [extent.polygon()];
+        const first = source('first', polygon, { endDate: 'not-a-date' });
+        const dated = source('dated', polygon, { endDate: '2026-01-01T00:00:00.000Z' });
+
+        expect(rendererDefaultBackground([first, dated], extent)).toBe(first);
+    });
+
+    it('preserves the existing order when equally specific sources have equal dates', function() {
+        const polygon = [extent.polygon()];
+        const first = source('first', polygon, { endDate: '2026-01-01T00:00:00.000Z' });
+        const second = source('second', polygon, { endDate: '2026-01-01T00:00:00.000Z' });
+
+        expect(rendererDefaultBackground([first, second], extent)).toBe(first);
+    });
+
+    it('ignores non-best sources and overlays', function() {
+        const polygon = [extent.polygon()];
+        const fallback = source('fallback', polygon);
+        const notBest = source('not-best', polygon, { best: false });
+        const overlay = source('overlay', polygon, { overlay: true });
+
+        expect(rendererDefaultBackground([notBest, overlay, fallback], extent)).toBe(fallback);
+    });
+
+    it('requires a source to cover more than half the view', function() {
+        const half = source('half', [[[0, 0], [0, 10], [5, 10], [5, 0], [0, 0]]]);
+
+        expect(rendererDefaultBackground([half], extent)).toBeNull();
+    });
+});


### PR DESCRIPTION
## What this changes

- extracts default background selection into a focused helper
- prefers the eligible `best` source with the smallest clipped coverage area
- breaks equal-area ties by newest ELI `end_date` (or `start_date`) when every tied source has a valid date
- preserves today's source order when date metadata is incomplete
- keeps the existing non-overlay and `> 50%` viewport eligibility rules

## Why

The current code selects the first qualifying source from name-sorted generated imagery. This can choose older broad imagery even when a newer local source covers the view, including Maui 2023 instead of the 2025/2026 layers discussed in #12752.

I also ran the requested worldwide before/after audit. A reverse-alphabetical tie-break changed 123 sampled overlap sets and selected known older imagery in 18 cases. The conservative date-aware rule changed 26 sampled sets, all toward newer dated imagery. Audit details and GeoJSON: https://gist.github.com/Rowan121/9c6b260a1648d0f5cea6ec856ede713d

## Verification

- 8 focused regression tests for specificity, dates, incomplete/invalid dates, stable ties, overlays, `best`, and the strict 50% threshold
- full test suite: 2,269 passed (137 files)
- full build passed
- type-check passed
- lint passed (one pre-existing `no-console` warning in `test/spec/core/difference.js`)

Closes #12752
