### PR TITLE
use = to move from tag key to value and fix input focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 
 #### :sparkles: Usability & Accessibility
 * Render diameter and radius tags when a node is selected ([#9732], thanks [@k-yle])
+* Allow to press `=` key to switch between _key_ and _value_ part of tag in the raw tag editor ([#12828], thanks [@hemaksh2007jain-bit])
 #### :scissors: Operations
 #### :camera: Street-Level
 #### :white_check_mark: Validation
@@ -52,7 +53,8 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 
 [#9732]: https://github.com/openstreetmap/iD/pull/9732
 [#12679]: https://github.com/openstreetmap/iD/pull/12679
-
+[#12828]: https://github.com/openstreetmap/iD/pull/12828
+[@hemaksh2007jain-bit]: https://github.com/hemaksh2007jain-bit
 
 # 2.42.1
 ##### 2026-Aug-18

--- a/modules/ui/sections/raw_tag_editor.js
+++ b/modules/ui/sections/raw_tag_editor.js
@@ -183,6 +183,16 @@ export function uiSectionRawTagEditor(id, context) {
             .attr('class', 'key')
             .call(utilNoAuto)
             .on('focus', interacted)
+            .on('keydown',function(d3_event){
+                    if (d3_event.key === '='){
+                        d3_event.preventDefault();
+                        var row = d3_select(this.parentNode.parentNode);
+                        var value = row.select('input.value').node();
+                        if (value){
+                            value.focus();
+                        }
+                    }
+                })
             .on('blur', keyChange)
             .on('change', keyChange);
 

--- a/modules/ui/sections/raw_tag_editor.js
+++ b/modules/ui/sections/raw_tag_editor.js
@@ -188,7 +188,7 @@ export function uiSectionRawTagEditor(id, context) {
                         d3_event.preventDefault();
                         var row = d3_select(this.parentNode.parentNode);
                         var value = row.select('input.value').node();
-                        if (value){
+                        if (value) {
                             value.focus();
                         }
                     }

--- a/modules/ui/sections/raw_tag_editor.js
+++ b/modules/ui/sections/raw_tag_editor.js
@@ -183,8 +183,8 @@ export function uiSectionRawTagEditor(id, context) {
             .attr('class', 'key')
             .call(utilNoAuto)
             .on('focus', interacted)
-            .on('keydown',function(d3_event){
-                    if (d3_event.key === '='){
+            .on('keydown', function(d3_event) {
+                    if (d3_event.key === '=') {
                         d3_event.preventDefault();
                         var row = d3_select(this.parentNode.parentNode);
                         var value = row.select('input.value').node();

--- a/test/spec/ui/sections/raw_tag_editor.js
+++ b/test/spec/ui/sections/raw_tag_editor.js
@@ -48,6 +48,15 @@ describe('iD.uiSectionRawTagEditor', function() {
         expect(element.select('.tag-list').selectAll('input').nodes()[3].value).toBe('');
     });
 
+    it('moves focus to the value input when pressing equals in the key input', function(){
+        element.remove();
+        render({});
+        var key = element.select('.tag-list input.key');
+        var value = element.select('.tag-list input.value');
+        iD.utilTriggerEvent(key,'keydown',{key:'='});
+        expect(document.activeElement).toBe(value.node());
+    });
+
     it('removes tags when clicking the remove button', async () => {
         const tags = new Promise(cb => {
             taglist.on('change', (_, tags) => cb(tags));

--- a/test/spec/ui/sections/raw_tag_editor.js
+++ b/test/spec/ui/sections/raw_tag_editor.js
@@ -48,12 +48,12 @@ describe('iD.uiSectionRawTagEditor', function() {
         expect(element.select('.tag-list').selectAll('input').nodes()[3].value).toBe('');
     });
 
-    it('moves focus to the value input when pressing equals in the key input', function(){
+    it('moves focus to the value input when pressing equals in the key input', function() {
         element.remove();
         render({});
         var key = element.select('.tag-list input.key');
         var value = element.select('.tag-list input.value');
-        iD.utilTriggerEvent(key,'keydown',{key:'='});
+        iD.utilTriggerEvent(key,'keydown', { key: '=' });
         expect(document.activeElement).toBe(value.node());
     });
 


### PR DESCRIPTION
Fixes #12806 
Changes 👍 
Handle = when entered in the tag key field.
prevents = being inserted into key value.
Move focus to the corresponding value field.
Added a regression test for the behavior.

testing 👍 
Targeted raw tag editor tests and pass: 5/5.
ESLint passes for the changed files.
git diff --check passes.

i reproduced the issue locally before implementing the fix.