### PR TITLE
fix unit tests calling the real panoramax api & osm api

### DIFF
--- a/test/spec/services/osm.js
+++ b/test/spec/services/osm.js
@@ -7,6 +7,16 @@ import { fakeServer } from 'nise';
 describe('iD.serviceOsm', function () {
     var context, connection, spy;
     var serverXHR;
+    const capabilitiesJSON = {
+        api: {
+            waynodes: { maximum: 2000 },
+            status: { database: 'online', api: 'online', gpx: 'online' },
+            changesets: { maximum_elements: 10000 }
+        },
+        policy: {
+            imagery: { blacklist: [{ regex: '.foo.com' }, { regex: '.bar.org' }] }
+        }
+    };
 
     function login() {
         connection.switch({
@@ -30,6 +40,10 @@ describe('iD.serviceOsm', function () {
 
     beforeEach(function () {
         serverXHR = fakeServer.create();      // authenticated calls use XHR via osm-auth
+        fetchMock.mock(/\/api\/capabilities\.json$/, {
+            body: JSON.stringify(capabilitiesJSON),
+            status: 200,
+        });
         context = iD.coreContext().assetPath('../dist/').init();
         connection = context.connection();
         connection.switch({ url: 'https://www.openstreetmap.org' });
@@ -38,6 +52,7 @@ describe('iD.serviceOsm', function () {
     });
 
     afterEach(function() {
+        connection.throttledReloadApiStatus?.cancel();
         fetchMock.reset();
         serverXHR.restore();
     });
@@ -239,7 +254,7 @@ describe('iD.serviceOsm', function () {
 
             await promisify(connection.loadFromAPI).call(connection, path);
 
-            expect(fetchMock.calls().length).toEqual(1);
+            expect(fetchMock.calls().length).toEqual(2); // /capabilities is also called
             expect(fetchMock.calls()[0][0]).toEqual('https://api.openstreetmap.org' + path);
         });
     });
@@ -703,26 +718,8 @@ describe('iD.serviceOsm', function () {
 
 
     describe('API capabilities', function() {
-        var capabilitiesJSON = {
-            api: {
-                waynodes: { maximum: 2000 },
-                status: { database: 'online', api: 'online', gpx: 'online' },
-                changesets: { maximum_elements: 10000 }
-            },
-            policy: {
-                imagery: { blacklist: [{ regex: '.foo.com' }, { regex: '.bar.org' }] }
-            }
-        };
-
         describe('#status', function() {
             it('gets API status', async () => {
-                fetchMock.mock('https://www.openstreetmap.org/api/capabilities.json', {
-                    body: JSON.stringify(capabilitiesJSON),
-                    status: 200,
-                }, {
-                    overwriteRoutes: true
-                });
-
                 const val = await promisify(connection.status).call(connection);
                 expect(val).toEqual('online');
             });
@@ -730,13 +727,6 @@ describe('iD.serviceOsm', function () {
 
         describe('#imageryBlocklists', function() {
             it('updates imagery blocklists', async () => {
-                fetchMock.mock('https://www.openstreetmap.org/api/capabilities.json', {
-                    body: JSON.stringify(capabilitiesJSON),
-                    status: 200,
-                }, {
-                    overwriteRoutes: true
-                });
-
                 await promisify(connection.status).call(connection);
                 var blocklists = connection.imageryBlocklists();
                 expect(blocklists).toEqual([new RegExp('\.foo\.com', 'i'), new RegExp('\.bar\.org', 'i')]);

--- a/test/spec/services/panoramax.js
+++ b/test/spec/services/panoramax.js
@@ -114,7 +114,7 @@ describe('iD.servicePanoramax', function() {
 
         it('handle API error response', async ({ expect }) => {
             fetchMock.reset();
-            fetchMock.mock('/api\.panoramax\.xyz/', 500);
+            fetchMock.mock(/api\.panoramax\.xyz/, 500);
             const promise = panoramax.getImageData('collection1', 'image1');
             await expect(promise).rejects.toThrowError();
         });

--- a/test/spec_helpers.ts
+++ b/test/spec_helpers.ts
@@ -156,7 +156,7 @@ fetchMock.sticky({
               request: 'GetCapabilities'
             }
           }, vegbilderOwsCapabilities, {sticky: true});
-fetchMock.config.fallbackToNetwork = true;
+fetchMock.config.fallbackToNetwork = false;
 fetchMock.config.overwriteRoutes = false;
 
 beforeAll(async () => {


### PR DESCRIPTION
I was mocking network requests while working on #7199, and noticed that our unit tests are currently spamming https://api.panoramax.xyz and https://osm.org/api/capabilities.json because the mocks are misconfigured. 

unit tests should never be calling real APIs, now it's completely blocked.