### PR TITLE
Don't report an intersection where two rings share a node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :bug: Bugfixes
 * Fix exceptions when resizing the browser tab when nothing is selected ([#12800], thanks [@k-yle])
 * Allow tags like `not:*:wikidata` to have multiple values ([#12736], thanks [@k-yle])
+* Allow dragging a node next to where two rings of a multipolygon touch ([#12796])
 #### :earth_asia: Localization
 #### :hourglass: Performance
 #### :mortar_board: Walkthrough / Help
@@ -61,6 +62,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#12679]: https://github.com/openstreetmap/iD/pull/12679
 [#12736]: https://github.com/openstreetmap/iD/pull/12736
 [#12740]: https://github.com/openstreetmap/iD/issues/12740
+[#12796]: https://github.com/openstreetmap/iD/pull/12796
 [#12800]: https://github.com/openstreetmap/iD/pull/12800
 [#12828]: https://github.com/openstreetmap/iD/pull/12828
 [#12830]: https://github.com/openstreetmap/iD/pull/12830

--- a/modules/geo/geom.ts
+++ b/modules/geo/geom.ts
@@ -117,6 +117,13 @@ export function geoHasLineIntersections(activeNodes: OsmNode[], inactiveNodes: O
         for (k = 0; k < inactives.length; k++) {
             var p = actives[j];
             var q = inactives[k];
+            // skip if segments share an endpoint, e.g. where two rings of the
+            // same multipolygon touch at a node
+            if (geoVecEqual(p[1], q[0]) || geoVecEqual(p[0], q[1]) ||
+                geoVecEqual(p[0], q[0]) || geoVecEqual(p[1], q[1]) ) {
+                continue;
+            }
+
             var hit = geoLineIntersection(p, q);
             if (hit) {
                 return true;

--- a/test/spec/geo/geom.js
+++ b/test/spec/geo/geom.js
@@ -231,6 +231,45 @@ describe('iD.geo - geometry', function() {
             expect(iD.geoHasLineIntersections(outer, inner, 'g')).toBe(true);
             expect(iD.geoHasLineIntersections(outer, inner, 'h')).toBe(false);
         });
+
+        it('returns false when the rings only touch at a shared node', function() {
+            //  b           f
+            //  | \       / |
+            //  |   \   /   |
+            //  |     x     |
+            //  |   /   \   |
+            //  | /       \ |
+            //  a           e
+            var a = new iD.osmNode({id: 'a', loc: [0, 0]});
+            var x = new iD.osmNode({id: 'x', loc: [4, 4]});
+            var b = new iD.osmNode({id: 'b', loc: [0, 8]});
+            var e = new iD.osmNode({id: 'e', loc: [8, 0]});
+            var f = new iD.osmNode({id: 'f', loc: [8, 8]});
+            var ring1 = [a, x, b, a];
+            var ring2 = [x, e, f, x];
+            expect(iD.geoHasLineIntersections(ring1, ring2, 'a')).toBe(false);
+            expect(iD.geoHasLineIntersections(ring1, ring2, 'b')).toBe(false);
+            expect(iD.geoHasLineIntersections(ring2, ring1, 'e')).toBe(false);
+            expect(iD.geoHasLineIntersections(ring2, ring1, 'f')).toBe(false);
+        });
+
+        it('returns true if a node of one ring lies on an edge of the other', function() {
+            //        c
+            //       / \
+            //  d --x-- e
+            //     /   \
+            //    a --- b
+            var a = new iD.osmNode({id: 'a', loc: [2, 2]});
+            var b = new iD.osmNode({id: 'b', loc: [6, 2]});
+            var c = new iD.osmNode({id: 'c', loc: [4, 6]});
+            var d = new iD.osmNode({id: 'd', loc: [0, 4]});
+            var e = new iD.osmNode({id: 'e', loc: [8, 4]});
+            var f = new iD.osmNode({id: 'f', loc: [8, 8]});
+            var ring1 = [a, b, c, a];
+            var ring2 = [d, e, f, d];
+            expect(iD.geoHasLineIntersections(ring1, ring2, 'a')).toBe(true);
+            expect(iD.geoHasLineIntersections(ring1, ring2, 'b')).toBe(true);
+        });
     });
 
     describe('geoHasSelfIntersections', function() {


### PR DESCRIPTION
Follow-up to #10120. That fix let you drag a node two rings of a multipolygon share, but dragging a node *next to* the shared one is still refused: the moved segment ends at the shared node, and `geoHasLineIntersections` counts that shared endpoint as a hit even though nothing crosses.

The sibling `geoHasSelfIntersections` already skips segment pairs sharing an endpoint, so this does the same. A node sitting on another ring's *edge* still counts, with a test to keep it that way.
