### PR TITLE
exclude icon dependencies from cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,9 @@ updates:
       semver-major-days: 7
       semver-minor-days: 7
       semver-patch-days: 7
+      exclude:
+        - "@waysidemapping/pinhead"
+        - "@enzet/roentgen"
     groups:
       fontawesome:
         patterns:


### PR DESCRIPTION
it is quite unlikely that waiting extra will help, if there is some rogue code there

it is frustrating to not be able to use new icons when it is released already, and making these update PRs manually is a waste of time