### PR TITLE
Validate integer field values

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1636,6 +1636,9 @@ en:
         message: '{feature} has an invalid email address'
         message_multi: '{feature} has multiple invalid email addresses'
         reference: 'Email addresses must look like "user@example.com".'
+      integer:
+        message: '{feature} has a non-integer value in {key}'
+        reference: 'This value must be an integer.'
       website:
         message: '{feature} has an invalid URL in {where}'
         message_multi: '{feature} has multiple invalid URLs in {where}'

--- a/modules/validations/invalid_format.js
+++ b/modules/validations/invalid_format.js
@@ -1,4 +1,5 @@
 import { t } from '../core/localizer';
+import { locationManager } from '../core/location_manager';
 import { utilDisplayLabel } from '../util/utilDisplayLabel';
 import { validationIssue, validationIssueFix } from '../core/validation';
 import { actionChangeTags } from '../actions/change_tags';
@@ -10,7 +11,7 @@ import { presetManager } from '../presets';
 export function validationFormatting(context) {
     var type = 'invalid_format';
 
-    var validation = function(entity) {
+    var validation = function(entity, graph) {
         var issues = [];
 
         function isValidEmail(email) {
@@ -22,6 +23,10 @@ export function validationFormatting(context) {
             return (!email || valid_email.test(email));
         }
 
+        function isIntegerValue(value) {
+            return value.split(';').every(part => /^[+-]?\d+$/.test(part.trim()));
+        }
+
         function showReferenceEmail(selection) {
             selection.selectAll('.issue-reference')
                 .data([0])
@@ -29,6 +34,15 @@ export function validationFormatting(context) {
                 .append('div')
                 .attr('class', 'issue-reference')
                 .call(t.append('issues.invalid_format.email.reference'));
+        }
+
+        function showReferenceInteger(selection) {
+            selection.selectAll('.issue-reference')
+                .data([0])
+                .enter()
+                .append('div')
+                .attr('class', 'issue-reference')
+                .call(t.append('issues.invalid_format.integer.reference'));
         }
 
         function isFixableURL(url) {
@@ -245,6 +259,47 @@ export function validationFormatting(context) {
                 }
             }
         }
+
+        const entityGeometry = entity.geometry(graph);
+        const entityExtent = entity.extent(graph);
+        const entityLocation = entityExtent.center();
+        const preset = presetManager.match(entity, graph);
+        const validHere = locationManager.locationSetsAt(entityLocation);
+        const integerFields = [
+            ...preset.fields(entityLocation),
+            ...preset.moreFields(entityLocation),
+            ...presetManager.universal().filter(field => {
+                return !field.locationSetID || validHere.has(field.locationSetID);
+            })
+        ].filter(field => field.type === 'integer' && field.matchGeometry(entityGeometry));
+
+        const checkedIntegerKeys = new Set();
+        integerFields.forEach(field => {
+            field.allKeys(entity.tags).forEach(key => {
+                if (checkedIntegerKeys.has(key)) return;
+                checkedIntegerKeys.add(key);
+
+                const value = entity.tags[key];
+                if (!value || isIntegerValue(value)) return;
+
+                issues.push(new validationIssue({
+                    type: type,
+                    subtype: 'integer',
+                    severity: 'warning',
+                    message: function(context) {
+                        const entity = context.hasEntity(this.entityIds[0]);
+                        return entity ? t.append('issues.invalid_format.integer.message', {
+                            feature: utilDisplayLabel(entity, context.graph()),
+                            key: selection => selection.append('code').text(this.data.key)
+                        }) : '';
+                    },
+                    reference: showReferenceInteger,
+                    entityIds: [entity.id],
+                    hash: `${key}=${value}`,
+                    data: { key, value }
+                }));
+            });
+        });
 
         if (entity.tags.email) {
             // Multiple emails are possible

--- a/test/spec/validations/invalid_format.js
+++ b/test/spec/validations/invalid_format.js
@@ -1,3 +1,6 @@
+import { select as d3_select } from 'd3-selection';
+import { locationManager } from '../../../modules/core/location_manager';
+
 describe('iD.validations.invalid_format', function () {
     var context;
 
@@ -225,6 +228,275 @@ describe('iD.validations.invalid_format', function () {
                 .replace(/#.*/, '')
                 .replace(/_/g, ' ');
             expect(fixedEntity.tags.wikimedia_commons).to.eql(expected);
+        });
+    });
+
+    describe('Integer field validation', function() {
+        const fieldID = 'test_integer';
+        const duplicateFieldID = 'test_integer_duplicate';
+        const presetID = 'test/integer';
+        const originalLocationSetsAt = locationManager.locationSetsAt;
+
+        beforeEach(function() {
+            iD.presetManager.merge({
+                fields: {
+                    [fieldID]: { key: 'test:count', type: 'integer' }
+                },
+                presets: {
+                    [presetID]: {
+                        tags: { amenity: 'test_integer' },
+                        geometry: ['point'],
+                        fields: [fieldID]
+                    }
+                }
+            });
+        });
+
+        afterEach(function() {
+            locationManager.locationSetsAt = originalLocationSetsAt;
+            iD.presetManager.merge({
+                fields: {
+                    [fieldID]: null,
+                    [duplicateFieldID]: null
+                },
+                presets: { [presetID]: null }
+            });
+        });
+
+        it.each(['-2', '+7', '0', '42', '01', '1; 2'])(
+            'accepts integer field value %s',
+            function(value) {
+                const entity = createPointWithTags({
+                    amenity: 'test_integer',
+                    'test:count': value
+                });
+
+                expect(validate(entity)).toHaveLength(0);
+            }
+        );
+
+        it('reports a universal integer field only once when the preset also includes it', function() {
+            iD.presetManager.merge({
+                fields: {
+                    [fieldID]: { key: 'test:count', type: 'integer', universal: true }
+                }
+            });
+            const entity = createPointWithTags({
+                amenity: 'test_integer',
+                'test:count': '1.5'
+            });
+
+            expect(validate(entity)).toHaveLength(1);
+        });
+
+        it('reports a tag only once when multiple integer fields control the same key', function() {
+            iD.presetManager.merge({
+                fields: {
+                    [duplicateFieldID]: {
+                        key: 'test:count',
+                        type: 'integer',
+                        universal: true
+                    }
+                }
+            });
+            const entity = createPointWithTags({
+                amenity: 'test_integer',
+                'test:count': '1.5'
+            });
+
+            expect(validate(entity)).toHaveLength(1);
+        });
+
+        it.each([
+            'abc',
+            '2.5',
+            '1; 2.5',
+            '1;',
+            '9007199254740992.5',
+            '5.0000000000000001',
+            '1e3',
+            '0x10'
+        ])(
+            'flags non-integer field value %s',
+            function(value) {
+                const entity = createPointWithTags({
+                    amenity: 'test_integer',
+                    'test:count': value
+                });
+
+                const issues = validate(entity);
+                expect(issues).toHaveLength(1);
+                expect(issues[0].data).toEqual({
+                    key: 'test:count',
+                    value
+                });
+            }
+        );
+
+        it('validates populated alternative keys for an integer field', function() {
+            iD.presetManager.merge({
+                fields: {
+                    [fieldID]: {
+                        keys: ['test:count', 'test:count:alt'],
+                        type: 'integer'
+                    }
+                }
+            });
+            const entity = createPointWithTags({
+                amenity: 'test_integer',
+                'test:count': '2',
+                'test:count:alt': '2.5'
+            });
+
+            const issues = validate(entity);
+            expect(issues).toHaveLength(1);
+            expect(issues[0].data.key).toEqual('test:count:alt');
+        });
+
+        it('validates integer fields listed as more fields', function() {
+            iD.presetManager.merge({
+                presets: {
+                    [presetID]: {
+                        tags: { amenity: 'test_integer' },
+                        geometry: ['point'],
+                        moreFields: [fieldID]
+                    }
+                }
+            });
+            const entity = createPointWithTags({
+                amenity: 'test_integer',
+                'test:count': '2.5'
+            });
+
+            expect(validate(entity)).toHaveLength(1);
+        });
+
+        it('validates universal integer fields on fallback presets', function() {
+            iD.presetManager.merge({
+                fields: {
+                    [fieldID]: { key: 'test:count', type: 'integer', universal: true }
+                }
+            });
+            const entity = createPointWithTags({
+                amenity: 'not_a_test_preset',
+                'test:count': '2.5'
+            });
+
+            expect(validate(entity)).toHaveLength(1);
+        });
+
+        it('ignores integer fields that do not match the entity geometry', function() {
+            iD.presetManager.merge({
+                fields: {
+                    [fieldID]: {
+                        key: 'test:count',
+                        type: 'integer',
+                        universal: true,
+                        geometry: ['line']
+                    }
+                }
+            });
+            const entity = createPointWithTags({
+                amenity: 'not_a_test_preset',
+                'test:count': '2.5'
+            });
+
+            expect(validate(entity)).toHaveLength(0);
+        });
+
+        it('ignores universal integer fields outside their location set', function() {
+            locationManager.locationSetsAt = () => new Map();
+            iD.presetManager.merge({
+                fields: {
+                    [fieldID]: {
+                        key: 'test:count',
+                        type: 'integer',
+                        universal: true,
+                        locationSet: { include: ['Q2'] }
+                    }
+                }
+            });
+            const entity = createPointWithTags({
+                amenity: 'test_integer',
+                'test:count': '1.5'
+            });
+
+            expect(validate(entity)).toHaveLength(0);
+        });
+
+        it('uses the graph snapshot supplied by the validator', function() {
+            locationManager.locationSetsAt = loc => {
+                return loc[0] > 5 ? new Map([['+[Q2]', 1]]) : new Map();
+            };
+            iD.presetManager.merge({
+                fields: {
+                    [fieldID]: {
+                        key: 'test:count',
+                        type: 'integer',
+                        universal: true,
+                        geometry: ['line'],
+                        locationSet: { include: ['Q2'] }
+                    }
+                }
+            });
+
+            const way = new iD.osmWay({
+                id: 'w-1',
+                nodes: ['n-1', 'n-2'],
+                tags: { 'test:count': '1.5' }
+            });
+            context.perform(
+                iD.actionAddEntity(new iD.osmNode({ id: 'n-1', loc: [0, 0] })),
+                iD.actionAddEntity(new iD.osmNode({ id: 'n-2', loc: [1, 0] })),
+                iD.actionAddEntity(way)
+            );
+
+            const snapshotGraph = new iD.coreGraph([
+                new iD.osmNode({ id: 'n-1', loc: [10, 10] }),
+                new iD.osmNode({ id: 'n-2', loc: [11, 10] }),
+                way
+            ]);
+            const validator = iD.validationFormatting(context);
+
+            expect(validator(way, snapshotGraph)).toHaveLength(1);
+        });
+
+        it('does not apply integer validation to number fields', function() {
+            iD.presetManager.merge({
+                fields: {
+                    [fieldID]: { key: 'test:count', type: 'number' }
+                }
+            });
+            const entity = createPointWithTags({
+                amenity: 'test_integer',
+                'test:count': '2.5'
+            });
+
+            expect(validate(entity)).toHaveLength(0);
+        });
+
+        it('flags a fractional value for an integer field', function() {
+            const entity = createPointWithTags({
+                amenity: 'test_integer',
+                'test:count': '1.5'
+            });
+
+            const issues = validate(entity);
+            expect(issues).toHaveLength(1);
+            expect(issues[0].type).toEqual('invalid_format');
+            expect(issues[0].subtype).toEqual('integer');
+            expect(issues[0].data).toEqual({
+                key: 'test:count',
+                value: '1.5'
+            });
+
+            const container = d3_select(document.createElement('div'));
+            issues[0].message(context)(container);
+            expect(container.text()).toEqual('test/integer has a non-integer value in test:count');
+
+            container.html('');
+            issues[0].reference(container);
+            expect(container.text()).toEqual('This value must be an integer.');
         });
     });
 


### PR DESCRIPTION
## Summary

- Validate values using `integer` fields from the tagging schema instead of hard-coding lane tags.
- Check applicable preset, additional, and universal fields, including alternative keys.
- Respect field geometry, location sets, and the graph snapshot being validated.
- Accept signed integers and semicolon-separated integer lists while leaving `number` fields unchanged.
- Show only one warning when multiple fields point to the same tag.

## Testing

- `npx vitest run --no-isolate test/spec/validations/invalid_format.js`: 47 tests passed
- `npm test`: 136 test files passed and 4 skipped; 2,285 tests passed, 9 skipped, and 6 todo
- `git diff --check`: passed

The full test run still reports existing warnings in unchanged `modules/core/file_fetcher.ts` and `test/spec/core/difference.js`.

Fixes #12827

## AI assistance

I used Hermes Agent (GPT-5.6) to help implement and test this change.
