### PR TITLE
Focus member role input immediately after selecting relation

### DIFF
--- a/modules/ui/sections/raw_membership_editor.js
+++ b/modules/ui/sections/raw_membership_editor.js
@@ -681,6 +681,13 @@ export function uiSectionRawMembershipEditor(context) {
 
             var role = context.cleanRelationRole(list.selectAll('.member-row-new .member-role').property('value'));
             addMembership(d, role);
+
+            // Focus the role input of the newly added membership row so the user
+            // can immediately type the member role after selecting a relation. #9112
+            if (!role) {
+                var newRoleInput = list.selectAll('.member-row-normal:last-child input.member-role').node();
+                if (newRoleInput) newRoleInput.focus();
+            }
         }
 
 


### PR DESCRIPTION
Fixes #9112

### Problem
When adding an entity to a relation via the "+" button in the Relations section, selecting a relation from the dropdown blurred the input and left the keyboard cursor with no focus. The user was required to manually click on the "Role" text box with the mouse.

### Solution
In `uiSectionRawMembershipEditor`, when a relation is selected and added as a membership, automatically focus the member role input field of the newly added relation row so users can immediately continue typing the role without using the mouse.

### Validation
- [x] Verified locally by adding a relation and observing that focus automatically jumps into the Role text box.
- [x] ESLint passed with 0 errors (`npm run lint`).
- [x] Full test suite passed (`npm run test:once`).
