### PR TITLE
Fix displayLength parameter doc saying area

### DIFF
--- a/modules/util/units.ts
+++ b/modules/util/units.ts
@@ -8,7 +8,7 @@ var OSM_PRECISION = 7;
 /**
  * Returns a localized representation of the given length measurement.
  *
- * @param {Number} m area in meters
+ * @param {Number} m length in meters
  * @param {Boolean} isImperial true for U.S. customary units; false for metric
  */
 export function displayLength(m: number, isImperial: boolean) {


### PR DESCRIPTION
`displayLength` documents its first parameter as "area in meters", but the summary line right above it says length, and the sibling `displayArea` documents `m2` as "area in square meters".
