### PR TITLE
remove name:wlp (typo)

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -702,7 +702,6 @@
   "was": {},
   "wbl": {"nativeName": "وخی"},
   "wbp": {"nativeName": "Warlpiri"},
-  "wlp": {"nativeName": "Warlpiri"},
   "wo": {"nativeName": "Wolof"},
   "wrh": {"nativeName": "Wiradjuri"},
   "wth": {"nativeName": "Wathawurrung"},

--- a/scripts/language_names.js
+++ b/scripts/language_names.js
@@ -193,7 +193,6 @@ function getCLDROverrides() {
     'wbl': {
       nativeName: 'وخی'
     },
-    wlp: { nativeName: 'Warlpiri' },
     wrh: { nativeName: 'Wiradjuri' },
     wth: { nativeName: 'Wathawurrung' },
     'wuu': {


### PR DESCRIPTION
[`wlp`](https://r12a.github.io/app-subtags/index?lookup=wlp) is a typo, it should have been [`wbp`](https://r12a.github.io/app-subtags/index?lookup=wbp) which is already in CLDR (see line above).

neither of them are currently used in osm.