### PR TITLE
fix the merge-conflict resolution UI getting stuck in an infinite loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 
 # Unreleased (2.43.0-dev)
 
+#### :mega: Release Highlights
+* Fix the merge-conflict resolution UI getting stuck in an infinite loop ([#12814], thanks [@k-yle])
 #### :sparkles: Usability & Accessibility
 * Render diameter and radius tags when a node is selected ([#9732], thanks [@k-yle])
 #### :scissors: Operations
@@ -73,6 +75,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 [#12734]: https://github.com/openstreetmap/iD/pull/12734
 [#12735]: https://github.com/openstreetmap/iD/pull/12735
 [#12736]: https://github.com/openstreetmap/iD/pull/12736
+[#12814]: https://github.com/openstreetmap/iD/pull/12814
 
 
 # 2.42.0

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1055,6 +1055,7 @@ en:
   merge_remote_changes:
     conflict:
       deleted: 'This feature has been deleted by {user}.'
+      deleted_locally: '{user} changed this feature, but you deleted it.'
       location: 'This feature was moved by both you and {user}.'
       nodelist: 'Nodes were changed by both you and {user}.'
       memberlist: 'Relation members were changed by both you and {user}.'

--- a/modules/actions/merge_remote_changes.ts
+++ b/modules/actions/merge_remote_changes.ts
@@ -3,6 +3,7 @@ import { diff3Merge } from 'node-diff3';
 import type { Discarded } from '@openstreetmap/id-tagging-schema';
 import { t } from '../core/localizer';
 import { actionDeleteMultiple } from './delete_multiple';
+import { actionRevert } from './revert';
 import { createEntity, type osmNode, type EntityId, type NodeId, type OsmEntity, type osmRelation, type osmWay } from '../osm';
 import { utilArrayUnion, utilArrayUniq } from '../util';
 import type { coreGraph } from '../core';
@@ -118,6 +119,8 @@ export function actionMergeRemoteChanges(id: EntityId, localGraph: coreGraph, re
             var target;
 
             if (_option === 'force_remote' && remote && remote.visible) {
+                // skip if this feature didn't actually change
+                if (local && local.version === remote.version) continue;
                 updates.replacements.push(remote);
 
             } else if (_option === 'force_local' && local) {
@@ -220,8 +223,29 @@ export function actionMergeRemoteChanges(id: EntityId, localGraph: coreGraph, re
     const action: ActionMergeRemoteChanges = function(graph) {
         var updates = { replacements: [], removeIds: [] };
         var base = graph.base().entities[id]!;
-        var local = localGraph.entity(id);
+        var local = localGraph.hasEntity(id);
         var remote = remoteGraph.entity(id);
+
+        // if it was deleted locally
+        if (!local) {
+            if (!remote.visible) {
+                // both us and them deleted it. So revert our deletion.
+                return actionRevert(id)(graph);
+            }
+
+            if (_option === 'force_local') {
+                // keep our deletion
+                return actionDeleteMultiple([id])(graph);
+            } else if (_option === 'force_remote') {
+                // revert the graph back the base version
+                // (which uploader.ts rebased into the graph)
+                return actionRevert(id)(graph);
+            } else {
+                _conflicts.push(t.append('merge_remote_changes.conflict.deleted_locally', { user: user(remote.user) }));
+                return graph; // do nothing
+            }
+        }
+
         var target = createEntity(local, { version: remote.version }) as OsmEntity;
 
         // delete/undelete

--- a/modules/actions/revert.ts
+++ b/modules/actions/revert.ts
@@ -4,6 +4,14 @@ import { actionDeleteRelation } from './delete_relation';
 import { actionDeleteWay } from './delete_way';
 
 
+/**
+ * 'revert' means that the local state of an entity is reverted
+ * back to the 'base' state (at download time).
+ *
+ * The merge conflict UI abuses this action by first rebasing
+ * the graph (i.e. updating the base version), and then "reverting"
+ * the local version to the (new) "base" version.
+ */
 export function actionRevert(id: EntityId): Action {
     const action: Action = function(graph) {
         var entity = graph.hasEntity(id),
@@ -33,7 +41,28 @@ export function actionRevert(id: EntityId): Action {
                 });
         }
 
-        return graph.revert(id);
+        graph = graph.revert(id);
+
+
+        // now deal with children
+        const queue = [graph.hasEntity(id)];
+        while (queue.length) {
+            const next = queue.pop();
+            if (!next) continue;
+
+            for (const childId of next.children()) {
+                // it's a local deletion if it exists in the base graph,
+                // but does not exist in the current graph
+                if (graph.base().entities[childId] && !graph.hasEntity(childId)) {
+                    graph = graph.revert(childId);
+
+                    // check children recusively
+                    queue.push(graph.hasEntity(childId));
+                }
+            }
+        }
+
+        return graph;
     };
 
     return action;

--- a/modules/core/rebaser.ts
+++ b/modules/core/rebaser.ts
@@ -1,0 +1,57 @@
+import type { coreGraph } from './graph';
+import type { coreContext } from './context';
+import type { EntityId, OsmEntity } from '../osm';
+
+function getChildrenRecursive(entity: OsmEntity, graph: coreGraph) {
+    const results: Record<EntityId, OsmEntity | undefined> = {};
+    const queue = [entity];
+
+    while (queue.length) {
+        const next = queue.pop()!;
+        for (const childId of next.children()) {
+            if (childId in results) continue;
+
+            const child = graph.hasEntity(childId);
+            results[childId] = child;
+            if (child) queue.push(child);
+        }
+    }
+
+    return Object.values(results).filter(Boolean);
+}
+
+/**
+ * This prepares the graph for a merge conflict situation where
+ * we have local_delete + remote_modify.
+ *
+ * If `keep_remote` is chosen, actionRevert will reset all our
+ * local changes to the "base" version. Therefore, this function
+ * needs to rebease the graph, so that the base version is
+ * replaced with the latest remote version.
+ *
+ * Similar to a git rebase, this effectively rewrites history.
+ * It also cannot be easily reversed, since it mutates the
+ * base graph.
+ */
+export function rebaseRemoteChangesIntoBaseGraph(context: coreContext, remote: OsmEntity, remoteGraph: coreGraph) {
+    const history = context.history();
+    const baseGraph = history.base();
+    const base = baseGraph.base();
+    const entities = [remote, ...getChildrenRecursive(remote, remoteGraph)];
+
+    const known: OsmEntity[] = [];
+    for (const entity of entities) {
+        if (!entity.visible) continue; // skip deleted
+
+        if (baseGraph.hasEntity(entity.id)) known.push(entity);
+
+        baseGraph._updateCalculated(base.entities[entity.id], entity, base.parentWays, base.parentRels);
+        base.entities[entity.id] = entity;
+    }
+    baseGraph.transients = {};
+
+    history.tree().rebase(
+        known.filter((entity) => history.graph().hasEntity(entity.id)),
+        /* force */ true,
+    );
+}

--- a/modules/core/uploader.ts
+++ b/modules/core/uploader.ts
@@ -7,15 +7,22 @@ import { actionNoop } from '../actions/noop';
 import { actionRevert } from '../actions/revert';
 import { coreGraph } from './graph';
 import { t } from './localizer';
-import { utilArrayUnion, utilArrayUniq, utilDisplayName, utilDisplayType, utilRebind } from '../util';
+import { utilArrayUnion, utilDisplayName, utilDisplayType, utilRebind } from '../util';
 import type { coreContext } from './context';
 import type { EntityId, osmChangeset, OsmEntity } from '../osm';
 import type { Action } from './history';
 import type { OsmChange } from '../osm/changeset';
 import type { Discarded } from '@openstreetmap/id-tagging-schema';
+import { rebaseRemoteChangesIntoBaseGraph } from './rebaser';
 
+
+export enum ConflictChoiceType {
+    KEEP_LOCAL = 0,
+    KEEP_REMOTE = 1,
+}
 
 export interface Choice {
+    choiceType: ConflictChoiceType;
     id: EntityId;
     text: string;
     action(): void;
@@ -25,7 +32,7 @@ export interface Conflict {
     id: EntityId;
     name: string;
     details: d3.Selector[];
-    chosen: number;
+    chosen: ConflictChoiceType;
     choices: Choice[];
 }
 
@@ -145,14 +152,11 @@ export function coreUploader(context: coreContext) {
         var localGraph = context.graph();
         var remoteGraph = new coreGraph(history.base(), true);
 
-        var summary = history.difference().summary();
-        var _toCheck: EntityId[] = [];
-        for (var i = 0; i < summary.length; i++) {
-            var item = summary[i];
-            if (item.changeType === 'modified') {
-                _toCheck.push(item.entity.id);
-            }
-        }
+        const difference = history.difference();
+        const _toCheck = [
+            ...difference.modified(),
+            ...difference.deleted(),
+        ].map(entity => entity.id);
 
         var _toLoad = withChildNodes(_toCheck, localGraph);
         var _loaded: { [id: string]: boolean } = {};
@@ -172,8 +176,8 @@ export function coreUploader(context: coreContext) {
         function withChildNodes(ids: EntityId[], graph: coreGraph) {
             var s = new Set(ids);
             ids.forEach(function(id) {
-                var entity = graph.entity(id);
-                if (entity.type !== 'way') return;
+                var entity = graph.hasEntity(id);
+                if (entity?.type !== 'way') return;
 
                 graph.childNodes(entity).forEach(function(child) {
                     if (child.version !== undefined) {
@@ -247,8 +251,9 @@ export function coreUploader(context: coreContext) {
 
 
         function detectConflicts() {
-            function choice(id: EntityId, text: string, action: Action): Choice {
+            function choice(choiceType: ConflictChoiceType, id: EntityId, text: string, action: Action): Choice {
                 return {
+                    choiceType,
                     id: id,
                     text: text,
                     action: function() {
@@ -270,6 +275,9 @@ export function coreUploader(context: coreContext) {
             function sameVersions(local: OsmEntity, remote: OsmEntity) {
                 if (local.version !== remote.version) return false;
 
+                // if the local version was deleted, no need to continue
+                if (!localGraph.hasEntity(local.id)) return true;
+
                 if (local.type === 'way' && remote.type === 'way') {
                     var children = utilArrayUnion(local.nodes, remote.nodes);
                     for (var i = 0; i < children.length; i++) {
@@ -283,10 +291,16 @@ export function coreUploader(context: coreContext) {
             }
 
             _toCheck.forEach(function(id) {
-                var local = localGraph.entity(id);
+                // for local_delete, we need to find the feature from the base graph
+                var local = localGraph.hasEntity(id) || localGraph.base().entities[id]!;
                 var remote = remoteGraph.entity(id);
 
                 if (sameVersions(local, remote)) return;
+
+                if (!localGraph.hasEntity(id) && remote.visible) {
+                    // local_delete + remote_modify
+                    rebaseRemoteChangesIntoBaseGraph(context, remote, remoteGraph);
+                }
 
                 var merge = actionMergeRemoteChanges(id, localGraph, remoteGraph, _discardTags, formatUser);
 
@@ -307,10 +321,10 @@ export function coreUploader(context: coreContext) {
                     id: id,
                     name: entityName(local),
                     details: mergeConflicts,
-                    chosen: 1,
+                    chosen: ConflictChoiceType.KEEP_LOCAL,
                     choices: [
-                        choice(id, keepMine, forceLocal),
-                        choice(id, keepTheirs, forceRemote)
+                        choice(ConflictChoiceType.KEEP_LOCAL, id, keepMine, forceLocal),
+                        choice(ConflictChoiceType.KEEP_REMOTE, id, keepTheirs, forceRemote)
                     ]
                 });
             });
@@ -414,7 +428,7 @@ export function coreUploader(context: coreContext) {
             endSave();
 
             context.flush(); // reset iD
-        }, 2500);
+        }, window.VITEST ? 0 : 2500);
     }
 
 
@@ -426,6 +440,9 @@ export function coreUploader(context: coreContext) {
 
 
     uploader.cancelConflictResolution = function() {
+        // this doesn't work, and it seems like it hasn't worked
+        // properly for many years.
+        // TODO: consider disabling the cancel button, since we know it's broken?
         context.history().pop();
     };
 
@@ -434,14 +451,7 @@ export function coreUploader(context: coreContext) {
         var history = context.history();
 
         for (var i = 0; i < _conflicts.length; i++) {
-            if (_conflicts[i].chosen === 1) {  // user chose "use theirs"
-                var entity = context.hasEntity(_conflicts[i].id);
-                if (entity && entity.type === 'way') {
-                    var children = utilArrayUniq(entity.nodes);
-                    for (var j = 0; j < children.length; j++) {
-                        history.replace(actionRevert(children[j]));
-                    }
-                }
+            if (_conflicts[i].chosen === ConflictChoiceType.KEEP_REMOTE) {  // user chose "use theirs"
                 history.replace(actionRevert(_conflicts[i].id));
             }
         }

--- a/modules/osm/abstract-entity.ts
+++ b/modules/osm/abstract-entity.ts
@@ -75,6 +75,8 @@ export abstract class OsmAbstractEntity implements OsmEntityProps {
 
     abstract isDegenerate(): boolean;
 
+    abstract children(): EntityId[];
+
     abstract asGeoJSON(resolver: coreGraph): GeoJSON;
 
     abstract asJXON(changesetId: EntityId): unknown;

--- a/modules/osm/node.ts
+++ b/modules/osm/node.ts
@@ -84,6 +84,10 @@ export class osmNode extends OsmAbstractEntity {
         );
     }
 
+    children(): never[] {
+        return [];
+    }
+
     // Inspect tags and geometry to determine which direction(s) this node/vertex points
     directions(resolver: coreGraph, projection: Projection) {
         const rawValues: { type: 'side' | 'turnout_side' | 'direction'; value: string | number }[] = [];

--- a/modules/osm/relation.ts
+++ b/modules/osm/relation.ts
@@ -5,6 +5,7 @@ import { osmJoinWays, type Sequence } from './multipolygon';
 import { geoExtent, geoPolygonContainsPolygon, geoPolygonIntersectsPolygon } from '../geo';
 import { OsmAbstractEntity, type OsmEntityProps, type OsmEntity } from './abstract-entity';
 import { debug } from '..';
+import { utilArrayUniq } from '../util';
 import { osmIdManager, type ChangesetId, type EntityId, type OsmType, type RelationId } from './id_manager';
 import type { coreGraph } from '../core/graph';
 import type { Vec2 } from '../geo/vector';
@@ -75,6 +76,10 @@ export class osmRelation extends OsmAbstractEntity {
 
     isDegenerate() {
         return this.members.length === 0;
+    }
+
+    children(): EntityId[] {
+        return utilArrayUniq(this.members.map((member) => member.id));
     }
 
     // Return an array of members, each extended with an 'index' property whose value

--- a/modules/osm/way.ts
+++ b/modules/osm/way.ts
@@ -247,6 +247,10 @@ export class osmWay extends OsmAbstractEntity {
         return (new Set(this.nodes).size < (this.isClosed() ? 3 : 2));
     }
 
+    children(): NodeId[] {
+        return utilArrayUniq(this.nodes);
+    }
+
     areAdjacent(n1: NodeId, n2: NodeId) {
         for (var i = 0; i < this.nodes.length; i++) {
             if (this.nodes[i] === n1) {

--- a/modules/ui/conflicts.js
+++ b/modules/ui/conflicts.js
@@ -248,7 +248,7 @@ export function uiConflicts(context) {
             .attr('name', function(d) { return d.id; })
             .on('change', function(d3_event, d) {
                 var ul = this.parentNode.parentNode.parentNode;
-                ul.__data__.chosen = d.id;
+                ul.__data__.chosen = d.choiceType;
                 choose(d3_event, ul, d);
             });
 
@@ -261,7 +261,7 @@ export function uiConflicts(context) {
             .merge(choices)
             .each(function(d) {
                 var ul = this.parentNode;
-                if (ul.__data__.chosen === d.id) {
+                if (ul.__data__.chosen === d.choiceType) {
                     choose(null, ul, d);
                 }
             });
@@ -314,10 +314,10 @@ export function uiConflicts(context) {
     //     id: id,
     //     name: entityName(local),
     //     details: merge.conflicts(),
-    //     chosen: 1,
+    //     chosen: ConflictChoiceType.KEEP_LOCAL,
     //     choices: [
-    //         choice(id, keepMine, forceLocal),
-    //         choice(id, keepTheirs, forceRemote)
+    //         choice(ConflictChoiceType.KEEP_LOCAL, id, keepMine, forceLocal),
+    //         choice(ConflictChoiceType.KEEP_REMOTE, id, keepTheirs, forceRemote)
     //     ]
     // }
     conflicts.conflictList = function(_) {

--- a/test/spec/actions/merge_remote_changes.js
+++ b/test/spec/actions/merge_remote_changes.js
@@ -542,4 +542,80 @@ describe('iD.actionMergeRemoteChanges', function () {
         });
     });
 
+    describe('local deletions', () => {
+        it('local_delete + remote_edit -> graph unchanged, conflict generated', () => {
+            const remote = base.entity('a').update({ tags: { foo: 'foo_remote' }, version: '2' });
+            const localGraph = new iD.coreGraph(base).remove(base.entity('a'));
+            const remoteGraph = makeGraph([remote]);
+            const action = iD.actionMergeRemoteChanges('a', localGraph, remoteGraph, discardTags);
+
+            expect(action(localGraph)).toStrictEqual(localGraph); // no change
+            expect(action.conflicts()).toHaveLength(1);
+        });
+
+        it('local_delete + remote_delete -> revert local deletion', () => {
+            const remote = base.entity('a').update({ visible: false, version: '2' });
+            const localGraph = new iD.coreGraph(base).remove(base.entity('a'));
+            const remoteGraph = makeGraph([remote]);
+            const action = iD.actionMergeRemoteChanges('a', localGraph, remoteGraph, discardTags);
+            const result = action(localGraph);
+
+            expect(result.entity('a')).toStrictEqual(base.entity('a'));
+            expect(action.conflicts()).toHaveLength(0);
+        });
+
+        it('local_delete + remote_edit (with force_local) -> delete', () => {
+            const remote = base.entity('a').update({ tags: { foo: 'foo_remote' }, version: '2' });
+            const localGraph = new iD.coreGraph(base).remove(base.entity('a'));
+            const remoteGraph = makeGraph([remote]);
+            const action = iD.actionMergeRemoteChanges('a', localGraph, remoteGraph, discardTags)
+                .withOption('force_local');
+            const result = action(localGraph);
+
+            expect(result.hasEntity('a')).toBeUndefined();
+            expect(action.conflicts()).toHaveLength(0);
+        });
+
+        it('local_delete of a relation (with force_remote) -> restores its members too', () => {
+            const remote = base.entity('r').update({ tags: { type: 'multipolygon', foo: 'foo_remote' }, version: '2' });
+            const deleted = ['r', 'w1', 'w2', 'p1', 'p2', 'p3', 'p4', 'q1', 'q2', 'q3', 'q4'];
+            const localGraph = deleted.reduce((graph, id) => graph.remove(base.entity(id)), new iD.coreGraph(base));
+            const remoteGraph = makeGraph([remote]);
+            const action = iD.actionMergeRemoteChanges('r', localGraph, remoteGraph, discardTags)
+                .withOption('force_remote');
+            const result = action(localGraph);
+
+            for (const id of deleted) {
+                expect(result.entity(id)).toStrictEqual(base.entity(id));
+            }
+            expect(action.conflicts()).toHaveLength(0);
+        });
+
+        it('local_delete of a relation + remote_delete -> restores its members too', () => {
+            const remote = base.entity('r').update({ visible: false, version: '2' });
+            const deleted = ['r', 'w1', 'w2', 'p1', 'p2', 'p3', 'p4', 'q1', 'q2', 'q3', 'q4'];
+            const localGraph = deleted.reduce((graph, id) => graph.remove(base.entity(id)), new iD.coreGraph(base));
+            const remoteGraph = makeGraph([remote]);
+            const action = iD.actionMergeRemoteChanges('r', localGraph, remoteGraph, discardTags);
+            const result = action(localGraph);
+
+            for (const id of deleted) {
+                expect(result.entity(id)).toStrictEqual(base.entity(id));
+            }
+            expect(action.conflicts()).toHaveLength(0);
+        });
+
+        it('local_delete + remote_edit (with force_remote) -> revert local deletion', () => {
+            const remote = base.entity('a').update({ tags: { foo: 'foo_remote' }, version: '2' });
+            const localGraph = new iD.coreGraph(base).remove(base.entity('a'));
+            const remoteGraph = makeGraph([remote]);
+            const action = iD.actionMergeRemoteChanges('a', localGraph, remoteGraph, discardTags)
+                .withOption('force_remote');
+            const result = action(localGraph);
+
+            expect(result.hasEntity('a')).toStrictEqual(base.hasEntity('a'));
+            expect(action.conflicts()).toHaveLength(0);
+        });
+    });
+
 });

--- a/test/spec/actions/revert.js
+++ b/test/spec/actions/revert.js
@@ -192,4 +192,54 @@ describe('iD.actionRevert', function() {
         });
     });
 
+    describe('reverting children recursively', () => {
+        const n1 = new iD.osmNode({ id: 'n1' });
+        const n2 = new iD.osmNode({ id: 'n2' });
+        const n3 = new iD.osmNode({ id: 'n3', tags: { a: 'b' } }); // won't be deleted
+        const w1 = new iD.osmWay({ id: 'w1', nodes: ['n1', 'n2', 'n3'] });
+        const r1 = new iD.osmRelation({ id: 'r1', members: [{ id: 'w1', role: 'outer', type: 'way' }] });
+        const r2 = new iD.osmRelation({ id: 'r2', members: [{ id: 'r1', role: '', type: 'relation' }] });
+
+        it('reverts the child nodes of a way too', () => {
+            let graph = new iD.coreGraph([n1, n2, n3, w1]);
+
+            // delete w1, which would delete the child nodes n1 and n2
+            graph = iD.actionDeleteWay('w1')(graph);
+            expect(graph.hasEntity('n1')).toBeUndefined();
+            expect(graph.hasEntity('n2')).toBeUndefined();
+            expect(graph.hasEntity('n3')).toStrictEqual(n3); // not deleted
+            expect(graph.hasEntity('w1')).toBeUndefined();
+
+            // revert the deletion, which should bring back the child nodes
+            graph = iD.actionRevert('w1')(graph);
+            expect(graph.hasEntity('n1')).toStrictEqual(n1);
+            expect(graph.hasEntity('n2')).toStrictEqual(n2);
+            expect(graph.hasEntity('n3')).toStrictEqual(n3);
+            expect(graph.hasEntity('w1')).toStrictEqual(w1);
+        });
+
+        it('reverts relation members recursively', () => {
+            let graph = new iD.coreGraph([n1, n2, n3, w1, r1, r2]);
+
+            // delete r1, which would delete w1, which would delete the child nodes n1 and n2
+            // it will also delete the parent which has no more members (r2)
+            graph = iD.actionDeleteRelation('r1')(graph);
+            expect(graph.hasEntity('n1')).toBeUndefined();
+            expect(graph.hasEntity('n2')).toBeUndefined();
+            expect(graph.hasEntity('n3')).toStrictEqual(n3); // not deleted
+            expect(graph.hasEntity('w1')).toBeUndefined();
+            expect(graph.hasEntity('r1')).toBeUndefined();
+            expect(graph.hasEntity('r2')).toBeUndefined();
+
+            // revert the deletion, which should bring back the child nodes
+            graph = iD.actionRevert('r1')(graph);
+            expect(graph.hasEntity('n1')).toStrictEqual(n1);
+            expect(graph.hasEntity('n2')).toStrictEqual(n2);
+            expect(graph.hasEntity('n3')).toStrictEqual(n3);
+            expect(graph.hasEntity('w1')).toStrictEqual(w1);
+            expect(graph.hasEntity('r1')).toStrictEqual(r1);
+            expect(graph.hasEntity('r2')).toBeUndefined(); // parent is not restored
+        });
+    });
+
 });

--- a/test/spec/core/rebaser.ts
+++ b/test/spec/core/rebaser.ts
@@ -1,0 +1,50 @@
+import type { coreContext, coreHistory } from '../../../modules';
+import { rebaseRemoteChangesIntoBaseGraph } from '../../../modules/core/rebaser';
+
+describe('rebaseRemoteChangesIntoBaseGraph', () => {
+    let context: coreContext;
+    let history: coreHistory;
+
+    beforeEach(() => {
+        context = iD.coreContext().assetPath('../dist/').init();
+        history = context.history();
+    });
+
+    // this is the base state, when the tab first loaded
+    const n1 = new iD.osmNode({ id: 'n1', version: 1, loc: [1, 1] });
+    const n2 = new iD.osmNode({ id: 'n2', version: 1, loc: [2, 2] });
+    const n3 = new iD.osmNode({ id: 'n3', version: 1, loc: [3, 3] });
+    const w1 = new iD.osmWay({ id: 'w1', version: 1, nodes: ['n1', 'n2', 'n3'] });
+
+    it('rebases the graph with the latest versions from the remote', () => {
+        history.merge([n1, n2, n3, w1]);
+
+        // we deleted n3
+        history.perform(iD.actionDeleteNode('n3'));
+
+        // someone else moved n1 and deleted n2
+        const n1_new = new iD.osmNode({ id: 'n1', version: 2, loc: [11, 11] });
+        const n2_new = new iD.osmNode({ id: 'n2', version: 2, visible: false });
+        const remoteGraph = new iD.coreGraph([n1_new, n2_new], true);
+
+        rebaseRemoteChangesIntoBaseGraph(context, w1, remoteGraph);
+
+        const base = history.base();
+        expect(base.entity('w1')).toBe(w1);
+
+        // n1: updated to reflect the other user's change
+        expect(base.entity('n1')).toBe(n1_new);
+        expect(history.graph().hasEntity('n1')).toBe(n1_new);
+
+        // n2: local kept bc it was deleted by the other user
+        expect(base.entity('n2')).toBe(n2);
+        expect(history.graph().hasEntity('n2')).toBe(n2);
+
+        // n3 is still in the base, but not in the current graph (bc we deleted it locally)
+        expect(base.entity('n3')).toBe(n3);
+        expect(history.graph().hasEntity('n3')).toBeUndefined();
+
+        // and the derived state should be updated
+        expect(base.parentWays(base.entity('n1'))).toStrictEqual([w1]);
+    });
+});

--- a/test/spec/core/uploader.ts
+++ b/test/spec/core/uploader.ts
@@ -1,0 +1,1017 @@
+import { setTimeout } from 'node:timers/promises';
+import { osmIdManager, type coreContext, type coreHistory, type coreUploader, type OsmEntity, type services } from '../../../modules';
+import { ConflictChoiceType, type Conflict } from '../../../modules/core/uploader';
+import type { OsmChange } from '../../../modules/osm/changeset';
+import { osmChangeset } from '../../../modules/osm/changeset';
+import { ApiError } from '../../../modules/util/error';
+
+describe('iD.coreUploader', () => {
+    let context: coreContext;
+    let history: coreHistory;
+    let uploader: coreUploader;
+    let changeset: osmChangeset;
+
+    // temporary hack since uploader.save is not await-able
+    let isDone: Promise<void>;
+    let uploaderEvents: [name: string, ...args: unknown[]][] = [];
+
+    function spyOnEvents() {
+        let _setIsDone: () => void;
+        isDone = new Promise<void>((cb) => { _setIsDone = cb; });
+        uploaderEvents = [];
+
+        // spy on all events from the uploader
+        const events = [
+            'saveStarted',
+            'saveEnded',
+            'willAttemptUpload',
+            'progressChanged',
+            'resultNoChanges',
+            'resultErrors',
+            'resultConflicts',
+            'resultSuccess',
+        ] as const;
+        for (const event of events) {
+            // eslint-disable-next-line no-loop-func -- false positive
+            uploader.on(event, (...args) => {
+                uploaderEvents.push([event, ...args]);
+                if (event === 'saveEnded') _setIsDone();
+            });
+        }
+    }
+
+    beforeEach(() => {
+        context = iD.coreContext().assetPath('../dist/').init();
+        changeset = new osmChangeset();
+        context.changeset = changeset;
+        history = context.history();
+        uploader = context.uploader();
+        spyOnEvents();
+    });
+
+    describe('merge conflicts', () => {
+        /**
+         * mock implementation of the OSM API, for basic uploading & downloading
+         * copied from https://github.com/osmlab/osm-api-js/blob/db5276e3/src/api/changesets/__tests__/uploadChangeset.test.ts
+         *
+         * @param remoteEntities - what we will re-download when trying to upload the changeset
+         */
+        function mockMergeConflict(remoteEntities: OsmEntity[]) {
+            let db = remoteEntities;
+
+            const partial: Partial<typeof services.osm> = {
+                authenticated: () => true,
+                isDataLoaded: () => true,
+                maxWayNodes: () => Infinity,
+                updateChangesetTags: vi.fn(),
+                loadMultiple: vi.fn(async (ids: string[], callback: Callback<{ data: OsmEntity[] }>) => {
+                    await setTimeout(0);
+                    try {
+                        const data = ids.map(id => {
+                            const match = db.find((x) => x.id === id);
+                            if (!match) throw new ApiError(`Not Found ${id}`, 404);
+                            return match;
+                        });
+                        callback(null, { data });
+                    } catch (ex) {
+                        callback(ex as Error);
+                    }
+                }),
+                putChangeset: vi.fn((changeset: osmChangeset, osmChange: OsmChange, callback: Callback<osmChangeset>) => {
+                    const newDB = [...db];
+                    try {
+                        // create is easy. just need to allocate a new ID
+                        newDB.push(
+                            ...osmChange.created.map((feature) => {
+                                return feature.update({
+                                    id: osmIdManager.newId(feature.type),
+                                    version: 1,
+                                });
+                            }),
+                        );
+
+                        // modify & delete needs to check for conflicts
+                        for (const type of <const>['modified', 'deleted']) {
+                            for (let local of osmChange[type]) {
+                                const remoteIndex = newDB.findIndex((f) => f.id === local.id);
+                                const remote = newDB[remoteIndex];
+
+                                const diffId = `${local.id}@(${local.version}…${remote?.version || ''})`;
+
+                                if (!remote) throw new ApiError(`Not Found ${local.type}/${local.id}`, 404);
+                                if (remote.version !== local.version) {
+                                    throw Object.assign(new ApiError(`Conflicts ${diffId}`, 409));
+                                }
+
+                                if (type === 'deleted') {
+                                    newDB.splice(remoteIndex, 1);
+                                } else {
+                                    newDB[remoteIndex] = local.update({ version: local.version! + 1 });
+                                }
+                            }
+                        }
+                        db = newDB; // commit changes
+
+                        callback(null, changeset);
+                    } catch (ex) {
+                        callback(ex as never, changeset);
+                    }
+                }),
+            };
+            context.connection = () => partial as typeof services.osm;
+        }
+
+        /** simulates clicking the "use mine" or "use theirs" buttons, and then rëuploading */
+        async function makeConflictChoice(decisions: ConflictChoiceType[]) {
+            const event = uploaderEvents.find(([name]) => name === 'resultConflicts')!;
+            const changeset = event[1] as osmChangeset;
+            const conflicts = event[2] as Conflict[];
+
+            expect(decisions).toHaveLength(conflicts.length); // sanity check
+
+            for (let i = 0; i < conflicts.length; i++) {
+                conflicts[i].chosen = decisions[i];
+                const choice = conflicts[i].choices.find(c => c.choiceType === decisions[i])!;
+                choice.action();
+            }
+
+            spyOnEvents();
+            uploader.processResolvedConflicts(changeset);
+            await isDone;
+        }
+
+        it('handles local_edit vs remote_edit (same edit -> auto resolved)', async () => {
+            history.merge([
+                new iD.osmNode({ id: 'n1', version: 1, tags: { name: 'original' } }),
+            ]);
+            mockMergeConflict([
+                // someone else made the exact same edit as us
+                new iD.osmNode({ id: 'n1', version: 2, tags: { name: 'SAME edit' } }),
+            ]);
+            history.perform(iD.actionChangeTags('n1', { name: 'SAME edit' }));
+
+            uploader.save(changeset);
+            await isDone;
+
+            expect(uploaderEvents).toStrictEqual([
+                ['saveStarted'],
+                ['willAttemptUpload'],
+                ['progressChanged', 0, 1],
+                ['progressChanged', 1, 1],
+                // no resultConflicts, because conflicts were automatically resolved
+                ['willAttemptUpload'],
+                ['resultSuccess', expect.objectContaining({ tags: { merge_conflict_resolved: 'automatically' } })],
+                ['saveEnded'],
+            ]);
+            expect(context.connection().putChangeset).toHaveBeenCalledTimes(2);
+        });
+
+        it('allows uploading if there is no conflict', async () => {
+            history.merge([
+                new iD.osmNode({ id: 'n1', version: 1, tags: { name: 'original' } }),
+            ]);
+            mockMergeConflict([
+                // no conflicts, node is unchanged.
+                new iD.osmNode({ id: 'n1', version: 1, tags: { name: 'original' } }),
+            ]);
+            // and we also changed the name:
+            history.perform(iD.actionChangeTags('n1', { name: 'OUR edit' }));
+
+            uploader.save(changeset);
+            await isDone;
+
+            expect(uploaderEvents).toStrictEqual([
+                ['saveStarted'],
+                ['willAttemptUpload'],
+                ['resultSuccess', changeset],
+                ['saveEnded'],
+            ]);
+            expect(context.connection().putChangeset).toHaveBeenCalledTimes(1);
+        });
+
+        it('handles local_edit vs remote_edit (accept remote -> noop)', async () => {
+            history.merge([
+                new iD.osmNode({ id: 'n1', version: 1, tags: { name: 'original' } }),
+            ]);
+            mockMergeConflict([
+                // someone else changed the name
+                new iD.osmNode({ id: 'n1', version: 2, tags: { name: 'THEIR edit' } }),
+            ]);
+            // and we also changed the name:
+            history.perform(iD.actionChangeTags('n1', { name: 'OUR edit' }));
+
+            uploader.save(changeset);
+            await isDone;
+
+            expect(uploaderEvents).toStrictEqual([
+                ['saveStarted'],
+                ['willAttemptUpload'],
+                ['progressChanged', 0, 1],
+                ['progressChanged', 1, 1],
+                [
+                    'resultConflicts',
+                    expect.objectContaining({ tags: { merge_conflict_resolved: 'manually' }}),
+                    [
+                        {
+                            choices: [
+                                {
+                                    choiceType: ConflictChoiceType.KEEP_LOCAL,
+                                    id: 'n1',
+                                    text: 'Keep mine',
+                                    action: expect.any(Function),
+                                },
+                                {
+                                    choiceType: ConflictChoiceType.KEEP_REMOTE,
+                                    id: 'n1',
+                                    text: 'Use theirs',
+                                    action: expect.any(Function),
+                                },
+                            ],
+                            chosen: ConflictChoiceType.KEEP_LOCAL,
+                            details: [expect.any(Function)],
+                            id: 'n1',
+                            name: 'OUR edit',
+                        },
+                    ],
+                    {
+                        created: [],
+                        modified: [context.graph().entity('n1')],
+                        deleted: [],
+                    },
+                ],
+                ['saveEnded'],
+            ]);
+            expect(context.connection().putChangeset).toHaveBeenCalledTimes(1);
+
+            await makeConflictChoice([ConflictChoiceType.KEEP_REMOTE]);
+
+            expect(uploaderEvents).toStrictEqual([
+                ['saveStarted'],
+                ['resultNoChanges'], // our changeset is now a no-op, so nothing to upload
+                ['saveEnded'],
+            ]);
+            expect(context.connection().putChangeset).toHaveBeenCalledTimes(1);
+        });
+
+        it('handles local_edit vs remote_edit (accept remote -> partial noop, partial reupload)', async () => {
+            history.merge([
+                new iD.osmNode({ id: 'n1', version: 1, tags: { name: 'original' } }),
+                new iD.osmNode({ id: 'n2', version: 1, tags: { name: 'original 2' } }),
+            ]);
+            mockMergeConflict([
+                // someone else changed the name
+                new iD.osmNode({ id: 'n1', version: 2, tags: { name: 'THEIR edit' } }),
+                // no change to n2
+                new iD.osmNode({ id: 'n2', version: 1, tags: { name: 'original 2' } }),
+            ]);
+            // we modified both nodes:
+            history.perform(iD.actionChangeTags('n1', { name: 'OUR edit' }));
+            history.perform(iD.actionChangeTags('n2', { name: 'OUR edit 2' }));
+
+            uploader.save(changeset);
+            await isDone;
+
+            expect(uploaderEvents).toStrictEqual([
+                ['saveStarted'],
+                ['willAttemptUpload'],
+                ['progressChanged', 0, 2],
+                ['progressChanged', 2, 2],
+                [
+                    'resultConflicts',
+                    expect.objectContaining({ tags: { merge_conflict_resolved: 'manually' }}),
+                    [expect.objectContaining({ id: 'n1' })], // n2 has no conflicts
+                    {
+                        created: [],
+                        modified: [context.graph().entity('n1'), context.graph().entity('n2')],
+                        deleted: [],
+                    },
+                ],
+                ['saveEnded'],
+            ]);
+            expect(context.connection().putChangeset).toHaveBeenCalledTimes(1);
+
+            await makeConflictChoice([ConflictChoiceType.KEEP_REMOTE]);
+
+            expect(uploaderEvents).toStrictEqual([
+                ['saveStarted'],
+                ['willAttemptUpload'], // uploading n1 and n2
+                ['resultSuccess', expect.objectContaining({ tags: { merge_conflict_resolved: 'manually' } })],
+                ['saveEnded'],
+            ]);
+            expect(context.connection().putChangeset).toHaveBeenCalledTimes(2);
+        });
+
+        it('handles local_edit vs remote_edit (accept local)', async () => {
+            history.merge([
+                new iD.osmNode({ id: 'n1', version: 1, tags: { name: 'original' } }),
+            ]);
+            mockMergeConflict([
+                // someone else changed the name
+                new iD.osmNode({ id: 'n1', version: 2, tags: { name: 'THEIR edit' } }),
+            ]);
+            // and we also changed the name:
+            history.perform(iD.actionChangeTags('n1', { name: 'OUR edit' }));
+
+            uploader.save(changeset);
+            await isDone;
+
+            expect(uploaderEvents).toStrictEqual([
+                ['saveStarted'],
+                ['willAttemptUpload'],
+                ['progressChanged', 0, 1],
+                ['progressChanged', 1, 1],
+                [
+                    'resultConflicts',
+                    expect.objectContaining({ tags: { merge_conflict_resolved: 'manually' }}),
+                    [expect.objectContaining({ id: 'n1' })],
+                    {
+                        created: [],
+                        modified: [context.graph().entity('n1')],
+                        deleted: [],
+                    },
+                ],
+                ['saveEnded'],
+            ]);
+            expect(context.connection().putChangeset).toHaveBeenCalledTimes(1);
+
+            await makeConflictChoice([ConflictChoiceType.KEEP_LOCAL]);
+
+            expect(uploaderEvents).toStrictEqual([
+                ['saveStarted'],
+                ['willAttemptUpload'],
+                ['resultSuccess', expect.objectContaining({ tags: { merge_conflict_resolved: 'manually' } })],
+                ['saveEnded'],
+            ]);
+            expect(context.connection().putChangeset).toHaveBeenCalledTimes(2);
+        });
+
+        it('handles local_edit vs remote_delete (accept local)', async () => {
+            history.merge([
+                new iD.osmNode({ id: 'n1', version: 1, tags: { name: 'original' } }),
+            ]);
+            mockMergeConflict([
+                // someone else deleted the node
+                new iD.osmNode({ id: 'n1', version: 2, visible: false }),
+            ]);
+            // and we changed the name:
+            history.perform(iD.actionChangeTags('n1', { name: 'OUR edit' }));
+
+            uploader.save(changeset);
+            await isDone;
+
+            expect(uploaderEvents).toStrictEqual([
+                ['saveStarted'],
+                ['willAttemptUpload'],
+                ['progressChanged', 0, 1],
+                ['progressChanged', 1, 1],
+                [
+                    'resultConflicts',
+                    expect.objectContaining({ tags: { merge_conflict_resolved: 'manually' }}),
+                    [expect.objectContaining({ id: 'n1' })],
+                    {
+                        created: [],
+                        modified: [context.graph().entity('n1')],
+                        deleted: [],
+                    },
+                ],
+                ['saveEnded'],
+            ]);
+            expect(context.connection().putChangeset).toHaveBeenCalledTimes(1);
+
+            await makeConflictChoice([ConflictChoiceType.KEEP_LOCAL]);
+
+            expect(uploaderEvents).toStrictEqual([
+                ['saveStarted'],
+                ['willAttemptUpload'],
+                ['resultSuccess', expect.objectContaining({ tags: { merge_conflict_resolved: 'manually' } })],
+                ['saveEnded'],
+            ]);
+            expect(context.connection().putChangeset).toHaveBeenCalledTimes(2);
+        });
+
+        it('handles local_edit vs remote_delete (accept remote -> noop)', async () => {
+            history.merge([
+                new iD.osmNode({ id: 'n1', version: 1, tags: { name: 'original' } }),
+            ]);
+            mockMergeConflict([
+                // someone else deleted the node
+                new iD.osmNode({ id: 'n1', version: 2, visible: false }),
+            ]);
+            // and we changed the name:
+            history.perform(iD.actionChangeTags('n1', { name: 'OUR edit' }));
+
+            uploader.save(changeset);
+            await isDone;
+
+            expect(uploaderEvents).toStrictEqual([
+                ['saveStarted'],
+                ['willAttemptUpload'],
+                ['progressChanged', 0, 1],
+                ['progressChanged', 1, 1],
+                [
+                    'resultConflicts',
+                    expect.objectContaining({ tags: { merge_conflict_resolved: 'manually' } }),
+                    [expect.objectContaining({ id: 'n1' })],
+                    {
+                        created: [],
+                        modified: [context.graph().entity('n1')],
+                        deleted: [],
+                    },
+                ],
+                ['saveEnded'],
+            ]);
+            expect(context.connection().putChangeset).toHaveBeenCalledTimes(1);
+
+            await makeConflictChoice([ConflictChoiceType.KEEP_REMOTE]);
+
+            expect(uploaderEvents).toStrictEqual([
+                ['saveStarted'],
+                ['resultNoChanges'], // we accepted their deletion, so nothing to upload
+                ['saveEnded'],
+            ]);
+            expect(context.connection().putChangeset).toHaveBeenCalledTimes(1);
+        });
+
+        it('handles local_edit vs remote_delete (accept remote -> reupload)', async () => {
+            history.merge([
+                new iD.osmNode({ id: 'n1', version: 1, tags: { name: 'original' } }),
+                new iD.osmNode({ id: 'n2', version: 1, tags: { name: 'unrelated' } }),
+            ]);
+            mockMergeConflict([
+                // someone else deleted n1, but nobody touched n2
+                new iD.osmNode({ id: 'n1', version: 2, visible: false }),
+                new iD.osmNode({ id: 'n2', version: 1, tags: { name: 'unrelated' } }),
+            ]);
+            // and we changed both:
+            history.perform(iD.actionChangeTags('n1', { name: 'OUR edit' }));
+            history.perform(iD.actionChangeTags('n2', { name: 'OUR unrelated edit' }));
+
+            uploader.save(changeset);
+            await isDone;
+
+            expect(uploaderEvents).toStrictEqual([
+                ['saveStarted'],
+                ['willAttemptUpload'],
+                ['progressChanged', 0, 2],
+                ['progressChanged', 2, 2],
+                [
+                    'resultConflicts',
+                    expect.objectContaining({ tags: { merge_conflict_resolved: 'manually' } }),
+                    [expect.objectContaining({ id: 'n1' })],
+                    {
+                        created: [],
+                        modified: [context.graph().entity('n1'), context.graph().entity('n2')],
+                        deleted: [],
+                    }
+                ],
+                ['saveEnded'],
+            ]);
+            expect(context.connection().putChangeset).toHaveBeenCalledTimes(1);
+
+            await makeConflictChoice([ConflictChoiceType.KEEP_REMOTE]);
+
+            expect(uploaderEvents).toStrictEqual([
+                ['saveStarted'],
+                ['willAttemptUpload'], // n2 is unaffected, so it still gets uploaded
+                ['resultSuccess', expect.objectContaining({ tags: { merge_conflict_resolved: 'manually' } })],
+                ['saveEnded'],
+            ]);
+            expect(context.connection().putChangeset).toHaveBeenCalledTimes(2);
+        });
+
+        it('handles local_delete vs remote_edit (accept local)', async () => {
+            history.merge([
+                new iD.osmNode({ id: 'n1', version: 1, tags: { name: 'original' } }),
+            ]);
+            mockMergeConflict([
+                // someone else changed the name
+                new iD.osmNode({ id: 'n1', version: 2, tags: { name: 'THEIR edit' } }),
+            ]);
+            // and we deleted the node:
+            history.perform(iD.actionDeleteNode('n1'));
+
+            uploader.save(changeset);
+            await isDone;
+
+            expect(uploaderEvents).toStrictEqual([
+                ['saveStarted'],
+                ['willAttemptUpload'], // fist time we're trying to delete v1
+                ['progressChanged', 0, 1],
+                ['progressChanged', 1, 1],
+                [
+                    'resultConflicts',
+                    expect.objectContaining({ tags: { merge_conflict_resolved: 'manually' } }),
+                    [expect.objectContaining({ id: 'n1' })],
+                    {
+                        created: [],
+                        modified: [],
+                        deleted: [expect.objectContaining({ id: 'n1', version: 1 })],
+                    },
+                ],
+                ['saveEnded'],
+            ]);
+            expect(context.connection().putChangeset).toHaveBeenCalledTimes(1);
+
+            await makeConflictChoice([ConflictChoiceType.KEEP_LOCAL]);
+
+            expect(uploaderEvents).toStrictEqual([
+                ['saveStarted'],
+                ['willAttemptUpload'], // now we're trying to delete v2
+                ['resultSuccess', expect.objectContaining({ tags: { merge_conflict_resolved: 'manually' } })],
+                ['saveEnded'],
+            ]);
+            expect(context.connection().putChangeset).toHaveBeenCalledTimes(2);
+        });
+
+        it('handles local_delete vs remote_edit (accept remote -> noop)', async () => {
+            history.merge([
+                new iD.osmNode({ id: 'n1', version: 1, tags: { name: 'original' } }),
+            ]);
+            mockMergeConflict([
+                // someone else changed the name
+                new iD.osmNode({ id: 'n1', version: 2, tags: { name: 'THEIR edit' } }),
+            ]);
+            // and we deleted n1:
+            history.perform(iD.actionDeleteNode('n1'));
+
+            uploader.save(changeset);
+            await isDone;
+
+            expect(uploaderEvents).toStrictEqual([
+                ['saveStarted'],
+                ['willAttemptUpload'],
+                ['progressChanged', 0, 1],
+                ['progressChanged', 1, 1],
+                [
+                    'resultConflicts',
+                    expect.objectContaining({ tags: { merge_conflict_resolved: 'manually' } }),
+                    [expect.objectContaining({ id: 'n1' })],
+                    {
+                        created: [],
+                        modified: [],
+                        deleted: [expect.objectContaining({ id: 'n1', version: 1 })],
+                    },
+                ],
+                ['saveEnded'],
+            ]);
+            expect(context.connection().putChangeset).toHaveBeenCalledTimes(1);
+
+            await makeConflictChoice([ConflictChoiceType.KEEP_REMOTE]);
+
+            expect(uploaderEvents).toStrictEqual([
+                ['saveStarted'],
+                ['resultNoChanges'], // we undid our deletion, so nothing to upload
+                ['saveEnded'],
+            ]);
+            expect(context.connection().putChangeset).toHaveBeenCalledTimes(1);
+        });
+
+        it('handles local_delete vs remote_edit (accept remote -> reupload)', async () => {
+            history.merge([
+                new iD.osmNode({ id: 'n1', version: 1, tags: { name: 'original' } }),
+                new iD.osmNode({ id: 'n2', version: 1, tags: { name: 'unrelated' } }),
+            ]);
+            mockMergeConflict([
+                // someone else changed the name
+                new iD.osmNode({ id: 'n1', version: 2, tags: { name: 'THEIR edit' } }),
+                new iD.osmNode({ id: 'n2', version: 1, tags: { name: 'unrelated' } }),
+            ]);
+            // and we deleted n1:
+            history.perform(iD.actionDeleteNode('n1'));
+            // and we changed the unrelated n2:
+            history.perform(iD.actionChangeTags('n2', { name: 'OUR unrelated edit' }));
+
+            uploader.save(changeset);
+            await isDone;
+
+            expect(uploaderEvents).toStrictEqual([
+                ['saveStarted'],
+                ['willAttemptUpload'],
+                ['progressChanged', 0, 2],
+                ['progressChanged', 2, 2],
+                [
+                    'resultConflicts',
+                    expect.objectContaining({ tags: { merge_conflict_resolved: 'manually' } }),
+                    [expect.objectContaining({ id: 'n1' })], // n2 has no conflicts
+                    {
+                        created: [],
+                        modified: [context.graph().entity('n2')],
+                        deleted: [expect.objectContaining({ id: 'n1', version: 1 })],
+                    },
+                ],
+                ['saveEnded'],
+            ]);
+            expect(context.connection().putChangeset).toHaveBeenCalledTimes(1);
+
+            await makeConflictChoice([ConflictChoiceType.KEEP_REMOTE]);
+
+            expect(uploaderEvents).toStrictEqual([
+                ['saveStarted'],
+                ['willAttemptUpload'], // n2 is unaffected, so it still gets uploaded
+                ['resultSuccess', expect.objectContaining({ tags: { merge_conflict_resolved: 'manually' } })],
+                ['saveEnded'],
+            ]);
+            expect(context.connection().putChangeset).toHaveBeenCalledTimes(2);
+        });
+
+        it('handles local_delete vs remote_delete (auto resolved -> noop)', async () => {
+            history.merge([
+                new iD.osmNode({ id: 'n1', version: 1, tags: { name: 'original' } }),
+            ]);
+            mockMergeConflict([
+                // someone else deleted the node
+                new iD.osmNode({ id: 'n1', version: 2, visible: false }),
+            ]);
+            // and we also deleted it:
+            history.perform(iD.actionDeleteNode('n1'));
+
+            uploader.save(changeset);
+            await isDone;
+
+            // there is nothing for the user to decide, we both wanted it gone
+            expect(uploaderEvents).toStrictEqual([
+                ['saveStarted'],
+                ['willAttemptUpload'],
+                ['progressChanged', 0, 1],
+                ['progressChanged', 1, 1],
+                ['resultNoChanges'],
+                ['saveEnded'],
+            ]);
+            expect(context.connection().putChangeset).toHaveBeenCalledTimes(1);
+            // nothing to upload
+        });
+
+        it('handles local_delete vs remote_delete (auto resolved -> reupload)', async () => {
+            history.merge([
+                new iD.osmNode({ id: 'n1', version: 1, tags: { name: 'original' } }),
+                new iD.osmNode({ id: 'n2', version: 1, tags: { name: 'unrelated' } }),
+            ]);
+            mockMergeConflict([
+                // someone else deleted the node
+                new iD.osmNode({ id: 'n1', version: 2, visible: false }),
+                new iD.osmNode({ id: 'n2', version: 1, tags: { name: 'unrelated' } }),
+            ]);
+            // and we deleted n1:
+            history.perform(iD.actionDeleteNode('n1'));
+            // and we changed the unrelated n2:
+            history.perform(iD.actionChangeTags('n2', { name: 'OUR unrelated edit' }));
+
+            uploader.save(changeset);
+            await isDone;
+
+            expect(uploaderEvents).toStrictEqual([
+                ['saveStarted'],
+                ['willAttemptUpload'],
+                ['progressChanged', 0, 2],
+                ['progressChanged', 2, 2],
+                ['willAttemptUpload'], // only n2 is left to upload
+                ['resultSuccess', expect.objectContaining({ tags: { merge_conflict_resolved: 'automatically' } })],
+                ['saveEnded'],
+            ]);
+            expect(context.connection().putChangeset).toHaveBeenCalledTimes(2);
+        });
+
+        it('handles local_delete vs remote_edit FOR A WAY (accept local)', async () => {
+            history.merge([
+                new iD.osmNode({ id: 'n1', version: 1, loc: [0, 0] }),
+                new iD.osmNode({ id: 'n2', version: 1, loc: [1, 1] }),
+                new iD.osmWay({ id: 'w1', version: 1, nodes: ['n1', 'n2'], tags: { highway: 'residential' } }),
+            ]);
+            mockMergeConflict([
+                new iD.osmNode({ id: 'n1', version: 1, loc: [0, 0] }),
+                new iD.osmNode({ id: 'n2', version: 1, loc: [1, 1] }),
+                // someone else changed the tags of the way
+                new iD.osmWay({ id: 'w1', version: 2, nodes: ['n1', 'n2'], tags: { highway: 'primary' } }),
+            ]);
+            // and we deleted the way, which also deletes its untagged child nodes:
+            history.perform(iD.actionDeleteWay('w1'));
+
+            uploader.save(changeset);
+            await isDone;
+
+            expect(uploaderEvents).toStrictEqual([
+                ['saveStarted'],
+                ['willAttemptUpload'], // v1 of w1
+                ['progressChanged', 0, 3],
+                ['progressChanged', 3, 3],
+                [
+                    'resultConflicts',
+                    expect.objectContaining({ tags: { merge_conflict_resolved: 'manually' } }),
+                    [expect.objectContaining({ id: 'w1' })],
+                    {
+                        created: [],
+                        modified: [],
+                        deleted: [
+                            expect.objectContaining({ id: 'w1', version: 1 }),
+                            expect.objectContaining({ id: 'n1', version: 1 }),
+                            expect.objectContaining({ id: 'n2', version: 1 }),
+                        ],
+                    },
+                ],
+                ['saveEnded'],
+            ]);
+            expect(context.connection().putChangeset).toHaveBeenCalledTimes(1);
+            expect(context.connection().putChangeset).toHaveBeenNthCalledWith(
+                1,
+                changeset,
+                {
+                    created: [],
+                    modified: [],
+                    deleted: [
+                        expect.objectContaining({ id: 'w1', version: 1 }), // v1 this attempt
+                        expect.objectContaining({ id: 'n1', version: 1 }),
+                        expect.objectContaining({ id: 'n2', version: 1 }),
+                    ],
+                },
+                expect.any(Function)
+            );
+
+            await makeConflictChoice([ConflictChoiceType.KEEP_LOCAL]);
+
+            expect(uploaderEvents).toStrictEqual([
+                ['saveStarted'],
+                ['willAttemptUpload'], // v2 of w1
+                ['resultSuccess', expect.objectContaining({ tags: { merge_conflict_resolved: 'manually' } })],
+                ['saveEnded'],
+            ]);
+
+            // check that the child nodes are being deleted too
+            expect(context.connection().putChangeset).toHaveBeenCalledTimes(2);
+            expect(context.connection().putChangeset).toHaveBeenNthCalledWith(
+                2,
+                expect.objectContaining({ tags: { merge_conflict_resolved: 'manually' } }),
+                {
+                    created: [],
+                    modified: [],
+                    deleted: [
+                        expect.objectContaining({ id: 'w1', version: 2 }), // v2 this attempt
+                        expect.objectContaining({ id: 'n1', version: 1 }),
+                        expect.objectContaining({ id: 'n2', version: 1 }),
+                    ],
+                },
+                expect.any(Function)
+            );
+        });
+
+        it('handles a massive mess of conflicts (auto & manual, and every combination of local/remote <-> edit/delete)', async () => {
+            history.merge([
+                new iD.osmNode({ id: 'n1', version: 1, tags: { name: 'original 1' } }),
+                new iD.osmNode({ id: 'n2', version: 1, tags: { name: 'original 2' } }),
+                new iD.osmNode({ id: 'n3', version: 1, tags: { name: 'original 3' } }),
+                new iD.osmNode({ id: 'n4', version: 1, tags: { name: 'original 4' } }),
+                new iD.osmNode({ id: 'n5', version: 1, tags: { name: 'original 5' } }),
+                new iD.osmNode({ id: 'n6', version: 1, tags: { name: 'original 6' } }),
+                new iD.osmNode({ id: 'n7', version: 1, tags: { name: 'original 7' } }),
+                new iD.osmNode({ id: 'n8', version: 1, tags: { name: 'original 8' } }),
+                new iD.osmNode({ id: 'n9', version: 1, tags: { name: 'original 9' } }),
+            ]);
+            mockMergeConflict([
+                // n1: local_edit + remote_unchanged (no conflicts)
+                new iD.osmNode({ id: 'n1', version: 1, tags: { name: 'original 1' } }),
+                // n2: local_edit + remote_edit (both edits are the same, auto resolved)
+                new iD.osmNode({ id: 'n2', version: 2, tags: { name: 'SAME edit' } }),
+                // n3: local_delete + remote_delete
+                new iD.osmNode({ id: 'n3', version: 2, visible: false }),
+                // n4+n7: local_edit + remote_edit
+                new iD.osmNode({ id: 'n4', version: 2, tags: { name: 'THEIR edit' } }),
+                new iD.osmNode({ id: 'n7', version: 2, tags: { name: 'THEIR edit' } }),
+                // n5+n8: local_edit + remote_delete
+                new iD.osmNode({ id: 'n5', version: 2, visible: false }),
+                new iD.osmNode({ id: 'n8', version: 2, visible: false }),
+                // n6+n9: local_delete + remote_edit
+                new iD.osmNode({ id: 'n6', version: 2, tags: { name: 'THEIR edit' } }),
+                new iD.osmNode({ id: 'n9', version: 2, tags: { name: 'THEIR edit' } }),
+            ]);
+            history.perform(iD.actionChangeTags('n1', { name: 'OUR edit 1' }));
+            history.perform(iD.actionChangeTags('n2', { name: 'SAME edit' }));
+            history.perform(iD.actionDeleteNode('n3'));
+            history.perform(iD.actionChangeTags('n4', { name: 'OUR edit 4' }));
+            history.perform(iD.actionChangeTags('n5', { name: 'OUR edit 5' }));
+            history.perform(iD.actionDeleteNode('n6'));
+            history.perform(iD.actionChangeTags('n7', { name: 'OUR edit 7' }));
+            history.perform(iD.actionChangeTags('n8', { name: 'OUR edit 8' }));
+            history.perform(iD.actionDeleteNode('n9'));
+
+            uploader.save(changeset);
+            await isDone;
+
+            expect(uploaderEvents).toStrictEqual([
+                ['saveStarted'],
+                ['willAttemptUpload'],
+                ['progressChanged', 0, 9],
+                ['progressChanged', 9, 9],
+                [
+                    'resultConflicts',
+                    expect.objectContaining({ tags: { merge_conflict_resolved: 'manually' } }),
+                    [
+                        expect.objectContaining({ id: 'n9' }),
+                        expect.objectContaining({ id: 'n8' }),
+                        expect.objectContaining({ id: 'n7' }),
+                        expect.objectContaining({ id: 'n6' }),
+                        expect.objectContaining({ id: 'n5' }),
+                        expect.objectContaining({ id: 'n4' }),
+                        // n3 was auto-resolved
+                        // n2 was auto-resolved
+                        // n1 has no conflicts
+                    ],
+                    {
+                        created: [],
+                        modified: [
+                            context.graph().entity('n1'), // keep ours
+                            expect.objectContaining({ id: 'n2', version: 1 }), // TODO: why is it different?
+                            context.graph().entity('n4'), // keep ours
+                            context.graph().entity('n5'), // keep ours
+                            context.graph().entity('n7'), // keep ours
+                            context.graph().entity('n8'), // keep ours
+                        ],
+                        deleted: [
+                            expect.objectContaining({ id: 'n3', version: 1 }),
+                            expect.objectContaining({ id: 'n6', version: 1 }),
+                            expect.objectContaining({ id: 'n9', version: 1 }),
+                        ],
+                    },
+                ],
+                ['saveEnded'],
+            ]);
+            expect(context.connection().putChangeset).toHaveBeenCalledTimes(1);
+
+            await makeConflictChoice([
+                ConflictChoiceType.KEEP_REMOTE, // n9: undo our deletion, keep their edit
+                ConflictChoiceType.KEEP_LOCAL,  // n8: keep our edit, undo their deletion
+                ConflictChoiceType.KEEP_REMOTE, // n7: undo our edit, keep their edit
+                ConflictChoiceType.KEEP_LOCAL,  // n6: keep our delete, undo their edit
+                ConflictChoiceType.KEEP_REMOTE, // n5: undo our edit, keep their delete
+                ConflictChoiceType.KEEP_LOCAL,  // n4: keep our edit, undo their edit
+            ]);
+
+            expect(uploaderEvents).toStrictEqual([
+                ['saveStarted'],
+                ['willAttemptUpload'], // rëupload n1,n2,n4,n6,n8 only (but not n3 and not n5,n7,n9)
+                ['resultSuccess', expect.objectContaining({ tags: { merge_conflict_resolved: 'manually' } })], // TODO: should this be automatically;manually ?
+                ['saveEnded'],
+            ]);
+            expect(context.connection().putChangeset).toHaveBeenCalledTimes(2);
+            expect(context.connection().putChangeset).toHaveBeenNthCalledWith(
+                2,
+                expect.any(osmChangeset),
+                {
+                    created: [],
+                    modified: [
+                        expect.objectContaining({ id: 'n1', version: 1, tags: { name: 'OUR edit 1' } }),
+                        expect.objectContaining({ id: 'n2', version: 2, tags: { name: 'SAME edit' } }),
+                        expect.objectContaining({ id: 'n4', version: 2, tags: { name: 'OUR edit 4' } }),
+                        expect.objectContaining({ id: 'n8', version: 2, tags: { name: 'OUR edit 8' } }),
+                    ],
+                    deleted: [expect.objectContaining({ id: 'n6', version: 2 })],
+                },
+                expect.any(Function),
+            );
+            expect(context.connection().updateChangesetTags).toHaveBeenCalledTimes(1); // not called again
+        });
+
+        it('handles local_delete of a way vs remote_edit of its child node', async () => {
+            history.merge([
+                new iD.osmNode({ id: 'n1', version: 1, loc: [0, 0] }),
+                new iD.osmNode({ id: 'n2', version: 1, loc: [1, 1] }),
+                new iD.osmWay({ id: 'w1', version: 1, nodes: ['n1', 'n2'] }),
+            ]);
+            mockMergeConflict([
+                // someone else moved n1, but did not touch the way
+                new iD.osmNode({ id: 'n1', version: 2, loc: [9, 9] }),
+                new iD.osmNode({ id: 'n2', version: 1, loc: [1, 1] }),
+                new iD.osmWay({ id: 'w1', version: 1, nodes: ['n1', 'n2'] }),
+            ]);
+            history.perform(iD.actionDeleteWay('w1'));
+
+            uploader.save(changeset);
+            await isDone;
+
+            expect(uploaderEvents).toStrictEqual([
+                ['saveStarted'],
+                ['willAttemptUpload'],
+                ['progressChanged', 0, 3],
+                ['progressChanged', 3, 3],
+                [
+                    'resultConflicts',
+                    expect.objectContaining({ tags: { merge_conflict_resolved: 'manually' } }),
+                    [expect.objectContaining({ id: 'n1' })],
+                    {
+                        created: [],
+                        modified: [],
+                        deleted: [
+                            expect.objectContaining({ id: 'w1', version: 1 }),
+                            expect.objectContaining({ id: 'n1', version: 1 }), // trying to delete v1, not v2
+                            expect.objectContaining({ id: 'n2', version: 1 }),
+                        ],
+                    },
+                ],
+                ['saveEnded'],
+            ]);
+            expect(context.connection().putChangeset).toHaveBeenCalledTimes(1);
+            expect(context.connection().putChangeset).toHaveBeenNthCalledWith(
+                1,
+                changeset,
+                {
+                    created: [],
+                    modified: [],
+                    deleted: [
+                        expect.objectContaining({ id: 'w1', version: 1 }),
+                        expect.objectContaining({ id: 'n1', version: 1 }),// v1 this attempt
+                        expect.objectContaining({ id: 'n2', version: 1 }),
+                    ],
+                },
+                expect.any(Function)
+            );
+
+            await makeConflictChoice([ConflictChoiceType.KEEP_LOCAL]);
+
+            expect(uploaderEvents).toStrictEqual([
+                ['saveStarted'],
+                ['willAttemptUpload'],
+                ['resultSuccess', expect.objectContaining({ tags: { merge_conflict_resolved: 'manually' } })],
+                ['saveEnded'],
+            ]);
+            expect(context.connection().putChangeset).toHaveBeenCalledTimes(2);
+            expect(context.connection().putChangeset).toHaveBeenNthCalledWith(
+                2,
+                expect.objectContaining({ tags: { merge_conflict_resolved: 'manually' } }),
+                {
+                    created: [],
+                    modified: [],
+                    deleted: [
+                        expect.objectContaining({ id: 'w1', version: 1 }),
+                        expect.objectContaining({ id: 'n1', version: 2 }), // v2 this attempt
+                        expect.objectContaining({ id: 'n2', version: 1 }),
+                    ],
+                },
+                expect.any(Function)
+            );
+        });
+
+        it('does not produce a conflict for local_delete (parent way), and remote_edit of a child node', async () => {
+            history.merge([
+                // café as a vertex of a building
+                new iD.osmNode({ id: 'n1', version: 1, loc: [0, 0] }),
+                new iD.osmNode({ id: 'n2', version: 1, loc: [1, 1], tags: { amenity: 'cafe', name: 'original' } }),
+                new iD.osmWay({ id: 'w1', version: 1, nodes: ['n1', 'n2'], tags: { building: 'yes' } }),
+            ]);
+            mockMergeConflict([
+                new iD.osmNode({ id: 'n1', version: 1, loc: [0, 0] }),
+                // someone else renamed the café vertex (n2)
+                new iD.osmNode({ id: 'n2', version: 2, loc: [1, 1], tags: { amenity: 'cafe', name: 'THEIR edit' } }),
+                new iD.osmWay({ id: 'w1', version: 1, nodes: ['n1', 'n2'], tags: { building: 'yes' } }),
+            ]);
+            // and we also renamed the café vertex (n2), and deleted the building (w1 + n1)
+            history.perform(iD.actionDeleteWay('w1'));
+            history.perform(iD.actionChangeTags('n2', { amenity: 'cafe', name: 'OUR edit' }));
+
+            uploader.save(changeset);
+            await isDone;
+
+            expect(uploaderEvents).toStrictEqual([
+                ['saveStarted'],
+                ['willAttemptUpload'],
+                ['progressChanged', 0, 3],
+                ['progressChanged', 3, 3],
+                [
+                    'resultConflicts',
+                    expect.objectContaining({ tags: { merge_conflict_resolved: 'manually' } }),
+                    [expect.objectContaining({ id: 'n2' })],  // conflict on n2 only, not on w1
+                    {
+                        created: [],
+                        modified: [context.graph().entity('n2')],
+                        deleted: [
+                            expect.objectContaining({ id: 'w1', version: 1 }),
+                            expect.objectContaining({ id: 'n1', version: 1 }),
+                        ],
+                    },
+                ],
+                ['saveEnded'],
+            ]);
+            expect(context.connection().putChangeset).toHaveBeenCalledTimes(1);
+
+            await makeConflictChoice([ConflictChoiceType.KEEP_REMOTE]);
+
+            expect(uploaderEvents).toStrictEqual([
+                ['saveStarted'],
+                ['willAttemptUpload'],
+                ['resultSuccess', expect.objectContaining({ tags: { merge_conflict_resolved: 'manually' } })],
+                ['saveEnded'],
+            ]);
+            expect(context.connection().putChangeset).toHaveBeenCalledTimes(2);
+            expect(context.connection().putChangeset).toHaveBeenNthCalledWith(
+                2,
+                expect.objectContaining({ tags: { merge_conflict_resolved: 'manually' } }),
+                {
+                    created: [],
+                    modified: [], // no n2
+                    deleted: [
+                        expect.objectContaining({ id: 'w1', version: 1 }),
+                        expect.objectContaining({ id: 'n1', version: 1 }),
+                    ],
+                },
+                expect.any(Function)
+            );
+        });
+    });
+});


### PR DESCRIPTION
Closes #2768, Closes #2803, Closes #5114, Closes #5228, Closes #7163, Closes #7199, Closes #8790, Closes #9039, Closes #9324, Closes #9697, Closes #10157, Closes #10166, Closes #11041, Closes #11044, Closes #11464, and equivalently https://github.com/facebook/Rapid/issues/1361, https://github.com/facebook/Rapid/issues/1366, https://github.com/facebook/Rapid/issues/1480.

---

This PR should finally fix the merge-conflict UI getting stuck in an infinite loop, which has been broken for at least 5 years.

There were actually 3 different bugs:

1. the UI buttons did nothing 😆 No matter what you selected, it would always choose `keep_local`. these two buttons were supposed to have `id=0` and `id=1` to distinguish them, but the `.id` prop was accidentally being used for the OSM entity's ID. TypeScript detected this one.

2. merge conflicts were never being checked for tagless vertices. The list of features to check for conflicts used `coreDifference.summary()`, which is designed to generate a user-facing list of changes for the upload panel. Therefore it was skipping features like tagless vertices.

3. merge conflicts were not even being checked for features that are deleted locally. because local deletions don't exist in the graph anymore. Thanks to @DujaOSM for [pinpointing this](https://github.com/openstreetmap/iD/issues/7199#issuecomment-5438130142).

Numbers 1 and 2 were easy to fix, but 3 was an absolute pain. I added a lot of comments inline to explain how rebasing coreGraph works, won't repeat that here. 

Out of scope:
- This PR doesn't adjust the location of the <kbd>download osmChange</kbd> button. In a future PR we can add that button to the merge conflict UI.
- The "cancel" button in the merge conflict window doesn't work either. It leaves iD with a broken mix of local and remote versions:
  <img height="400" src="https://github.com/user-attachments/assets/335be437-8ca9-4ab9-b563-a39eace247d7" />     
  this PR is already unreasonably large, so I'm not going to try to fix that. i don't even know how 🥲🥲
- i did not look into [#10048](https://github.com/openstreetmap/iD/issues/10048) nor [#5541](https://github.com/openstreetmap/iD/issues/5541)

if you plan to manually test, run `globalThis.CompressionStream=undefined` in the devtools first, to bypass #11353, so that you can see the osmChange XML in the devtools instead of [this nonsense](https://github.com/user-attachments/assets/a8a3546b-9bf0-4dd4-aad7-fb42a759e185)

[^1]: some tests copied from https://github.com/osmlab/osm-api-js/pull/34
