### PR TITLE
Give each mismatched geometry fix its own annotation

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1791,9 +1791,10 @@ en:
         title: Continue drawing from end
       convert_to_line:
         title: Convert this to a line
+        annotation: Converted an area to a line.
       convert_to_area:
         title: Convert this to an area
-        annotation: Converted an area to a line.
+        annotation: Converted a line to an area.
       delete_feature:
         title: Delete this feature
       extract_point:

--- a/modules/validations/mismatched_geometry.js
+++ b/modules/validations/mismatched_geometry.js
@@ -379,7 +379,7 @@ export function validationMismatchedGeometry() {
                 };
                 context.perform(
                     actionChangeTags(entityId, newTags),
-                    t('issues.fix.convert_to_line.annotation')
+                    t('issues.fix.convert_to_area.annotation')
                 );
             },
         });

--- a/test/spec/validations/mismatched_geometry.js
+++ b/test/spec/validations/mismatched_geometry.js
@@ -159,6 +159,34 @@ describe('iD.validations.mismatched_geometry', function () {
         expect(context.entity(way.id).tags).toStrictEqual({});
     });
 
+    it('labels the edit made by the convert-to-line fix', async () => {
+        await iD.presetManager.ensureLoaded(true);
+        createClosedWay({ barrier: 'gate', area: 'yes' });
+        const issue = validate()[0];
+        expect(issue.subtype).toEqual('line_as_area');
+
+        const container = d3_select(document.createElement('div'));
+        issue.fixes(context)[0].title(container);
+        expect(container.text()).toBe('Convert this to a line');
+
+        issue.fixes(context)[0].onClick(context);
+        expect(context.history().undoAnnotation()).toBe('Converted an area to a line.');
+    });
+
+    it('labels the edit made by the convert-to-area fix', async () => {
+        await iD.presetManager.ensureLoaded(true);
+        createClosedWay({ junction: 'yes' });
+        const issue = validate()[0];
+        expect(issue.subtype).toEqual('area_as_line');
+
+        const container = d3_select(document.createElement('div'));
+        issue.fixes(context)[0].title(container);
+        expect(container.text()).toBe('Convert this to an area');
+
+        issue.fixes(context)[0].onClick(context);
+        expect(context.history().undoAnnotation()).toBe('Converted a line to an area.');
+    });
+
     it('flags open way with both area and line tags', function() {
         const way = createOpenWay({ area: 'yes', barrier: 'fence' });
         var issues = validate();


### PR DESCRIPTION
Both fixes from the mismatched-geometry validation call `t('issues.fix.convert_to_line.annotation')`, but that key doesn't exist — in core.yaml the annotation is nested under `convert_to_area`. So undoing either fix shows "Missing translation: issues.fix.convert_to_line.annotation" in the history tooltip, and logs a console error.

Gives each fix its own annotation, and points the convert-to-area fix at its own.
