### PR TITLE
Flag multipolygon type on nodes and ways

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1669,6 +1669,9 @@ en:
         message: "{feature} has no descriptive tags"
       relation_type:
         message: "{feature} is a relation without a type"
+    multipolygon_type_on_non_relation:
+      message: "{feature} has type=multipolygon but is not a relation"
+      reference: "The type=multipolygon tag is only valid on relations."
     mutually_exclusive_tags:
       title: Contradictory Tags
       tip: "Find features that have contradictory tags."

--- a/modules/validations/mismatched_geometry.js
+++ b/modules/validations/mismatched_geometry.js
@@ -18,6 +18,45 @@ import { validationIssue, validationIssueFix } from '../core/validation';
 export function validationMismatchedGeometry() {
     var type = 'mismatched_geometry';
 
+    function multipolygonTypeOnNonRelationIssue(entity) {
+        if (entity.type === 'relation' || entity.tags.type !== 'multipolygon') return null;
+
+        return new validationIssue({
+            type: type,
+            subtype: 'multipolygon_type_on_non_relation',
+            severity: 'warning',
+            message: function(context) {
+                var entity = context.hasEntity(this.entityIds[0]);
+                return entity ? t.append('issues.multipolygon_type_on_non_relation.message', {
+                    feature: utilDisplayLabel(entity, context.graph(), true /* verbose */)
+                }) : '';
+            },
+            reference: function showReference(selection) {
+                selection.selectAll('.issue-reference')
+                    .data([0])
+                    .enter()
+                    .append('div')
+                    .attr('class', 'issue-reference')
+                    .call(t.append('issues.multipolygon_type_on_non_relation.reference'));
+            },
+            entityIds: [entity.id],
+            dynamicFixes: () => [new validationIssueFix({
+                icon: 'iD-operation-delete',
+                title: t.append('issues.fix.remove_named_tag.title', { tag: 'type' }),
+                onClick: function(context) {
+                    var entityId = this.issue.entityIds[0];
+                    var entity = context.entity(entityId);
+                    var tags = Object.assign({}, entity.tags);
+                    delete tags.type;
+                    context.perform(
+                        actionChangeTags(entityId, tags),
+                        t('issues.fix.remove_named_tag.annotation', { tag: 'type' })
+                    );
+                }
+            })]
+        });
+    }
+
     function tagSuggestingLineIsArea(entity) {
         if (entity.type !== 'way' || entity.isClosed()) return null;
 
@@ -470,6 +509,9 @@ export function validationMismatchedGeometry() {
     }
 
     var validation = function checkMismatchedGeometry(entity, graph) {
+        var multipolygonTypeOnNonRelation = multipolygonTypeOnNonRelationIssue(entity);
+        if (multipolygonTypeOnNonRelation) return [multipolygonTypeOnNonRelation];
+
         var vertexPoint = vertexPointIssue(entity, graph);
         if (vertexPoint) return [vertexPoint];
 

--- a/test/spec/validations/mismatched_geometry.js
+++ b/test/spec/validations/mismatched_geometry.js
@@ -88,6 +88,45 @@ describe('iD.validations.mismatched_geometry', function () {
         expect(issues).toHaveLength(0);
     });
 
+    it('flags type=multipolygon on a point and removes the tag', function() {
+        const container = d3_select(document.createElement('div'));
+        createPoint({ type: 'multipolygon', name: 'Test' });
+
+        const issues = validate();
+        expect(issues).toHaveLength(1);
+        expect(issues[0].type).toEqual('mismatched_geometry');
+        expect(issues[0].subtype).toEqual('multipolygon_type_on_non_relation');
+        expect(issues[0].severity).toEqual('warning');
+        issues[0].message(context)(container);
+        expect(container.text()).toBe('Point Test has type=multipolygon but is not a relation');
+
+        issues[0].fixes(context)[0].onClick(context);
+        expect(context.entity('n-1').tags).toStrictEqual({ name: 'Test' });
+    });
+
+    it('flags type=multipolygon on a way', function() {
+        createOpenWay({ type: 'multipolygon', highway: 'service' });
+
+        const issues = validate();
+        expect(issues).toHaveLength(1);
+        expect(issues[0].subtype).toEqual('multipolygon_type_on_non_relation');
+        expect(issues[0].entityIds).toEqual(['w-1']);
+    });
+
+    it('does not flag other type tags on nodes or ways', function() {
+        createOpenWay({ type: 'palm', natural: 'tree' });
+        var issues = validate();
+        expect(issues).toHaveLength(0);
+    });
+
+    it('does not flag type=multipolygon on a relation', function() {
+        var relation = new iD.osmRelation({ id: 'r-1', tags: { type: 'multipolygon', landuse: 'forest' } });
+        context.perform(iD.actionAddEntity(relation));
+
+        var issues = validate();
+        expect(issues).toHaveLength(0);
+    });
+
     it('ignores points', function() {
         createPoint({ building: 'yes' });
         var issues = validate();


### PR DESCRIPTION
Closes #8508.

## Summary

- warn when a node or way is tagged `type=multipolygon`
- offer a one-click fix that removes only the invalid `type` tag
- leave proper multipolygon relations and unrelated `type=*` tags unchanged

The check is intentionally narrow. The issue discussion notes legitimate non-relation values such as `type=palm`, so warning on every `type` tag would introduce false positives.

## Validation

- 18 focused `mismatched_geometry` tests pass
- targeted ESLint passes
- TypeScript checking passes
- `npm run build:data` passes
- `git diff --check` passes

