### PR TITLE
Add rendering for `ford` tag on highway features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 
 #### :sparkles: Usability & Accessibility
 * Render diameter and radius tags when a node is selected ([#9732], thanks [@k-yle])
+* Dedicated rendering for road sections tagged with `ford=yes` ([#12830], thansk [@Geo-2695])
 #### :scissors: Operations
 #### :camera: Street-Level
 #### :white_check_mark: Validation
@@ -52,6 +53,8 @@ _Breaking developer changes, which may affect downstream projects or sites that 
 
 [#9732]: https://github.com/openstreetmap/iD/pull/9732
 [#12679]: https://github.com/openstreetmap/iD/pull/12679
+[#12830]: https://github.com/openstreetmap/iD/pull/12830
+[@Geo-2695]: https://github.com/Geo-2695
 
 
 # 2.42.1

--- a/css/50_misc.css
+++ b/css/50_misc.css
@@ -360,6 +360,18 @@ path.line.casing.tag-location-underwater {
 }
 
 
+/* fords */
+path.line.stroke.tag-highway.tag-ford {
+    stroke-opacity: 0.7;
+}
+path.line.casing.tag-highway.tag-ford {
+    stroke: rgba(119, 221, 221, 0.6);
+    stroke-opacity: 0.5;
+    stroke-linecap: butt;
+    stroke-dasharray: none;
+}
+
+
 /* embankments / cuttings */
 /* see also #ideditor-sided-marker-embankment */
 path.line.stroke.tag-man_made-embankment {

--- a/modules/svg/tag_classes.ts
+++ b/modules/svg/tag_classes.ts
@@ -13,7 +13,7 @@ export function svgTagClasses<T>() {
     ];
     const statuses: string[] = Object.keys(osmLifecyclePrefixes);
     const secondaries = [
-        'oneway', 'bridge', 'tunnel', 'barrier',
+        'oneway', 'bridge', 'tunnel', `ford`, 'barrier',
         'surface', 'tracktype', 'footway', 'crossing', 'service', 'sport',
         'public_transport', 'location', 'parking', 'golf', 'type', 'leisure',
         'man_made', 'indoor', 'construction', 'proposed', 'bicycle', 'foot'

--- a/modules/svg/tag_classes.ts
+++ b/modules/svg/tag_classes.ts
@@ -13,7 +13,7 @@ export function svgTagClasses<T>() {
     ];
     const statuses: string[] = Object.keys(osmLifecyclePrefixes);
     const secondaries = [
-        'oneway', 'bridge', 'tunnel', `ford`, 'barrier',
+        'oneway', 'bridge', 'tunnel', 'ford', 'barrier',
         'surface', 'tracktype', 'footway', 'crossing', 'service', 'sport',
         'public_transport', 'location', 'parking', 'golf', 'type', 'leisure',
         'man_made', 'indoor', 'construction', 'proposed', 'bicycle', 'foot'


### PR DESCRIPTION
When a mapper tries to add a ford to a road segment, they will naturally go to the **Structure** field in the sidebar and select `Ford`. However, iD currently applies no special rendering after selection, which looks inconsistent. This adds rendering logic for this case.

Local `npm test` keeps reporting repeated CRLF linebreak errors, but this should not be an issue in here

<img width="877" height="523" alt="Ford" src="https://github.com/user-attachments/assets/9a550a22-581b-4019-ac94-7ffd50c60db6" />
