### PR TITLE
fix crash when resizing the browser tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :camera: Street-Level
 #### :white_check_mark: Validation
 #### :bug: Bugfixes
+* Fix crash when resizing the browser tab ([#12800])
 #### :earth_asia: Localization
 #### :hourglass: Performance
 #### :mortar_board: Walkthrough / Help
@@ -52,6 +53,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 
 [#9732]: https://github.com/openstreetmap/iD/pull/9732
 [#12679]: https://github.com/openstreetmap/iD/pull/12679
+[#12800]: https://github.com/openstreetmap/iD/pull/12800
 
 
 # 2.42.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 #### :camera: Street-Level
 #### :white_check_mark: Validation
 #### :bug: Bugfixes
-* Fix crash when resizing the browser tab ([#12800])
+* Fix exceptions when resizing the browser tab when nothing is selected ([#12800], thanks [@k-yle])
 #### :earth_asia: Localization
 #### :hourglass: Performance
 #### :mortar_board: Walkthrough / Help

--- a/modules/ui/inspector.js
+++ b/modules/ui/inspector.js
@@ -18,6 +18,8 @@ export function uiInspector(context) {
 
 
     function inspector(selection, options = {}) {
+        if (!_entityIDs?.length) return;
+
         presetList
             .entityIDs(_entityIDs)
             .autofocus(_newFeature)


### PR DESCRIPTION
when you resize the browser tab with nothing selected, there's heaps of console errors. In this situation, I think we can simply not render the inspector? seems to be caused by 43042695

<img width="625" height="535" alt="image" src="https://github.com/user-attachments/assets/b9d0a0f4-7f24-41b8-9a6b-13f808023566" />
