### PR TITLE
fix: unescape quotes in stringify()

### DIFF
--- a/modules/ui/sections/raw_tag_editor.js
+++ b/modules/ui/sections/raw_tag_editor.js
@@ -309,7 +309,7 @@ export function uiSectionRawTagEditor(id, context) {
     }
 
     function stringify(s) {
-        const stringified = JSON.stringify(s).slice(1, -1);   // without leading/trailing "
+        const stringified = JSON.stringify(s).slice(1, -1).replace(/\\"/g, '"');   // without leading/trailing "
         if (stringified !== s) {
             return `"${stringified}"`;
         } else {


### PR DESCRIPTION
fixes - #12819 

Added `.replace(/\\"/g, '"')` to unescape quotes back

before:
<img width="377" height="118" alt="image" src="https://github.com/user-attachments/assets/9f4955ec-812e-413d-8e12-77db01a58688" />

after:
<img width="383" height="81" alt="image" src="https://github.com/user-attachments/assets/bd3ec017-456f-413b-a311-3a2e420253dd" />
